### PR TITLE
[ENG-420] Add ListObjectMetadata to Salesforce & Hubspot connectors

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -54,6 +54,9 @@ var (
 
 	// ErrNotImplemented is returned when a method is not implemented.
 	ErrNotImplemented = errors.New("not implemented")
+
+	// ErrMissingObjects is returned when no objects are provided in the request.
+	ErrMissingObjects = errors.New("no objects provided")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/common/types.go
+++ b/common/types.go
@@ -149,10 +149,11 @@ func (r HTTPStatusError) Unwrap() error {
 	return r.err
 }
 
+type ListObjectMetadataResult map[string]ObjectMetadata
+
 type ObjectMetadata struct {
 	DisplayName string
+
 	// FieldsMap is a map of field names to field display names
 	FieldsMap map[string]string
 }
-
-type ListObjectMetadataResponse map[string]ObjectMetadata

--- a/common/types.go
+++ b/common/types.go
@@ -145,3 +145,11 @@ func (r HTTPStatusError) Error() string {
 func (r HTTPStatusError) Unwrap() error {
 	return r.err
 }
+
+type ObjectMetadata struct {
+	DisplayName string
+	// FieldsMap is a map of field names to field display names
+	FieldsMap map[string]string
+}
+
+type ListObjectMetadataResponse map[string]ObjectMetadata

--- a/common/types.go
+++ b/common/types.go
@@ -152,6 +152,7 @@ func (r HTTPStatusError) Unwrap() error {
 type ListObjectMetadataResult map[string]ObjectMetadata
 
 type ObjectMetadata struct {
+	// Provider's display name for the object
 	DisplayName string
 
 	// FieldsMap is a map of field names to field display names

--- a/connectors.go
+++ b/connectors.go
@@ -30,6 +30,8 @@ type Connector interface {
 
 	Write(ctx context.Context, params WriteParams) (*WriteResult, error)
 
+	ListObjectMetadata(ctx context.Context, objectNames []string) (*ListObjectMetadataResponse, error)
+
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector
 	// interface directly. Authentication and token refreshes will be handled automatically.
@@ -56,10 +58,12 @@ var Hubspot API[*hubspot.Connector, hubspot.Option] = hubspot.NewConnector //nol
 
 // We re-export the following types so that they can be used by consumers of this library.
 type (
-	ReadParams      = common.ReadParams
-	WriteParams     = common.WriteParams
-	ReadResult      = common.ReadResult
-	WriteResult     = common.WriteResult
+	ReadParams                 = common.ReadParams
+	WriteParams                = common.WriteParams
+	ReadResult                 = common.ReadResult
+	WriteResult                = common.WriteResult
+	ListObjectMetadataResponse = common.ListObjectMetadataResponse
+
 	ErrorWithStatus = common.HTTPStatusError
 )
 

--- a/connectors.go
+++ b/connectors.go
@@ -30,7 +30,7 @@ type Connector interface {
 
 	Write(ctx context.Context, params WriteParams) (*WriteResult, error)
 
-	ListObjectMetadata(ctx context.Context, objectNames []string) (*ListObjectMetadataResponse, error)
+	ListObjectMetadata(ctx context.Context, objectNames []string) (*ListObjectMetadataResult, error)
 
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector
@@ -58,11 +58,11 @@ var Hubspot API[*hubspot.Connector, hubspot.Option] = hubspot.NewConnector //nol
 
 // We re-export the following types so that they can be used by consumers of this library.
 type (
-	ReadParams                 = common.ReadParams
-	WriteParams                = common.WriteParams
-	ReadResult                 = common.ReadResult
-	WriteResult                = common.WriteResult
-	ListObjectMetadataResponse = common.ListObjectMetadataResponse
+	ReadParams               = common.ReadParams
+	WriteParams              = common.WriteParams
+	ReadResult               = common.ReadResult
+	WriteResult              = common.WriteResult
+	ListObjectMetadataResult = common.ListObjectMetadataResult
 
 	ErrorWithStatus = common.HTTPStatusError
 )

--- a/connectors.go
+++ b/connectors.go
@@ -30,7 +30,7 @@ type Connector interface {
 
 	Write(ctx context.Context, params WriteParams) (*WriteResult, error)
 
-	ListObjectMetadata(ctx context.Context, objectNames []string) (*ListObjectMetadataResult, error)
+	ListObjectMetadata(ctx context.Context, objectNames []string) (ListObjectMetadataResult, error)
 
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -63,6 +63,7 @@ type describeObjectResult struct {
 	Label string `json:"label"`
 }
 
+// describeObject returns object metadata for the given object name.
 func (c *Connector) describeObject(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
 	data, err := c.get(ctx, c.BaseURL+"/properties/"+objectName)
 	if err != nil {
@@ -87,6 +88,7 @@ func (c *Connector) describeObject(ctx context.Context, objectName string) (*com
 	}, nil
 }
 
+// makeFieldsMap returns a map of field name to field label.
 func makeFieldsMap(data *describeObjectResponse) map[string]string {
 	fieldsMap := make(map[string]string)
 

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -11,10 +11,13 @@ import (
 )
 
 // ListObjectMetadata returns object metadata for each object name provided.
-func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResponse, error) {
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResponse, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
-		return nil, fmt.Errorf("no objects provided")
+		return nil, common.ErrMissingObjects
 	}
 
 	metadataChannel := make(chan common.ObjectMetadata)
@@ -31,8 +34,10 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string
 	}
 
 	objectsMap := make(common.ListObjectMetadataResponse)
+
 	for range objectNames {
 		objectMetadata := <-metadataChannel
+
 		objectsMap[objectMetadata.DisplayName] = objectMetadata
 	}
 

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -22,7 +22,7 @@ func (c *Connector) ListObjectMetadata(
 
 	// Use goroutines to fetch metadata for each object in parallel
 	metadataChannel := make(chan common.ObjectMetadata, len(objectNames))
-	errChannel := make(chan error)
+	errChannel := make(chan error, len(objectNames))
 
 	for _, objectName := range objectNames {
 		go func(object string) {

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -14,7 +14,7 @@ import (
 func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 	ctx context.Context,
 	objectNames []string,
-) (*common.ListObjectMetadataResult, error) {
+) (common.ListObjectMetadataResult, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
 		return nil, common.ErrMissingObjects
@@ -73,7 +73,7 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 		}
 	}
 
-	return &objectsMap, nil
+	return objectsMap, nil
 }
 
 type describeObjectResponse struct {

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -94,14 +94,14 @@ func (c *Connector) describeObject(ctx context.Context, objectName string) (*com
 
 	rawResponse, err := ajson.Marshal(data)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling composite response into byte array: %w", err)
+		return nil, fmt.Errorf("error marshalling object metadata response into byte array: %w", err)
 	}
 
 	resp := &describeObjectResponse{}
 
 	err = json.Unmarshal(rawResponse, resp)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling composite response into JSON: %w", err)
+		return nil, fmt.Errorf("error unmarshalling object metadata response into JSON: %w", err)
 	}
 
 	return &common.ObjectMetadata{

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -1,0 +1,86 @@
+package hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+// ListObjectMetadata returns object metadata for each object name provided.
+func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResponse, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, fmt.Errorf("no objects provided")
+	}
+
+	metadataChannel := make(chan common.ObjectMetadata)
+
+	for _, objectName := range objectNames {
+		go func(object string) {
+			objectMetadata, err := c.describeObject(ctx, object)
+			if err != nil {
+				return
+			}
+
+			metadataChannel <- *objectMetadata
+		}(objectName)
+	}
+
+	objectsMap := make(common.ListObjectMetadataResponse)
+	for range objectNames {
+		objectMetadata := <-metadataChannel
+		objectsMap[objectMetadata.DisplayName] = objectMetadata
+	}
+
+	return &objectsMap, nil
+}
+
+type describeObjectResponse struct {
+	Results []describeObjectResult `json:"results"`
+}
+
+type describeObjectResult struct {
+	Name  string `json:"name"`
+	Label string `json:"label"`
+}
+
+func (c *Connector) describeObject(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
+	data, err := c.get(ctx, c.BaseURL+"/properties/"+objectName)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching HubSpot fields: %w", err)
+	}
+
+	rawResponse, err := ajson.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling composite response into byte array: %w", err)
+	}
+
+	resp := &describeObjectResponse{}
+
+	err = json.Unmarshal(rawResponse, resp)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling composite response into JSON: %w", err)
+	}
+
+	return &common.ObjectMetadata{
+		DisplayName: objectName,
+		FieldsMap:   makeFieldsMap(resp),
+	}, nil
+}
+
+func makeFieldsMap(data *describeObjectResponse) map[string]string {
+	fieldsMap := make(map[string]string)
+
+	for _, field := range data.Results {
+		fieldName := strings.ToLower(field.Name)
+
+		// Add entry to fieldsMap
+		fieldsMap[fieldName] = field.Label
+	}
+
+	return fieldsMap
+}

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -15,5 +15,5 @@ var ModuleCRM = APIModule{ // nolint: gochecknoglobals
 }
 
 func (a APIModule) String() string {
-	return fmt.Sprintf("%s/%s/%s", a.Label, a.Version)
+	return fmt.Sprintf("%s/%s", a.Label, a.Version)
 }

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -5,17 +5,15 @@ import (
 )
 
 type APIModule struct {
-	Label      string // e.g. "crm"
-	Version    string // e.g. "v3"
-	SuffixBase string // e.g. "objects"
+	Label   string // e.g. "crm"
+	Version string // e.g. "v3"
 }
 
 var ModuleCRM = APIModule{ // nolint: gochecknoglobals
-	Label:      "crm",
-	Version:    "v3",
-	SuffixBase: "objects",
+	Label:   "crm",
+	Version: "v3",
 }
 
 func (a APIModule) String() string {
-	return fmt.Sprintf("%s/%s/%s", a.Label, a.Version, a.SuffixBase)
+	return fmt.Sprintf("%s/%s/%s", a.Label, a.Version)
 }

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -45,7 +45,7 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 // WithModule sets the hubspot API module to use for the connector. It's required.
 func WithModule(module APIModule) Option {
 	return func(params *hubspotParams) {
-		path := []string{module.Label, module.Version, module.SuffixBase}
+		path := []string{module.Label, module.Version}
 		params.module = strings.Join(path, "/")
 	}
 }

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -31,7 +31,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	} else {
 		// If NextPage is not set, then we're reading the first page of results.
 		// We need to construct the SOQL query and then make the request.
-		data, err = c.get(ctx, c.BaseURL+"/"+config.ObjectName+"?"+makeQueryValues(config))
+		data, err = c.get(ctx, c.BaseURL+"/objects/"+config.ObjectName+"?"+makeQueryValues(config))
 	}
 
 	if err != nil {

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -27,7 +27,7 @@ func (c *Connector) search(ctx context.Context, config common.ReadParams) (*comm
 	// in the filter body. As always, we attach the query values in the request.
 	data, err = c.post(
 		ctx,
-		c.BaseURL+"/"+config.ObjectName+"/search"+"?"+makeQueryValues(config),
+		c.BaseURL+"/objects/"+config.ObjectName+"/search"+"?"+makeQueryValues(config),
 		makeFilterBody(config),
 	)
 	if err != nil {

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -10,14 +10,15 @@ import (
 )
 
 var (
-	ErrNotArray         = errors.New("records is not an array")
-	ErrNotObject        = errors.New("record isn't an object")
-	ErrNoFields         = errors.New("no fields specified")
-	ErrNotString        = errors.New("nextRecordsUrl isn't a string")
-	ErrNotBool          = errors.New("done isn't a boolean")
-	ErrNotNumeric       = errors.New("totalSize isn't numeric")
-	ErrMissingSubdomain = errors.New("missing Salesforce workspace name")
-	ErrMissingClient    = errors.New("JSON http client not set")
+	ErrNotArray           = errors.New("records is not an array")
+	ErrNotObject          = errors.New("record isn't an object")
+	ErrNoFields           = errors.New("no fields specified")
+	ErrNotString          = errors.New("nextRecordsUrl isn't a string")
+	ErrNotBool            = errors.New("done isn't a boolean")
+	ErrNotNumeric         = errors.New("totalSize isn't numeric")
+	ErrMissingSubdomain   = errors.New("missing Salesforce workspace name")
+	ErrMissingClient      = errors.New("JSON http client not set")
+	ErrCannotReadMetadata = errors.New("cannot read object metadata, it is possible you don't have the correct permissions set")
 )
 
 type jsonError struct {

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -18,7 +18,7 @@ var (
 	ErrNotNumeric         = errors.New("totalSize isn't numeric")
 	ErrMissingSubdomain   = errors.New("missing Salesforce workspace name")
 	ErrMissingClient      = errors.New("JSON http client not set")
-	ErrCannotReadMetadata = errors.New("cannot read object metadata, it is possible you don't have the correct permissions set")
+	ErrCannotReadMetadata = errors.New("cannot read object metadata, it is possible you don't have the correct permissions set") // nolint:lll
 )
 
 type jsonError struct {

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -15,7 +15,7 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context,
 	objectNames []string,
-) (*common.ListObjectMetadataResponse, error) {
+) (*common.ListObjectMetadataResult, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
 		return nil, common.ErrMissingObjects
@@ -62,8 +62,8 @@ func (c *Connector) ListObjectMetadata(
 }
 
 // constructResponseMap constructs a map of object names to object metadata from the composite response.
-func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResponse, error) {
-	objectsMap := make(common.ListObjectMetadataResponse)
+func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult, error) {
+	objectsMap := make(common.ListObjectMetadataResult)
 
 	rawResponse, err := ajson.Marshal(result)
 	if err != nil {

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -1,0 +1,156 @@
+package salesforce
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+// ListObjectMetadata returns object metadata for each object name provided.
+func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResponse, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, fmt.Errorf("no objects provided")
+	}
+
+	requests := make([]compositeRequestItem, len(objectNames))
+
+	// Construct describe requests for each object name
+	for idx, objectName := range objectNames {
+		describeObjectUrl, err := url.JoinPath(fmt.Sprintf("/services/data/%s/sobjects/%s/describe", apiVersion, objectName))
+		if err != nil {
+			return nil, err
+		}
+
+		requests[idx] = compositeRequestItem{
+			Method:      "GET",
+			URL:         describeObjectUrl,
+			ReferenceId: objectName,
+		}
+	}
+
+	// Construct endpoint for the request
+	compositeRequestEndpoint, err := url.JoinPath(c.BaseURL, "composite")
+	if err != nil {
+		return nil, err
+	}
+
+	// Make the request
+	result, err := c.post(
+		context.Background(),
+		compositeRequestEndpoint,
+		compositeRequest{
+			CompositeRequest: requests,
+			// If we fail to fetch metadata for one object, we don't want to fail the entire request.
+			AllOrNone: false,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching Salesforce fields: %w", err)
+	}
+
+	// Construct map of object names to object metadata
+	return constructResponseMap(result)
+}
+
+// constructResponseMap constructs a map of object names to object metadata from the composite response.
+func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResponse, error) {
+	objectsMap := make(common.ListObjectMetadataResponse)
+
+	rawResponse, err := ajson.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling composite response into byte array: %w", err)
+	}
+
+	resp := &compositeResponse{}
+
+	err = json.Unmarshal(rawResponse, resp)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling composite response into JSON: %w", err)
+	}
+
+	// Construct map of object names to object metadata
+	for _, subRes := range resp.CompositeResponse {
+		result := &describeSObjectResult{}
+
+		err = json.Unmarshal(subRes.Body, result)
+		if err != nil {
+			// If one of the sub-requests of the composite request fails, then subRes.Body will look like:
+			// "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]"
+			// which will fail the json.Unmarshall
+			return nil, fmt.Errorf("%w: object name: %v, original error: %s", ErrCannotReadMetadata,
+				subRes.ReferenceId,
+				string(subRes.Body))
+		}
+
+		objectsMap[strings.ToLower(result.Name)] = common.ObjectMetadata{
+			DisplayName: result.Label,
+			// Map that satisfies type constraint
+			FieldsMap: makeFieldsMap(result.Fields),
+		}
+	}
+
+	return &objectsMap, nil
+}
+
+// makeFieldsMap constructs a map of field names to field labels from a describeSObjectResult.
+func makeFieldsMap(fields []fieldResult) map[string]string {
+	fieldsMap := make(map[string]string)
+
+	for _, field := range fields {
+		fieldName := strings.ToLower(field.Name)
+
+		// Add entry to fieldsMap
+		fieldsMap[fieldName] = field.Label
+	}
+
+	return fieldsMap
+}
+
+type compositeRequest struct {
+	AllOrNone        bool                   `json:"allOrNone"`
+	CompositeRequest []compositeRequestItem `json:"compositeRequest"`
+}
+
+type compositeResponse struct {
+	CompositeResponse []compositeResponseItem `json:"compositeResponse"`
+}
+
+type compositeRequestItem struct {
+	// ReferenceId allows us to map the result to the original request
+	ReferenceId string `json:"referenceId"`
+	Method      string `json:"method"`
+	URL         string `json:"url"`
+	Body        any    `json:"body,omitempty"`
+}
+
+type compositeResponseItem struct {
+	// ReferenceId comes from the original request
+	ReferenceId    string            `json:"referenceId"`
+	Body           json.RawMessage   `json:"body"`
+	HttpHeaders    map[string]string `json:"httpHeaders"`    //nolint:revive
+	HttpStatusCode int               `json:"httpStatusCode"` //nolint:revive
+}
+
+// See https://developer.salesforce.com/docs/atlas.en-us.244.0.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm.
+// NOTE: doc page is for SOAP API, but REST API returns the same result.
+//
+//nolint:lll
+type describeSObjectResult struct {
+	Name   string        `json:"name"`
+	Label  string        `json:"label"`
+	Fields []fieldResult `json:"fields" validate:"required"`
+}
+
+// See https://developer.salesforce.com/docs/atlas.en-us.244.0.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm#field.
+//
+//nolint:lll
+type fieldResult struct {
+	Name  string `json:"name"`
+	Label string `json:"label"`
+}

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -12,24 +12,27 @@ import (
 )
 
 // ListObjectMetadata returns object metadata for each object name provided.
-func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResponse, error) {
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResponse, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
-		return nil, fmt.Errorf("no objects provided")
+		return nil, common.ErrMissingObjects
 	}
 
 	requests := make([]compositeRequestItem, len(objectNames))
 
 	// Construct describe requests for each object name
 	for idx, objectName := range objectNames {
-		describeObjectUrl, err := url.JoinPath(fmt.Sprintf("/services/data/%s/sobjects/%s/describe", apiVersion, objectName))
+		describeObjectURL, err := url.JoinPath(fmt.Sprintf("/services/data/%s/sobjects/%s/describe", apiVersion, objectName))
 		if err != nil {
 			return nil, err
 		}
 
 		requests[idx] = compositeRequestItem{
 			Method:      "GET",
-			URL:         describeObjectUrl,
+			URL:         describeObjectURL,
 			ReferenceId: objectName,
 		}
 	}
@@ -42,7 +45,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string
 
 	// Make the request
 	result, err := c.post(
-		context.Background(),
+		ctx,
 		compositeRequestEndpoint,
 		compositeRequest{
 			CompositeRequest: requests,

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -15,7 +15,7 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context,
 	objectNames []string,
-) (*common.ListObjectMetadataResult, error) {
+) (common.ListObjectMetadataResult, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
 		return nil, common.ErrMissingObjects
@@ -62,7 +62,7 @@ func (c *Connector) ListObjectMetadata(
 }
 
 // constructResponseMap constructs a map of object names to object metadata from the composite response.
-func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult, error) {
+func constructResponseMap(result *ajson.Node) (common.ListObjectMetadataResult, error) {
 	objectsMap := make(common.ListObjectMetadataResult)
 
 	rawResponse, err := ajson.Marshal(result)
@@ -98,7 +98,7 @@ func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult,
 		}
 	}
 
-	return &objectsMap, nil
+	return objectsMap, nil
 }
 
 // makeFieldsMap constructs a map of field names to field labels from a describeSObjectResult.


### PR DESCRIPTION
* Adds ListObjectMetadata to describe an object's properties
* Adds ObjectMetadata to hold an object's metadata
* Adds the ListObjectMetadata function in the Connector interface

## Results
### Hubspot
![Screenshot 2023-11-01 at 4 18 50 PM](https://github.com/amp-labs/connectors/assets/18614743/c2f6526f-2c85-4828-bafc-8f771c78f089)

### Salesforce
![Screenshot 2023-11-01 at 4 23 42 PM](https://github.com/amp-labs/connectors/assets/18614743/cf3a6dd6-8b9a-4f3b-818a-0da18e23a37e)

