### PR TITLE
[On-call] invalid grant error. 

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -580,7 +580,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// DocuSign configuration
 	// TODO: we don't have a good way to get the server string yet. Need to make API call to /oauth/userinfo.
 	// Leaving this connector commented out until that is unblocked.
-	//DocuSign: {
+	// DocuSign: {
 	//	AuthType: Oauth2,
 	//	BaseURL:  "https://{{.server}}.docusign.net",
 	//	OauthOpts: OauthOpts{

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -49,7 +50,7 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error {
 	}
 
 	for _, sfErr := range errs {
-		switch sfErr.ErrorCode {
+		switch strings.ToUpper(sfErr.ErrorCode) {
 		case "INVALID_SESSION_ID":
 			return createError(common.ErrInvalidSessionId, sfErr)
 		case "INSUFFICIENT_ACCESS_OR_READONLY":

--- a/salesforce/read.go
+++ b/salesforce/read.go
@@ -50,6 +50,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		if strings.Contains(err.Error(), "invalid_grant") {
 			return nil, common.ErrInvalidGrant
 		}
+
 		return nil, err
 	}
 

--- a/salesforce/read.go
+++ b/salesforce/read.go
@@ -47,6 +47,9 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	if err != nil {
+		if strings.Contains(err.Error(), "invalid_grant") {
+			return nil, common.ErrInvalidGrant
+		}
 		return nil, err
 	}
 

--- a/salesforce/read.go
+++ b/salesforce/read.go
@@ -47,10 +47,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	if err != nil {
-		if strings.Contains(err.Error(), "invalid_grant") {
-			return nil, common.ErrInvalidGrant
-		}
-
 		return nil, err
 	}
 


### PR DESCRIPTION
When salesforce returns invalid_grant error, it is not exactly captured with right error type. We should capture it and return invalid error type so the caller can better handle it. 

