### PR TITLE
feat: Add Typeform auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -55,6 +55,7 @@ const (
 	GoogleMail                          Provider = "googleMail"
 	Monday                              Provider = "monday"
 	Miro                                Provider = "miro"
+	Typeform                            Provider = "typeform"
 )
 
 // ================================================================================
@@ -1329,6 +1330,30 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				WorkspaceRefField: "team_id",
 				ScopesField:       "scope",
 			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	Typeform: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.typeform.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://api.typeform.com/oauth/authorize",
+			TokenURL:                  "https://api.typeform.com/oauth/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1506,6 +1506,34 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    Typeform,
+		description: "Valid Typeform provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://api.typeform.com/oauth/authorize",
+				TokenURL:                  "https://api.typeform.com/oauth/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+			},
+			Support: Support{
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+			BaseURL: "https://api.typeform.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
Closes #242 

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Token Response
```
{
  "access_token":"....",
  "expires_in":604800,
  "refresh_token":"...",
  "state":"",
  "token_type":"bearer"
}
```


## Catalog variables
We are using default data center by omitting it. We couldv'e specfied `eu.`
```
  "substitutions": {
    "dataCenter" : ""
  }
```

## Notes

## Testing
### GET
URL: http://localhost:4444/forms
List forms.
![image](https://github.com/amp-labs/connectors/assets/60330780/9276663d-5db0-4ac0-916b-1b67abaa1063)

### POST
URL: http://localhost:4444/forms
![image](https://github.com/amp-labs/connectors/assets/60330780/fc7f78a5-00cf-46a6-993c-bd2ecf30be0a)


### PATCH
URL: http://localhost:4444/forms/BvXy6fa1
Changed form tittle. We are giving an array of changes to apply.
![image](https://github.com/amp-labs/connectors/assets/60330780/41bdc7d3-d459-44e4-901b-7cea3a8bdd02)


### PUT
URL: http://localhost:4444/forms/BvXy6fa1
Same as Patch but the whole object is published.
![image](https://github.com/amp-labs/connectors/assets/60330780/3c58fd49-69ba-4a49-9513-80fa7288a419)


### DELETE
URL: http://localhost:4444/forms/BvXy6fa1
Remove form.
![image](https://github.com/amp-labs/connectors/assets/60330780/115db329-ea39-4a52-8f70-3fbc911b9ba4)


## Pagination

### First page
URL: http://localhost:4444/forms?page=1&page_size=3
![image](https://github.com/amp-labs/connectors/assets/60330780/bc126ec2-b15b-4b3e-b3f4-dc1f5ef2a9b3)


### Second Page
URL: http://localhost:4444/forms?page=2&page_size=3
![image](https://github.com/amp-labs/connectors/assets/60330780/6adb335d-935e-4157-b5ec-9fbbc1ba0841)

