### PR TITLE
[ENG-796] feat: Add Keap connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -10,6 +10,7 @@ const (
 	LinkedIn   Provider = "linkedIn"
 	Salesloft  Provider = "salesloft"
 	Outreach   Provider = "outreach"
+	Keap       Provider = "keap"
 )
 
 // ================================================================================
@@ -105,6 +106,26 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://api.outreach.io/oauth/authorize",
 			TokenURL:                  "https://api.outreach.io/oauth/token",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	Keap: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.infusionsoft.com/crm/rest/v1",
+
+		OauthOpts: OauthOpts{
+
+			AuthURL:                   "https://accounts.infusionsoft.com/app/oauth/authorize",
+			TokenURL:                  "https://api.infusionsoft.com/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -149,6 +149,30 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+
+	{
+		provider:    Keap,
+		description: "Valid Keap provider config with no substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:  false,
+				Write: false,
+
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://accounts.infusionsoft.com/app/oauth/authorize",
+				TokenURL:                  "https://api.infusionsoft.com/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.infusionsoft.com/crm/rest/v1",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No required variables.

## Notes

## Testing 
### GET 
 localhost:4444/contacts/model
![proxy_get](https://github.com/amp-labs/connectors/assets/95291462/63577f17-0a7a-4c81-877d-577b35471db3)


### POST
localhost:4444/companies 
![proxy_post](https://github.com/amp-labs/connectors/assets/95291462/b97e4d5e-1021-4eb7-ba53-ece15c8c7e25)

### PUT
localhost:4444/account/profile
![proxy_put](https://github.com/amp-labs/connectors/assets/95291462/1d39eb04-9739-4186-9d7d-431ca373a941)

### PATCH
doesn't work via proxy localhost:4444/contacts?contactId=60 (returns 405 error - method not allowed)
![patch-proxy-doesn't work](https://github.com/amp-labs/connectors/assets/95291462/6729679b-d440-451d-a35d-cea079919953)
while if hit directly at https://api.infusionsoft.com/crm/rest/v1/contacts/contactId=60 everything works fine
![patch-direct-works](https://github.com/amp-labs/connectors/assets/95291462/5d811cc5-66da-4eb1-be2f-b3f58f169efe)

### DEL
localhost:4444/contacts?contactId=60 via proxy returns 405 
![del-via-proxy-doesn't work](https://github.com/amp-labs/connectors/assets/95291462/e8680806-9c47-4cc2-8e92-d85ec6cbd59b)

if run directly works correctly - https://api.infusionsoft.com/crm/rest/v1/contacts/contactId=60 
![del-directly-works](https://github.com/amp-labs/connectors/assets/95291462/7ea99458-8093-45e6-a10d-d4072b2cfc01)

## Pagination
Pagination via proxy returns all contracts and there are two links at the bottom for next and prev page. 

![pagination-proxy](https://github.com/amp-labs/connectors/assets/95291462/76dbba71-cabe-41f2-92aa-c1da9d8cf12a)

if run directly, the same output is shown. I.e. seems they have a bug as it should have returned only fraction of contacts, not all of them. At the same time, the pagination links are correct. 

![pagination_next_page](https://github.com/amp-labs/connectors/assets/95291462/218b2ff7-b78c-4077-aa24-bef0b04c60c3)

