### PR TITLE
[ENG-206] feat: Handle common Salesforce errors

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -16,6 +16,18 @@ var (
 	// ErrForbidden means the user doesn't have access to this resource.
 	ErrForbidden = errors.New("forbidden")
 
+	// ErrInvalidSessionId means the session ID is invalid.
+	ErrInvalidSessionId = errors.New("invalid session id")
+
+	// ErrUnableToLockRow means the resource couldn't be locked.
+	ErrUnableToLockRow = errors.New("unable to lock row")
+
+	// ErrInvalidGrant means the OAuth grant is invalid.
+	ErrInvalidGrant = errors.New("invalid grant")
+
+	// ErrLimitExceeded means a quota limit was exceeded.
+	ErrLimitExceeded = errors.New("request limit exceeded")
+
 	// ErrRetryable represents a temporary error. Can retry.
 	ErrRetryable = errors.New("retryable error")
 

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -33,18 +33,18 @@ func (c *Connector) interpretError(res *http.Response, body []byte) error {
 	return common.InterpretError(res, body)
 }
 
+func createError(baseErr error, sfErr jsonError) error {
+	if len(sfErr.Message) > 0 {
+		return fmt.Errorf("%w: %s", baseErr, sfErr.Message)
+	}
+
+	return baseErr
+}
+
 func (c *Connector) interpretJSONError(res *http.Response, body []byte) error {
 	errs := []jsonError{}
 	if err := json.Unmarshal(body, &errs); err != nil {
 		return fmt.Errorf("json.Unmarshal failed: %w", err)
-	}
-
-	createError := func(e error, sfErr jsonError) error {
-		if len(sfErr.Message) > 0 {
-			return fmt.Errorf("%w: %s", e, sfErr.Message)
-		}
-
-		return e
 	}
 
 	for _, sfErr := range errs {


### PR DESCRIPTION
Some Salesforce errors are structured as JSON. This PR adds the ability to introspect that JSON and return a more specific/relevant error to the caller.