### PR TITLE
[ENG-833] feat: Add Notion connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -13,6 +13,7 @@ const (
 	Close      Provider = "close"
 	Keap       Provider = "keap"
 	Asana      Provider = "asana"
+	Notion     Provider = "notion"
 )
 
 // ================================================================================
@@ -166,6 +167,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://app.asana.com/-/oauth_authorize",
 			TokenURL:                  "https://app.asana.com/-/oauth_token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Notion configuration
+	Notion: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.notion.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://api.notion.com/v1/oauth/token",
+			TokenURL:                  "https://api.notion.com/v1/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -219,6 +219,28 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Notion,
+		description: "Valid Notion provider config with no substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://api.notion.com/v1/oauth/token",
+				TokenURL:                  "https://api.notion.com/v1/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.notion.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Catalog variables
No variables required

## Notes
No refresh token, the Access token does not expire.

## Testing 
### GET 
<img width="1145" alt="Screenshot 2024-03-13 at 14 05 32" src="https://github.com/amp-labs/connectors/assets/52887226/4e923f37-75b9-4ace-ac51-3f65268bc684">

### POST
<img width="1142" alt="Screenshot 2024-03-13 at 14 02 55" src="https://github.com/amp-labs/connectors/assets/52887226/5d3b2d09-4304-4133-86f5-e20d43fdcaa6">

### PATCH
<img width="1148" alt="Screenshot 2024-03-13 at 14 02 23" src="https://github.com/amp-labs/connectors/assets/52887226/f04fc31d-f953-4432-bfbc-6063a24cbf1e">

### DELETE
<img width="1159" alt="Screenshot 2024-03-13 at 14 14 39" src="https://github.com/amp-labs/connectors/assets/52887226/3d4c6a0c-b139-4f2b-b459-5c39fd6e7f94">

## Pagination
Retrieving data that has paginated values.
<img width="1144" alt="Screenshot 2024-03-13 at 14 05 54" src="https://github.com/amp-labs/connectors/assets/52887226/4a37f38f-6803-403d-82e7-426277a40a32">

We use the value next_cursor from above to retrieve the next page list of values, but the parameter is now start_cursor
<img width="1148" alt="Screenshot 2024-03-13 at 14 06 28" src="https://github.com/amp-labs/connectors/assets/52887226/17c46443-957e-4986-b2f9-241eeca567f3">

