### PR TITLE
feat: Add oauth grant types to catalog

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -49,6 +49,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://{{.workspace}}.my.salesforce.com",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://{{.workspace}}.my.salesforce.com/services/oauth2/authorize",
 			TokenURL:                  "https://{{.workspace}}.my.salesforce.com/services/oauth2/token",
 			ExplicitScopesRequired:    false,
@@ -77,6 +78,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://api.hubapi.com",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://app.hubspot.com/oauth/authorize",
 			TokenURL:                  "https://api.hubapi.com/oauth/v1/token",
 			ExplicitScopesRequired:    true,
@@ -96,6 +98,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://api.linkedin.com",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://www.linkedin.com/oauth/v2/authorization",
 			TokenURL:                  "https://www.linkedin.com/oauth/v2/accessToken",
 			ExplicitScopesRequired:    true,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -30,6 +30,7 @@ var testCases = []struct { // nolint
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
 				AuthURL:                   "https://example.my.salesforce.com/services/oauth2/authorize",
 				TokenURL:                  "https://example.my.salesforce.com/services/oauth2/token",
 				ExplicitWorkspaceRequired: true,
@@ -64,6 +65,7 @@ var testCases = []struct { // nolint
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
 				AuthURL:                   "https://app.hubspot.com/oauth/authorize",
 				TokenURL:                  "https://api.hubapi.com/oauth/v1/token",
 				ExplicitScopesRequired:    true,
@@ -89,6 +91,7 @@ var testCases = []struct { // nolint
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
 				AuthURL:                   "https://www.linkedin.com/oauth/v2/authorization",
 				TokenURL:                  "https://www.linkedin.com/oauth/v2/accessToken",
 				ExplicitScopesRequired:    true,

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -8,6 +8,13 @@ const (
 	Oauth2 AuthType = "oauth2"
 )
 
+// Defines values for OauthOptsGrantType.
+const (
+	AuthorizationCode OauthOptsGrantType = "authorizationCode"
+	ClientCredentials OauthOptsGrantType = "clientCredentials"
+	PKCE              OauthOptsGrantType = "PKCE"
+)
+
 // AuthType defines model for AuthType.
 type AuthType string
 
@@ -19,9 +26,13 @@ type OauthOpts struct {
 	AuthURL                   string              `json:"authURL" validate:"required"`
 	ExplicitScopesRequired    bool                `json:"explicitScopesRequired"`
 	ExplicitWorkspaceRequired bool                `json:"explicitWorkspaceRequired"`
+	GrantType                 OauthOptsGrantType  `json:"grantType"`
 	TokenMetadataFields       TokenMetadataFields `json:"tokenMetadataFields"`
 	TokenURL                  string              `json:"tokenURL" validate:"required"`
 }
+
+// OauthOptsGrantType defines model for OauthOpts.GrantType.
+type OauthOptsGrantType string
 
 // Provider defines model for Provider.
 type Provider = string

--- a/providers/types.yaml
+++ b/providers/types.yaml
@@ -63,12 +63,16 @@ components:
       x-oapi-codegen-extra-tags:
         validate: required
       required:
+          - grantType
           - authURL
           - tokenURL
           - explicitScopesRequired
           - explicitWorkspaceRequired
           - tokenMetadataFields
       properties:
+        grantType:
+          type: string
+          enum: [authorizationCode, clientCredentials, PKCE]
         authURL:
           type: string
           example: https://login.salesforce.com/services/oauth2/authorize


### PR DESCRIPTION
We currently support only OAuth 2.0 Authorization code flow (& refresh token flow), but there's [multiple types of grants possible with OAuth 2.0](https://oauth.net/2/grant-types/). 

Some providers that we are working on are using these flows, so it might be a good idea to specify the grant types.