### PR TITLE
[ENG-493] feat: Improve the JSON response interface to be more flexible

### DIFF
--- a/common/json.go
+++ b/common/json.go
@@ -30,11 +30,20 @@ type JSONHTTPClient struct {
 }
 
 type JSONHTTPResponse struct {
+	// bodyBytes is the raw response body. It's not JSON-unmarshalled.
+	// We keep it around so that we can unmarshal it into a struct later,
+	// if needed (via the UnmarshalJSON function).
 	bodyBytes []byte
 
-	Code    int
+	// Code is the HTTP status code of the response.
+	Code int
+
+	// Headers are the HTTP headers of the response.
 	Headers http.Header
-	Body    *ajson.Node
+
+	// Body is the JSON-unmarshalled response body. Aside from the fact
+	// that it's JSON-unmarshalled, it's identical to bodyBytes.
+	Body *ajson.Node
 }
 
 func UnmarshalJSON[T any](rsp *JSONHTTPResponse) (*T, error) {

--- a/common/parse.go
+++ b/common/parse.go
@@ -14,24 +14,24 @@ import (
 // The marshalFunc is used to structure the data into an array of ReadResultRows.
 // The fields are used to populate ReadResultRow.Fields.
 func ParseResult(
-	data *ajson.Node,
+	resp *JSONHTTPResponse,
 	sizeFunc func(*ajson.Node) (int64, error),
 	recordsFunc func(*ajson.Node) ([]map[string]any, error),
 	nextPageFunc func(*ajson.Node) (string, error),
 	marshalFunc func([]map[string]any, []string) ([]ReadResultRow, error),
 	fields []string,
 ) (*ReadResult, error) {
-	totalSize, err := sizeFunc(data)
+	totalSize, err := sizeFunc(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	records, err := recordsFunc(data)
+	records, err := recordsFunc(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	nextPage, err := nextPageFunc(data)
+	nextPage, err := nextPageFunc(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/hubspot/get.go
+++ b/hubspot/get.go
@@ -6,12 +6,11 @@ import (
 	"log/slog"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // get reads data from Hubspot. It handles retries and access token refreshes.
-func (c *Connector) get(ctx context.Context, url string) (*ajson.Node, error) {
-	node, err := c.Client.Get(ctx, url)
+func (c *Connector) get(ctx context.Context, url string) (*common.JSONHTTPResponse, error) {
+	rsp, err := c.Client.Get(ctx, url)
 	if err != nil {
 		switch {
 		case errors.Is(err, common.ErrAccessToken):
@@ -34,5 +33,5 @@ func (c *Connector) get(ctx context.Context, url string) (*ajson.Node, error) {
 	}
 
 	// Success
-	return node, nil
+	return rsp, nil
 }

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -86,12 +86,12 @@ type describeObjectResult struct {
 
 // describeObject returns object metadata for the given object name.
 func (c *Connector) describeObject(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	data, err := c.get(ctx, c.BaseURL+"/properties/"+objectName)
+	rsp, err := c.get(ctx, c.BaseURL+"/properties/"+objectName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching HubSpot fields: %w", err)
 	}
 
-	rawResponse, err := ajson.Marshal(data)
+	rawResponse, err := ajson.Marshal(rsp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling object metadata response into byte array: %w", err)
 	}

--- a/hubspot/post.go
+++ b/hubspot/post.go
@@ -6,12 +6,11 @@ import (
 	"log/slog"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // post writes data to Hubspot. It handles retries and access token refreshes.
-func (c *Connector) post(ctx context.Context, url string, body any) (*ajson.Node, error) {
-	node, err := c.Client.Post(ctx, url, body)
+func (c *Connector) post(ctx context.Context, url string, body any) (*common.JSONHTTPResponse, error) {
+	rsp, err := c.Client.Post(ctx, url, body)
 	if err != nil {
 		switch {
 		case errors.Is(err, common.ErrAccessToken):
@@ -34,5 +33,5 @@ func (c *Connector) post(ctx context.Context, url string, body any) (*ajson.Node
 	}
 
 	// Success
-	return node, nil
+	return rsp, nil
 }

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // Read reads data from Hubspot. If Since is set, it will use the
@@ -17,8 +16,8 @@ import (
 // Deleted objects can only be read by using this endpoint.
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
 	var (
-		data *ajson.Node
-		err  error
+		rsp *common.JSONHTTPResponse
+		err error
 	)
 
 	// If filtering is required, then we have to use the search endpoint.
@@ -50,11 +49,11 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	if len(config.NextPage) > 0 {
 		// If NextPage is set, then we're reading the next page of results.
 		// All that matters is the NextPage URL, the fields are ignored.
-		data, err = c.get(ctx, config.NextPage)
+		rsp, err = c.get(ctx, config.NextPage)
 	} else {
 		// If NextPage is not set, then we're reading the first page of results.
 		// We need to construct the SOQL query and then make the request.
-		data, err = c.get(ctx, c.BaseURL+"/objects/"+config.ObjectName+"?"+makeQueryValues(config))
+		rsp, err = c.get(ctx, c.BaseURL+"/objects/"+config.ObjectName+"?"+makeQueryValues(config))
 	}
 
 	if err != nil {
@@ -62,7 +61,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	return common.ParseResult(
-		data,
+		rsp,
 		getTotalSize,
 		getRecords,
 		getNextRecordsURL,

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // Search uses the POST /search endpoint to filter object records and return the result.
@@ -16,17 +15,17 @@ import (
 // Read more @ https://developers.hubspot.com/docs/api/crm/search
 func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.ReadResult, error) {
 	var (
-		data *ajson.Node
-		err  error
+		rsp *common.JSONHTTPResponse
+		err error
 	)
 
-	data, err = c.post(ctx, c.BaseURL+"/objects/"+config.ObjectName+"/search", makeFilterBody(config))
+	rsp, err = c.post(ctx, c.BaseURL+"/objects/"+config.ObjectName+"/search", makeFilterBody(config))
 	if err != nil {
 		return nil, err
 	}
 
 	return common.ParseResult(
-		data,
+		rsp,
 		getTotalSize,
 		getRecords,
 		getNextRecordsAfter,

--- a/salesforce/get.go
+++ b/salesforce/get.go
@@ -3,11 +3,11 @@ package salesforce
 import (
 	"context"
 
-	"github.com/spyzhov/ajson"
+	"github.com/amp-labs/connectors/common"
 )
 
 // get reads data from Salesforce. It handles retries and access token refreshes.
-func (c *Connector) get(ctx context.Context, url string) (*ajson.Node, error) {
+func (c *Connector) get(ctx context.Context, url string) (*common.JSONHTTPResponse, error) {
 	node, err := c.Client.Get(ctx, url)
 	if err != nil {
 		return nil, c.HandleError(err)

--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // ListObjectMetadata returns object metadata for each object name provided.
@@ -62,21 +61,14 @@ func (c *Connector) ListObjectMetadata(
 }
 
 // constructResponseMap constructs a map of object names to object metadata from the composite response.
-func constructResponseMap(result *ajson.Node) (*common.ListObjectMetadataResult, error) {
+func constructResponseMap(result *common.JSONHTTPResponse) (*common.ListObjectMetadataResult, error) {
 	objectsMap := &common.ListObjectMetadataResult{}
 	objectsMap.Result = make(map[string]common.ObjectMetadata)
 	objectsMap.Errors = make(map[string]error)
 
-	rawResponse, err := ajson.Marshal(result)
+	resp, err := common.UnmarshalJSON[compositeResponse](result)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling composite response into byte array: %w", err)
-	}
-
-	resp := &compositeResponse{}
-
-	err = json.Unmarshal(rawResponse, resp)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling composite response into JSON: %w", err)
+		return nil, fmt.Errorf("error unmarshalling response from JSON: %w", err)
 	}
 
 	// Construct map of object names to object metadata

--- a/salesforce/patch.go
+++ b/salesforce/patch.go
@@ -3,15 +3,15 @@ package salesforce
 import (
 	"context"
 
-	"github.com/spyzhov/ajson"
+	"github.com/amp-labs/connectors/common"
 )
 
 // Patch writes data to Salesforce. It handles retries and access token refreshes.
-func (c *Connector) patch(ctx context.Context, url string, body any) (*ajson.Node, error) {
-	node, err := c.Client.Patch(ctx, url, body)
+func (c *Connector) patch(ctx context.Context, url string, body any) (*common.JSONHTTPResponse, error) {
+	rsp, err := c.Client.Patch(ctx, url, body)
 	if err != nil {
 		return nil, c.HandleError(err)
 	}
 
-	return node, nil
+	return rsp, nil
 }

--- a/salesforce/post.go
+++ b/salesforce/post.go
@@ -3,15 +3,15 @@ package salesforce
 import (
 	"context"
 
-	"github.com/spyzhov/ajson"
+	"github.com/amp-labs/connectors/common"
 )
 
 // post writes data to Salesforce. It handles retries and access token refreshes.
-func (c *Connector) post(ctx context.Context, url string, body any) (*ajson.Node, error) {
-	node, err := c.Client.Post(ctx, url, body)
+func (c *Connector) post(ctx context.Context, url string, body any) (*common.JSONHTTPResponse, error) {
+	rsp, err := c.Client.Post(ctx, url, body)
 	if err != nil {
 		return nil, c.HandleError(err)
 	}
 
-	return node, nil
+	return rsp, nil
 }

--- a/salesforce/read.go
+++ b/salesforce/read.go
@@ -7,15 +7,14 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 // Read reads data from Salesforce. By default it will read all rows (backfill). However, if Since is set,
 // it will read only rows that have been updated since the specified time.
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
 	var (
-		data *ajson.Node
-		err  error
+		rsp *common.JSONHTTPResponse
+		err error
 	)
 
 	if len(config.NextPage) > 0 {
@@ -26,7 +25,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			return nil, joinErr
 		}
 
-		data, err = c.get(ctx, location)
+		rsp, err = c.get(ctx, location)
 	} else {
 		// If NextPage is not set, then we're reading the first page of results.
 		// We need to construct the SOQL query and then make the request.
@@ -44,7 +43,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			return nil, joinErr
 		}
 
-		data, err = c.get(ctx, location+"?"+qp.Encode())
+		rsp, err = c.get(ctx, location+"?"+qp.Encode())
 	}
 
 	if err != nil {
@@ -52,7 +51,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	return common.ParseResult(
-		data,
+		rsp,
 		getTotalSize,
 		getRecords,
 		getNextRecordsURL,


### PR DESCRIPTION
I was writing this for another PR (not yet published) when I realized the changes here are substantial enough to warrant a dedicated PR of its own.

Basically I needed access to the HTTP status code. This led me down a rabbit hole to eventually re-working the JSON return type. The caller can still get the ajson.Node body, but they can also access the response code, the response body -- and crucially then can even unmarshal the response in to a structure if it makes sense to do so. This should cut down on boilerplate code in other places.