### PR TITLE
fix: Remove client_id as a token metadata field from Gong connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -614,7 +614,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
-				ScopesField:      "scope",
+				ScopesField: "scope",
 			},
 		},
 		Support: Support{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -615,7 +615,6 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField:      "scope",
-				ConsumerRefField: "client_id",
 			},
 		},
 		Support: Support{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -671,7 +671,7 @@ var testCases = []struct { // nolint
 				ExplicitWorkspaceRequired: false,
 				ExplicitScopesRequired:    true,
 				TokenMetadataFields: TokenMetadataFields{
-					ScopesField:      "scope",
+					ScopesField: "scope",
 				},
 			},
 			BaseURL: "https://api.gong.io",

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -672,7 +672,6 @@ var testCases = []struct { // nolint
 				ExplicitScopesRequired:    true,
 				TokenMetadataFields: TokenMetadataFields{
 					ScopesField:      "scope",
-					ConsumerRefField: "client_id",
 				},
 			},
 			BaseURL: "https://api.gong.io",


### PR DESCRIPTION
The OAuth token returned by Gong does not actually include a client_id field, which led to the following error:

![Screenshot 2024-05-13 at 2 41 26 PM](https://github.com/amp-labs/connectors/assets/3990804/bc0abd1b-2cdc-4dfb-a5df-29d1588d4004)
