### PR TITLE
feat: Add PandaDoc connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -34,6 +34,7 @@ const (
 	MicrosoftDynamics365BusinessCentral Provider = "microsoftDynamics365BusinessCentral"
 	Gainsight                           Provider = "gainsight"
 	GoogleCalendar                      Provider = "googleCalendar"
+	PandaDoc                            Provider = "pandaDoc"
 )
 
 // ================================================================================
@@ -598,6 +599,27 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://accounts.google.com/o/oauth2/v2/auth",
 			TokenURL:                  "https://oauth2.googleapis.com/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: false,
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	PandaDoc: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.pandadoc.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://app.pandadoc.com/oauth2/authorize",
+			TokenURL:                  "https://api.pandadoc.com/oauth2/access_token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -717,6 +717,31 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    PandaDoc,
+		description: "PandaDoc provider config with substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://app.pandadoc.com/oauth2/authorize",
+				TokenURL:                  "https://api.pandadoc.com/oauth2/access_token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
+			},
+			BaseURL: "https://api.pandadoc.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
Closes #147 

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Catalog variables
scopes: `read+write`

## Notes

## Testing
### GET
URL: http://localhost:4444/

## Pagination

### First Page

### Next Page
