### PR TITLE
[ENG-620] chore: Add empty module to enable hubspot proxying

### DIFF
--- a/hubspot/connector.go
+++ b/hubspot/connector.go
@@ -1,8 +1,6 @@
 package hubspot
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 )
 
@@ -35,7 +33,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	var err error
 	params, err = params.prepare()
 
-	params.client.HTTPClient.Base = fmt.Sprintf("https://api.hubapi.com/%s", params.module)
+	params.client.HTTPClient.Base = "https://api.hubapi.com"
 
 	if err != nil {
 		return nil, err

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -86,7 +86,9 @@ type describeObjectResult struct {
 
 // describeObject returns object metadata for the given object name.
 func (c *Connector) describeObject(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	rsp, err := c.get(ctx, c.BaseURL+"/properties/"+objectName)
+	relativeUrl := strings.Join([]string{"properties", objectName}, "/")
+
+	rsp, err := c.get(ctx, c.getUrl(relativeUrl))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching HubSpot fields: %w", err)
 	}

--- a/hubspot/metadata.go
+++ b/hubspot/metadata.go
@@ -86,9 +86,9 @@ type describeObjectResult struct {
 
 // describeObject returns object metadata for the given object name.
 func (c *Connector) describeObject(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	relativeUrl := strings.Join([]string{"properties", objectName}, "/")
+	relativeURL := strings.Join([]string{"properties", objectName}, "/")
 
-	rsp, err := c.get(ctx, c.getUrl(relativeUrl))
+	rsp, err := c.get(ctx, c.getURL(relativeURL))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching HubSpot fields: %w", err)
 	}

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -9,9 +9,16 @@ type APIModule struct {
 	Version string // e.g. "v3"
 }
 
+// ModuleCRM is the module used for accessing standard CRM objects
 var ModuleCRM = APIModule{ // nolint: gochecknoglobals
 	Label:   "crm",
 	Version: "v3",
+}
+
+// ModuleEmpty is Used for proxying requests through
+var ModuleEmpty = APIModule{ // nolint: gochecknoglobals
+	Label:   "",
+	Version: "",
 }
 
 func (a APIModule) String() string {

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -9,13 +9,13 @@ type APIModule struct {
 	Version string // e.g. "v3"
 }
 
-// ModuleCRM is the module used for accessing standard CRM objects
+// ModuleCRM is the module used for accessing standard CRM objects.
 var ModuleCRM = APIModule{ // nolint: gochecknoglobals
 	Label:   "crm",
 	Version: "v3",
 }
 
-// ModuleEmpty is Used for proxying requests through
+// ModuleEmpty is Used for proxying requests through.
 var ModuleEmpty = APIModule{ // nolint: gochecknoglobals
 	Label:   "",
 	Version: "",

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -15,7 +15,7 @@ var ModuleCRM = APIModule{ // nolint: gochecknoglobals
 	Version: "v3",
 }
 
-// ModuleEmpty is Used for proxying requests through.
+// ModuleEmpty is used for proxying requests through.
 var ModuleEmpty = APIModule{ // nolint: gochecknoglobals
 	Label:   "",
 	Version: "",

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -68,7 +68,7 @@ func (p *hubspotParams) prepare() (out *hubspotParams, err error) {
 	if p.client == nil {
 		return nil, ErrMissingClient
 	}
-	
+
 	return p, nil
 }
 

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -68,11 +68,7 @@ func (p *hubspotParams) prepare() (out *hubspotParams, err error) {
 	if p.client == nil {
 		return nil, ErrMissingClient
 	}
-
-	if len(p.module) == 0 {
-		return nil, ErrMissingAPIModule
-	}
-
+	
 	return p, nil
 }
 

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -53,8 +53,8 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	} else {
 		// If NextPage is not set, then we're reading the first page of results.
 		// We need to construct the query and then make the request.
-		relativeUrl := strings.Join([]string{"objects", config.ObjectName, "?" + makeQueryValues(config)}, "/")
-		rsp, err = c.get(ctx, c.getUrl(relativeUrl))
+		relativeURL := strings.Join([]string{"objects", config.ObjectName, "?" + makeQueryValues(config)}, "/")
+		rsp, err = c.get(ctx, c.getURL(relativeURL))
 	}
 
 	if err != nil {

--- a/hubspot/read.go
+++ b/hubspot/read.go
@@ -52,8 +52,9 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		rsp, err = c.get(ctx, config.NextPage)
 	} else {
 		// If NextPage is not set, then we're reading the first page of results.
-		// We need to construct the SOQL query and then make the request.
-		rsp, err = c.get(ctx, c.BaseURL+"/objects/"+config.ObjectName+"?"+makeQueryValues(config))
+		// We need to construct the query and then make the request.
+		relativeUrl := strings.Join([]string{"objects", config.ObjectName, "?" + makeQueryValues(config)}, "/")
+		rsp, err = c.get(ctx, c.getUrl(relativeUrl))
 	}
 
 	if err != nil {

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -2,6 +2,7 @@ package hubspot
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -19,7 +20,8 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 		err error
 	)
 
-	rsp, err = c.post(ctx, c.BaseURL+"/objects/"+config.ObjectName+"/search", makeFilterBody(config))
+	relativeUrl := strings.Join([]string{"objects", config.ObjectName, "search"}, "/")
+	rsp, err = c.post(ctx, c.getUrl(relativeUrl), makeFilterBody(config))
 	if err != nil {
 		return nil, err
 	}

--- a/hubspot/search.go
+++ b/hubspot/search.go
@@ -20,8 +20,9 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 		err error
 	)
 
-	relativeUrl := strings.Join([]string{"objects", config.ObjectName, "search"}, "/")
-	rsp, err = c.post(ctx, c.getUrl(relativeUrl), makeFilterBody(config))
+	relativeURL := strings.Join([]string{"objects", config.ObjectName, "search"}, "/")
+
+	rsp, err = c.post(ctx, c.getURL(relativeURL), makeFilterBody(config))
 	if err != nil {
 		return nil, err
 	}

--- a/hubspot/url.go
+++ b/hubspot/url.go
@@ -1,0 +1,10 @@
+package hubspot
+
+import (
+	"strings"
+)
+
+// getUrl is a helper to return the full URL considering the base URL & module.
+func (c *Connector) getUrl(arg string) string {
+	return strings.Join([]string{c.BaseURL, c.Module, arg}, "/")
+}

--- a/hubspot/url.go
+++ b/hubspot/url.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-// getUrl is a helper to return the full URL considering the base URL & module.
-func (c *Connector) getUrl(arg string) string {
+// getURL is a helper to return the full URL considering the base URL & module.
+func (c *Connector) getURL(arg string) string {
 	return strings.Join([]string{c.BaseURL, c.Module, arg}, "/")
 }

--- a/hubspot/write.go
+++ b/hubspot/write.go
@@ -3,6 +3,7 @@ package hubspot
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -22,7 +23,8 @@ type writeMethod func(context.Context, string, any, ...common.Header) (*common.J
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
 	var write writeMethod
 
-	url := fmt.Sprintf("%s/objects/%s", c.BaseURL, config.ObjectName)
+	relativeUrl := strings.Join([]string{"objects", config.ObjectName}, "/")
+	url := c.getUrl(relativeUrl)
 
 	if config.RecordId != "" {
 		write = c.Client.Patch
@@ -30,6 +32,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	} else {
 		write = c.Client.Post
 	}
+
+	fmt.Println("url", url)
 
 	// Hubspot requires everything to be wrapped in a "properties" object.
 	// We do this automatically in the write method so that the user doesn't

--- a/hubspot/write.go
+++ b/hubspot/write.go
@@ -23,8 +23,8 @@ type writeMethod func(context.Context, string, any, ...common.Header) (*common.J
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
 	var write writeMethod
 
-	relativeUrl := strings.Join([]string{"objects", config.ObjectName}, "/")
-	url := c.getUrl(relativeUrl)
+	relativeURL := strings.Join([]string{"objects", config.ObjectName}, "/")
+	url := c.getURL(relativeURL)
 
 	if config.RecordId != "" {
 		write = c.Client.Patch
@@ -32,8 +32,6 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	} else {
 		write = c.Client.Post
 	}
-
-	fmt.Println("url", url)
 
 	// Hubspot requires everything to be wrapped in a "properties" object.
 	// We do this automatically in the write method so that the user doesn't


### PR DESCRIPTION
* Our current setup always requires a module to be input which is a problem for proxy requests since a CRM specific prefix is automatically added to it. 
* This PR adds an empty module which we can use in the server repo for proxy request building

### Testing
- [x] Read
- [x] Write
- [x] ListObjectMetadata
- [x] Search