### PR TITLE
Gong workspace substitution removal

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -532,7 +532,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	// Gong configuration
 	Gong: {
 		AuthType: Oauth2,
-		BaseURL:  "https://{{.workspace}}.api.gong.io",
+		BaseURL:  "https://api.gong.io",
 		OauthOpts: OauthOpts{
 			AuthURL:                   "https://app.gong.io/oauth2/authorize",
 			TokenURL:                  "https://app.gong.io/oauth2/generate-customer-token",

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -573,10 +573,7 @@ var testCases = []struct { // nolint
 	},
 	{
 		provider:    Gong,
-		description: "Gong provider config with valid substitutions",
-		substitutions: map[string]string{
-			"workspace": "testing",
-		},
+		description: "Gong provider config without substitutions",
 		expected: &ProviderInfo{
 			Support: Support{
 				Read:  false,
@@ -601,7 +598,7 @@ var testCases = []struct { // nolint
 					ConsumerRefField: "client_id",
 				},
 			},
-			BaseURL: "https://testing.api.gong.io",
+			BaseURL: "https://api.gong.io",
 		},
 		expectedErr: nil,
 	},


### PR DESCRIPTION
Changes to the base URL as per Gong API webcast 

+ branch
+ tests

##GET direct no shards

![Gong ok direct no shards](https://github.com/amp-labs/connectors/assets/95291462/a7a8b109-fc1f-4562-9a02-1dd595b82946)

##GET proxy no shards

![Gong proxy ok no shards (1)](https://github.com/amp-labs/connectors/assets/95291462/b49263b1-1782-4dfa-8298-924381784ca8)



Closes #267 