### PR TITLE
[ENG-907] feat: Add Mailchimp connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -23,7 +23,7 @@ const (
 	Gong                                Provider = "gong"
 	Zoom                                Provider = "zoom"
 	Intercom                            Provider = "intercom"
-  	Capsule                             Provider = "capsule"
+	Capsule                             Provider = "capsule"
 	DocuSign                            Provider = "docuSign"
 	DocuSignDeveloper                   Provider = "docuSignDeveloper"
 	Calendly                            Provider = "calendly"
@@ -33,6 +33,7 @@ const (
 	MicrosoftDynamics365Sales           Provider = "microsoftDynamics365Sales"
 	MicrosoftDynamics365BusinessCentral Provider = "microsoftDynamics365BusinessCentral"
 	Gainsight                           Provider = "gainsight"
+	Mailchimp                           Provider = "mailchimp"
 )
 
 // ================================================================================
@@ -118,6 +119,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://accounts.salesloft.com/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: false,
@@ -137,6 +141,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://api.outreach.io/oauth/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: false,
@@ -308,6 +315,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://app.asana.com/-/oauth_token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ConsumerRefField: "data.id",
+			},
 		},
 		Support: Support{
 			BulkWrite: false,
@@ -369,6 +379,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: false,
@@ -579,6 +592,24 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://{{.workspace}}.gainsightcloud.com/v1/authorize",
 			TokenURL:                  "https://{{.workspace}}.gainsightcloud.com/v1/users/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: true,
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+	// Mailchimp configuration
+	Mailchimp: {
+		AuthType: Oauth2,
+		BaseURL:  "https://{{.workspace}}.api.mailchimp.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://login.mailchimp.com/oauth2/authorize",
+			TokenURL:                  "https://login.mailchimp.com/oauth2/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: true,
 		},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -130,6 +130,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://accounts.salesloft.com/oauth/token",
 				ExplicitScopesRequired:    false,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
 			},
 			BaseURL: "https://api.salesloft.com",
 		},
@@ -152,6 +155,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://api.outreach.io/oauth/token",
 				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
 			},
 			BaseURL: "https://api.outreach.io",
 		},
@@ -360,6 +366,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://app.asana.com/-/oauth_token",
 				ExplicitScopesRequired:    false,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ConsumerRefField: "data.id",
+				},
 			},
 			BaseURL: "https://app.asana.com/api",
 		},
@@ -432,6 +441,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
 				ExplicitWorkspaceRequired: false,
 				ExplicitScopesRequired:    true,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
 			},
 			BaseURL: "https://testing.api.gong.io",
 		},
@@ -689,6 +701,31 @@ var testCases = []struct { // nolint
 				ExplicitWorkspaceRequired: true,
 			},
 			BaseURL: "https://company.gainsightcloud.com",
+		},
+		expectedErr: nil,
+	},
+	{
+		provider:    Mailchimp,
+		description: "Mailchimp provider config with valid datacenter substitutions",
+		substitutions: map[string]string{
+			"workspace": "us22",
+		},
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://login.mailchimp.com/oauth2/authorize",
+				TokenURL:                  "https://login.mailchimp.com/oauth2/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: true,
+			},
+			BaseURL: "https://us22.api.mailchimp.com",
 		},
 		expectedErr: nil,
 	},

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -242,6 +242,7 @@ func setup() *OAuthApp {
 	provider := registry.MustString("Provider")
 	clientId := registry.MustString("ClientId")
 	clientSecret := registry.MustString("ClientSecret")
+
 	state, err := registry.GetString("State")
 	if err != nil {
 		slog.Warn("no state attached, ensure that the provider doesn't require state")


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
datacenter/server-prefix which represents the servers hosting the Mailchimp. Used in the api base url. 

## Notes


## Testing 
### GET 
<img width="1157" alt="Screenshot 2024-03-27 at 16 26 33" src="https://github.com/amp-labs/connectors/assets/52887226/9c489096-5998-4676-b345-b2d10b5c83c3">

### POST
<img width="1145" alt="Screenshot 2024-03-27 at 18 27 41" src="https://github.com/amp-labs/connectors/assets/52887226/aec437ab-b81a-4dea-8efa-6fba5daad26c">

### PATCH
<img width="1157" alt="Screenshot 2024-03-28 at 12 01 26" src="https://github.com/amp-labs/connectors/assets/52887226/65538040-9039-4591-baa1-8dba89654f79">

### DELETE
<img width="1151" alt="Screenshot 2024-03-28 at 12 01 52" src="https://github.com/amp-labs/connectors/assets/52887226/8dc47ee9-d380-46b6-9318-3de7423dae19">

## Pagination
Requesting a paginated results of campaigns. We request a list of campaigns and by default we get 10 campaigns.
<img width="1144" alt="Screenshot 2024-03-28 at 13 22 05" src="https://github.com/amp-labs/connectors/assets/52887226/d83283af-065e-4718-9f50-b58f33da0253">

From the result above we can see there are 32 campaigns, We use query parameters `count` and `offset` to retrieve the remaining campaigns.
<img width="1147" alt="Screenshot 2024-03-28 at 13 21 17" src="https://github.com/amp-labs/connectors/assets/52887226/50449cd6-67f5-4512-a63e-4d16f454ed8b">
