### PR TITLE
chore: Sort hubspot reads by default

### DIFF
--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -26,7 +26,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		searchParams := SearchParams{
 			ObjectName:   config.ObjectName,
 			FilterGroups: buildLastModifiedFilterGroup(config.Since),
-			SortBy:       buildDefaultSort(),
+			SortBy:       buildSort(ObjectFieldHsObjectId, SortDirectionAsc),
 			NextPage:     config.NextPage,
 			Fields:       config.Fields,
 		}

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -22,6 +22,9 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	)
 
 	// If filtering is required, then we have to use the search endpoint.
+	// The Search endpoint has a 10K record limit. In case this limit is reached,
+	// the sorting allows the caller to continue in another call by offsetting
+	// until the ID of the last record that was successfully fetched.
 	if requiresFiltering(config) {
 		searchParams := SearchParams{
 			ObjectName:   config.ObjectName,

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -26,6 +26,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		searchParams := SearchParams{
 			ObjectName:   config.ObjectName,
 			FilterGroups: buildLastModifiedFilterGroup(config.Since),
+			SortBy:       buildDefaultSort(),
 			NextPage:     config.NextPage,
 			Fields:       config.Fields,
 		}

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -12,6 +12,7 @@ import (
 // This endpoint has a limit of 10,000 records. If the result has more than 10,000 records,
 // the caller should employ sorting to paginate through the result on the client side.
 // This endpoint paginates using paging.next.after which is to be used as an offset.
+// Archived results do not appear in search results.
 // Read more @ https://developers.hubspot.com/docs/api/crm/search
 func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.ReadResult, error) {
 	var (
@@ -63,11 +64,20 @@ func buildLastModifiedFilterGroup(since time.Time) []FilterGroup {
 		{
 			Filters: []Filter{
 				{
-					FieldName: "lastmodifieddate",
+					FieldName: string(ObjectFieldLastModifiedDate),
 					Operator:  FilterOperatorTypeGTE,
 					Value:     since.Format(time.RFC3339),
 				},
 			},
+		},
+	}
+}
+
+func buildDefaultSort() []SortBy {
+	return []SortBy{
+		{
+			PropertyName: string(ObjectFieldHsObjectId),
+			Direction:    SortDirectionAsc,
 		},
 	}
 }

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -73,11 +73,11 @@ func buildLastModifiedFilterGroup(since time.Time) []FilterGroup {
 	}
 }
 
-func buildDefaultSort() []SortBy {
+func buildSort(field ObjectField, dir SortDirection) []SortBy {
 	return []SortBy{
 		{
-			PropertyName: string(ObjectFieldHsObjectId),
-			Direction:    SortDirectionAsc,
+			PropertyName: string(field),
+			Direction:    dir,
 		},
 	}
 }

--- a/hubspot/types.go
+++ b/hubspot/types.go
@@ -53,3 +53,11 @@ const (
 	FilterPropertyContainsToken    FilterOperatorType = "CONTAINS_TOKEN"
 	FilterPropertyNotContainsToken FilterOperatorType = "NOT_CONTAINS_TOKEN"
 )
+
+// ObjectField is used to define fields that exist on a hubspot object.
+type ObjectField string
+
+const (
+	ObjectFieldHsObjectId       ObjectField = "hs_object_id"
+	ObjectFieldLastModifiedDate ObjectField = "lastmodifieddate"
+)


### PR DESCRIPTION
The hubspot `Read` method redirects a request to `Search` if `ReadParams.Since` is set, but unknown to the caller, they will get cut off at 10,000 records. This sorts the result by the id that the request can be continued via a search if required.

### Testing 
<img width="305" alt="Screenshot 2023-12-07 at 10 18 50 AM" src="https://github.com/amp-labs/connectors/assets/18614743/bb51e888-c0c3-48f1-8938-1d59afa0d831">
