### PR TITLE
feat: Implement Outreach ListMetadata

### DIFF
--- a/outreach/errors.go
+++ b/outreach/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrNotArray      = errors.New("results data is not an array")
 	ErrNotObject     = errors.New("record is not an object")
 	ErrNotString     = errors.New("next is not a string")
+	ErrEmptyResponse = errors.New("empty response body")
 )
 
 func (c *Connector) HandleError(err error) error {

--- a/outreach/metadata.go
+++ b/outreach/metadata.go
@@ -41,6 +41,8 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 
 		// Check nil response body, to avoid panic.
 		if res == nil || res.Body == nil {
+			objMetadata.Errors[obj] = ErrEmptyResponse
+
 			continue
 		}
 

--- a/outreach/metadata.go
+++ b/outreach/metadata.go
@@ -1,0 +1,77 @@
+package outreach
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+type ObjectOKResponse struct {
+	Data []map[string]any `json:"data"`
+}
+
+func (c *Connector) ListObjectMetadata(ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	objMetadata := common.ListObjectMetadataResult{
+		Result: make(map[string]common.ObjectMetadata),
+		Errors: make(map[string]error),
+	}
+
+	for _, obj := range objectNames {
+		// Constructing the  request url.
+		objURL, err := url.JoinPath(c.BaseURL, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := c.get(ctx, objURL)
+		if err != nil {
+			objMetadata.Errors[obj] = err
+		}
+
+		// Check nil response body, to avoid panic.
+		if res == nil || res.Body == nil {
+			objMetadata.Errors[obj] = ErrEmptyResponse
+			continue
+		}
+
+		metadata, err := metadataMapper(res.Body.Source())
+		if err != nil {
+			return nil, err
+		}
+
+		metadata.DisplayName = obj
+		objMetadata.Result[obj] = metadata
+	}
+
+	return &objMetadata, nil
+}
+
+func metadataMapper(body []byte) (common.ObjectMetadata, error) {
+	metadata := common.ObjectMetadata{
+		FieldsMap: make(map[string]string),
+	}
+
+	var response ObjectOKResponse
+
+	err := json.Unmarshal(body, &response)
+	if err != nil {
+		return metadata, err
+	}
+
+	for _, dataMap := range response.Data {
+		for attr := range dataMap {
+			metadata.FieldsMap[attr] = attr
+		}
+	}
+
+	return metadata, nil
+}

--- a/outreach/metadata.go
+++ b/outreach/metadata.go
@@ -35,6 +35,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		res, err := c.get(ctx, objURL)
 		if err != nil {
 			objMetadata.Errors[obj] = err
+			continue
 		}
 
 		// Check nil response body, to avoid panic.

--- a/outreach/metadata.go
+++ b/outreach/metadata.go
@@ -35,12 +35,12 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		res, err := c.get(ctx, objURL)
 		if err != nil {
 			objMetadata.Errors[obj] = err
+
 			continue
 		}
 
 		// Check nil response body, to avoid panic.
 		if res == nil || res.Body == nil {
-			objMetadata.Errors[obj] = ErrEmptyResponse
 			continue
 		}
 

--- a/test/outreach/metadata/metadata.go
+++ b/test/outreach/metadata/metadata.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/outreach"
+	testUtils "github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/utils"
+)
+
+const (
+	DefaultCredsFile = "creds.json"
+)
+
+func GetOutreachConnector(ctx context.Context, filePath string) *outreach.Connector {
+	registry := utils.NewCredentialsRegistry()
+
+	readers := []utils.Reader{
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['clientId']",
+			CredKey:  "clientId",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['clientSecret']",
+			CredKey:  "clientSecret",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['refreshToken']",
+			CredKey:  "refreshToken",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['accessToken']",
+			CredKey:  "accessToken",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['provider']",
+			CredKey:  "provider",
+		},
+	}
+	registry.AddReaders(readers...)
+
+	cfg := utils.OutreachOAuthConfigFromRegistry(registry)
+	tok := utils.OutreachOauthTokenFromRegistry(registry)
+
+	conn, err := connectors.Outreach(
+		outreach.WithClient(ctx, http.DefaultClient, cfg, tok),
+	)
+	if err != nil {
+		testUtils.Fail("error creating outreach connector", "error", err)
+	}
+
+	return conn
+}
+
+func main() {
+	objects := []string{"emailAddresses", "users", "ladecima"}
+
+	ctx := context.Background()
+
+	conn := GetOutreachConnector(ctx, "creds.json")
+
+	m, err := conn.ListObjectMetadata(ctx, objects)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("The Object-Metadata: %v\n", m.Result)
+
+	fmt.Printf("The Errors: %v\n", m.Errors)
+}


### PR DESCRIPTION
Implemented the ListMetdata function for the Outreach connector. Loops through the objects one by one and from the response we generate the metadata field values or errors.
- Include tests for the success and failures.

Running the tests:
<img width="1279" alt="Screenshot 2024-05-09 at 17 56 04" src="https://github.com/amp-labs/connectors/assets/52887226/6e5ba37a-6364-4633-bf3c-be4d5226c351">