### PR TITLE
enable proxy: Zendesk Support

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -932,7 +932,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1031,7 +1031,7 @@ var testCases = []struct { // nolint
 					Delete: false,
 				},
 				Subscribe: false,
-				Proxy:     false,
+				Proxy:     true,
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{


### PR DESCRIPTION
Closes #146 

## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Catalog variables
Workspace: d3v-ampersand
Scopes: read write

## Notes
Access token doesn't expire. There is no refresh token.
In postman the proxy is set to Ampersand: `{{amp}}=https://proxy.withampersand.com`

## Testing
### GET
URL: https://proxy.withampersand.com/api/v2/tickets
List Tickets.
![image](https://github.com/amp-labs/connectors/assets/60330780/2c08de8b-ed3c-455b-8c7c-6ffc7b670190)

### POST
URL: https://proxy.withampersand.com/api/v2/tickets
Create ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/bf761594-6376-4474-8da8-3e44ad576132)

### PUT
URL: https://proxy.withampersand.com/api/v2/tickets/1
Update ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/2d18e83a-c857-48b7-9efe-7380ef314a27)

### DELETE
URL: https://proxy.withampersand.com/api/v2/tickets/8
Remove ticket.
![image](https://github.com/amp-labs/connectors/assets/60330780/09e1857e-e615-41a5-941d-f88954655d27)
Deleting or getting resource one more time returns expected error from API.
![image](https://github.com/amp-labs/connectors/assets/60330780/68e5ac1d-d9c2-4fd4-92cd-65f99f96bc1b)


## Incorrect requests

### Wrong verb
DELETE https://proxy.withampersand.com/api/v2/tickets
![image](https://github.com/amp-labs/connectors/assets/60330780/22031e65-cadb-4b5e-b7b5-4376609ee4ed)

### Wrong path
GET https://proxy.withampersand.com/api/v2/bananas
![image](https://github.com/amp-labs/connectors/assets/60330780/ae7d6d90-702b-413d-947a-3f406ba4e000)


## Pagination
### First Page
![image](https://github.com/amp-labs/connectors/assets/60330780/7f05ef3a-28bc-4f41-a2b0-00b19a5e5efc)

### Second Page
URL: https://proxy.withampersand.com/api/v2/users?page[after]=eyJvIjoiaWQiLCJ2IjoiYVpQMTJrRDZGd0FBIn0%3D&page[size]=1
![image](https://github.com/amp-labs/connectors/assets/60330780/29eae4f8-c01f-4b43-9406-3936f3915dcb)
