### PR TITLE
chore: Pass back raw net/http/Client.Do error

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -272,7 +272,7 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 	// Send the request
 	res, err := h.Client.Do(req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error sending request: %w", err)
+		return nil, nil, err
 	}
 
 	// Read the response body


### PR DESCRIPTION
This passes back any error encountered while making a request without modifying it