### PR TITLE
feat: Add Zendesk Support connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -622,7 +622,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://{{.workspace}}.zendesk.com/oauth/authorizations/new",
 			TokenURL:                  "https://{{.workspace}}.zendesk.com/oauth/tokens",
-      ExplicitScopesRequired:    true,
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
 		},
 		Support: Support{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -34,6 +34,7 @@ const (
 	MicrosoftDynamics365BusinessCentral Provider = "microsoftDynamics365BusinessCentral"
 	Gainsight                           Provider = "gainsight"
 	GoogleCalendar                      Provider = "googleCalendar"
+	ZendeskSupport                      Provider = "zendeskSupport"
 )
 
 // ================================================================================
@@ -603,6 +604,25 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
 			},
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Zendesk Support configuration
+	ZendeskSupport: {
+		AuthType: Oauth2,
+		BaseURL:  "https://{{.workspace}}.zendesk.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://{{.workspace}}.zendesk.com/oauth/authorizations/new",
+			TokenURL:                  "https://{{.workspace}}.zendesk.com/oauth/tokens",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: true,
 		},
 		Support: Support{
 			BulkWrite: false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -739,10 +739,10 @@ var testCases = []struct { // nolint
 				ExplicitWorkspaceRequired: true,
 			},
 			BaseURL: "https://testing.zendesk.com",
-    },
+		},
 		expectedErr: nil,
 	},
-  {
+	{
 		provider:    ZendeskChat,
 		description: "Valid ZendeskChat provider config with substitutions",
 		substitutions: map[string]string{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -717,6 +717,31 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    ZendeskSupport,
+		description: "Zendesk Support provider config with valid substitutions",
+		substitutions: map[string]string{
+			"workspace": "testing",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://testing.zendesk.com/oauth/authorizations/new",
+				TokenURL:                  "https://testing.zendesk.com/oauth/tokens",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: true,
+			},
+			BaseURL: "https://testing.zendesk.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
Closes #146 

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Catalog variables
Workspace: `d3v-ampersand`
Scopes: `read write`

## Notes

## Testing Ticketing
### GET
URL: http://localhost:4444/api/v2/account/settings
List account settigns for Zendesk urser.
![image](https://github.com/amp-labs/connectors/assets/60330780/af58c520-2bd9-4bed-9552-40b9fb2b9758)
URL: http://localhost:4444/api/v2/tickets
List all tickets
![image](https://github.com/amp-labs/connectors/assets/60330780/27d5792e-0b95-4748-af84-96d4b14db313)

### POST
URL: http://localhost:4444/api/v2/tickets
Create ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/c8cd6a4d-6bdf-4771-8ebd-b9583a4d19f1)
![image](https://github.com/amp-labs/connectors/assets/60330780/256de745-e8cf-4e66-8f94-f92432b96684)


### PUT
URL: http://localhost:4444/api/v2/tickets/15
Update subject of the ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/68daf3ee-ba9a-4e9b-bcbf-f5421cfc76bf)
![image](https://github.com/amp-labs/connectors/assets/60330780/b8feebb7-7248-451d-b317-a3e6817f9c05)


### DELETE
URL: http://localhost:4444/api/v2/tickets/15
Delete ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/4360f8c1-e97b-4d7c-80c0-d1035cb302d5)
Ticket is also gone at Zendesk Support portal.

## Testing Voice
### GET
URL: http://localhost:4444/api/v2/channels/voice/phone_numbers.json
List phone numbers
![image](https://github.com/amp-labs/connectors/assets/60330780/e4d2714c-e9fb-4596-a90d-e0685665b283)


## Testing Help Center
### GET
URL: http://localhost:4444/api/v2/help_center/integration/account_custom_claims
Custom claims of help center
![image](https://github.com/amp-labs/connectors/assets/60330780/f609684a-d46f-4bde-bb67-1bd40e839730)

## Pagination
Please add screenshots that show successful pagination using the connector. 

### First Page
URL: http://localhost:4444/api/v2/users?page[size]=1
Get users displaying only one per page via query param `page[size]`
![image](https://github.com/amp-labs/connectors/assets/60330780/8446b79a-c84f-42ef-be77-6d42ee50f12e)


### Next Page
Following next page.
URL: http://localhost:4444/api/v2/users?page%5Bafter%5D=eyJvIjoiaWQiLCJ2IjoiYVpQMTJrRDZGd0FBIn0%3D&page%5Bsize%5D=1
![image](https://github.com/amp-labs/connectors/assets/60330780/282e8280-c463-4dc8-a89b-2c9e53cedff6)

### Last page
Set page size to 50 to see one and only, so last page:
![image](https://github.com/amp-labs/connectors/assets/60330780/a8a93ad4-06d2-44c1-89d1-f7853785a9bd)
Following the link back or forward results in empty data.
![image](https://github.com/amp-labs/connectors/assets/60330780/cd885c8c-24b0-4710-9fe6-c32588b52953)
