### PR TITLE
feat: Add DropboxSign auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -58,6 +58,7 @@ const (
 	Miro                                Provider = "miro"
 	Typeform                            Provider = "typeform"
 	Zuora                               Provider = "zuora"
+	DropboxSign                         Provider = "dropboxSign"
 )
 
 // ================================================================================
@@ -1405,6 +1406,30 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			AuthURL:                   "https://{{.subdomain}}.zuora.com/oauth/auth_mock",
 			TokenURL:                  "https://{{.subdomain}}.zuora.com/oauth/token",
 			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// DropboxSign Configuration
+	DropboxSign: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.hellosign.com",
+		OauthOpts: OauthOpts{
+			AuthURL:                   "https://app.hellosign.com/oauth/authorize",
+			TokenURL:                  "https://app.hellosign.com/oauth/token",
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -1427,6 +1427,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://api.hellosign.com",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://app.hellosign.com/oauth/authorize",
 			TokenURL:                  "https://app.hellosign.com/oauth/token",
 			ExplicitScopesRequired:    true,

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1594,6 +1594,35 @@ var testCases = []struct { // nolint
 		},
 		expectedErr: nil,
 	},
+	{
+		provider:    DropboxSign,
+		description: "Valid DropboxSign provider config with no substitutions",
+		expected: &ProviderInfo{
+			AuthType: Oauth2,
+			OauthOpts: OauthOpts{
+				GrantType:                 AuthorizationCode,
+				AuthURL:                   "https://app.hellosign.com/oauth/authorize",
+				TokenURL:                  "https://app.hellosign.com/oauth/token",
+				ExplicitScopesRequired:    true,
+				ExplicitWorkspaceRequired: false,
+			},
+			Support: Support{
+				BulkWrite: BulkWriteSupport{
+					Insert: false,
+					Update: false,
+					Upsert: false,
+					Delete: false,
+				},
+				Proxy:     false,
+				Read:      false,
+				Subscribe: false,
+				Write:     false,
+			},
+
+			BaseURL: "https://api.hellosign.com",
+		},
+		expectedErr: nil,
+	},
 }
 
 func TestReadInfo(t *testing.T) { // nolint


### PR DESCRIPTION
Closes https://github.com/amp-labs/connectors/issues/280

## Checklist
 
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch
- [x] Catalog variables

## Provider 
dropboxSign Provider = "dropboxSign"

## Notes
It supports pagination and batching

## Testing
### GET
URL: http://localhost:4444/v3/account?email_address=sanjaykanth@gmail.com
![GET](https://github.com/amp-labs/connectors/assets/163011126/bca37e6d-3b04-4974-96c9-2f29f24e258e)



### POST
URL: http://localhost:4444/v3/account/create
![POST](https://github.com/amp-labs/connectors/assets/163011126/f3a44bf7-40cf-4341-940b-ebff1f6b5440)


### PUT
URL: http://localhost:4444/v3/account
![PUT](https://github.com/amp-labs/connectors/assets/163011126/a8ef2222-bd3f-4859-baac-d6cf52b56b75)
