### PR TITLE
[ENG-792] feat: Add Close CRM connector (fix)

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -128,8 +128,8 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 
 			AuthURL:                   "https://app.close.com/oauth2/authorize",
-			TokenURL:                  "https://api.close.com/oauth2/token/",
-			ExplicitScopesRequired:    true,
+			TokenURL:                  "https://api.close.com/oauth2/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -165,7 +165,7 @@ var testCases = []struct { // nolint
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
 				AuthURL:                   "https://app.close.com/oauth2/authorize",
-				TokenURL:                  "https://api.close.com/oauth2/token/",
+				TokenURL:                  "https://api.close.com/oauth2/token",
 				ExplicitScopesRequired:    false,
 				ExplicitWorkspaceRequired: false,
 			},
@@ -236,7 +236,11 @@ var testCases = []struct { // nolint
 				Subscribe: false,
 				Write:     false,
 			},
-			BaseURL:  "https://api.dropboxapi.com/2/",
+			BaseURL: "https://api.dropboxapi.com/2/",
+		},
+		expectedErr: nil,
+	},
+	{
 		provider:    Notion,
 		description: "Valid Notion provider config with no substitutions",
 		expected: &ProviderInfo{


### PR DESCRIPTION
Fixed the failed test issue, CloseCRM is no longer mentioned in the list of the failed ones:


--- FAIL: TestReadInfo (0.00s)
    --- FAIL: TestReadInfo/notion (0.00s)
        c:\Users\nadia\Desktop\projects\connectors\providers\catalog_test.go:284: [Valid Notion provider config with no substitutions] Expected support: {false false false false false}, but got: {false true false false false}
FAIL
coverage: 68.8% of statements
FAIL	github.com/amp-labs/connectors/providers	0.278s
FAIL
