### PR TITLE
feat: Add LinkedIn Ads Manager Auth Connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -125,7 +125,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		},
 	},
 
-	// LinkedIn configuration
+	// LinkedIn & Linkedin Ads Manageconfiguration
 	LinkedIn: {
 		AuthType: Oauth2,
 		BaseURL:  "https://api.linkedin.com",


### PR DESCRIPTION
## Checklist
- Linter
- Branch
 
## Notes
No changes to code are required, existing LinkedIn connector is used to connect to Ads Manager

## Testing

## GET 
URL [localhost:4444/rest/adAccounts/513144939/adCampaignGroups?q=search&search=(status:(values:List(ACTIVE)))&pageSize=2&pageToken=DgFRx4cDaLeuudhDph5Xjfr3AEuymamVjFlklZSh1OA](url)


![LinkedIn Ad Mgr - proxy get](https://github.com/amp-labs/connectors/assets/95291462/e9f29e99-1fc3-4355-8d54-8d004f4d58bd)

## POST
URL [localhost:4444/rest/adAccounts/513144939/adCampaignGroups/691114844](url)

![LinkedIn Ads Mgr post proxy ok](https://github.com/amp-labs/connectors/assets/95291462/86239383-b059-4a6a-ad8b-fd8dc6ef340b)

## Pagination
![linkedinAd-cursorPagination](https://github.com/amp-labs/connectors/assets/95291462/b651e12c-e785-48b5-a4ec-01e1eef461e0)


Closes #284 