### PR TITLE
[ENG-858] fix: add error message

### DIFF
--- a/salesforce/bulkwrite.go
+++ b/salesforce/bulkwrite.go
@@ -73,7 +73,7 @@ type GetJobInfoResult struct {
 	LineEnding             string  `json:"lineEnding"`
 	NumberRecordsFailed    float64 `json:"numberRecordsFailed"`
 	NumberRecordsProcessed float64 `json:"numberRecordsProcessed"`
-	ErrorMessage           string  `json:"errorMessage"`
+	ErrorMessage           string  `json:"errorMessage,omitempty"`
 
 	ApexProcessingTime      float64 `json:"apexProcessingTime"`
 	ApiActiveProcessingTime float64 `json:"apiActiveProcessingTime"`

--- a/salesforce/bulkwrite.go
+++ b/salesforce/bulkwrite.go
@@ -73,6 +73,7 @@ type GetJobInfoResult struct {
 	LineEnding             string  `json:"lineEnding"`
 	NumberRecordsFailed    float64 `json:"numberRecordsFailed"`
 	NumberRecordsProcessed float64 `json:"numberRecordsProcessed"`
+	ErrorMessage           string  `json:"errorMessage"`
 
 	ApexProcessingTime      float64 `json:"apexProcessingTime"`
 	ApiActiveProcessingTime float64 `json:"apiActiveProcessingTime"`


### PR DESCRIPTION
Job result information had "errorMessage" field omitted. 

Test

```
=============================================
Testing Complete Failure
=============================================

Upload complete.
{
    "state": "UploadComplete",
    "jobId": "750Dp0000090ZSUIA2"
}
Write Result
{
    "jobId": "750Dp0000090ZSUIA2",
    "state": "Failed",
    "jobInfo": {
        "id": "750Dp0000090ZSUIA2",
        "object": "Touchpoint__c",
        "createdById": "005Dp000003Cd1SIAS",
        "externalIdFieldName": "external_id__c",
        "state": "Failed",
        "operation": "upsert",
        "columnDelimiter": "COMMA",
        "lineEnding": "LF",
        "numberRecordsFailed": 0,
        "numberRecordsProcessed": 0,
        "errorMessage": "InvalidBatch : Field name not found : ContactId__c",
        "apexProcessingTime": 0,
        "apiActiveProcessingTime": 0,
        "apiVersion": 59,
        "concurrencyMode": "Parallel",
        "contentType": "CSV",
        "createdDate": "2024-03-20T21:42:13.000+0000",
        "jobType": "V2Ingest",
        "retries": 0,
        "systemModstamp": "2024-03-20T21:42:15.000+0000",
        "totalProcessingTime": 0
    },
    "message": "No records processed successfully. This is likely due the CSV being empty or issues with CSV column names."
}
```