### PR TITLE
chore: Use hs_lastmodifeddate field for hubspot objects

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -69,6 +69,9 @@ var (
 
 	// ErrParseError is returned data parsing failed.
 	ErrParseError = errors.New("parse error")
+
+	// ErrBadRequest is returned when we get a 400 response from the provider.
+	ErrBadRequest = errors.New("bad request")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/hubspot/errors.go
+++ b/hubspot/errors.go
@@ -11,12 +11,11 @@ import (
 )
 
 var (
-	ErrMissingAPIModule    = errors.New("missing Hubspot API module")
-	ErrMissingClient       = errors.New("JSON http client not set")
-	ErrNotArray            = errors.New("results is not an array")
-	ErrNotObject           = errors.New("result is not an object")
-	ErrNotString           = errors.New("link is not a string")
-	ErrSearchLimitExceeded = errors.New("search endpoint limit exceeded")
+	ErrMissingAPIModule = errors.New("missing Hubspot API module")
+	ErrMissingClient    = errors.New("JSON http client not set")
+	ErrNotArray         = errors.New("results is not an array")
+	ErrNotObject        = errors.New("result is not an object")
+	ErrNotString        = errors.New("link is not a string")
 )
 
 type HubspotError struct {
@@ -83,7 +82,7 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error {
 	switch res.StatusCode {
 	// Hubspot sends us a 400 when the search endpoint returns over 10K records.
 	case http.StatusBadRequest:
-		return createError(ErrSearchLimitExceeded, apiError)
+		return createError(common.ErrBadRequest, apiError)
 	case http.StatusUnauthorized:
 		return createError(common.ErrAccessToken, apiError)
 	case http.StatusForbidden:

--- a/hubspot/types.go
+++ b/hubspot/types.go
@@ -59,5 +59,5 @@ type ObjectField string
 
 const (
 	ObjectFieldHsObjectId       ObjectField = "hs_object_id"
-	ObjectFieldLastModifiedDate ObjectField = "lastmodifieddate"
+	ObjectFieldLastModifiedDate ObjectField = "hs_lastmodifieddate"
 )


### PR DESCRIPTION
## Change 1
Correcting an invalid assumption about the lastmodifieddate field for hubspot objects. Verified that this field exists for all objects using the properties endpoint - 
```
{
  "Result": {
    "companies": {
      "DisplayName": "companies",
      "FieldsMap": {
        "hs_lastmodifieddate": "Last Modified Date"
      }
    },
    "contacts": {
      "DisplayName": "contacts",
      "FieldsMap": {
        "hs_lastmodifieddate": "Object last modified date/time"
      }
    },
    "deals": {
      "DisplayName": "deals",
      "FieldsMap": {
        "hs_lastmodifieddate": "Last Modified Date"
      }
    },
    "line_items": {
      "DisplayName": "line_items",
      "FieldsMap": {
        "hs_lastmodifieddate": "Last Modified Date"
      }
    },
    "taxes": {
      "DisplayName": "taxes",
      "FieldsMap": {
        "hs_lastmodifieddate": "Object last modified date/time"
      }
    },
    "tickets": {
      "DisplayName": "tickets",
      "FieldsMap": {
        "hs_lastmodifieddate": "Last modified date"
      }
    }
  }
}

```

Couldn't retrieve the properties for `feedback_submissions`, `products`, `goal_targets` & `quotes`, manually verified it for these objects from the API documentation. 

## Change 2
Since we are avoiding the search endpoint's 10K record limit error, we shouldn't ideally hit the 400 error, so turning the error class into a generic ErrBadRequest which is more appropiate. 