### PR TITLE
fix: Remove the mock connector from the catalog

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -57,26 +57,6 @@ const (
 // ================================================================================
 
 var catalog = CatalogType{ // nolint:gochecknoglobals
-	Mock: {
-		AuthType: None,
-		BaseURL:  "https://not-a-real-domain.mock",
-		Support: Support{
-			BulkWrite: BulkWriteSupport{
-				Insert: false,
-				Update: false,
-				Upsert: false,
-				Delete: false,
-			},
-			Proxy:     true,
-			Read:      true,
-			Subscribe: false,
-			Write:     true,
-		},
-		ProviderOpts: ProviderOpts{
-			"isMock": "true",
-		},
-	},
-
 	// Salesforce configuration
 	Salesforce: {
 		AuthType: Oauth2,


### PR DESCRIPTION
Does as the title says. This is necessary because the OpenAPI validations are failing, and frankly the frontend doesn't need this to be visible anyways.