### PR TITLE
Smartsheet: Add connector

### DIFF
--- a/microsoftdynamicscrm/read_test.go
+++ b/microsoftdynamicscrm/read_test.go
@@ -232,6 +232,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			defer tt.server.Close()
 
 			ctx := context.Background()

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -1080,7 +1080,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://app.smartsheet.com/b/authorize",
 			TokenURL:                  "https://api.smartsheet.com/2.0/token",
-      ExplicitScopesRequired:    true,
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
@@ -1132,7 +1132,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	GoogleContacts: {
 		AuthType: Oauth2,
 		BaseURL:  "https://people.googleapis.com",
-    OauthOpts: OauthOpts{
+		OauthOpts: OauthOpts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://accounts.google.com/o/oauth2/v2/auth",
 			TokenURL:                  "https://oauth2.googleapis.com/token",

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -42,6 +42,7 @@ const (
 	Slack                               Provider = "slack"
 	HelpScoutMailbox                    Provider = "helpScoutMailbox"
 	Webflow                             Provider = "webflow"
+	Smartsheet                          Provider = "smartsheet"
 )
 
 // ================================================================================
@@ -959,6 +960,33 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://webflow.com/oauth/authorize",
 			TokenURL:                  "https://api.webflow.com/oauth/access_token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+	// Smartsheet Support Configuration
+	Smartsheet: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.smartsheet.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://app.smartsheet.com/b/authorize",
+			TokenURL:                  "https://api.smartsheet.com/2.0/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1183,13 +1183,13 @@ var testCases = []struct { // nolint
 	{
 		provider:    Smartsheet,
 		description: "Valid Smartsheet provider config with no substitutions",
-    expected: &ProviderInfo{
+		expected: &ProviderInfo{
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
 				GrantType:                 AuthorizationCode,
-        AuthURL:                   "https://app.smartsheet.com/b/authorize",
+				AuthURL:                   "https://app.smartsheet.com/b/authorize",
 				TokenURL:                  "https://api.smartsheet.com/2.0/token",
-        ExplicitScopesRequired:    true,
+				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
 				TokenMetadataFields: TokenMetadataFields{
 					ScopesField: "scope",
@@ -1207,11 +1207,11 @@ var testCases = []struct { // nolint
 				Subscribe: false,
 				Write:     false,
 			},
-      BaseURL: "https://api.smartsheet.com",
-    },
+			BaseURL: "https://api.smartsheet.com",
+		},
 		expectedErr: nil,
 	},
-  {
+	{
 		provider:    StackExchange,
 		description: "Valid StackExchange provider config with non-existent substitutions",
 		expected: &ProviderInfo{
@@ -1245,7 +1245,7 @@ var testCases = []struct { // nolint
 	{
 		provider:    GoogleContacts,
 		description: "Valid GoogleContacts provider config with no substitutions",
-    	expected: &ProviderInfo{
+		expected: &ProviderInfo{
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{
 				GrantType:                 AuthorizationCode,
@@ -1269,11 +1269,11 @@ var testCases = []struct { // nolint
 				Subscribe: false,
 				Write:     false,
 			},
-      		BaseURL: "https://people.googleapis.com",
-    	},
+			BaseURL: "https://people.googleapis.com",
+		},
 		expectedErr: nil,
 	},
-  	{
+	{
 		provider:    GoogleMail,
 		description: "Valid GoogleMail provider config with no substitutions",
 		expected: &ProviderInfo{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1108,6 +1108,37 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Smartsheet,
+		description: "Valid Smartsheet provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://app.smartsheet.com/b/authorize",
+				TokenURL:                  "https://api.smartsheet.com/2.0/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
+			},
+			Support: Support{
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+			BaseURL: "https://api.smartsheet.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables

* {{scope}}

## Notes
Resolves #205
use 2.0 instead of v2 in the API call

## Testing 
### GET 
URL: <localhost:4444/2.0/sheets> 
List Sheets
![Screenshot 2567-04-14 at 12 57 23](https://github.com/amp-labs/connectors/assets/103050835/0accb9d4-eef0-4ddd-ac31-0320b1c83ae7)

### POST
URL: <localhost:4444/2.0/folders/3384993222289284/sheets> 
Create Sheet
![Screenshot 2567-04-14 at 12 50 20](https://github.com/amp-labs/connectors/assets/103050835/f856fe10-6525-4b3a-b961-9bf46c4768f8)

### PUT 
URL:<localhost:4444/2.0/folders/3384993222289284>
Update Folder
![Screenshot 2567-04-16 at 09 54 00](https://github.com/amp-labs/connectors/assets/103050835/da86a99d-aaad-4dd5-9d00-4f631f8da206)

### DELETE
URL:<localhost:4444/2.0/sheets/557813268959108>
Delete Sheet
![Screenshot 2567-04-16 at 09 30 58](https://github.com/amp-labs/connectors/assets/103050835/8052fd3d-6b3d-44f8-b817-a438678b02cd)

## Pagination
GET <localhost:4444/2.0/sheets?pageSize=2&page=3>
List Sheets with pagination, 2 items per page, display page 3
![Screenshot 2567-04-14 at 12 58 58](https://github.com/amp-labs/connectors/assets/103050835/64f6e90a-9070-4aeb-a5cc-098cfd716081)