### PR TITLE
[ENG-423] Add Search functionality

### DIFF
--- a/hubspot/README.md
+++ b/hubspot/README.md
@@ -1,0 +1,62 @@
+# Hubspot connector
+
+This connector has two ways of reading data from Hubspot:
+1. Read
+2. Search
+
+## Read
+Read is used to list all records of a given type. For example, if you want to list all contacts, you would use the `Read` method with the `contacts` object.
+
+### Example
+To list all contacts with the fields `email`, `firstname`, and `lastname`:
+```
+client.Read(context.Background(), &common.ReadParams{
+    ObjectName: "contacts",
+    Fields:    []string{"email", "firstname", "lastname"},
+})
+```
+
+If you try to use the 'Since' field in the `ReadParams`, it will cause an error. You should use the `Search` method instead.
+
+## Search
+Search is used to find records of a given type that match a given query. For example, if you want to find all contacts with the name "John", you would use the `Search` method with the `contacts` object.
+
+### Example
+
+To find all contacts with the firstname "Brian" and a last modified date after "2023-10-26T17:56:14.834Z", sorted by the `hs_object_id` field in descending order:
+```
+result, err := client.Search(context.Background(), hubspot.SearchParams{
+    ObjectName: "contacts",
+    FilterGroups: []hubspot.FilterGroup{
+        {
+            Filters: []hubspot.Filter{
+                {
+                    FieldName: "firstname",
+                    Operator:  hubspot.FilterOperatorTypeEQ,
+                    Value:     "Brian",
+                },
+                {
+                    FieldName: "lastname",
+                    Operator:  hubspot.FilterOperatorTypeEQ,
+                    Value:     "Halligan (Sample Contact)",
+                },
+            },
+        },
+        {
+            Filters: []hubspot.Filter{
+                {
+                    FieldName: "firstname",
+                    Operator:  hubspot.FilterOperatorTypeEQ,
+                    Value:     "Maria",
+                },
+            },
+        },
+    },
+    SortBy: []hubspot.SortBy{
+        {
+            PropertyName: "hs_object_id",
+            Direction:    hubspot.SortDirectionDesc,
+        },
+    },
+})
+```

--- a/hubspot/README.md
+++ b/hubspot/README.md
@@ -16,7 +16,7 @@ client.Read(context.Background(), &common.ReadParams{
 })
 ```
 
-If you try to use the 'Since' field in the `ReadParams`, it will cause an error. You should use the `Search` method instead.
+If the 'Since' field in the `ReadParams` is set, the connector will use the search endpoint to filter records using the `lastmodifieddate` property. However, this result set is limited to a maximum of 10,000 records. This limit is applicable to any call made via the `Search` endpoint. Read more @ https://developers.hubspot.com/docs/api/crm/search#limitations.
 
 ## Search
 Search is used to find records of a given type that match a given query. For example, if you want to find all contacts with the name "John", you would use the `Search` method with the `contacts` object.

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -19,7 +19,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	// If filtering is required, then we have to use the search endpoint.
 	if requiresFiltering(config) {
-		return c.search(ctx, config)
+		return nil, ErrFilteringNotSupported
 	}
 
 	// Object endpoints have a link

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Search uses the POST /search endpoint to filter object records and return the result.
-// This is used when Since is set. Otherwise, the Read endpoint is used.
+// This endpoint has a limit of 10,000 records. If the result has more than 10,000 records,
+// the caller should employ sorting to paginate through the result on the client side.
 // This endpoint paginates using paging.next.after which is to be used as an offset.
 // Read more @ https://developers.hubspot.com/docs/api/crm/search
 func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.ReadResult, error) {
@@ -40,6 +41,10 @@ func makeFilterBody(config SearchParams) map[string]any {
 
 	if config.SortBy != nil {
 		filterBody["sorts"] = config.SortBy
+	}
+
+	if config.Fields != nil {
+		filterBody["properties"] = config.Fields
 	}
 
 	return filterBody

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -2,34 +2,22 @@ package hubspot
 
 import (
 	"context"
-	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/spyzhov/ajson"
 )
 
-// search uses the POST /search endpoint to filter object records and return the result.
+// Search uses the POST /search endpoint to filter object records and return the result.
 // This is used when Since is set. Otherwise, the Read endpoint is used.
 // This endpoint paginates using paging.next.after which is to be used as an offset.
 // Read more @ https://developers.hubspot.com/docs/api/crm/search
-func (c *Connector) search(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.ReadResult, error) {
 	var (
 		data *ajson.Node
 		err  error
 	)
 
-	// If filtering is not required, then we have to use the read endpoint.
-	if !requiresFiltering(config) {
-		return c.Read(ctx, config)
-	}
-
-	// If the next page is set, then we have to use the next page as the offset
-	// in the filter body. As always, we attach the query values in the request.
-	data, err = c.post(
-		ctx,
-		c.BaseURL+"/objects/"+config.ObjectName+"/search"+"?"+makeQueryValues(config),
-		makeFilterBody(config),
-	)
+	data, err = c.post(ctx, c.BaseURL+"/objects/"+config.ObjectName+"/search", makeFilterBody(config))
 	if err != nil {
 		return nil, err
 	}
@@ -37,25 +25,21 @@ func (c *Connector) search(ctx context.Context, config common.ReadParams) (*comm
 	return parseResult(data, getNextRecordsAfter)
 }
 
-// makeFilterBody is specifically implemented for the Since filter currently.
-func makeFilterBody(config common.ReadParams) map[string]any {
+func makeFilterBody(config SearchParams) map[string]any {
 	filterBody := map[string]any{
-		"filterGroups": []map[string]any{
-			{
-				"filters": []map[string]any{
-					{
-						"propertyName": "lastmodifieddate",
-						"operator":     "GT",
-						"value":        config.Since.Format(time.RFC3339),
-					},
-				},
-			},
-		},
 		"limit": DefaultPageSize,
 	}
 
-	if len(config.NextPage) > 0 {
+	if config.FilterGroups != nil {
+		filterBody["filterGroups"] = config.FilterGroups
+	}
+
+	if config.NextPage != "" {
 		filterBody["after"] = config.NextPage
+	}
+
+	if config.SortBy != nil {
+		filterBody["sorts"] = config.SortBy
 	}
 
 	return filterBody

--- a/hubspot/types.go
+++ b/hubspot/types.go
@@ -1,0 +1,59 @@
+package hubspot
+
+import (
+	"errors"
+)
+
+var ErrFilteringNotSupported = errors.New("filtering is not supported in this endpoint")
+
+type SearchParams struct {
+	// The name of the object we are reading, e.g. "Account"
+	ObjectName string // required
+	// NextPage is an opaque token that can be used to get the next page of results.
+	NextPage string // optional, only set this if you want to read the next page of results
+	// SortBy is the field to sort by in the direction specified by SortDirection.
+	SortBy []SortBy // optional
+	// FilterBy is the filter to apply to the search
+	FilterGroups []FilterGroup // optional
+}
+
+type SortBy struct {
+	// The name of the field to sort by.
+	PropertyName string `json:"propertyName,omitempty"`
+	// The direction to sort by.
+	Direction SortDirection `json:"direction,omitempty"`
+}
+
+type FilterGroup struct {
+	Filters []Filter `json:"filters,omitempty"`
+}
+
+type Filter struct {
+	FieldName string             `json:"propertyName,omitempty"`
+	Operator  FilterOperatorType `json:"operator,omitempty"`
+	Value     string             `json:"value,omitempty"`
+}
+
+type (
+	SortDirection      string
+	FilterOperatorType string
+)
+
+const (
+	SortDirectionAsc  SortDirection = "ASCENDING"
+	SortDirectionDesc SortDirection = "DESCENDING"
+
+	FilterOperatorTypeEQ           FilterOperatorType = "EQ"
+	FilterOperatorTypeNEQ          FilterOperatorType = "NEQ"
+	FilterOperatorTypeGT           FilterOperatorType = "GT"
+	FilterOperatorTypeGTE          FilterOperatorType = "GTE"
+	FilterOperatorTypeLT           FilterOperatorType = "LT"
+	FilterOperatorTypeLTE          FilterOperatorType = "LTE"
+	FilterOperatorBetween          FilterOperatorType = "BETWEEN"
+	FilterOperatorIN               FilterOperatorType = "IN"
+	FilterOperatorNIN              FilterOperatorType = "NIN"
+	FilterPropertyHasProperty      FilterOperatorType = "HAS_PROPERTY"
+	FilterPropertyNotHasProperty   FilterOperatorType = "NOT_HAS_PROPERTY"
+	FilterPropertyContainsToken    FilterOperatorType = "CONTAINS_TOKEN"
+	FilterPropertyNotContainsToken FilterOperatorType = "NOT_CONTAINS_TOKEN"
+)

--- a/hubspot/types.go
+++ b/hubspot/types.go
@@ -1,11 +1,5 @@
 package hubspot
 
-import (
-	"errors"
-)
-
-var ErrFilteringNotSupported = errors.New("filtering is not supported in this endpoint")
-
 type SearchParams struct {
 	// The name of the object we are reading, e.g. "Account"
 	ObjectName string // required
@@ -15,6 +9,8 @@ type SearchParams struct {
 	SortBy []SortBy // optional
 	// FilterBy is the filter to apply to the search
 	FilterGroups []FilterGroup // optional
+	// Fields is the list of fields to return in the result.
+	Fields []string // optional
 }
 
 type SortBy struct {


### PR DESCRIPTION
This PR updates the search function to the hubspot connector to allow filters & sorting.

However, this causes an issue with the initialization method `connectors.Provider.New` which returns the `Connector` interface, as the interface doesn't have `Search` as a method on it. 

To solve this, we have to either instantiate the connector via the package directly - `hubspot.New`, or add `Search` to the Connector interface & return a `NotImplemented` for Salesforce. I have opted for the first to avoid adding unnecessary methods to the interface. We will need to change this in the server codebase post merge.