### PR TITLE
[ENG-786] feat: Add Gong connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -15,6 +15,7 @@ const (
 	Asana      Provider = "asana"
 	Dropbox    Provider = "dropbox"
 	Notion     Provider = "notion"
+	Gong       Provider = "gong"
 )
 
 // ================================================================================
@@ -83,7 +84,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		},
 	},
 
-	// SalesLoft configuration
+	// Salesloft configuration
 	Salesloft: {
 		AuthType: Oauth2,
 		BaseURL:  "https://api.salesloft.com",
@@ -212,6 +213,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		Support: Support{
 			BulkWrite: false,
 			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Gong configuration
+	Gong: {
+		AuthType: Oauth2,
+		BaseURL:  "https://{{.workspace}}.api.gong.io",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://app.gong.io/oauth2/authorize",
+			TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -127,7 +127,6 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://api.close.com/api",
 		OauthOpts: OauthOpts{
-
 			AuthURL:                   "https://app.close.com/oauth2/authorize",
 			TokenURL:                  "https://api.close.com/oauth2/token",
 			ExplicitScopesRequired:    false,
@@ -147,7 +146,6 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		BaseURL:  "https://api.infusionsoft.com",
 
 		OauthOpts: OauthOpts{
-
 			AuthURL:                   "https://accounts.infusionsoft.com/app/oauth/authorize",
 			TokenURL:                  "https://api.infusionsoft.com/token",
 			ExplicitScopesRequired:    false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -275,7 +275,7 @@ var testCases = []struct { // nolint
 				Write:     false,
 				BulkWrite: false,
 				Subscribe: false,
-				Proxy:     false,
+				Proxy:     true,
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -262,6 +262,31 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Gong,
+		description: "Gong provider config with valid substitutions",
+		substitutions: map[string]string{
+			"workspace": "testing",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://app.gong.io/oauth2/authorize",
+				TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
+				ExplicitWorkspaceRequired: false,
+				ExplicitScopesRequired:    true,
+			},
+			BaseURL: "https://testing.api.gong.io",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch

## Catalog variables
workspace variable is required. It's given by Gong. Sample is us-49467 in https://us-49467.api.gong.io/

## Notes
It's currently private, The only OAuth user who can access the app is the Creator. Publishing it requires filling a form.
Also the token endpoint requires Basic Authorization header whose values is base64 encoded `client_id:client_secret`

## Testing
### GET
<img width="1150" alt="Screenshot 2024-03-15 at 12 14 22" src="https://github.com/amp-labs/connectors/assets/52887226/af390b63-e575-46ff-b886-09c952edc1b8">

### POST
<img width="1148" alt="Screenshot 2024-03-15 at 13 03 09" src="https://github.com/amp-labs/connectors/assets/52887226/fec1224c-4359-4a6c-ace5-a3cd1a0c80c2">

### PUT
<img width="1157" alt="Screenshot 2024-03-15 at 13 10 26" src="https://github.com/amp-labs/connectors/assets/52887226/ee60ed79-9427-49ac-bd9e-8bb59658dd37">

### DELETE
<img width="1155" alt="Screenshot 2024-03-15 at 13 26 22"  src="https://github.com/amp-labs/connectors/assets/52887226/ad530342-9931-4bb6-88ad-eb3b8e196cf7">

## Pagination
For pagination, we would have the cursor value in the records object below: We would in turn use that value as the query parameter in the next request. 
<img width="1151" alt="Screenshot 2024-03-15 at 12 12 41" src="https://github.com/amp-labs/connectors/assets/52887226/afae1a35-5127-46b7-9e0e-2c927cf3e1bc">
