### PR TITLE
feat: Add HTTPClient

### DIFF
--- a/common/csv.go
+++ b/common/csv.go
@@ -14,7 +14,7 @@ import (
 */
 
 func (j *JSONHTTPClient) PutCSV(ctx context.Context, url string, reqBody []byte, headers ...Header) ([]byte, error) {
-	fullURL, err := j.getURL(url)
+	fullURL, err := j.HTTPClient.getURL(url)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (j *JSONHTTPClient) httpPutCSV(ctx context.Context, url string,
 		return nil, nil, err
 	}
 
-	return j.sendRequest(req)
+	return j.HTTPClient.sendRequest(req)
 }
 
 func makeTextCSVPutRequest(ctx context.Context, url string, headers []Header, body []byte) (*http.Request, error) {
@@ -50,6 +50,7 @@ func makeTextCSVPutRequest(ctx context.Context, url string, headers []Header, bo
 	return addHeaders(req, headers)
 }
 
+// TODO: Move this out.
 func addHeaders(req *http.Request, headers []Header) (*http.Request, error) {
 	// Apply any custom headers
 	for _, hdr := range headers {

--- a/common/csv.go
+++ b/common/csv.go
@@ -50,16 +50,6 @@ func makeTextCSVPutRequest(ctx context.Context, url string, headers []Header, bo
 	return addHeaders(req, headers)
 }
 
-// TODO: Move this out.
-func addHeaders(req *http.Request, headers []Header) (*http.Request, error) {
-	// Apply any custom headers
-	for _, hdr := range headers {
-		req.Header.Add(hdr.Key, hdr.Value)
-	}
-
-	return req, nil
-}
-
 // TODO: to be migrated to CSVHTTPClient once implemented
 // func (j *JSONHTTPClient) GetCSV(ctx context.Context, url string, headers ...Header) ([]byte, error) {
 // 	fullURL, err := j.getURL(url)

--- a/common/error.go
+++ b/common/error.go
@@ -19,7 +19,7 @@ func InterpretError(res *http.Response, body []byte) error {
 		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
 		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: entity not found (%s)", ErrRetryable, string(body)))
 	case http.StatusTooManyRequests:
-		// Too many requests, sleep and then retry
+		// Too many requests, retryable
 		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
 	}
 

--- a/common/error.go
+++ b/common/error.go
@@ -17,7 +17,7 @@ func InterpretError(res *http.Response, body []byte) error {
 		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body)))
 	case http.StatusNotFound:
 		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: entity not found (%s)", ErrRetryable, string(body)))
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
 	case http.StatusTooManyRequests:
 		// Too many requests, retryable
 		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))

--- a/common/error.go
+++ b/common/error.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// InterpretError interprets the given HTTP response (in a fairly straightforward
+// way) and returns an error that can be handled by the caller.
+func InterpretError(res *http.Response, body []byte) error {
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		// Access token invalid, refresh token and retry
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrAccessToken, string(body)))
+	case http.StatusForbidden:
+		// Forbidden, not retryable
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body)))
+	case http.StatusNotFound:
+		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: entity not found (%s)", ErrRetryable, string(body)))
+	case http.StatusTooManyRequests:
+		// Too many requests, sleep and then retry
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
+	}
+
+	if res.StatusCode >= 400 && res.StatusCode < 500 {
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrCaller, string(body)))
+	} else if res.StatusCode >= 500 && res.StatusCode < 600 {
+		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrServer, string(body)))
+	}
+
+	return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrUnknown, string(body)))
+}

--- a/common/http.go
+++ b/common/http.go
@@ -1,7 +1,12 @@
 package common
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,33 +18,216 @@ type Header struct {
 	Value string
 }
 
-// InterpretError interprets the given HTTP response (in a fairly straightforward
-// way) and returns an error that can be handled by the caller.
-func InterpretError(res *http.Response, body []byte) error {
-	switch res.StatusCode {
-	case http.StatusUnauthorized:
-		// Access token invalid, refresh token and retry
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrAccessToken, string(body)))
-	case http.StatusForbidden:
-		// Forbidden, not retryable
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body)))
-	case http.StatusNotFound:
-		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: entity not found (%s)", ErrRetryable, string(body)))
-	case http.StatusTooManyRequests:
-		// Too many requests, sleep and then retry
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
-	}
+// ErrorHandler allows the caller to inject their own HTTP error handling logic.
+// All non-2xx responses will be passed to the error handler. If the error handler
+// returns nil, then the error is ignored and the caller is responsible for handling
+// the error. If the error handler returns an error, then that error is returned
+// to the caller, as-is. Both the response and the response body are passed
+// to the error handler as arguments.
+type ErrorHandler func(rsp *http.Response, body []byte) error
 
-	if res.StatusCode >= 400 && res.StatusCode < 500 {
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrCaller, string(body)))
-	} else if res.StatusCode >= 500 && res.StatusCode < 600 {
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrServer, string(body)))
-	}
-
-	return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrUnknown, string(body)))
+// HTTPClient is an HTTP client that handles OAuth access token refreshes.
+type HTTPClient struct {
+	Base         string                  // optional base URL. If not set, then all URLs must be absolute.
+	Client       AuthenticatedHTTPClient // underlying HTTP client. Required.
+	ErrorHandler ErrorHandler            // optional error handler. If not set, then the default error handler is used.
 }
 
+// getURL returns the base prefixed URL.
+func (h *HTTPClient) getURL(url string) (string, error) {
+	return getURL(h.Base, url)
+}
+
+// Get makes a GET request to the given URL and returns the response. If the response is not a 2xx,
+// an error is returned. If the response is a 401, the caller should refresh the access token
+// and retry the request. If errorHandler is nil, then the default error handler is used.
+// If not, the caller can inject their own error handling logic.
+func (h *HTTPClient) Get(ctx context.Context, url string, headers []Header) (*http.Response, []byte, error) {
+	fullURL, err := h.getURL(url)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Make the request, get the response body
+	res, body, err := h.httpGet(ctx, fullURL, headers) //nolint:bodyclose
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return res, body, nil
+}
+
+// Post makes a POST request to the given URL and returns the response & response body.
+// If the response is not a 2xx, an error is returned. If the response is a 401, the caller should
+// refresh the access token and retry the request. If errorHandler is nil, then the default error
+// handler is used. If not, the caller can inject their own error handling logic.
+func (h *HTTPClient) Post(ctx context.Context,
+	url string, reqBody any, headers []Header,
+) (*http.Response, []byte, error) {
+	fullURL, err := h.getURL(url)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Make the request, get the response body
+	res, body, err := h.httpPost(ctx, fullURL, headers, reqBody) //nolint:bodyclose
+	if err != nil {
+		return nil, nil, err
+	}
+	// empty response body should not be parsed as JSON since it will cause ajson to err
+	// TODO: Check
+	if len(body) == 0 {
+		return nil, nil, nil //nolint:nilnil
+	}
+
+	return res, body, nil
+}
+
+// Patch makes a PATCH request to the given URL and returns the response & response body.
+// If the response is not a 2xx, an error is returned. If the response is a 401, the caller should
+// refresh the access token and retry the request. If errorHandler is nil, then the default error
+// handler is used. If not, the caller can inject their own error handling logic.
+func (h *HTTPClient) Patch(ctx context.Context,
+	url string, reqBody any, headers []Header,
+) (*http.Response, []byte, error) {
+	fullURL, err := h.getURL(url)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Make the request, get the response body
+	res, body, err := h.httpPatch(ctx, fullURL, headers, reqBody) //nolint:bodyclose
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// empty response body should not be parsed as JSON since it will cause ajson to err
+	if len(body) == 0 {
+		return nil, nil, nil //nolint:nilnil
+	}
+
+	return res, body, nil
+}
+
+// httpGet makes a GET request to the given URL and returns the response & response body.
+func (h *HTTPClient) httpGet(ctx context.Context,
+	url string, headers []Header,
+) (*http.Response, []byte, error) {
+	req, err := makeGetRequest(ctx, url, headers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return h.sendRequest(req)
+}
+
+// httpPost makes a POST request to the given URL and returns the response & response body.
+func (h *HTTPClient) httpPost(ctx context.Context, url string,
+	headers []Header, body any,
+) (*http.Response, []byte, error) {
+	req, err := makePostRequest(ctx, url, headers, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return h.sendRequest(req)
+}
+
+// httpPatch makes a PATCH request to the given URL and returns the response & response body.
+func (h *HTTPClient) httpPatch(ctx context.Context,
+	url string, headers []Header, body any,
+) (*http.Response, []byte, error) {
+	req, err := makePatchRequest(ctx, url, headers, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return h.sendRequest(req)
+}
+
+// makeGetRequest creates a GET request with the given headers.
+func makeGetRequest(ctx context.Context, url string, headers []Header) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	return addHeaders(req, headers)
+}
+
+// makePostRequest creates a POST request with the given headers and body, and adds the
+// Content-Type header. It then returns the request.
+func makePostRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
+	jBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jBody))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
+	req.ContentLength = int64(len(jBody))
+
+	return addHeaders(req, headers)
+}
+
+// makePatchRequest creates a PATCH request with the given headers and body, and adds the
+// Content-Type header. It then returns the request.
+func makePatchRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
+	jBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewBuffer(jBody))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
+	req.ContentLength = int64(len(jBody))
+
+	return addHeaders(req, headers)
+}
+
+// sendRequest sends the given request and returns the response & response body.
+func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, error) {
+	// Send the request
+	res, err := h.Client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error sending request: %w", err)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(res.Body)
+
+	defer func() {
+		if res != nil && res.Body != nil {
+			if closeErr := res.Body.Close(); closeErr != nil {
+				slog.Warn("unable to close response body", "error", closeErr)
+			}
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	// Check the response status code
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		if h.ErrorHandler != nil {
+			return nil, nil, h.ErrorHandler(res, body)
+		}
+
+		return nil, nil, InterpretError(res, body)
+	}
+
+	return res, body, nil
+}
+
+// getURL returns the given URL if it is an absolute URL, or the given URL joined with the base URL.
 func getURL(baseURL string, urlString string) (string, error) {
 	if strings.HasPrefix(urlString, "http://") || strings.HasPrefix(urlString, "https://") {
 		return urlString, nil

--- a/common/http.go
+++ b/common/http.go
@@ -74,11 +74,6 @@ func (h *HTTPClient) Post(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	// empty response body should not be parsed as JSON since it will cause ajson to err
-	// TODO: Check
-	if len(body) == 0 {
-		return nil, nil, nil //nolint:nilnil
-	}
 
 	return res, body, nil
 }
@@ -98,11 +93,6 @@ func (h *HTTPClient) Patch(ctx context.Context,
 	res, body, err := h.httpPatch(ctx, fullURL, headers, reqBody) //nolint:bodyclose
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// empty response body should not be parsed as JSON since it will cause ajson to err
-	if len(body) == 0 {
-		return nil, nil, nil //nolint:nilnil
 	}
 
 	return res, body, nil
@@ -238,4 +228,14 @@ func getURL(baseURL string, urlString string) (string, error) {
 	}
 
 	return url.JoinPath(baseURL, urlString)
+}
+
+// addHeaders adds the given headers to the request.
+func addHeaders(req *http.Request, headers []Header) (*http.Request, error) {
+	// Apply any custom headers
+	for _, hdr := range headers {
+		req.Header.Add(hdr.Key, hdr.Value)
+	}
+
+	return req, nil
 }

--- a/common/json.go
+++ b/common/json.go
@@ -60,6 +60,11 @@ func (j *JSONHTTPClient) Post(ctx context.Context,
 		return nil, err
 	}
 
+	// empty response body should not be parsed as JSON since it will cause ajson to err
+	if len(body) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
 	return parseJSONResponse(res, body)
 }
 
@@ -69,6 +74,11 @@ func (j *JSONHTTPClient) Patch(ctx context.Context,
 	res, body, err := j.HTTPClient.Patch(ctx, url, reqBody, addAcceptJSONHeader(headers)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
+	}
+
+	// empty response body should not be parsed as JSON since it will cause ajson to err
+	if len(body) == 0 {
+		return nil, nil //nolint:nilnil
 	}
 
 	return parseJSONResponse(res, body)

--- a/common/json.go
+++ b/common/json.go
@@ -1,34 +1,22 @@
 package common
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
 	"mime"
 	"net/http"
 
 	"github.com/spyzhov/ajson"
 )
 
-// ErrorHandler allows the caller to inject their own HTTP error handling logic.
-// All non-2xx responses will be passed to the error handler. If the error handler
-// returns nil, then the error is ignored and the caller is responsible for handling
-// the error. If the error handler returns an error, then that error is returned
-// to the caller, as-is. Both the response and the response body are passed
-// to the error handler as arguments.
-type ErrorHandler func(rsp *http.Response, body []byte) error
-
 // JSONHTTPClient is an HTTP client which makes certain assumptions, such as
 // that the response body is JSON. It also handles OAuth access token refreshes.
 type JSONHTTPClient struct {
-	Base         string                  // optional base URL. If not set, then all URLs must be absolute.
-	Client       AuthenticatedHTTPClient // underlying HTTP client. Required.
-	ErrorHandler ErrorHandler            // optional error handler. If not set, then the default error handler is used.
+	HTTPClient *HTTPClient // underlying HTTP client. Required.
 }
 
+// JSONHTTPResponse is a JSON response from an HTTP request.
 type JSONHTTPResponse struct {
 	// bodyBytes is the raw response body. It's not JSON-unmarshalled.
 	// We keep it around so that we can unmarshal it into a struct later,
@@ -46,32 +34,12 @@ type JSONHTTPResponse struct {
 	Body *ajson.Node
 }
 
-func UnmarshalJSON[T any](rsp *JSONHTTPResponse) (*T, error) {
-	var data T
-
-	if err := json.Unmarshal(rsp.bodyBytes, &data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response body into JSON: %w", err)
-	}
-
-	return &data, nil
-}
-
-func (j *JSONHTTPClient) getURL(url string) (string, error) {
-	return getURL(j.Base, url)
-}
-
 // Get makes a GET request to the given URL and returns the response body as a JSON object.
 // If the response is not a 2xx, an error is returned. If the response is a 401, the caller should
 // refresh the access token and retry the request. If errorHandler is nil, then the default error
 // handler is used. If not, the caller can inject their own error handling logic.
 func (j *JSONHTTPClient) Get(ctx context.Context, url string, headers ...Header) (*JSONHTTPResponse, error) {
-	fullURL, err := j.getURL(url)
-	if err != nil {
-		return nil, err
-	}
-
-	// Make the request, get the response body
-	res, body, err := j.httpGet(ctx, fullURL, headers) //nolint:bodyclose
+	res, body, err := j.HTTPClient.Get(ctx, url, addAcceptJSONHeader(headers)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
@@ -87,19 +55,9 @@ func (j *JSONHTTPClient) Get(ctx context.Context, url string, headers ...Header)
 func (j *JSONHTTPClient) Post(ctx context.Context,
 	url string, reqBody any, headers ...Header,
 ) (*JSONHTTPResponse, error) {
-	fullURL, err := j.getURL(url)
+	res, body, err := j.HTTPClient.Post(ctx, url, reqBody, addAcceptJSONHeader(headers)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
-	}
-
-	// Make the request, get the response body
-	res, body, err := j.httpPost(ctx, fullURL, headers, reqBody) //nolint:bodyclose
-	if err != nil {
-		return nil, err
-	}
-	// empty response body should not be parsed as JSON since it will cause ajson to err
-	if len(body) == 0 {
-		return nil, nil //nolint:nilnil
 	}
 
 	return parseJSONResponse(res, body)
@@ -108,24 +66,15 @@ func (j *JSONHTTPClient) Post(ctx context.Context,
 func (j *JSONHTTPClient) Patch(ctx context.Context,
 	url string, reqBody any, headers ...Header,
 ) (*JSONHTTPResponse, error) {
-	fullURL, err := j.getURL(url)
+	res, body, err := j.HTTPClient.Patch(ctx, url, reqBody, addAcceptJSONHeader(headers)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
-	}
-	// Make the request, get the response body
-	res, body, err := j.httpPatch(ctx, fullURL, headers, reqBody) //nolint:bodyclose
-	if err != nil {
-		return nil, err
-	}
-
-	// empty response body should not be parsed as JSON since it will cause ajson to err
-	if len(body) == 0 {
-		return nil, nil //nolint:nilnil
 	}
 
 	return parseJSONResponse(res, body)
 }
 
+// parseJSONResponse parses the given HTTP response and returns a JSONHTTPResponse.
 func parseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, error) {
 	// Ensure the response is JSON
 	ct := res.Header.Get("Content-Type")
@@ -154,124 +103,30 @@ func parseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, erro
 	}, nil
 }
 
-func (j *JSONHTTPClient) httpGet(ctx context.Context, url string,
-	headers []Header,
-) (*http.Response, []byte, error) {
-	req, err := MakeJSONGetRequest(ctx, url, headers)
-	if err != nil {
-		return nil, nil, err
+// UnmarshalJSON deserializes the response body into the given type.
+func UnmarshalJSON[T any](rsp *JSONHTTPResponse) (*T, error) {
+	var data T
+
+	if err := json.Unmarshal(rsp.bodyBytes, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body into JSON: %w", err)
 	}
 
-	return j.sendRequest(req)
+	return &data, nil
 }
 
-func (j *JSONHTTPClient) httpPost(ctx context.Context, url string,
-	headers []Header, body any,
-) (*http.Response, []byte, error) {
-	req, err := makeJSONPostRequest(ctx, url, headers, body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return j.sendRequest(req)
-}
-
-func (j *JSONHTTPClient) httpPatch(ctx context.Context, url string,
-	headers []Header, body any,
-) (*http.Response, []byte, error) {
-	req, err := makeJSONPatchRequest(ctx, url, headers, body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return j.sendRequest(req)
-}
-
-func (j *JSONHTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, error) {
-	// Send the request
-	res, err := j.Client.Do(req)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error sending request: %w", err)
-	}
-
-	// Read the response body
-	body, err := io.ReadAll(res.Body)
-
-	defer func() {
-		if res != nil && res.Body != nil {
-			if closeErr := res.Body.Close(); closeErr != nil {
-				slog.Warn("unable to close response body", "error", closeErr)
-			}
-		}
-	}()
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("error reading response body: %w", err)
-	}
-
-	// Check the response status code
-	if res.StatusCode < 200 || res.StatusCode > 299 {
-		if j.ErrorHandler != nil {
-			return nil, nil, j.ErrorHandler(res, body)
-		}
-
-		return nil, nil, InterpretError(res, body)
-	}
-
-	return res, body, nil
-}
-
+// MakeJSONGetRequest creates a GET request with the given headers and adds the
+// Accept: application/json header. It then returns the request.
 func MakeJSONGetRequest(ctx context.Context, url string, headers []Header) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
-	}
+	headers = append(headers, Header{Key: "Accept", Value: "application/json"})
 
-	return addAcceptJSONHeaders(req, headers)
+	return makeGetRequest(ctx, url, headers)
 }
 
-func makeJSONPostRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
-	jBody, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
+// addAcceptJSONHeader adds the Accept: application/json header to the given headers.
+func addAcceptJSONHeader(headers []Header) []Header {
+	if headers == nil {
+		headers = make([]Header, 0)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jBody))
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
-	}
-
-	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
-	req.ContentLength = int64(len(jBody))
-
-	return addAcceptJSONHeaders(req, headers)
-}
-
-func makeJSONPatchRequest(ctx context.Context, url string, headers []Header, body any) (*http.Request, error) {
-	jBody, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("request body is not valid JSON, body is %v:\n%w", body, err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewBuffer(jBody))
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
-	}
-
-	headers = append(headers, Header{Key: "Content-Type", Value: "application/json"})
-	req.ContentLength = int64(len(jBody))
-
-	return addAcceptJSONHeaders(req, headers)
-}
-
-func addAcceptJSONHeaders(req *http.Request, headers []Header) (*http.Request, error) {
-	// Request JSON
-	req.Header.Add("Accept", "application/json")
-
-	// Apply any custom headers
-	for _, hdr := range headers {
-		req.Header.Add(hdr.Key, hdr.Value)
-	}
-
-	return req, nil
+	return append(headers, Header{Key: "Accept", Value: "application/json"})
 }

--- a/common/json.go
+++ b/common/json.go
@@ -127,9 +127,7 @@ func UnmarshalJSON[T any](rsp *JSONHTTPResponse) (*T, error) {
 // MakeJSONGetRequest creates a GET request with the given headers and adds the
 // Accept: application/json header. It then returns the request.
 func MakeJSONGetRequest(ctx context.Context, url string, headers []Header) (*http.Request, error) {
-	headers = append(headers, Header{Key: "Accept", Value: "application/json"})
-
-	return makeGetRequest(ctx, url, headers)
+	return makeGetRequest(ctx, url, addAcceptJSONHeader(headers))
 }
 
 // addAcceptJSONHeader adds the Accept: application/json header to the given headers.

--- a/hubspot/connector.go
+++ b/hubspot/connector.go
@@ -35,19 +35,19 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	var err error
 	params, err = params.prepare()
 
-	params.client.Base = fmt.Sprintf("https://api.hubapi.com/%s", params.module)
+	params.client.HTTPClient.Base = fmt.Sprintf("https://api.hubapi.com/%s", params.module)
 
 	if err != nil {
 		return nil, err
 	}
 
 	conn = &Connector{
-		BaseURL: params.client.Base,
+		BaseURL: params.client.HTTPClient.Base,
 		Module:  params.module,
 		Client:  params.client,
 	}
 
-	conn.Client.ErrorHandler = conn.interpretError
+	conn.Client.HTTPClient.ErrorHandler = conn.interpretError
 
 	return conn, nil
 }

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -41,8 +41,10 @@ func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config,
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 	return func(params *hubspotParams) {
 		params.client = &common.JSONHTTPClient{
-			Client:       client,
-			ErrorHandler: common.InterpretError,
+			HTTPClient: &common.HTTPClient{
+				Client:       client,
+				ErrorHandler: common.InterpretError,
+			},
 		}
 	}
 }

--- a/salesforce/bulkwrite.go
+++ b/salesforce/bulkwrite.go
@@ -310,7 +310,9 @@ func (c *Connector) getJobResults(ctx context.Context, jobId string) (*http.Resp
 		return nil, fmt.Errorf("failed to create get request: %w", err)
 	}
 
-	return c.Client.Client.Do(req)
+	// Get the connector's JSONHTTPClient, which is a special HTTPClient that handles JSON responses,
+	// and use it's underlying http.Client to make the request.
+	return c.Client.HTTPClient.Client.Do(req)
 }
 
 //nolint:funlen

--- a/salesforce/connector.go
+++ b/salesforce/connector.go
@@ -48,7 +48,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	var err error
 	params, err = params.prepare()
 
-	params.client.Base = fmt.Sprintf("https://%s.my.salesforce.com", params.subdomain)
+	params.client.HTTPClient.Base = fmt.Sprintf("https://%s.my.salesforce.com", params.subdomain)
 
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		Client:  params.client,
 	}
 
-	conn.Client.ErrorHandler = conn.interpretError
+	conn.Client.HTTPClient.ErrorHandler = conn.interpretError
 
 	return conn, nil
 }

--- a/salesforce/metadataApi.go
+++ b/salesforce/metadataApi.go
@@ -68,7 +68,7 @@ func (c *Connector) prepareXMLRequest(
 ) (*http.Request, error) {
 	data := preparePayload(metadata, tok.AccessToken)
 
-	endPointURL, err := url.JoinPath(c.Client.Base, "services/Soap/m/"+APIVersionSOAP())
+	endPointURL, err := url.JoinPath(c.Client.HTTPClient.Base, "services/Soap/m/"+APIVersionSOAP())
 	if err != nil {
 		return nil, errors.Join(ErrCreatingRequest, err)
 	}
@@ -87,7 +87,7 @@ func (c *Connector) prepareXMLRequest(
 }
 
 func (c *Connector) makeRequest(req *http.Request) (*http.Response, []byte, error) {
-	res, err := c.Client.Client.Do(req)
+	res, err := c.Client.HTTPClient.Client.Do(req)
 	if err != nil {
 		return res, nil, err
 	}

--- a/salesforce/params.go
+++ b/salesforce/params.go
@@ -35,8 +35,10 @@ func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config,
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 	return func(params *sfParams) {
 		params.client = &common.JSONHTTPClient{
-			Client:       client,
-			ErrorHandler: common.InterpretError,
+			HTTPClient: &common.HTTPClient{
+				Client:       client,
+				ErrorHandler: common.InterpretError,
+			},
 		}
 	}
 }


### PR DESCRIPTION
* `JSONHTTPClient` expects the response to be of a json type. 
* This PR refactors it so that it wraps around an `HTTPClient`, which makes no assumptions about the response type and returns the raw `http.Response` as it is. 
* `JSONHTTPClient` now wraps around this `HTTPClient` and parses the response before returning it.

There is no difference WRT to the functionality of all of these components. This PR just makes it easier for us to reuse the tried & tested HTTP client.

This should also open up the possibility to handle CSV/XML exchanges better for a future refactor.

### Testing
Tested by making sample calls to Hubspot/Salesforce `Read` & `ListObjectMetadata`