### PR TITLE
Zuora: Add connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -1402,8 +1402,8 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		BaseURL:  "https://{{.subdomain}}.zuora.com",
 		OauthOpts: OauthOpts{
 			GrantType:                 ClientCredentials,
-			AuthURL:                   "https://rest.test.zuora.com/oauth/auth_mock",
-			TokenURL:                  "https://rest.test.zuora.com/oauth/token",
+			AuthURL:                   "https://{{.subdomain}}.zuora.com/oauth/auth_mock",
+			TokenURL:                  "https://{{.subdomain}}.zuora.com/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -57,6 +57,7 @@ const (
 	Figma                               Provider = "figma"
 	Miro                                Provider = "miro"
 	Typeform                            Provider = "typeform"
+	Zuora                               Provider = "zuora"
 )
 
 // ================================================================================
@@ -1379,6 +1380,31 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://api.typeform.com/oauth/authorize",
 			TokenURL:                  "https://api.typeform.com/oauth/token",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Zuora Configuration
+	Zuora: {
+		AuthType: Oauth2,
+		BaseURL:  "https://rest.test.zuora.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 ClientCredentials,
+			AuthURL:                   "https://rest.test.zuora.com/oauth/auth_mock",
+			TokenURL:                  "https://rest.test.zuora.com/oauth/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -1399,7 +1399,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// Zuora Configuration
 	Zuora: {
 		AuthType: Oauth2,
-		BaseURL:  "https://rest.test.zuora.com",
+		BaseURL:  "https://{{.subdomain}}.zuora.com",
 		OauthOpts: OauthOpts{
 			GrantType:                 ClientCredentials,
 			AuthURL:                   "https://rest.test.zuora.com/oauth/auth_mock",

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1565,7 +1565,10 @@ var testCases = []struct { // nolint
 	},
 	{
 		provider:    Zuora,
-		description: "Valid Zuora provider config with no substitutions",
+		description: "Valid Zuora provider config with substitutions",
+		substitutions: map[string]string{
+			"subdomain": "rest.test",
+		},
 		expected: &ProviderInfo{
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1563,6 +1563,34 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Zuora,
+		description: "Valid Zuora provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 ClientCredentials,
+				AuthURL:                   "https://rest.test.zuora.com/oauth/auth_mock",
+				TokenURL:                  "https://rest.test.zuora.com/oauth/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+			},
+			Support: Support{
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+			BaseURL: "https://rest.test.zuora.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch 

## Catalog variables
no variables

## Notes
Resolves #226 

AuthURL used is a mock URL, since Zuora does not require a code for receiving a token.

Use /v1/ instead of /v2/ in the API calls.

## Testing 
### GET 
URL: <localhost:4444/v1/object/product/8a8aa2028ef98921018eff24f27d799b> 
Retrieve a Product
<img width="684" alt="Screenshot 2024-04-21 at 13 33 57" src="https://github.com/amp-labs/connectors/assets/103050835/ae22b96c-2d15-404a-a7d9-a43bdb8b53b1">

### POST
URL: <localhost:4444/v1/object/product> 
Create a Product
<img width="684" alt="Screenshot 2024-04-21 at 13 30 16" src="https://github.com/amp-labs/connectors/assets/103050835/9af380c7-9724-4d55-8fd1-47238c806be0">

### PUT
URL: <localhost:4444/v1/object/product/8a8aa2028ef98921018eff24f27d799b> 
Update a Product
<img width="699" alt="Screenshot 2024-04-21 at 13 36 00" src="https://github.com/amp-labs/connectors/assets/103050835/38a534c2-9b37-4e3e-8bb2-bd509a261cee">


### DELETE
URL: <localhost:4444/v1/object/product/8a8aa2028ef98921018eff24f27d799b> 
Delete a Product
<img width="684" alt="Screenshot 2024-04-21 at 13 36 20" src="https://github.com/amp-labs/connectors/assets/103050835/32ef3783-efaf-4a96-a751-a3b2e5764485">

## Pagination
Get a list of products without pagination
<img width="677" alt="Screenshot 2024-04-21 at 13 38 33" src="https://github.com/amp-labs/connectors/assets/103050835/1ec85bff-dfb2-4c0b-9649-ae7bce959620">

Get a list of products with pagination (3 items per page, land on page 3)
<img width="691" alt="Screenshot 2024-04-21 at 13 39 29" src="https://github.com/amp-labs/connectors/assets/103050835/7a45618a-68bc-4946-bdff-8f0ea7e7cdc7">
