### PR TITLE
fix: update errors values

### DIFF
--- a/outreach/errors.go
+++ b/outreach/errors.go
@@ -1,16 +1,5 @@
 package outreach
 
-import (
-	"errors"
-)
-
-var (
-	ErrMissingClient = errors.New("JSON http client not set")
-	ErrNotArray      = errors.New("results data is not an array")
-	ErrNotObject     = errors.New("record is not an object")
-	ErrNotString     = errors.New("next is not a string")
-)
-
 func (c *Connector) HandleError(err error) error {
 	return err
 }

--- a/outreach/params.go
+++ b/outreach/params.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"golang.org/x/oauth2"
 )
 
@@ -43,7 +44,7 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 func (params *outreachParams) prepare() (*outreachParams, error) {
 	if params.client == nil {
-		return nil, ErrMissingClient
+		return nil, paramsbuilder.ErrMissingClient
 	}
 
 	return params, nil

--- a/outreach/parse.go
+++ b/outreach/parse.go
@@ -33,7 +33,7 @@ func parsePagingNext(node *ajson.Node) (*ajson.Node, error) {
 	}
 
 	if !links.IsObject() {
-		return nil, ErrNotObject
+		return nil, common.ErrNotObject
 	}
 
 	return links, nil
@@ -51,7 +51,7 @@ func checkURL(node *ajson.Node) (string, error) {
 	}
 
 	if !next.IsString() {
-		return "", ErrNotString
+		return "", common.ErrNotString
 	}
 
 	return next.String(), nil
@@ -65,7 +65,7 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 	}
 
 	if !records.IsArray() {
-		return nil, ErrNotArray
+		return nil, common.ErrNotArray
 	}
 
 	arr := records.MustArray()
@@ -74,7 +74,7 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 
 	for _, v := range arr {
 		if !v.IsObject() {
-			return nil, ErrNotObject
+			return nil, common.ErrNotObject
 		}
 
 		data, err := v.Unpack()
@@ -84,7 +84,7 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 
 		m, ok := data.(map[string]interface{})
 		if !ok {
-			return nil, ErrNotObject
+			return nil, common.ErrNotObject
 		}
 
 		out = append(out, m)
@@ -101,7 +101,7 @@ func getTotalSize(node *ajson.Node) (int64, error) {
 	}
 
 	if !node.IsArray() {
-		return 0, ErrNotArray
+		return 0, common.ErrNotArray
 	}
 
 	return int64(node.Size()), nil


### PR DESCRIPTION
Updates the error variables being used, Updates outreach connector to use the exported errors in common package instead of creating it's own variables. Would also prefer if they were all in error.go. All providers may need this update 