### PR TITLE
Expose JSONHTTPClient in the Connector interface

### DIFF
--- a/common/json.go
+++ b/common/json.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/spyzhov/ajson"
 )
@@ -15,26 +17,30 @@ import (
 // All non-2xx responses will be passed to the error handler. If the error handler
 // returns nil, then the error is ignored and the caller is responsible for handling
 // the error. If the error handler returns an error, then that error is returned
-// to the caller, as-is. Both the response as well as the response body are passed
+// to the caller, as-is. Both the response and the response body are passed
 // to the error handler as arguments.
 type ErrorHandler func(rsp *http.Response, body []byte) error
 
 // JSONHTTPClient is an HTTP client which makes certain assumptions, such as
 // that the response body is JSON. It also handles OAuth access token refreshes.
 type JSONHTTPClient struct {
-	Client       AuthenticatedHTTPClient
-	ErrorHandler ErrorHandler
+	Base         string                  // optional base URL. If not set, then all URLs must be absolute.
+	Client       AuthenticatedHTTPClient // underlying HTTP client. Required.
+	ErrorHandler ErrorHandler            // optional error handler. If not set, then the default error handler is used.
 }
 
 // Get makes a GET request to the given URL and returns the response body as a JSON object.
 // If the response is not a 2xx, an error is returned. If the response is a 401, the caller should
 // refresh the access token and retry the request. If errorHandler is nil, then the default error
 // handler is used. If not, the caller can inject their own error handling logic.
-func (j *JSONHTTPClient) Get(ctx context.Context,
-	url string, headers ...Header,
-) (*ajson.Node, error) {
+func (j *JSONHTTPClient) Get(ctx context.Context, url string, headers ...Header) (*ajson.Node, error) {
+	fullURL, err := j.getURL(url)
+	if err != nil {
+		return nil, err
+	}
+
 	// Make the request, get the response body
-	res, body, err := j.httpGet(ctx, url, headers) //nolint:bodyclose
+	res, body, err := j.httpGet(ctx, fullURL, headers) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +65,18 @@ func (j *JSONHTTPClient) Get(ctx context.Context,
 	}
 
 	return jsonBody, nil
+}
+
+func (j *JSONHTTPClient) getURL(u string) (string, error) {
+	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+		return u, nil
+	}
+
+	if len(j.Base) == 0 {
+		return "", fmt.Errorf("%w (input is %q)", ErrEmptyBaseURL, u)
+	}
+
+	return url.JoinPath(j.Base, u)
 }
 
 func (j *JSONHTTPClient) httpGet(ctx context.Context, url string,

--- a/common/types.go
+++ b/common/types.go
@@ -36,6 +36,9 @@ var (
 
 	// ErrMissingRefreshToken is returned when the refresh token is missing.
 	ErrMissingRefreshToken = errors.New("missing refresh token")
+
+	// ErrEmptyBaseURL is returned when the URL is relative, and the base URL is empty.
+	ErrEmptyBaseURL = errors.New("empty base URL")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/connectors.go
+++ b/connectors.go
@@ -29,7 +29,7 @@ type Connector interface {
 
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector
-	// interface directly. Authentication will be handled automatically.
+	// interface directly. Authentication and token refreshes will be handled automatically.
 	JSONHTTPClient() *common.JSONHTTPClient
 }
 

--- a/connectors.go
+++ b/connectors.go
@@ -26,6 +26,11 @@ type Connector interface {
 	// Authentication corner cases are handled internally, but all other errors
 	// are returned to the caller.
 	Read(ctx context.Context, params ReadParams) (*ReadResult, error)
+
+	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
+	// testing, or for calling methods that aren't exposed by the Connector
+	// interface directly. Authentication will be handled automatically.
+	JSONHTTPClient() *common.JSONHTTPClient
 }
 
 // API is a function that returns a Connector. It's used as a factory.

--- a/salesforce/client.go
+++ b/salesforce/client.go
@@ -1,0 +1,8 @@
+package salesforce
+
+import "github.com/amp-labs/connectors/common"
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}

--- a/salesforce/connector.go
+++ b/salesforce/connector.go
@@ -39,13 +39,19 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	var err error
 	params, err = params.prepare()
 
+	params.client.Base = fmt.Sprintf("https://%s.my.salesforce.com", params.subdomain)
+
 	if err != nil {
 		return nil, err
 	}
 
-	return &Connector{
+	conn = &Connector{
 		BaseURL: fmt.Sprintf("https://%s.my.salesforce.com/services/data/%s", params.subdomain, apiVersion),
 		Domain:  fmt.Sprintf("%s.my.salesforce.com", params.subdomain),
 		Client:  params.client,
-	}, nil
+	}
+
+	conn.Client.ErrorHandler = conn.interpretError
+
+	return conn, nil
 }

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -1,6 +1,11 @@
 package salesforce
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+)
 
 var (
 	ErrNotArray         = errors.New("records is not an array")
@@ -12,3 +17,9 @@ var (
 	ErrMissingSubdomain = errors.New("missing Salesforce workspace name")
 	ErrMissingClient    = errors.New("JSON http client not set")
 )
+
+func (c *Connector) interpretError(res *http.Response, body []byte) error {
+	// TODO: handle salesforce errors in a more robust way. For now, we just
+	// handle the basic HTTP status codes and nothing else.
+	return common.InterpretError(res, body)
+}


### PR DESCRIPTION
This PR addresses a few small issues:
* Exposes JSONHTTPClient in the connector interface (avoids having to explicitly cast to get the client)
* Allow relative URLs to be passed in to JSONHTTPClient (full URLs will be auto-constructed)
