### PR TITLE
Feat/add slack connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ playground/
 
 *creds.json
 **/.DS_Store
+
+# ssl certificates
+.ssl/

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -893,7 +893,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// Slack configuration
 	Slack: {
 		AuthType: Oauth2,
-		BaseURL:  "https://slack.com",
+		BaseURL:  "https://slack.com/api",
 		OauthOpts: OauthOpts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://slack.com/oauth/v2/authorize",

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -893,7 +893,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// Slack configuration
 	Slack: {
 		AuthType: Oauth2,
-		BaseURL:  "https://api.slack.com",
+		BaseURL:  "https://slack.com",
 		OauthOpts: OauthOpts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://slack.com/oauth/v2/authorize",

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -895,6 +895,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://api.slack.com",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://slack.com/oauth/v2/authorize",
 			TokenURL:                  "https://slack.com/api/oauth.v2.access",
 			ExplicitScopesRequired:    true,

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -906,7 +906,12 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			},
 		},
 		Support: Support{
-			BulkWrite: false,
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
 			Proxy:     false,
 			Read:      false,
 			Subscribe: false,

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -39,6 +39,7 @@ const (
 	ZendeskChat                         Provider = "zendeskChat"
 	WordPress                           Provider = "wordPress"
 	Airtable                            Provider = "airtable"
+	Slack                               Provider = "slack"
 )
 
 // ================================================================================
@@ -882,6 +883,29 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				Upsert: false,
 				Delete: false,
 			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Slack configuration
+	Slack: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.slack.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://slack.com/oauth/v2/authorize",
+			TokenURL:                  "https://slack.com/api/oauth.v2.access",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: true,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField:       "scope",
+				WorkspaceRefField: "workspace_name",
+			},
+		},
+		Support: Support{
+			BulkWrite: false,
 			Proxy:     false,
 			Read:      false,
 			Subscribe: false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1023,6 +1023,7 @@ var testCases = []struct { // nolint
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
 				AuthURL:                   "https://slack.com/oauth/v2/authorize",
 				TokenURL:                  "https://slack.com/api/oauth.v2.access",
 				ExplicitScopesRequired:    true,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1010,6 +1010,32 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Slack,
+		description: "Valid Slack provider config with non-existent substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:      false,
+				Write:     false,
+				BulkWrite: false,
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				AuthURL:                   "https://slack.com/oauth/v2/authorize",
+				TokenURL:                  "https://slack.com/api/oauth.v2.access",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: true,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField:       "scope",
+					WorkspaceRefField: "workspace_name",
+				},
+			},
+			BaseURL: "https://api.slack.com/",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1038,7 +1038,7 @@ var testCases = []struct { // nolint
 					WorkspaceRefField: "workspace_name",
 				},
 			},
-			BaseURL: "https://slack.com",
+			BaseURL: "https://slack.com/api",
 		},
 		expectedErr: nil,
 	},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1038,7 +1038,7 @@ var testCases = []struct { // nolint
 					WorkspaceRefField: "workspace_name",
 				},
 			},
-			BaseURL: "https://api.slack.com",
+			BaseURL: "https://slack.com",
 		},
 		expectedErr: nil,
 	},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1033,7 +1033,7 @@ var testCases = []struct { // nolint
 					WorkspaceRefField: "workspace_name",
 				},
 			},
-			BaseURL: "https://api.slack.com/",
+			BaseURL: "https://api.slack.com",
 		},
 		expectedErr: nil,
 	},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1015,9 +1015,14 @@ var testCases = []struct { // nolint
 		description: "Valid Slack provider config with non-existent substitutions",
 		expected: &ProviderInfo{
 			Support: Support{
-				Read:      false,
-				Write:     false,
-				BulkWrite: false,
+				Read:  false,
+				Write: false,
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
 				Subscribe: false,
 				Proxy:     false,
 			},

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -151,6 +151,7 @@ func parseAccessTokenExpiry(expiryStr, timeFormat string) time.Time {
 		"RFC3339":     time.RFC3339,
 		"RFC3339Nano": time.RFC3339Nano,
 		"Kitchen":     time.Kitchen,
+		"DateOnly":    time.DateOnly,
 	}
 
 	format, found := formatEnums[timeFormat]
@@ -202,7 +203,8 @@ func buildProxy(provider string, scopes []string, clientId, clientSecret string,
 func getProviderConfig(provider string, substitutions map[string]string) *providers.ProviderInfo {
 	config, err := providers.ReadInfo(provider, &substitutions)
 	if err != nil {
-		panic(err)
+
+		panic(fmt.Errorf("%w: %s", err, provider))
 	}
 
 	return config


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables

* scope

## Notes

fix #167
resolved #155

- localhost:4444/v2/  did not work to call API methods, localhost:4444/api used
- Slack does not support HTTP links, updated the code to support HTTPS using self-signed certificate. copy ssl key and cert in ./ssl folder, use "go run scripts/oauth/token.go --proto https " to run https protocol
- Slack access tokens do not expire therefore added an expiry date in the creds and a time.DateOly format to support it
- Struggled to detect why proxy was not running, updated the error for clarify

## Testing 
### GET 
URL: <localhost:4444/api/conversations.list> 
![Screenshot 2567-04-04 at 17 45 14](https://github.com/amp-labs/connectors/assets/103050835/d4b5c3ff-e643-4128-bbf8-536559bce21a)

### POST
URL: <localhost:4444/api/chat.postMessage>
![Screenshot 2567-04-04 at 17 57 25](https://github.com/amp-labs/connectors/assets/103050835/825769ea-be1a-4fa4-8eaa-233acaec78a3)
Message was posted on Slack App
![Screenshot 2567-04-04 at 17 57 34](https://github.com/amp-labs/connectors/assets/103050835/5df76441-165d-47df-9205-74e4d8309a61)

Wrong API call
![Screenshot 2567-04-04 at 17 45 46](https://github.com/amp-labs/connectors/assets/103050835/f14e082f-e7ad-4302-98b4-3a75c981ed72)

## Pagination
Users list with pagination
![Screenshot 2567-04-04 at 20 04 46](https://github.com/amp-labs/connectors/assets/103050835/eed218a9-1bf5-4385-a232-833125acd658)
