### PR TITLE
[ENG-827] feat: Add Intercom connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -20,6 +20,7 @@ const (
 	Notion     Provider = "notion"
 	Gong       Provider = "gong"
 	Zoom       Provider = "zoom"
+	Intercom   Provider = "intercom"
 )
 
 // ================================================================================
@@ -316,6 +317,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://zoom.us/oauth/authorize",
 			TokenURL:                  "https://zoom.us/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Intercom configuration
+	Intercom: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.intercom.io",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://app.intercom.com/oauth",
+			TokenURL:                  "https://api.intercom.io/auth/eagle/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -370,7 +370,7 @@ var testCases = []struct { // nolint
 		expectedErr: nil,
 	},
 	{
-		provider: Zoom,
+		provider:    Zoom,
 		description: "Zoom provider config with no substitutions",
 		expected: &ProviderInfo{
 			Support: Support{
@@ -388,6 +388,28 @@ var testCases = []struct { // nolint
 				ExplicitWorkspaceRequired: false,
 			},
 			BaseURL: "https://api.zoom.us",
+		},
+		expectedErr: nil,
+	},
+	{
+		provider:    Intercom,
+		description: "Valid Intercom provider config with no substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://app.intercom.com/oauth",
+				TokenURL:                  "https://api.intercom.io/auth/eagle/token",
+				ExplicitWorkspaceRequired: false,
+				ExplicitScopesRequired:    false,
+			},
+			BaseURL: "https://api.intercom.io",
 		},
 		expectedErr: nil,
 	},


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
None

## Notes
No refresh tokens. The access token does not expire.

## Testing 
### GET 

<img width="1151" alt="Screenshot 2024-03-18 at 14 51 01" src="https://github.com/amp-labs/connectors/assets/52887226/bf3cf506-a2f8-48e9-b106-90ba9a253135">

### POST
<img width="1150" alt="Screenshot 2024-03-18 at 14 34 51" src="https://github.com/amp-labs/connectors/assets/52887226/3a1947b5-c3d5-4c1b-80d8-ec35f87f9fc0">

### PUT
<img width="1142" alt="Screenshot 2024-03-18 at 14 49 20" src="https://github.com/amp-labs/connectors/assets/52887226/4bdca246-fed7-4053-8ac4-51fb34d4e71f">

### DELETE
<img width="1152" alt="Screenshot 2024-03-18 at 14 35 35" src="https://github.com/amp-labs/connectors/assets/52887226/ab3960b0-3c47-4932-93ec-dff0638a7326">

## Pagination
Now pagination has 2 flavours: 
### Listing APIs
Retrieving paginated data in a listing API(GETs)
<img width="1148" alt="Screenshot 2024-03-18 at 14 30 17" src="https://github.com/amp-labs/connectors/assets/52887226/b4cd642b-fab5-4634-b1ea-cd84f5b42654">

Using the `pages.next.starting_after` to retrieve the next page data
<img width="1152" alt="Screenshot 2024-03-18 at 14 31 04" src="https://github.com/amp-labs/connectors/assets/52887226/ae89b514-b1d5-4422-95d1-c3bf43de064c">

### Searching APIs
Retrieving paginated data in a searching API(POSTs)
<img width="1144" alt="Screenshot 2024-03-18 at 14 28 35" src="https://github.com/amp-labs/connectors/assets/52887226/4f73ccfc-29fb-4a35-8016-2b8631e34cd9">

Using the `pages.next.starting_after` to retrieve the next page data. Now in the request body.
<img width="1152" alt="Screenshot 2024-03-18 at 14 29 17" src="https://github.com/amp-labs/connectors/assets/52887226/7790156e-1ec0-4280-bd7e-db219368f2a7">

