### PR TITLE
feat: introduce `displayName` to catalog

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -930,6 +930,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 
 	// Zendesk Support configuration
 	ZendeskSupport: {
+		DisplayName: "Zendesk Support",
 		AuthType: Oauth2,
 		BaseURL:  "https://{{.workspace}}.zendesk.com",
 		OauthOpts: OauthOpts{
@@ -954,6 +955,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	},
 
 	ZendeskChat: {
+		DisplayName: "Zendesk Chat",
 		AuthType: Oauth2,
 		BaseURL:  "https://www.zopim.com",
 		OauthOpts: OauthOpts{

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -66,6 +66,14 @@ const (
 	Zuora                               Provider = "zuora"
 )
 
+func optionalString(s string) *string {
+	if s == "" {
+		return nil
+	}
+
+	return &s
+}
+
 // ================================================================================
 // Contains critical provider configuration (using types from types.gen.go)
 // ================================================================================
@@ -930,9 +938,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 
 	// Zendesk Support configuration
 	ZendeskSupport: {
-		DisplayName: "Zendesk Support",
-		AuthType: Oauth2,
-		BaseURL:  "https://{{.workspace}}.zendesk.com",
+		DisplayName: optionalString("Zendesk Support"),
+		AuthType:    Oauth2,
+		BaseURL:     "https://{{.workspace}}.zendesk.com",
 		OauthOpts: OauthOpts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://{{.workspace}}.zendesk.com/oauth/authorizations/new",
@@ -955,9 +963,9 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	},
 
 	ZendeskChat: {
-		DisplayName: "Zendesk Chat",
-		AuthType: Oauth2,
-		BaseURL:  "https://www.zopim.com",
+		DisplayName: optionalString("Zendesk Chat"),
+		AuthType:    Oauth2,
+		BaseURL:     "https://www.zopim.com",
 		OauthOpts: OauthOpts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://www.zopim.com/oauth2/authorizations/new?subdomain={{.workspace}}",

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -66,14 +66,6 @@ const (
 	Zuora                               Provider = "zuora"
 )
 
-func optionalString(s string) *string {
-	if s == "" {
-		return nil
-	}
-
-	return &s
-}
-
 // ================================================================================
 // Contains critical provider configuration (using types from types.gen.go)
 // ================================================================================
@@ -938,7 +930,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 
 	// Zendesk Support configuration
 	ZendeskSupport: {
-		DisplayName: optionalString("Zendesk Support"),
+		DisplayName: "Zendesk Support",
 		AuthType:    Oauth2,
 		BaseURL:     "https://{{.workspace}}.zendesk.com",
 		OauthOpts: OauthOpts{
@@ -963,7 +955,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 	},
 
 	ZendeskChat: {
-		DisplayName: optionalString("Zendesk Chat"),
+		DisplayName: "Zendesk Chat",
 		AuthType:    Oauth2,
 		BaseURL:     "https://www.zopim.com",
 		OauthOpts: OauthOpts{

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -52,7 +52,7 @@ type ProviderInfo struct {
 	BaseURL  string   `json:"baseURL" validate:"required"`
 
 	// DisplayName The display name of the provider, if omitted, defaults to provider name.
-	DisplayName  *string      `json:"displayName,omitempty"`
+	DisplayName  string       `json:"displayName,omitempty"`
 	OauthOpts    OauthOpts    `json:"oauthOpts" validate:"required"`
 	ProviderOpts ProviderOpts `json:"providerOpts"`
 	Support      Support      `json:"support" validate:"required"`

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -48,8 +48,11 @@ type Provider = string
 
 // ProviderInfo defines model for ProviderInfo.
 type ProviderInfo struct {
-	AuthType     AuthType     `json:"authType" validate:"required"`
-	BaseURL      string       `json:"baseURL" validate:"required"`
+	AuthType AuthType `json:"authType" validate:"required"`
+	BaseURL  string   `json:"baseURL" validate:"required"`
+
+	// DisplayName The display name of the provider, if omitted, defaults to provider name.
+	DisplayName  *string      `json:"displayName,omitempty"`
 	OauthOpts    OauthOpts    `json:"oauthOpts" validate:"required"`
 	ProviderOpts ProviderOpts `json:"providerOpts"`
 	Support      Support      `json:"support" validate:"required"`

--- a/providers/types.yaml
+++ b/providers/types.yaml
@@ -143,6 +143,7 @@ components:
           type: string
           example: Zendesk Chat
           description: The display name of the provider, if omitted, defaults to provider name.
+          x-go-type-skip-optional-pointer: true
     CatalogType:
       type: object
       additionalProperties:

--- a/providers/types.yaml
+++ b/providers/types.yaml
@@ -139,7 +139,10 @@ components:
           $ref: '#/components/schemas/Support'
         providerOpts:
           $ref: '#/components/schemas/ProviderOpts'
-
+        displayName:
+          type: string
+          example: Zendesk Chat
+          description: The display name of the provider, if omitted, defaults to provider name.
     CatalogType:
       type: object
       additionalProperties:


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing

This PR introduces a `displayName` field to ProviderInfo and adds display names for Zendesk Chat and Zendesk Support
