### PR TITLE
fix: Trigger Refresh grant on expired AT

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -449,8 +449,8 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			Write:     false,
 		},
 	},
-  
-  // GetResponse configuration
+
+	// GetResponse configuration
 	GetResponse: {
 		AuthType: Oauth2,
 		BaseURL:  "https://api.getresponse.com",
@@ -468,8 +468,8 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			Write:     false,
 		},
 	},
-  
-  // AWeber configuration
+
+	// AWeber configuration
 	AWeber: {
 		AuthType: Oauth2,
 		BaseURL:  "https://api.aweber.com",

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -548,7 +548,7 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
-  {
+	{
 		provider:    AWeber,
 		description: "Valid AWeber provider config with no substitutions",
 		expected: &ProviderInfo{

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -265,6 +265,7 @@ func setup() *OAuthApp {
 	if state != "" {
 		app.State = state
 	}
+
 	substitutions, err := registry.GetMap("Substitutions")
 	if err != nil {
 		slog.Warn("no substitutions, ensure that the provider info doesn't have any {{variables}}")

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/amp-labs/connectors/basic"
 	"github.com/amp-labs/connectors/providers"
@@ -86,6 +87,16 @@ var readers = []utils.Reader{
 		JSONPath: "$['refreshToken']",
 		CredKey:  "RefreshToken",
 	},
+	&utils.JSONReader{
+		FilePath: DefaultCredsFile,
+		JSONPath: "$['expiry']",
+		CredKey:  "Expiry",
+	},
+	&utils.JSONReader{
+		FilePath: DefaultCredsFile,
+		JSONPath: "$['expiryFormat']",
+		CredKey:  "ExpiryFormat",
+	},
 }
 
 func main() {
@@ -99,6 +110,8 @@ func main() {
 	clientSecret := registry.MustString("ClientSecret")
 	accessToken := registry.MustString("AccessToken")
 	refreshToken := registry.MustString("RefreshToken")
+	atExpiry := registry.MustString("Expiry")
+	atExpiryTimeFormat := registry.MustString("ExpiryFormat")
 
 	scopes, err := registry.GetString("Scopes")
 	if err != nil {
@@ -118,8 +131,40 @@ func main() {
 		substitutionsMap[key] = val.MustString()
 	}
 
+	expiry := parseAccessTokenExpiry(atExpiry, atExpiryTimeFormat)
+
 	validateRequiredFlags(provider, clientId, clientSecret)
-	startProxy(provider, oauthScopes, clientId, clientSecret, substitutionsMap, DefaultPort, accessToken, refreshToken)
+	startProxy(provider, oauthScopes, clientId, clientSecret, substitutionsMap, DefaultPort, accessToken, refreshToken, expiry)
+}
+
+func parseAccessTokenExpiry(expiryStr, timeFormat string) time.Time {
+	formatEnums := map[string]string{
+		"Layout":      time.Layout,
+		"ANSIC":       time.ANSIC,
+		"UnixDate":    time.UnixDate,
+		"RubyDate":    time.RubyDate,
+		"RFC822":      time.RFC822,
+		"RFC822Z":     time.RFC822Z,
+		"RFC850":      time.RFC850,
+		"RFC1123":     time.RFC1123,
+		"RFC1123Z":    time.RFC1123Z,
+		"RFC3339":     time.RFC3339,
+		"RFC3339Nano": time.RFC3339Nano,
+		"Kitchen":     time.Kitchen,
+	}
+
+	format, found := formatEnums[timeFormat]
+	if !found {
+		// specific format is specified instead of enum
+		format = timeFormat
+	}
+
+	expiry, err := time.Parse(format, expiryStr)
+	if err != nil {
+		panic(err)
+	}
+
+	return expiry
 }
 
 func validateRequiredFlags(provider, clientId, clientSecret string) {
@@ -130,8 +175,8 @@ func validateRequiredFlags(provider, clientId, clientSecret string) {
 	}
 }
 
-func startProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, port int, accessToken, refreshToken string) {
-	proxy := buildProxy(provider, scopes, clientId, clientSecret, substitutions, accessToken, refreshToken)
+func startProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, port int, accessToken, refreshToken string, expiry time.Time) {
+	proxy := buildProxy(provider, scopes, clientId, clientSecret, substitutions, accessToken, refreshToken, expiry)
 	http.Handle("/", proxy)
 
 	fmt.Printf("\nProxy server listening on :%d\n", port)
@@ -141,10 +186,10 @@ func startProxy(provider string, scopes []string, clientId, clientSecret string,
 	}
 }
 
-func buildProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, accessToken, refreshToken string) *Proxy {
+func buildProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, accessToken, refreshToken string, expiry time.Time) *Proxy {
 	providerInfo := getProviderConfig(provider, substitutions)
 	cfg := configureOAuth(clientId, clientSecret, scopes, providerInfo)
-	httpClient := setupHttpClient(cfg, accessToken, refreshToken, provider, providerInfo)
+	httpClient := setupHttpClient(cfg, accessToken, refreshToken, provider, expiry, providerInfo)
 
 	target, err := url.Parse(providerInfo.BaseURL)
 	if err != nil {
@@ -177,12 +222,16 @@ func configureOAuth(clientId, clientSecret string, scopes []string, providerInfo
 }
 
 // This helps with refreshing tokens automatically.
-func setupHttpClient(cfg *oauth2.Config, accessToken, refreshToken string, provider string, providerInfo *providers.ProviderInfo) *http.Client {
+func setupHttpClient(cfg *oauth2.Config, accessToken, refreshToken, provider string, expiry time.Time, providerInfo *providers.ProviderInfo) *http.Client {
 	ctx := context.Background()
 
 	conn, err := basic.NewConnector(
 		provider,
-		basic.WithClient(ctx, http.DefaultClient, cfg, &oauth2.Token{AccessToken: accessToken, RefreshToken: refreshToken}),
+		basic.WithClient(ctx, http.DefaultClient, cfg, &oauth2.Token{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			Expiry:       expiry, // will trigger reuse of refresh token
+		}),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Bug Description

After creating AT/RT tokens for Ms Dynamics Sales I used them to make proxy requests. After 1 hour and 20 min token expired any proxy requests would fail with 401 Unauthorized.


# Fix

Oauth2 library we use states that we must specify `expiry` field for it to consider using `refresh_token`.
[Reference](https://pkg.go.dev/golang.org/x/oauth2#Token).
There are different formats for time parsing so in `cred.json` we could use enum.


Contents of `cred.json` file:
```
{
  "accessToken": "...",
  "refreshToken": "...",

  "expiry": "2024-03-26T16:22:32.768450621+02:00",
  "expiryFormat": "RFC3339Nano"
}
```

# Thoughts

Other connectors may have different field name, time format or even null value.
For example Zendesk returns null value signifying no refresh_token flow. More thought should be put to make it universal.
