### PR TITLE
[ENG-436] Modify ListObjectMetadata to return metadata & a list of errors

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -149,7 +149,13 @@ func (r HTTPStatusError) Unwrap() error {
 	return r.err
 }
 
-type ListObjectMetadataResult map[string]ObjectMetadata
+type ListObjectMetadataResult struct {
+	// Result is a map of object names to object metadata
+	Result map[string]ObjectMetadata
+
+	// Errors is a map of object names to errors
+	Errors map[string]error
+}
 
 type ObjectMetadata struct {
 	// Provider's display name for the object

--- a/connectors.go
+++ b/connectors.go
@@ -30,7 +30,7 @@ type Connector interface {
 
 	Write(ctx context.Context, params WriteParams) (*WriteResult, error)
 
-	ListObjectMetadata(ctx context.Context, objectNames []string) (ListObjectMetadataResult, error)
+	ListObjectMetadata(ctx context.Context, objectNames []string) (*ListObjectMetadataResult, error)
 
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -10,12 +10,12 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-type ObjectMetadataResult struct {
+type objectMetadataResult struct {
 	ObjectName string
 	Response   common.ObjectMetadata
 }
 
-type ObjectMetadataError struct {
+type objectMetadataError struct {
 	ObjectName string
 	Error      error
 }
@@ -31,8 +31,8 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 	}
 
 	// Use goroutines to fetch metadata for each object in parallel
-	metadataChannel := make(chan *ObjectMetadataResult, len(objectNames))
-	errChannel := make(chan *ObjectMetadataError, len(objectNames))
+	metadataChannel := make(chan *objectMetadataResult, len(objectNames))
+	errChannel := make(chan *objectMetadataError, len(objectNames))
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -41,7 +41,7 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 		go func(object string) {
 			objectMetadata, err := c.describeObject(ctx, object)
 			if err != nil {
-				errChannel <- &ObjectMetadataError{
+				errChannel <- &objectMetadataError{
 					ObjectName: object,
 					Error:      err,
 				}
@@ -50,7 +50,7 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 			}
 
 			// Send object metadata to metadataChannel
-			metadataChannel <- &ObjectMetadataResult{
+			metadataChannel <- &objectMetadataResult{
 				ObjectName: object,
 				Response:   *objectMetadata,
 			}

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -15,7 +15,7 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context,
 	objectNames []string,
-) (common.ListObjectMetadataResult, error) {
+) (*common.ListObjectMetadataResult, error) {
 	// Ensure that objectNames is not empty
 	if len(objectNames) == 0 {
 		return nil, common.ErrMissingObjects
@@ -62,8 +62,10 @@ func (c *Connector) ListObjectMetadata(
 }
 
 // constructResponseMap constructs a map of object names to object metadata from the composite response.
-func constructResponseMap(result *ajson.Node) (common.ListObjectMetadataResult, error) {
-	objectsMap := make(common.ListObjectMetadataResult)
+func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult, error) {
+	objectsMap := &common.ListObjectMetadataResult{}
+	objectsMap.Result = make(map[string]common.ObjectMetadata)
+	objectsMap.Errors = make(map[string]error)
 
 	rawResponse, err := ajson.Marshal(result)
 	if err != nil {
@@ -86,15 +88,14 @@ func constructResponseMap(result *ajson.Node) (common.ListObjectMetadataResult, 
 			// If one of the sub-requests of the composite request fails, then subRes.Body will look like:
 			// "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]"
 			// which will fail the json.Unmarshall
-			return nil, fmt.Errorf("%w: object name: %v, original error: %s", ErrCannotReadMetadata,
-				subRes.ReferenceId,
-				string(subRes.Body))
-		}
 
-		objectsMap[strings.ToLower(result.Name)] = common.ObjectMetadata{
-			DisplayName: result.Label,
-			// Map that satisfies type constraint
-			FieldsMap: makeFieldsMap(result.Fields),
+			objectsMap.Errors[strings.ToLower(subRes.ReferenceId)] = fmt.Errorf("%w: %s", ErrCannotReadMetadata, string(subRes.Body))
+		} else {
+			objectsMap.Result[strings.ToLower(result.Name)] = common.ObjectMetadata{
+				DisplayName: result.Label,
+				// Map that satisfies type constraint
+				FieldsMap: makeFieldsMap(result.Fields),
+			}
 		}
 	}
 

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -88,8 +88,9 @@ func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult,
 			// If one of the sub-requests of the composite request fails, then subRes.Body will look like:
 			// "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]"
 			// which will fail the json.Unmarshall
-
-			objectsMap.Errors[strings.ToLower(subRes.ReferenceId)] = fmt.Errorf("%w: %s", ErrCannotReadMetadata, string(subRes.Body))
+			objectsMap.Errors[strings.ToLower(subRes.ReferenceId)] = fmt.Errorf(
+				"%w: %s", ErrCannotReadMetadata, string(subRes.Body),
+			)
 		} else {
 			objectsMap.Result[strings.ToLower(result.Name)] = common.ObjectMetadata{
 				DisplayName: result.Label,


### PR DESCRIPTION
* Instead of failing completely, this returns successful results & a list of errors indexed against the object name

Once the PR is merged, I will create a PR in the server repo to update the connector dependency & work off this new structure