### PR TITLE
Add StackExchange connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -41,6 +41,7 @@ const (
 	Slack                               Provider = "slack"
 	HelpScoutMailbox                    Provider = "helpScoutMailbox"
 	Webflow                             Provider = "webflow"
+	StackExchange                       Provider = "stackExchange"
 )
 
 // ================================================================================
@@ -929,6 +930,33 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://webflow.com/oauth/authorize",
 			TokenURL:                  "https://api.webflow.com/oauth/access_token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+	// StackExchange configuration
+	StackExchange: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.stackexchange.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://stackoverflow.com/oauth",
+			TokenURL:                  "https://stackoverflow.com/oauth/access_token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1075,6 +1075,37 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    StackExchange,
+		description: "Valid StackExchange provider config with non-existent substitutions",
+		expected: &ProviderInfo{
+			Support: Support{
+				Read:  false,
+				Write: false,
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Subscribe: false,
+				Proxy:     false,
+			},
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://stackoverflow.com/oauth",
+				TokenURL:                  "https://stackoverflow.com/oauth/access_token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
+			},
+			BaseURL: "https://api.stackexchange.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
<Please mention any variables you had to use for the provider's info>
* {{scope}}

## Notes
Resolves #185
When calling an API use/2.3/ instead of v2
## Testing 
### GET 
URL: <localhost:4444/2.3/answers?order=desc&sort=activity&site=stackoverflow> 
![Screenshot 2567-04-11 at 12 37 23](https://github.com/amp-labs/connectors/assets/103050835/54c005f5-c110-455e-8fd7-2a6436c6508c)


### POST
URL: <localhost:4444/2.3/questions/render> 
![Screenshot 2567-04-11 at 10 50 28](https://github.com/amp-labs/connectors/assets/103050835/46220401-0b63-4cac-9885-428c2b00825b)
)

## Pagination
Requested pagesize= 2, which returned 2 elements. "has_more" = true indicates that more data is available.
![Screenshot 2567-04-11 at 15 10 25](https://github.com/amp-labs/connectors/assets/103050835/574b4816-5482-4682-ab6d-e9bf9211e71f)



