### PR TITLE
fix: Use text/template rather than html/template

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strings"
-	"text/template"
+	"text/template" // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 
 	"github.com/go-playground/validator"
 )

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
-	"html/template"
 	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/go-playground/validator"
 )


### PR DESCRIPTION
We're using `html/template` for substitutions. This probably won't work as intended, since part of html templating includes making the contents HTML-safe, which (for things like raw URLs) we probably don't want.

This PR just switches over to `text/template` so that we don't get this unintended side-effect.
