### PR TITLE
[ENG-493] feat: add Hubspot write functionality

### DIFF
--- a/hubspot/write.go
+++ b/hubspot/write.go
@@ -7,6 +7,43 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
+type writeResponse struct {
+	CreatedAt             string         `json:"createdAt"`
+	Archived              bool           `json:"archived"`
+	ArchivedAt            string         `json:"archivedAt"`
+	PropertiesWithHistory any            `json:"propertiesWithHistory"`
+	ID                    string         `json:"id"`
+	Properties            map[string]any `json:"properties"`
+	UpdatedAt             string         `json:"updatedAt"`
+}
+
+type writeMethod func(context.Context, string, any, ...common.Header) (*common.JSONHTTPResponse, error)
+
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
-	return nil, fmt.Errorf("%w: Write", common.ErrNotImplemented)
+	var write writeMethod
+
+	url := fmt.Sprintf("%s/objects/%s", c.BaseURL, config.ObjectName)
+
+	if config.ObjectId != "" {
+		write = c.Client.Patch
+		url = fmt.Sprintf("%s/%s", url, config.ObjectId)
+	} else {
+		write = c.Client.Post
+	}
+
+	json, err := write(ctx, url, config.ObjectData)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := common.UnmarshalJSON[writeResponse](json)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		ObjectId: rsp.ID,
+		Success:  true,
+		Data:     rsp.Properties,
+	}, nil
 }


### PR DESCRIPTION
This PR adds write functionality for the hubspot connector. This relies on functionality introduced in #40 

Related:
* https://github.com/amp-labs/connectors/pull/40

Example run:

```
$> go run ./main.go
{
  "success": true,
  "objectid": "29651",
  "data": {
    "company": "Compendia Bioscience Life Technologies",
    "createdate": "2023-12-21T21:51:13.394Z",
    "email": "nathanjacobson@kuhic.io",
    "firstname": "Jarod",
    "hs_all_contact_vids": "29651",
    "hs_email_domain": "kuhic.io",
    "hs_is_contact": "true",
    "hs_is_unworked": "true",
    "hs_lifecyclestage_lead_date": "2023-12-21T21:51:13.394Z",
    "hs_object_id": "29651",
    "hs_object_source": "INTEGRATION",
    "hs_object_source_id": "2317233",
    "hs_object_source_label": "INTEGRATION",
    "hs_pipeline": "contacts-lifecycle-pipeline",
    "hs_searchable_calculated_phone_number": "1554714476",
    "lastmodifieddate": "2023-12-21T21:51:13.394Z",
    "lastname": "Quigley",
    "lifecyclestage": "lead",
    "phone": "1554714476",
    "website": "http://www.dynamicinteractive.io/virtual/optimize/bricks-and-clicks"
  }
}
```