### PR TITLE
feat: Add Zendesk Chat connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -34,6 +34,7 @@ const (
 	MicrosoftDynamics365BusinessCentral Provider = "microsoftDynamics365BusinessCentral"
 	Gainsight                           Provider = "gainsight"
 	GoogleCalendar                      Provider = "googleCalendar"
+	ZendeskChat                         Provider = "zendeskChat"
 )
 
 // ================================================================================
@@ -603,6 +604,24 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
 			},
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	ZendeskChat: {
+		AuthType: Oauth2,
+		BaseURL:  "https://www.zopim.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://www.zopim.com/oauth2/authorizations/new?subdomain={{.workspace}}",
+			TokenURL:                  "https://www.zopim.com/oauth2/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: true,
 		},
 		Support: Support{
 			BulkWrite: false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -717,6 +717,31 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    ZendeskChat,
+		description: "Valid ZendeskChat provider config with substitutions",
+		substitutions: map[string]string{
+			"workspace": "test",
+		},
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://www.zopim.com/oauth2/authorizations/new?subdomain=test",
+				TokenURL:                  "https://www.zopim.com/oauth2/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: true,
+			},
+			Support: Support{
+				BulkWrite: false,
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+			BaseURL: "https://www.zopim.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
Closes #144 

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Catalog variables
scopes: `read write`
workspace: `d3v-ampersand`

## Notes

## Testing
### GET
URL: http://localhost:4444/api/v2/account
Get account description.
![image](https://github.com/amp-labs/connectors/assets/60330780/09b80f9c-e084-4f56-8e2e-0c0376cb265a)


### POST
Creating chat can be only done after you create visitors.
URL: http://localhost:4444/api/v2/chats
![image](https://github.com/amp-labs/connectors/assets/60330780/c9d74175-113a-48dc-a141-a6ed1c665d7c)

### PUT
Update visitor name of the chat.
URL:  http://localhost:4444/api/v2/chats/2404.20015967.U8hSBNJn7ON55
![image](https://github.com/amp-labs/connectors/assets/60330780/e04bb70c-6afa-46ce-b65e-980c1a4b3a49)

### DELETE
Remove the chat.
URL:  http://localhost:4444/api/v2/chats/2404.20015967.U8hSBNJn7ON55
![image](https://github.com/amp-labs/connectors/assets/60330780/556ee123-1e21-47fc-a38c-6da084f0c28c)

## Pagination
Chat list cannot be paginated with the same query paramaters as in Zendesk Support. Listing agents "claims" to support pagination but rather it is peeking id and seeking certain number of records in back or forward time directions, response has no page related fields.
