### PR TITLE
build: add support for multiple Github Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_connector.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_connector.md
@@ -1,0 +1,23 @@
+## Checklist
+- [ ] Ran Linter
+- [ ] Catalog tests passing
+
+## Catalog variables
+<Does the provider's info include any template variables such as `{{workspace}}`?>
+* {{workspace}}
+
+## Notes
+
+## Testing
+### GET
+URL: <localhost:4444/v2/some-api-call>
+Postman screenshot (must show the request URL, the response status code & body clearly)
+
+### POST
+URL: <localhost:4444/v2/some-api-call>
+Postman screenshot (must show the request URL, the response status code & body clearly)
+
+<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>
+
+## Pagination
+Please add screenshots that show successful pagination using the connector. 

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,10 @@ format: fix
 .PHONY: test
 test:
 	go test -v ./...
+
+# Creates PR URLs for each template
+# Click on one of them or manually add ?template=<file.md> to the URL if you are creating a PR via the Github website
+# Templates: Under github/PULL_REQUEST_TEMPLATE directory you can add more templates
+.PHONY: pr-template
+pr-template:
+	. ./scripts/bash/pr_options.sh; pr_template

--- a/scripts/bash/pr_options.sh
+++ b/scripts/bash/pr_options.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Referenced from Makefile
+#
+pr_template() {
+  SOURCE_BRANCH=$(git rev-parse --abbrev-ref HEAD); # current branch from which PR is created
+  TARGET_BRANCH="main"
+
+  USER_NAME=$(git config user.name)
+  REPO_NAME=$(basename -s .git `git config --get remote.origin.url`) # your repo name, can be fork name
+
+  echo "PR templates"
+  # For every template markdown file construct a URL
+  for FILE_NAME in ".github/PULL_REQUEST_TEMPLATE"/*
+  do
+    TEMPLATE=$(basename "$FILE_NAME")
+    # Construct URL for comparing branch against main origin
+    PR_URL="https://github.com/amp-labs/connectors/compare/${TARGET_BRANCH}...${USER_NAME}:${REPO_NAME}:${SOURCE_BRANCH}?template=${TEMPLATE}"
+
+    # Display 2 columns with ident, where first column is min 40 chars
+    printf "\t %-40s %--s\n" "${TEMPLATE}:" "$PR_URL"
+  done
+}


### PR DESCRIPTION
@RajatPawar please have a look

# How to add templates
Create `<filename>.md` under `.github/PULL_REQUEST_TEMPLATE`.
Ensure that filename has no spaces. It is used as query parameter.

# Script
Bash script implies Pull Request URL based on current branch.
Appends for every template a respective query parameter. See [template qp](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request).
![image](https://github.com/amp-labs/connectors/assets/60330780/80c06f00-e6e2-4cfb-b81b-5bda8b1f18bf)



# Reference
[Github docs.](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)

# IMPORTANT
In order to see the changes in action `.github/PULL_REQUEST_TEMPLATE` must be present on default branch first!

