### PR TITLE
feat: Add a callback to save OAuth tokens

### DIFF
--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -18,12 +18,17 @@ const (
 type Option func(params *hubspotParams)
 
 // WithClient sets the http client to use for the connector. Saves some boilerplate.
-func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token) Option {
+func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
+	opts ...common.OAuthOption,
+) Option {
 	return func(params *hubspotParams) {
-		oauthClient, err := common.NewOAuthHTTPClient(ctx,
+		options := []common.OAuthOption{
 			common.WithClient(client),
 			common.WithOAuthConfig(config),
-			common.WithOAuthToken(token))
+			common.WithOAuthToken(token),
+		}
+
+		oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)
 		if err != nil {
 			panic(err) // caught in NewConnector
 		}

--- a/salesforce/params.go
+++ b/salesforce/params.go
@@ -12,12 +12,17 @@ import (
 type Option func(params *sfParams)
 
 // WithClient sets the http client to use for the connector. Saves some boilerplate.
-func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token) Option {
+func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
+	opts ...common.OAuthOption,
+) Option {
 	return func(params *sfParams) {
-		oauthClient, err := common.NewOAuthHTTPClient(ctx,
+		options := []common.OAuthOption{
 			common.WithClient(client),
 			common.WithOAuthConfig(config),
-			common.WithOAuthToken(token))
+			common.WithOAuthToken(token),
+		}
+
+		oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)
 		if err != nil {
 			panic(err) // caught in NewConnector
 		}


### PR DESCRIPTION
Right now whenever a token is refreshed, we just discard the result. This leads to a lot of waste since we're effectively refreshing each time a workflow runs.

This PR makes it possible for us to be notified whenever a token is refreshed, so that we can persist it back to the database. This should cause fewer token refreshes over time.