### PR TITLE
feat: Add Timely auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -996,7 +996,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://api.timelyapp.com/1.1/oauth/authorize",
 			TokenURL:                  "https://api.timelyapp.com/1.1/oauth/token",
 			ExplicitScopesRequired:    false,
-      ExplicitWorkspaceRequired: false,
+            ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
 			},

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -41,6 +41,7 @@ const (
 	Airtable                            Provider = "airtable"
 	Slack                               Provider = "slack"
 	HelpScoutMailbox                    Provider = "helpScoutMailbox"
+	Timely                              Provider = "timely"
 )
 
 // ================================================================================
@@ -144,6 +145,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://accounts.salesloft.com/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -168,6 +172,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://api.outreach.io/oauth/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -384,6 +391,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://app.asana.com/-/oauth_token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ConsumerRefField: "data.id",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -460,6 +470,10 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField:      "scope",
+				ConsumerRefField: "client_id",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -903,6 +917,34 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://api.helpscout.net/v2/oauth2/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Timely Configuration
+	Timely: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.timelyapp.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://api.timelyapp.com/1.1/oauth/authorize",
+			TokenURL:                  "https://api.timelyapp.com/1.1/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1093,14 +1093,14 @@ var testCases = []struct { // nolint
 	{
 		provider:    Timely,
 		description: "Valid Timely provider config with no substitutions",
-    expected: &ProviderInfo{
+    	expected: &ProviderInfo{
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
 				GrantType:                 AuthorizationCode,
-        AuthURL:                   "https://api.timelyapp.com/1.1/oauth/authorize",
+        		AuthURL:                   "https://api.timelyapp.com/1.1/oauth/authorize",
 				TokenURL:                  "https://api.timelyapp.com/1.1/oauth/token",
 				ExplicitScopesRequired:    false,
-        ExplicitWorkspaceRequired: false,
+        		ExplicitWorkspaceRequired: false,
 				TokenMetadataFields: TokenMetadataFields{
 					ScopesField: "scope",
 				},
@@ -1117,22 +1117,22 @@ var testCases = []struct { // nolint
 				Subscribe: false,
 				Proxy:     false,
 			},
-      BaseURL: "https://api.timelyapp.com",
-    },
+     	 	BaseURL: "https://api.timelyapp.com",
+    	},
 		expectedErr: nil,
-  },
-  {
+  	},
+  	{
 		provider:    Atlassian,
 		description: "Valid Atlassian provider config with no substitutions",
-    expected: &ProviderInfo{
+    	expected: &ProviderInfo{
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
 				GrantType:                 AuthorizationCode,
-        AuthURL:                   "https://auth.atlassian.com/authorize",
+        		AuthURL:                   "https://auth.atlassian.com/authorize",
 				TokenURL:                  "https://auth.atlassian.com/oauth/token",
 				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
-      },
+      		},
 			Support: Support{
 				BulkWrite: BulkWriteSupport{
 					Insert: false,
@@ -1145,11 +1145,11 @@ var testCases = []struct { // nolint
 				Subscribe: false,
 				Write:     false,
 			},
-      BaseURL: "https://api.atlassian.com",
-    },
+      		BaseURL: "https://api.atlassian.com",
+    	},
 		expectedErr: nil,
-  },
-  {
+  	},
+  	{
 		provider:    Webflow,
 		description: "Valid Webflow provider config with no substitutions",
 		expected: &ProviderInfo{
@@ -1165,18 +1165,18 @@ var testCases = []struct { // nolint
 				},
 			},
 			Support: Support{
-				Read:  false,
-				Write: false,
 				BulkWrite: BulkWriteSupport{
 					Insert: false,
 					Update: false,
 					Upsert: false,
 					Delete: false,
 				},
-				Subscribe: false,
 				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
 			},
-      BaseURL: "https://api.webflow.com",
+      		BaseURL: "https://api.webflow.com",
 		},
 		expectedErr: nil,
 	},

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -153,6 +153,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://accounts.salesloft.com/oauth/token",
 				ExplicitScopesRequired:    false,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
 			},
 			BaseURL: "https://api.salesloft.com",
 		},
@@ -180,6 +183,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://api.outreach.io/oauth/token",
 				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
 			},
 			BaseURL: "https://api.outreach.io",
 		},
@@ -433,6 +439,9 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://app.asana.com/-/oauth_token",
 				ExplicitScopesRequired:    false,
 				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ConsumerRefField: "data.id",
+				},
 			},
 			BaseURL: "https://app.asana.com/api",
 		},
@@ -520,6 +529,10 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",
 				ExplicitWorkspaceRequired: false,
 				ExplicitScopesRequired:    true,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField:      "scope",
+					ConsumerRefField: "client_id",
+				},
 			},
 			BaseURL: "https://testing.api.gong.io",
 		},
@@ -1037,6 +1050,37 @@ var testCases = []struct { // nolint
 				Write:     false,
 			},
 			BaseURL: "https://api.helpscout.net",
+		},
+		expectedErr: nil,
+	},
+	{
+		provider:    Timely,
+		description: "Valid Timely provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://api.timelyapp.com/1.1/oauth/authorize",
+				TokenURL:                  "https://api.timelyapp.com/1.1/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
+			},
+			Support: Support{
+				Read:  false,
+				Write: false,
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Subscribe: false,
+				Proxy:     false,
+			},
+			BaseURL: "https://api.timelyapp.com",
 		},
 		expectedErr: nil,
 	},


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
None

## Notes

## Testing 
### GET 
<img width="1149" alt="Screenshot 2024-04-09 at 15 40 52" src="https://github.com/amp-labs/connectors/assets/52887226/ce488cd5-20c6-42e7-89a6-f619c7a47ccb">

### POST
<img width="1139" alt="Screenshot 2024-04-09 at 13 57 42" src="https://github.com/amp-labs/connectors/assets/52887226/d54fe711-4753-447f-9715-e3805628ef53">

### PUT
<img width="1146" alt="Screenshot 2024-04-09 at 13 59 03" src="https://github.com/amp-labs/connectors/assets/52887226/e49a001f-d2dd-4237-9abe-342ec803dd3b">

### DELETE
<img width="1144" alt="Screenshot 2024-04-09 at 14 04 08" src="https://github.com/amp-labs/connectors/assets/52887226/617cbef6-0246-46e7-8271-b7bc9a3a6431">

## Pagination
Sample retrieving paged result:
<img width="1144" alt="Screenshot 2024-04-09 at 16 08 26" src="https://github.com/amp-labs/connectors/assets/52887226/20f8e295-1dc3-4db6-b11e-66c0a616e2df">

Retrieving the next page
<img width="1143" alt="Screenshot 2024-04-09 at 16 17 42" src="https://github.com/amp-labs/connectors/assets/52887226/b21a7465-18dc-4a34-b82b-10e122ec43bc">

closes #191 