### PR TITLE
fix: add module validation for Hubspot connector

### DIFF
--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -21,6 +21,20 @@ var ModuleEmpty = APIModule{ // nolint: gochecknoglobals
 	Version: "",
 }
 
+// supportedModules represents currently working and supported modules within the Hubspot connector.
+// Any added module should be appended added here.
+var supportedModules = []APIModule{ModuleCRM} // nolint: gochecknoglobals
+
 func (a APIModule) String() string {
 	return fmt.Sprintf("%s/%s", a.Label, a.Version)
+}
+
+func supportsModule(module string) bool {
+	for _, mod := range supportedModules {
+		if module == mod.String() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -69,6 +69,12 @@ func (p *hubspotParams) prepare() (out *hubspotParams, err error) {
 		return nil, ErrMissingClient
 	}
 
+	// making sure the provided module is supported.
+	// If the provide module is not supprted. defaults to CRM.
+	if !supportsModule(p.module) {
+		p.module = ModuleCRM.String()
+	}
+
 	return p, nil
 }
 


### PR DESCRIPTION
This adds the validation of the module in hubspot package. The client is expected to provide this during Connector creation.