### PR TITLE
[ENG-790] feat: Add Attio connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -100,10 +100,10 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// Attio configuration
 	Attio: {
 		AuthType: Oauth2,
-		BaseURL:  "https://api.attio.com",
+		BaseURL:  "https://app.attio.com",
 		OauthOpts: OauthOpts{
-			AuthURL:                   "https://auth.attio.com/oauth/authorize",
-			TokenURL:                  "https://auth.attio.com/oauth/token",
+			AuthURL:                   "https://app.attio.com/authorize",
+			TokenURL:                  "https://app.attio.com/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -9,6 +9,7 @@ const (
 	Hubspot    Provider = "hubspot"
 	LinkedIn   Provider = "linkedIn"
 	Salesloft  Provider = "salesloft"
+	Attio      Provider = "attio"
 )
 
 // ================================================================================
@@ -93,6 +94,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+	},
+
+	// Attio configuration
+	Attio: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.attio.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://auth.attio.com/oauth/authorize",
+			TokenURL:                  "https://auth.attio.com/oauth/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: true,
+			Proxy:     true,
+			Read:      true,
+			Subscribe: false,
+			Write:     true,
 		},
 	},
 }

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -143,8 +143,8 @@ var testCases = []struct { // nolint
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
-				AuthURL:                   "https://auth.attio.com/oauth/authorize",
-				TokenURL:                  "https://auth.attio.com/oauth/token",
+				AuthURL:                   "https://auth.attio.com/authorize",
+				TokenURL:                  "https://auth.attio.com/token",
 				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
 			},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -127,6 +127,31 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Attio,
+		description: "Valid Attio provider config with non-existent substitutions",
+		substitutions: map[string]string{
+			"nonexistentvar": "abc",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      true,
+				Write:     true,
+				BulkWrite: true,
+				Subscribe: false,
+				Proxy:     true,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://auth.attio.com/oauth/authorize",
+				TokenURL:                  "https://auth.attio.com/oauth/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.attio.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No required catalog variables

## Notes
Attio provides 2 options for OAuth2 access: with and with no app. This is no app version. 

## Testing 
### GET 
URL: <localhost:4444/v2/some-api-call> 
Postman screenshot (must show the request URL, the response status code & body clearly)

### POST
URL: <localhost:4444/v2/some-api-call> 
Postman screenshot (must show the request URL, the response status code & body clearly)

<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>

## Pagination
Please add screenshots that show successful pagination using the connector