### PR TITLE
feat: Add Monday auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -50,6 +50,7 @@ const (
 	Google                              Provider = "google"
 	GoogleContacts                      Provider = "googleContacts"
 	GoogleMail                          Provider = "googleMail"
+	Monday                              Provider = "monday"
 )
 
 // ================================================================================
@@ -1197,6 +1198,33 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://accounts.google.com/o/oauth2/v2/auth",
 			TokenURL:                  "https://oauth2.googleapis.com/token",
 			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	Monday: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.monday.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://auth.monday.com/oauth2/authorize",
+			TokenURL:                  "https://auth.monday.com/oauth2/token",
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1338,6 +1338,37 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Monday,
+		description: "Valid Monday provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://auth.monday.com/oauth2/authorize",
+				TokenURL:                  "https://auth.monday.com/oauth2/token",
+				ExplicitScopesRequired:    false,
+				ExplicitWorkspaceRequired: false,
+				TokenMetadataFields: TokenMetadataFields{
+					ScopesField: "scope",
+				},
+			},
+			Support: Support{
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+			BaseURL: "https://api.monday.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -108,10 +108,7 @@ func main() {
 	provider := registry.MustString("Provider")
 	clientId := registry.MustString("ClientId")
 	clientSecret := registry.MustString("ClientSecret")
-	accessToken := registry.MustString("AccessToken")
-	refreshToken := registry.MustString("RefreshToken")
-	atExpiry := registry.MustString("Expiry")
-	atExpiryTimeFormat := registry.MustString("ExpiryFormat")
+	tokens := getTokensFromRegistry()
 
 	scopes, err := registry.GetString("Scopes")
 	if err != nil {
@@ -131,10 +128,33 @@ func main() {
 		substitutionsMap[key] = val.MustString()
 	}
 
+	validateRequiredFlags(provider, clientId, clientSecret)
+	startProxy(provider, oauthScopes, clientId, clientSecret, substitutionsMap, DefaultPort, tokens)
+}
+
+// Some connectors may implement Refresh tokens, when it happens expiry must be provided alongside.
+// Library shouldn't attempt to refresh tokens if API doesn't support `refresh_token` grant type.
+func getTokensFromRegistry() *oauth2.Token {
+	accessToken := registry.MustString("AccessToken")
+	refreshToken, err := registry.GetString("RefreshToken")
+
+	if err != nil {
+		// we are working without refresh token
+		return &oauth2.Token{
+			AccessToken: accessToken,
+		}
+	}
+
+	// refresh token should be specified with expiry
+	atExpiry := registry.MustString("Expiry")
+	atExpiryTimeFormat := registry.MustString("ExpiryFormat")
 	expiry := parseAccessTokenExpiry(atExpiry, atExpiryTimeFormat)
 
-	validateRequiredFlags(provider, clientId, clientSecret)
-	startProxy(provider, oauthScopes, clientId, clientSecret, substitutionsMap, DefaultPort, accessToken, refreshToken, expiry)
+	return &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Expiry:       expiry, // required: will trigger reuse of refresh token
+	}
 }
 
 func parseAccessTokenExpiry(expiryStr, timeFormat string) time.Time {
@@ -176,8 +196,8 @@ func validateRequiredFlags(provider, clientId, clientSecret string) {
 	}
 }
 
-func startProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, port int, accessToken, refreshToken string, expiry time.Time) {
-	proxy := buildProxy(provider, scopes, clientId, clientSecret, substitutions, accessToken, refreshToken, expiry)
+func startProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, port int, tokens *oauth2.Token) {
+	proxy := buildProxy(provider, scopes, clientId, clientSecret, substitutions, tokens)
 	http.Handle("/", proxy)
 
 	fmt.Printf("\nProxy server listening on :%d\n", port)
@@ -187,10 +207,10 @@ func startProxy(provider string, scopes []string, clientId, clientSecret string,
 	}
 }
 
-func buildProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, accessToken, refreshToken string, expiry time.Time) *Proxy {
+func buildProxy(provider string, scopes []string, clientId, clientSecret string, substitutions map[string]string, tokens *oauth2.Token) *Proxy {
 	providerInfo := getProviderConfig(provider, substitutions)
 	cfg := configureOAuth(clientId, clientSecret, scopes, providerInfo)
-	httpClient := setupHttpClient(cfg, accessToken, refreshToken, provider, expiry, providerInfo)
+	httpClient := setupHttpClient(cfg, tokens, provider, providerInfo)
 
 	target, err := url.Parse(providerInfo.BaseURL)
 	if err != nil {
@@ -223,16 +243,12 @@ func configureOAuth(clientId, clientSecret string, scopes []string, providerInfo
 }
 
 // This helps with refreshing tokens automatically.
-func setupHttpClient(cfg *oauth2.Config, accessToken, refreshToken, provider string, expiry time.Time, providerInfo *providers.ProviderInfo) *http.Client {
+func setupHttpClient(cfg *oauth2.Config, tokens *oauth2.Token, provider string, providerInfo *providers.ProviderInfo) *http.Client {
 	ctx := context.Background()
 
 	conn, err := connector.NewConnector(
 		provider,
-		connector.WithClient(ctx, http.DefaultClient, cfg, &oauth2.Token{
-			AccessToken:  accessToken,
-			RefreshToken: refreshToken,
-			Expiry:       expiry, // will trigger reuse of refresh token
-		}),
+		connector.WithClient(ctx, http.DefaultClient, cfg, tokens),
 	)
 	if err != nil {
 		panic(err)

--- a/test/outreach/read/read.go
+++ b/test/outreach/read/read.go
@@ -69,6 +69,7 @@ func main() {
 		ObjectName: "users",
 		// NextPage:   "https://api.outreach.io/api/v2/users?page%5Blimit%5D=1\u0026page%5Boffset%5D=2",
 	}
+
 	result, err := outreach.Read(context.Background(), config)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Closes #241
# Fix: make refresh process optional
Monday doesn't support refresh_token grant. Our library musn't even attempt to make such call in a first place. As of now the error would look as follows:
```
http: proxy error: Get "https://api.monday.com/v2/get_schema": oauth2: "unsupported_grant_type" "Unsupported grant_type param. Please use authorization_code"
```

# Add: Monday auth connector

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing


## Token Response
```
{
  "access_token":"...",
  "scope":"me:read,boards:read,boards:write,docs:read,docs:write,workspaces:read,workspaces:write,users:read,users:write,account:read,notifications:write,updates:read,assets:read,updates:write,teams:read,tags:read,webhooks:write,webhooks:read",
  "token_type":"bearer"  
}
```

## Catalog variables
No explicit scopes.

## Notes

## Testing GraphQL
URL: `http://localhost:4444/v2`
### READ
Get boards.
```
{
    "query":"query { boards {id name type communication board_kind creator {name}}}"
}
```
![image](https://github.com/amp-labs/connectors/assets/60330780/1d21de72-6a30-42f5-bdc3-0eab45713da9)


### CREATE
Create item on board.
```
{
    "query":"mutation{ create_item (board_id: 1859691069, item_name: \"New Item\"){id name}}"
}
```
![image](https://github.com/amp-labs/connectors/assets/60330780/3053950d-0722-4270-bfa0-a64d6caf9c59)


### METADATA
URL: `http://localhost:4444/v2/get_schema`
![image](https://github.com/amp-labs/connectors/assets/60330780/677f0def-f6dd-4346-896b-88248dafbba1)


## Pagination

### First Page
Get list of items on the board
```
{
    "query":"query { boards (ids: 1859691069) {items_page (limit: 4) {cursor items{id name}}}}"
}
```
![image](https://github.com/amp-labs/connectors/assets/60330780/5c07dea7-55aa-43aa-9606-2f67f8652c5e)

### Second Page
```
{
    "query":"query { boards (ids: 1859691069) {items_page (limit: 4, cursor: \"MSwxODU5NjkxMDY5LFB3Z0VoQ052dTZnS09IRDRVR0VuNSw2LDQsfDI0NjQ2NjU5NjM\") {cursor items{id name}}}}"
}
```
![image](https://github.com/amp-labs/connectors/assets/60330780/463fd7e2-e3c7-40e8-bae4-e7111e8b34ca)



