### PR TITLE
[ENG-788] feat: Add SalesLoft connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -8,6 +8,7 @@ const (
 	Salesforce Provider = "salesforce"
 	Hubspot    Provider = "hubspot"
 	LinkedIn   Provider = "linkedIn"
+	SalesLoft  Provider = "salesLoft"
 )
 
 // ================================================================================
@@ -65,6 +66,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://www.linkedin.com/oauth/v2/authorization",
 			TokenURL:                  "https://www.linkedin.com/oauth/v2/accessToken",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// SalesLoft configuration
+	SalesLoft: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.salesloft.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://accounts.salesloft.com/oauth/authorize",
+			TokenURL:                  "https://accounts.salesloft.com/oauth/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -102,6 +102,31 @@ var testCases = []struct { // nolint
 		expected:    nil,
 		expectedErr: ErrProviderCatalogNotFound,
 	},
+	{
+		provider:    SalesLoft,
+		description: "Valid SalesLoft provider config with non-existent substitutions",
+		substitutions: map[string]string{
+			"nonexistentvar": "abc",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://accounts.salesloft.com/oauth/authorize",
+				TokenURL:                  "https://accounts.salesloft.com/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.salesloft.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No catalog variables. 

## Notes
The proxy does not parse correctly response body from the API, when response is bad request(400). The output when using  API and proxy differs. 

## Testing
### GET
<img width="1143" alt="Screenshot 2024-03-07 at 12 34 01" src="https://github.com/amp-labs/connectors/assets/52887226/45c03010-fbfc-4e1d-9337-b3cd95b40f61">

### POST
<img width="1146" alt="Screenshot 2024-03-07 at 08 42 34" src="https://github.com/amp-labs/connectors/assets/52887226/ba289874-afa5-4892-b51d-db76bb54510e">

### PUT
<img width="1139" alt="Screenshot 2024-03-07 at 11 29 50" src="https://github.com/amp-labs/connectors/assets/52887226/8a9a7e69-b3de-478a-8afb-410f9bef0e3b">

### DELETE
<img width="1160" alt="Screenshot 2024-03-07 at 11 26 06" src="https://github.com/amp-labs/connectors/assets/52887226/73cce11f-5996-4024-b5a6-2988a21b8600">

## Pagination
Showing successfull pagination using connector. 
The first request have 25 records, the metadata object shows _next_page_ is 2(not null). 
<img width="1151" alt="Screenshot 2024-03-07 at 12 45 58" src="https://github.com/amp-labs/connectors/assets/52887226/674af1d6-5c17-43fe-9e2e-935dfcaa76b5">

We can then make a request to the next page index 2 as follows: 
<img width="1155" alt="Screenshot 2024-03-07 at 12 46 29" src="https://github.com/amp-labs/connectors/assets/52887226/b4e8c90b-5a10-4dce-af57-1ed5016e5d42">
 
