### PR TITLE
chore: Update contacts lastmodifieddate field

### DIFF
--- a/hubspot/parse.go
+++ b/hubspot/parse.go
@@ -146,3 +146,21 @@ func getMarshaledData(records []map[string]interface{}, fields []string) ([]comm
 
 	return data, nil
 }
+
+// GetLastResultId returns the last row's id from a result.
+func GetLastResultId(result *common.ReadResult) string {
+	numRecords := len(result.Data)
+	if numRecords == 0 {
+		return ""
+	}
+
+	// Get the last row and get the hs_object_id field's value
+	lastRow := result.Data[numRecords-1]
+
+	lastRowId, ok := lastRow.Fields[string(ObjectFieldHsObjectId)].(string)
+	if !ok {
+		return ""
+	}
+
+	return lastRowId
+}

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -30,7 +30,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			FilterGroups: []FilterGroup{
 				{
 					Filters: []Filter{
-						BuildLastModifiedFilterGroup(config.Since),
+						BuildLastModifiedFilterGroup(&config),
 						// Add more filters to AND them together
 					},
 					// Add more filter groups to OR them together

--- a/hubspot/types.go
+++ b/hubspot/types.go
@@ -58,6 +58,13 @@ const (
 type ObjectField string
 
 const (
-	ObjectFieldHsObjectId       ObjectField = "hs_object_id"
-	ObjectFieldLastModifiedDate ObjectField = "hs_lastmodifieddate"
+	ObjectFieldHsObjectId         ObjectField = "hs_object_id"
+	ObjectFieldHsLastModifiedDate ObjectField = "hs_lastmodifieddate"
+	ObjectFieldLastModifiedDate   ObjectField = "lastmodifieddate"
+)
+
+type ObjectType string
+
+const (
+	ObjectTypeContact ObjectType = "contacts"
 )


### PR DESCRIPTION
* The `contacts` object silently fails to return objects according to criteria even if we use `hs_lastmodifieddate`. 
* According to https://community.hubspot.com/t5/APIs-Integrations/CRM-V3-API-Search-issue-with-Contacts-when-using-Filters/m-p/324617 (and testing), the right field to use is `lastmodifieddate` for contacts and `hs_lastmodifieddate` for other objects.

Also shifts a function that gets the last ID of a result into the connector, so that the server has minimal knowledge of the internal structure of a connector's response

## Concerns
* The check for which `lastmodifiedfield` to use is a direct string comparison, so we need to be careful (https://linear.app/ampersand/issue/ENG-520/how-do-we-handle-inconsistent-plural-object-name)