### PR TITLE
StackExchange: Remove TokenMetadataFields

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -1232,9 +1232,6 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://stackoverflow.com/oauth/access_token/json",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
-			TokenMetadataFields: TokenMetadataFields{
-				ScopesField: "scope",
-			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/catalog_test.go
+++ b/providers/catalog_test.go
@@ -1439,9 +1439,6 @@ var testCases = []struct { // nolint
 				TokenURL:                  "https://stackoverflow.com/oauth/access_token/json",
 				ExplicitScopesRequired:    true,
 				ExplicitWorkspaceRequired: false,
-				TokenMetadataFields: TokenMetadataFields{
-					ScopesField: "scope",
-				},
 			},
 			BaseURL: "https://api.stackexchange.com",
 		},


### PR DESCRIPTION
Remove tokenMetadaFields as StackExchange only returns a token.

![image](https://github.com/amp-labs/connectors/assets/103050835/487695e8-7bce-4c6d-ae31-c53d44edc83b)
