### PR TITLE
feat: Update outreach proxy support

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -199,7 +199,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -175,7 +175,7 @@ var testCases = []struct { // nolint
 					Delete: false,
 				},
 				Subscribe: false,
-				Proxy:     false,
+				Proxy:     true,
 			},
 			AuthType: Oauth2,
 			OauthOpts: OauthOpts{


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

## Notes
No fishy behaviour observed. All the request/responses were parsed correctly.

## Testing 
### GET 
URL: https://proxy.withampersand.com/api/v2/emailAddresses
<img width="1157" alt="Screenshot 2024-05-06 at 08 33 29" src="https://github.com/amp-labs/connectors/assets/52887226/4c9a5570-b9d7-4e61-acd3-73c8d092c1ef">


### POST
URL: https://proxy.withampersand.com/api/v2/emailAddresses
<img width="1138" alt="Screenshot 2024-05-06 at 09 04 49" src="https://github.com/amp-labs/connectors/assets/52887226/16b1d89b-15ab-4160-9759-b5b856371ca0">

### PATCH
URL: https://proxy.withampersand.com/api/v2/templates/1
<img width="1150" alt="Screenshot 2024-05-06 at 10 08 42" src="https://github.com/amp-labs/connectors/assets/52887226/e74caff3-0e04-43c8-8724-29eed02c001c">

### DELETE
URL: https://proxy.withampersand.com/api/v2/emailAddresses/4
<img width="1149" alt="Screenshot 2024-05-06 at 08 35 31" src="https://github.com/amp-labs/connectors/assets/52887226/f07b9186-f1f8-43bd-b93c-3169d23f61ee">


## Pagination
Requeating a paginated list of emailAddresses:
URL: https://proxy.withampersand.com/api/v2/emailAddresses?count=false&page%5Bsize%5D=10
<img width="1143" alt="Screenshot 2024-05-06 at 09 06 36" src="https://github.com/amp-labs/connectors/assets/52887226/76eba0fd-6f7e-4ea6-a584-1fb34863f599">

Requesting the next page using the next link provided in the previous request.
<img width="1280" alt="Screenshot 2024-05-06 at 09 07 23" src="https://github.com/amp-labs/connectors/assets/52887226/0782c606-b53e-40cc-bcd3-ef9d59924584">

Going to the next and last page:
<img width="1280" alt="Screenshot 2024-05-06 at 09 07 51" src="https://github.com/amp-labs/connectors/assets/52887226/fe324a03-cc91-4287-add8-66b913840720">

closes #279 