### PR TITLE
[ENG-788] feat: Add SalesLoft connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -8,6 +8,7 @@ const (
 	Salesforce Provider = "salesforce"
 	Hubspot    Provider = "hubspot"
 	LinkedIn   Provider = "linkedIn"
+	Salesloft  Provider = "salesloft"
 )
 
 // ================================================================================
@@ -65,6 +66,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://www.linkedin.com/oauth/v2/authorization",
 			TokenURL:                  "https://www.linkedin.com/oauth/v2/accessToken",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// SalesLoft configuration
+	Salesloft: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.salesloft.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://accounts.salesloft.com/oauth/authorize",
+			TokenURL:                  "https://accounts.salesloft.com/oauth/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -102,6 +102,31 @@ var testCases = []struct { // nolint
 		expected:    nil,
 		expectedErr: ErrProviderCatalogNotFound,
 	},
+	{
+		provider:    Salesloft,
+		description: "Valid SalesLoft provider config with non-existent substitutions",
+		substitutions: map[string]string{
+			"nonexistentvar": "abc",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://accounts.salesloft.com/oauth/authorize",
+				TokenURL:                  "https://accounts.salesloft.com/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.salesloft.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No required catalog variables

## Notes 
The proxy and API responses differ when the response from the API is Bad Request(400). The proxy returns an empty body. The API has some details.

## Testing 
### GET
<img width="1146" alt="Screenshot 2024-03-07 at 13 34 40" src="https://github.com/amp-labs/connectors/assets/52887226/409255d6-dd37-4de9-9f7d-3d66a1bdd49f">

### POST
<img width="1146" alt="Screenshot 2024-03-07 at 08 42 34" src="https://github.com/amp-labs/connectors/assets/52887226/8f96bda3-9b4d-42de-894c-7371ac9f46f1">

### PUT
<img width="1139" alt="Screenshot 2024-03-07 at 11 29 50" src="https://github.com/amp-labs/connectors/assets/52887226/e3e27161-8b8f-40bf-a447-047cab58ace9">

### DELETE
<img width="1160" alt="Screenshot 2024-03-07 at 11 26 06" src="https://github.com/amp-labs/connectors/assets/52887226/d8ba6b8e-d0b3-47b9-8cb7-fa4997995ba8">


## Pagination
Showing pagination sample. The response data will have _next_page_ in the metadata.pagination object.
If the next_page value is not "null", There are more pages.
<img width="1151" alt="Screenshot 2024-03-07 at 12 45 58" src="https://github.com/amp-labs/connectors/assets/52887226/8edc67dd-43f3-4b61-ba57-90b0c753577e">

Then we can access the next page, by adding the page query parameter in the next response.
<img width="1155" alt="Screenshot 2024-03-07 at 12 46 29" src="https://github.com/amp-labs/connectors/assets/52887226/e43b96d5-aa5c-4a60-8efa-58f780b1758f">
 
