### PR TITLE
fix: Fix outdated salesforce version for ListObjectMetadata

### DIFF
--- a/salesforce/metadata.go
+++ b/salesforce/metadata.go
@@ -24,7 +24,7 @@ func (c *Connector) ListObjectMetadata(
 
 	// Construct describe requests for each object name
 	for idx, objectName := range objectNames {
-		describeObjectURL, err := url.JoinPath(fmt.Sprintf("/services/data/%s/sobjects/%s/describe", apiVersion, objectName))
+		describeObjectURL, err := url.JoinPath(fmt.Sprintf("/services/data/%s/sobjects/%s/describe", APIVersion(), objectName))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* The correct salesforce version now comes from `APIVersion()`.