### PR TITLE
feat: Add a mock connector

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/hubspot"
 	"github.com/amp-labs/connectors/microsoftdynamicscrm"
+	"github.com/amp-labs/connectors/mock"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/salesforce"
 )
@@ -80,6 +82,9 @@ var Hubspot API[*hubspot.Connector, hubspot.Option] = hubspot.NewConnector //nol
 // MSDynamicsSales is an API that returns a new MS Dynamics 365 Sales Connector.
 var MSDynamicsSales API[*microsoftdynamicscrm.Connector, microsoftdynamicscrm.Option] = microsoftdynamicscrm.NewConnector //nolint:gochecknoglobals,lll
 
+// Mock is an API that returns a new Mock Connector.
+var Mock API[*mock.Connector, mock.Option] = mock.NewConnector //nolint:gochecknoglobals
+
 // We re-export the following types so that they can be used by consumers of this library.
 type (
 	ReadParams               = common.ReadParams
@@ -118,6 +123,8 @@ var (
 // since you get type safety and more readable code.
 func New(provider providers.Provider, opts map[string]any) (Connector, error) { //nolint:ireturn
 	switch provider {
+	case providers.Mock:
+		return newMock(opts)
 	case providers.Salesforce:
 		return newSalesforce(opts)
 	case providers.Hubspot:
@@ -125,6 +132,39 @@ func New(provider providers.Provider, opts map[string]any) (Connector, error) { 
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnknownConnector, provider)
 	}
+}
+
+// newMock returns a new Mock Connector, by unwrapping the options and passing them to the Mock API.
+func newMock(opts map[string]any) (Connector, error) { //nolint:ireturn
+	var options []mock.Option
+
+	c, valid := getParam[*http.Client](opts, "client")
+	if valid {
+		options = append(options, mock.WithClient(c))
+	}
+
+	a, valid := getParam[common.AuthenticatedHTTPClient](opts, "authenticated-client")
+	if valid {
+		options = append(options, mock.WithAuthenticatedClient(a))
+	}
+
+	r, valid := getParam[func(ctx context.Context, params ReadParams) (*ReadResult, error)](opts, "read")
+	if valid {
+		options = append(options, mock.WithRead(r))
+	}
+
+	w, valid := getParam[func(ctx context.Context, params WriteParams) (*WriteResult, error)](opts, "write")
+	if valid {
+		options = append(options, mock.WithWrite(w))
+	}
+
+	l, valid := getParam[func(ctx context.Context, objectNames []string) (*ListObjectMetadataResult, error)](
+		opts, "list-object-metadata")
+	if valid {
+		options = append(options, mock.WithListObjectMetadata(l))
+	}
+
+	return Mock.New(options...)
 }
 
 // newSalesforce returns a new Salesforce Connector, by unwrapping the options and passing them to the Salesforce API.

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -12,9 +11,9 @@ import (
 type Connector struct {
 	client *common.JSONHTTPClient
 
-	read               func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)
-	write              func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)
-	listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)
+	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
+	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
@@ -31,13 +30,13 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	}()
 
 	params := &mockParams{
-		read: func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error) {
+		read: func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "read")
 		},
-		write: func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error) {
+		write: func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "write")
 		},
-		listObjectMetadata: func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error) {
+		listObjectMetadata: func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "listObjectMetadata")
 		},
 	}
@@ -78,14 +77,14 @@ func (c *Connector) Provider() providers.Provider {
 	return providers.Mock
 }
 
-func (c *Connector) Read(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error) {
+func (c *Connector) Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
 	return c.read(ctx, params)
 }
 
-func (c *Connector) Write(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error) {
+func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
 	return c.write(ctx, params)
 }
 
-func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error) {
+func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error) {
 	return c.listObjectMetadata(ctx, objectNames)
 }

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -85,6 +85,9 @@ func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*comm
 	return c.write(ctx, params)
 }
 
-func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error) {
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
 	return c.listObjectMetadata(ctx, objectNames)
 }

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -1,0 +1,91 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	client *common.JSONHTTPClient
+
+	read               func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)
+	write              func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer func() {
+		if re := recover(); re != nil {
+			tmp, ok := re.(error)
+			if !ok {
+				panic(re)
+			}
+
+			outErr = tmp
+			conn = nil
+		}
+	}()
+
+	params := &mockParams{
+		read: func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "read")
+		},
+		write: func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "write")
+		},
+		listObjectMetadata: func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "listObjectMetadata")
+		},
+	}
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	params, err := params.prepare()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Connector{
+		client:             params.client,
+		read:               params.read,
+		write:              params.write,
+		listObjectMetadata: params.listObjectMetadata,
+	}, nil
+}
+
+func (c *Connector) String() string {
+	return "mock"
+}
+
+func (c *Connector) Close() error {
+	return nil
+}
+
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.client.HTTPClient
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return providers.Mock
+}
+
+func (c *Connector) Read(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error) {
+	return c.read(ctx, params)
+}
+
+func (c *Connector) Write(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error) {
+	return c.write(ctx, params)
+}
+
+func (c *Connector) ListObjectMetadata(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error) {
+	return c.listObjectMetadata(ctx, objectNames)
+}

--- a/mock/errors.go
+++ b/mock/errors.go
@@ -1,0 +1,10 @@
+package mock
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+	ErrMissingParam   = errors.New("missing required parameter")
+)

--- a/mock/params.go
+++ b/mock/params.go
@@ -1,0 +1,82 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Option is a function which mutates the hubspot connector configuration.
+type Option func(params *mockParams)
+
+// WithClient sets the http client to use for the connector. Saves some boilerplate.
+func WithClient(client *http.Client) Option {
+	return func(params *mockParams) {
+		WithAuthenticatedClient(client)(params)
+	}
+}
+
+// WithAuthenticatedClient sets the http client to use for the connector. Its usage is optional.
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *mockParams) {
+		params.client = &common.JSONHTTPClient{
+			HTTPClient: &common.HTTPClient{
+				Client:       client,
+				ErrorHandler: common.InterpretError,
+			},
+		}
+	}
+}
+
+// WithRead sets the read function for the connector.
+func WithRead(read func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)) Option {
+	return func(params *mockParams) {
+		params.read = read
+	}
+}
+
+// WithWrite sets the write function for the connector.
+func WithWrite(write func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)) Option {
+	return func(params *mockParams) {
+		params.write = write
+	}
+}
+
+// WithListObjectMetadata sets the listObjectMetadata function for the connector.
+func WithListObjectMetadata(listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)) Option {
+	return func(params *mockParams) {
+		params.listObjectMetadata = listObjectMetadata
+	}
+}
+
+// mockParams is the internal configuration for the mock connector.
+type mockParams struct {
+	client             *common.JSONHTTPClient // required
+	read               func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)
+	write              func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)
+}
+
+// prepare finalizes and validates the connector configuration, and returns an error if it's invalid.
+func (p *mockParams) prepare() (out *mockParams, err error) {
+	if p.client == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "client")
+	}
+
+	if p.read == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "read")
+	}
+
+	if p.write == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "write")
+	}
+
+	if p.listObjectMetadata == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "listObjectMetadata")
+	}
+
+	return p, nil
+}

--- a/mock/params.go
+++ b/mock/params.go
@@ -45,7 +45,9 @@ func WithWrite(write func(ctx context.Context, params common.WriteParams) (*comm
 }
 
 // WithListObjectMetadata sets the listObjectMetadata function for the connector.
-func WithListObjectMetadata(listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)) Option {
+func WithListObjectMetadata(
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error),
+) Option {
 	return func(params *mockParams) {
 		params.listObjectMetadata = listObjectMetadata
 	}

--- a/mock/params.go
+++ b/mock/params.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
@@ -32,21 +31,21 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 }
 
 // WithRead sets the read function for the connector.
-func WithRead(read func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)) Option {
+func WithRead(read func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)) Option {
 	return func(params *mockParams) {
 		params.read = read
 	}
 }
 
 // WithWrite sets the write function for the connector.
-func WithWrite(write func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)) Option {
+func WithWrite(write func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)) Option {
 	return func(params *mockParams) {
 		params.write = write
 	}
 }
 
 // WithListObjectMetadata sets the listObjectMetadata function for the connector.
-func WithListObjectMetadata(listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)) Option {
+func WithListObjectMetadata(listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)) Option {
 	return func(params *mockParams) {
 		params.listObjectMetadata = listObjectMetadata
 	}
@@ -55,9 +54,9 @@ func WithListObjectMetadata(listObjectMetadata func(ctx context.Context, objectN
 // mockParams is the internal configuration for the mock connector.
 type mockParams struct {
 	client             *common.JSONHTTPClient // required
-	read               func(ctx context.Context, params connectors.ReadParams) (*connectors.ReadResult, error)
-	write              func(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error)
-	listObjectMetadata func(ctx context.Context, objectNames []string) (*connectors.ListObjectMetadataResult, error)
+	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
+	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
 }
 
 // prepare finalizes and validates the connector configuration, and returns an error if it's invalid.

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -52,7 +52,7 @@ const (
 var catalog = CatalogType{ // nolint:gochecknoglobals
 	Mock: {
 		AuthType: None,
-		BaseURL:  "https://mock.com",
+		BaseURL:  "https://not-a-real-domain.mock",
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
 				Insert: true,

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -55,14 +55,14 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		BaseURL:  "https://not-a-real-domain.mock",
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
-				Insert: true,
-				Update: true,
-				Upsert: true,
-				Delete: true,
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
 			},
 			Proxy:     true,
 			Read:      true,
-			Subscribe: true,
+			Subscribe: false,
 			Write:     true,
 		},
 		ProviderOpts: ProviderOpts{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -5,6 +5,7 @@ package providers
 // ================================================================================
 
 const (
+	Mock                                Provider = "mock"
 	Salesforce                          Provider = "salesforce"
 	Hubspot                             Provider = "hubspot"
 	LinkedIn                            Provider = "linkedIn"
@@ -49,6 +50,26 @@ const (
 // ================================================================================
 
 var catalog = CatalogType{ // nolint:gochecknoglobals
+	Mock: {
+		AuthType: None,
+		BaseURL:  "https://mock.com",
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: true,
+				Update: true,
+				Upsert: true,
+				Delete: true,
+			},
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+		ProviderOpts: ProviderOpts{
+			"isMock": "true",
+		},
+	},
+
 	// Salesforce configuration
 	Salesforce: {
 		AuthType: Oauth2,

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -5,6 +5,7 @@ package providers
 
 // Defines values for AuthType.
 const (
+	None   AuthType = "none"
 	Oauth2 AuthType = "oauth2"
 )
 

--- a/providers/types.yaml
+++ b/providers/types.yaml
@@ -16,7 +16,7 @@ components:
   schemas:
     AuthType:
       type: string
-      enum: [oauth2]
+      enum: [oauth2, none]
       x-oapi-codegen-extra-tags:
         validate: required
 


### PR DESCRIPTION
Certain tests are difficult to run against real providers. A prime example of that is a rate-limiting test, since we simply don't have enough actual data (in our test instance of salesforce, for example) to reliably trigger a 429 code. Another example is a load test, since we want to test the load tolerance of *our* system, not the load tolerance of the actual providers.

This PR introduces a mock connector, whose behavior can be dynamically configured via callback functions. It strives to be minimal, and leave the mock details up to the consumer.

This would be useful both in unit tests, as well as end-to-end tests.