### PR TITLE
fix: Correct the catalog to use new bulkwrite types

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -847,7 +847,12 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{
-			BulkWrite: false,
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
 			Proxy:     false,
 			Read:      false,
 			Subscribe: false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -964,7 +964,12 @@ var testCases = []struct { // nolint
 				ExplicitWorkspaceRequired: false,
 			},
 			Support: Support{
-				BulkWrite: false,
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
 				Proxy:     false,
 				Read:      false,
 				Subscribe: false,

--- a/test/salesforce/bulkdelete/main.go
+++ b/test/salesforce/bulkdelete/main.go
@@ -51,7 +51,6 @@ func main() {
 		ObjectName: "Touchpoint__c",
 		CSVData:    bytes.NewReader(objectCSVToDelete),
 	})
-
 	if err != nil {
 		slog.Error("Error bulk deleting", "error", err)
 		return

--- a/test/salesforce/metadata/main.go
+++ b/test/salesforce/metadata/main.go
@@ -55,7 +55,6 @@ func main() {
 	}()
 
 	example, err := xmldom.ParseXML(`<createMetadata><metadata xsi:type="CustomObject"><fullName>TestObject15__c</fullName><label>Test Object 15</label><pluralLabel>Test Objects 15</pluralLabel><nameField><type>Text</type><label>Test Object Name</label></nameField><deploymentStatus>Deployed</deploymentStatus><sharingModel>ReadWrite</sharingModel></metadata><metadata xsi:type="CustomField"><fullName>TestObject13__c.Comments__c</fullName><label>Comments</label><type>LongTextArea</type><length>500</length><inlineHelpText>This field contains help text for this object</inlineHelpText><description>Add your comments about this object here</description><visibleLines>30</visibleLines><required>false</required><trackFeedHistory>false</trackFeedHistory><trackHistory>false</trackHistory></metadata></createMetadata>`)
-
 	if err != nil {
 		slog.Error("err parsing", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
One of the new providers used the wrong type, this fixes it.

I also ran ran gofumpt, in case you're wondering about the formatting changes.