### PR TITLE
[ENG-787] feat: Add Outreach connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -9,6 +9,7 @@ const (
 	Hubspot    Provider = "hubspot"
 	LinkedIn   Provider = "linkedIn"
 	Salesloft  Provider = "salesloft"
+	Outreach   Provider = "outreach"
 )
 
 // ================================================================================
@@ -85,6 +86,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://accounts.salesloft.com/oauth/authorize",
 			TokenURL:                  "https://accounts.salesloft.com/oauth/token",
 			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Outreach configuration
+	Outreach: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.outreach.io",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://api.outreach.io/oauth/authorize",
+			TokenURL:                  "https://api.outreach.io/oauth/token",
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -127,6 +127,28 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Outreach,
+		description: "Valid Outreach provider config with no substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://api.outreach.io/oauth/authorize",
+				TokenURL:                  "https://api.outreach.io/oauth/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.outreach.io",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No required variables.

## Notes
An application can only retrieve an access token for a user once every 60 seconds.

## Testing
### GET
<img width="1142" alt="Screenshot 2024-03-09 at 16 15 48" src="https://github.com/amp-labs/connectors/assets/52887226/5c6a90c3-f1e1-4a68-8d3c-6bbebec88a98">

### POST
<img width="1140" alt="Screenshot 2024-03-09 at 15 13 26" src="https://github.com/amp-labs/connectors/assets/52887226/d9ae13e6-87e7-4b48-a534-4ff34bfa92ef">

### PATCH 
<img width="1141" alt="Screenshot 2024-03-09 at 15 34 30" src="https://github.com/amp-labs/connectors/assets/52887226/81856862-a5ad-43a7-9da3-bb6e4b7825de">

### DELETE
<img width="1155" alt="Screenshot 2024-03-09 at 15 43 30" src="https://github.com/amp-labs/connectors/assets/52887226/38282d54-c892-4e69-8811-b91456f07a2a">

## Pagination
The api uses query parameters to paginate. Retrieving a paginated response.
<img width="1142" alt="Screenshot 2024-03-09 at 12 42 23" src="https://github.com/amp-labs/connectors/assets/52887226/5a29b8a3-03d8-4a31-8c68-1577d370d4be">

Using the next field value to access the next page.
<img width="1143" alt="Screenshot 2024-03-09 at 12 41 19" src="https://github.com/amp-labs/connectors/assets/52887226/2abfba5e-f53d-4abf-8c8f-ccfca7eb3380">
 