### PR TITLE
[ENG-866] feat: Add Calendly connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -23,6 +23,7 @@ const (
 	Intercom          Provider = "intercom"
 	DocuSign          Provider = "docuSign"
 	DocuSignDeveloper Provider = "docuSignDeveloper"
+	Calendly          Provider = "calendly"
 )
 
 // ================================================================================
@@ -377,6 +378,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://account-d.docusign.com/oauth/auth",
 			TokenURL:                  "https://account-d.docusign.com/oauth/token",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Calendly configuration
+	Calendly: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.calendly.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://auth.calendly.com/oauth/authorize",
+			TokenURL:                  "https://auth.calendly.com/oauth/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -455,6 +455,28 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Calendly,
+		description: "Calendly provider config with no substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://auth.calendly.com/oauth/authorize",
+				TokenURL:                  "https://auth.calendly.com/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			BaseURL: "https://api.calendly.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
None

## Notes

## Testing 
### GET 
URL: http://localhost:4444/user/me
Describes the requester user
![Selection_015](https://github.com/amp-labs/connectors/assets/60330780/c4fc2ab8-2c7d-456f-a7ec-4855d2430550)

URL: http://localhost:4444/organizations/<ID>
Describes organization
![Selection_016](https://github.com/amp-labs/connectors/assets/60330780/e298542f-08a1-4f73-8957-6e2f3f30443c)



### POST
URL: http://localhost:4444/organizations/<ID>/invitations
Invite user to organisation with email.
![Selection_018](https://github.com/amp-labs/connectors/assets/60330780/797133d5-b08d-4499-ac41-53668e149beb)

### DELETE
URL: http://localhost:4444/organization_memberships/<ID>
Remove member from org. No content response
![Selection_023](https://github.com/amp-labs/connectors/assets/60330780/62ede2a3-f696-41f3-b083-61b4ec03d488)


## Pagination
### GET
URL: http://localhost:4444/organizations/<ID>/invitations
Lists user invitations to the org. Empty response
![Selection_017](https://github.com/amp-labs/connectors/assets/60330780/4aca25aa-afa2-4349-8d7f-0d2ae1802a6b)

URL: http://localhost:4444/organization_memberships/?organisation=<OrganisationURI>
Lists all users that belong to org. No pagination limit.
![Selection_019](https://github.com/amp-labs/connectors/assets/60330780/2d51ab39-3f3f-448d-b784-7875f4b67d86)

### First page
Lists all users that belong to org. Page limit 1.
![Selection_021](https://github.com/amp-labs/connectors/assets/60330780/8538185a-e645-4258-aaf7-0aa365904eca)

### Next page
Lists all users that belong to org.
![Selection_022](https://github.com/amp-labs/connectors/assets/60330780/4993f3f5-34c5-42e3-b5ad-e9f94ed8d61f)

