### PR TITLE
feat: Deep connector Salesloft (ListMetadata) 

### DIFF
--- a/common/scrapper/files.go
+++ b/common/scrapper/files.go
@@ -1,0 +1,56 @@
+package scrapper
+
+import "encoding/json"
+
+const (
+	IndexFile   = "index.json"
+	SchemasFile = "schemas.json"
+)
+
+// MetadataFileLocator locates index and schema files.
+// Every module stores these files in its own place.
+type MetadataFileLocator interface {
+	AbsPathTo(filename string) string
+}
+
+type MetadataFileManager struct {
+	schemas []byte
+	locator MetadataFileLocator
+}
+
+func NewMetadataFileManager(schemas []byte, locator MetadataFileLocator) *MetadataFileManager {
+	return &MetadataFileManager{
+		schemas: schemas,
+		locator: locator,
+	}
+}
+
+func (m MetadataFileManager) SaveIndex(index *ModelURLRegistry) error {
+	return FlushToFile(m.locator.AbsPathTo(IndexFile), index)
+}
+
+func (m MetadataFileManager) LoadIndex() (*ModelURLRegistry, error) {
+	var registry *ModelURLRegistry
+
+	err := LoadFile(m.locator.AbsPathTo(IndexFile), &registry)
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (m MetadataFileManager) SaveSchemas(schemas *ObjectMetadataResult) error {
+	return FlushToFile(m.locator.AbsPathTo(SchemasFile), schemas)
+}
+
+func (m MetadataFileManager) LoadSchemas() (*ObjectMetadataResult, error) {
+	var result *ObjectMetadataResult
+
+	err := json.Unmarshal(m.schemas, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/common/types.go
+++ b/common/types.go
@@ -79,6 +79,9 @@ var (
 
 	// ErrBadRequest is returned when we get a 400 response from the provider.
 	ErrBadRequest = errors.New("bad request")
+
+	// ErrMetadataLoadFailure is returned when files that contain metadata for a connector cannot be loaded.
+	ErrMetadataLoadFailure = errors.New("cannot load metadata")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/intercom/metadata.go
+++ b/intercom/metadata.go
@@ -2,6 +2,7 @@ package intercom
 
 import (
 	"context"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/intercom/metadata"
 )
@@ -14,7 +15,7 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.LoadSchemas()
+	schemas, err := metadata.FileManager.LoadSchemas()
 	if err != nil {
 		return nil, common.ErrMetadataLoadFailure
 	}

--- a/intercom/metadata.go
+++ b/intercom/metadata.go
@@ -2,13 +2,9 @@ package intercom
 
 import (
 	"context"
-	"errors"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/intercom/metadata"
 )
-
-var ErrLoadFailure = errors.New("cannot load metadata")
 
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
@@ -20,7 +16,7 @@ func (c *Connector) ListObjectMetadata(
 
 	schemas, err := metadata.LoadSchemas()
 	if err != nil {
-		return nil, ErrLoadFailure
+		return nil, common.ErrMetadataLoadFailure
 	}
 
 	return schemas.Select(objectNames)

--- a/intercom/metadata/scrapping.go
+++ b/intercom/metadata/scrapping.go
@@ -2,54 +2,24 @@ package metadata
 
 import (
 	_ "embed"
-	"encoding/json"
 	"path/filepath"
 	"runtime"
 
 	"github.com/amp-labs/connectors/common/scrapper"
 )
 
-const (
-	IndexFile   = "index.json"
-	SchemasFile = "schemas.json"
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
 )
 
-// Static file containing a list of object metadata is embedded and can be served.
-//
-//go:embed schemas.json
-var schemas []byte
+type locator struct{}
 
-func SaveIndex(index *scrapper.ModelURLRegistry) error {
-	return scrapper.FlushToFile(resolveRelativePath(IndexFile), index)
-}
-
-func LoadIndex() (*scrapper.ModelURLRegistry, error) {
-	var registry *scrapper.ModelURLRegistry
-
-	err := scrapper.LoadFile(resolveRelativePath(IndexFile), &registry)
-	if err != nil {
-		return nil, err
-	}
-
-	return registry, nil
-}
-
-func SaveSchemas(schemas *scrapper.ObjectMetadataResult) error {
-	return scrapper.FlushToFile(resolveRelativePath(SchemasFile), schemas)
-}
-
-func LoadSchemas() (*scrapper.ObjectMetadataResult, error) {
-	var result *scrapper.ObjectMetadataResult
-
-	err := json.Unmarshal(schemas, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-func resolveRelativePath(filename string) string {
+func (locator) AbsPathTo(filename string) string {
 	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
 	localDir := filepath.Dir(thisMethodsLocation)
 

--- a/salesloft/metadata.go
+++ b/salesloft/metadata.go
@@ -1,0 +1,24 @@
+package salesloft
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/salesloft/metadata"
+)
+
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	schemas, err := metadata.FileManager.LoadSchemas()
+	if err != nil {
+		return nil, common.ErrMetadataLoadFailure
+	}
+
+	return schemas.Select(objectNames)
+}

--- a/salesloft/metadata/index.json
+++ b/salesloft/metadata/index.json
@@ -1,0 +1,724 @@
+{
+  "data": [
+    {
+      "name": "me-index",
+      "displayName": "Fetch current user",
+      "url": "https://developers.salesloft.com/docs/api/me-index"
+    },
+    {
+      "name": "team-index",
+      "displayName": "Fetch current team",
+      "url": "https://developers.salesloft.com/docs/api/team-index"
+    },
+    {
+      "name": "data-control-account-redaction-create",
+      "displayName": "Execute an account redaction workflow",
+      "url": "https://developers.salesloft.com/docs/api/data-control-account-redaction-create"
+    },
+    {
+      "name": "account-stages-index",
+      "displayName": "List account stages",
+      "url": "https://developers.salesloft.com/docs/api/account-stages-index"
+    },
+    {
+      "name": "account-stages-show",
+      "displayName": "Fetch an account stage",
+      "url": "https://developers.salesloft.com/docs/api/account-stages-show"
+    },
+    {
+      "name": "account-tiers-index",
+      "displayName": "List Account Tiers",
+      "url": "https://developers.salesloft.com/docs/api/account-tiers-index"
+    },
+    {
+      "name": "account-tiers-show",
+      "displayName": "Fetch an account tier",
+      "url": "https://developers.salesloft.com/docs/api/account-tiers-show"
+    },
+    {
+      "name": "account-upserts-create",
+      "displayName": "Upsert an account",
+      "url": "https://developers.salesloft.com/docs/api/account-upserts-create"
+    },
+    {
+      "name": "data-control-account-and-people-redaction-create",
+      "displayName": "Submit an account and people redaction  request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-account-and-people-redaction-create"
+    },
+    {
+      "name": "accounts-index",
+      "displayName": "List accounts",
+      "url": "https://developers.salesloft.com/docs/api/accounts-index"
+    },
+    {
+      "name": "accounts-create",
+      "displayName": "Create an account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-create"
+    },
+    {
+      "name": "accounts-show",
+      "displayName": "Fetch an account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-show"
+    },
+    {
+      "name": "accounts-update",
+      "displayName": "Update an existing Account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-update"
+    },
+    {
+      "name": "accounts-destroy",
+      "displayName": "Delete an account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-destroy"
+    },
+    {
+      "name": "actions-index",
+      "displayName": "List actions",
+      "url": "https://developers.salesloft.com/docs/api/actions-index"
+    },
+    {
+      "name": "actions-show",
+      "displayName": "Fetch an action",
+      "url": "https://developers.salesloft.com/docs/api/actions-show"
+    },
+    {
+      "name": "activities-create",
+      "displayName": "Create an activity",
+      "url": "https://developers.salesloft.com/docs/api/activities-create"
+    },
+    {
+      "name": "activity-histories-index",
+      "displayName": "List Past Activities",
+      "url": "https://developers.salesloft.com/docs/api/activity-histories-index"
+    },
+    {
+      "name": "bulk-jobs-update",
+      "displayName": "Update a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-update"
+    },
+    {
+      "name": "bulk-jobs-show",
+      "displayName": "Fetch a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-show"
+    },
+    {
+      "name": "bulk-jobs-create",
+      "displayName": "Create a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-create"
+    },
+    {
+      "name": "bulk-jobs-index",
+      "displayName": "List bulk jobs",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-index"
+    },
+    {
+      "name": "bulk-jobs-job-data-create",
+      "displayName": "Create job data for a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-job-data-create"
+    },
+    {
+      "name": "bulk-jobs-job-data-index",
+      "displayName": "List job data for a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-job-data-index"
+    },
+    {
+      "name": "bulk-jobs-results-index",
+      "displayName": "List job data for a completed bulk job.",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-results-index"
+    },
+    {
+      "name": "bulk-reschedule-tasks-create",
+      "displayName": "Reschedule many tasks at once",
+      "url": "https://developers.salesloft.com/docs/api/bulk-reschedule-tasks-create"
+    },
+    {
+      "name": "cadence-exports-show",
+      "displayName": "Export a cadence",
+      "url": "https://developers.salesloft.com/docs/api/cadence-exports-show"
+    },
+    {
+      "name": "cadence-imports-create",
+      "displayName": "Import cadences from JSON",
+      "url": "https://developers.salesloft.com/docs/api/cadence-imports-create"
+    },
+    {
+      "name": "cadence-memberships-index",
+      "displayName": "List cadence memberships",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-index"
+    },
+    {
+      "name": "cadence-memberships-create",
+      "displayName": "Create a cadence membership",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-create"
+    },
+    {
+      "name": "cadence-memberships-show",
+      "displayName": "Fetch a cadence membership",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-show"
+    },
+    {
+      "name": "cadence-memberships-destroy",
+      "displayName": "Delete a cadence membership",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-destroy"
+    },
+    {
+      "name": "cadences-index",
+      "displayName": "List cadences",
+      "url": "https://developers.salesloft.com/docs/api/cadences-index"
+    },
+    {
+      "name": "cadences-show",
+      "displayName": "Fetch a cadence",
+      "url": "https://developers.salesloft.com/docs/api/cadences-show"
+    },
+    {
+      "name": "calendar-events-upsert-create",
+      "displayName": "Upsert a calendar event",
+      "url": "https://developers.salesloft.com/docs/api/calendar-events-upsert-create"
+    },
+    {
+      "name": "calendar-events-index",
+      "displayName": "List calendar events",
+      "url": "https://developers.salesloft.com/docs/api/calendar-events-index"
+    },
+    {
+      "name": "call-data-records-index",
+      "displayName": "List call data records",
+      "url": "https://developers.salesloft.com/docs/api/call-data-records-index"
+    },
+    {
+      "name": "call-data-records-show",
+      "displayName": "Fetch a call data record",
+      "url": "https://developers.salesloft.com/docs/api/call-data-records-show"
+    },
+    {
+      "name": "call-dispositions-index",
+      "displayName": "List call dispositions",
+      "url": "https://developers.salesloft.com/docs/api/call-dispositions-index"
+    },
+    {
+      "name": "action-details-call-instructions-index",
+      "displayName": "List call instructions",
+      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-index"
+    },
+    {
+      "name": "action-details-call-instructions-show",
+      "displayName": "Fetch a call instructions",
+      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-show"
+    },
+    {
+      "name": "call-sentiments-index",
+      "displayName": "List call sentiments",
+      "url": "https://developers.salesloft.com/docs/api/call-sentiments-index"
+    },
+    {
+      "name": "phone-numbers-caller-ids-index",
+      "displayName": "List caller ids",
+      "url": "https://developers.salesloft.com/docs/api/phone-numbers-caller-ids-index"
+    },
+    {
+      "name": "activities-calls-index",
+      "displayName": "List calls",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-index"
+    },
+    {
+      "name": "activities-calls-create",
+      "displayName": "Create a call",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-create"
+    },
+    {
+      "name": "activities-calls-show",
+      "displayName": "Fetch a call",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-show"
+    },
+    {
+      "name": "create-conversations-call",
+      "displayName": "Create Conversations Call",
+      "url": "https://developers.salesloft.com/docs/api/create-conversations-call"
+    },
+    {
+      "name": "tasks-counts-index",
+      "displayName": "Fetch task counts",
+      "url": "https://developers.salesloft.com/docs/api/tasks-counts-index"
+    },
+    {
+      "name": "crm-activities-index",
+      "displayName": "List crm activities",
+      "url": "https://developers.salesloft.com/docs/api/crm-activities-index"
+    },
+    {
+      "name": "crm-activities-show",
+      "displayName": "Fetch a crm activity",
+      "url": "https://developers.salesloft.com/docs/api/crm-activities-show"
+    },
+    {
+      "name": "crm-activity-fields-index",
+      "displayName": "List crm activity fields",
+      "url": "https://developers.salesloft.com/docs/api/crm-activity-fields-index"
+    },
+    {
+      "name": "crm-users-index",
+      "displayName": "List crm users",
+      "url": "https://developers.salesloft.com/docs/api/crm-users-index"
+    },
+    {
+      "name": "custom-fields-index",
+      "displayName": "List custom fields",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-index"
+    },
+    {
+      "name": "custom-fields-create",
+      "displayName": "Create a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-create"
+    },
+    {
+      "name": "custom-fields-show",
+      "displayName": "Fetch a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-show"
+    },
+    {
+      "name": "custom-fields-destroy",
+      "displayName": "Delete a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-destroy"
+    },
+    {
+      "name": "custom-roles-index",
+      "displayName": "List custom roles",
+      "url": "https://developers.salesloft.com/docs/api/custom-roles-index"
+    },
+    {
+      "name": "custom-roles-show",
+      "displayName": "Fetch a custom role",
+      "url": "https://developers.salesloft.com/docs/api/custom-roles-show"
+    },
+    {
+      "name": "email-missing-tags-create",
+      "displayName": "Requests a check of the template for missed tags",
+      "url": "https://developers.salesloft.com/docs/api/email-missing-tags-create"
+    },
+    {
+      "name": "email-template-attachments-index",
+      "displayName": "List email template attachments",
+      "url": "https://developers.salesloft.com/docs/api/email-template-attachments-index"
+    },
+    {
+      "name": "email-templates-index",
+      "displayName": "List email templates",
+      "url": "https://developers.salesloft.com/docs/api/email-templates-index"
+    },
+    {
+      "name": "email-templates-show",
+      "displayName": "Fetch an email template",
+      "url": "https://developers.salesloft.com/docs/api/email-templates-show"
+    },
+    {
+      "name": "activities-emails-index",
+      "displayName": "List emails",
+      "url": "https://developers.salesloft.com/docs/api/activities-emails-index"
+    },
+    {
+      "name": "activities-emails-show",
+      "displayName": "Fetch an email",
+      "url": "https://developers.salesloft.com/docs/api/activities-emails-show"
+    },
+    {
+      "name": "external-emails-create",
+      "displayName": "Create an External Email",
+      "url": "https://developers.salesloft.com/docs/api/external-emails-create"
+    },
+    {
+      "name": "groups-create",
+      "displayName": "Create a group",
+      "url": "https://developers.salesloft.com/docs/api/groups-create"
+    },
+    {
+      "name": "groups-index",
+      "displayName": "List groups",
+      "url": "https://developers.salesloft.com/docs/api/groups-index"
+    },
+    {
+      "name": "groups-show",
+      "displayName": "Fetch a group",
+      "url": "https://developers.salesloft.com/docs/api/groups-show"
+    },
+    {
+      "name": "groups-update",
+      "displayName": "Update a group",
+      "url": "https://developers.salesloft.com/docs/api/groups-update"
+    },
+    {
+      "name": "groups-destroy",
+      "displayName": "Deletes a Group by ID",
+      "url": "https://developers.salesloft.com/docs/api/groups-destroy"
+    },
+    {
+      "name": "imports-index",
+      "displayName": "List imports",
+      "url": "https://developers.salesloft.com/docs/api/imports-index"
+    },
+    {
+      "name": "imports-create",
+      "displayName": "Create an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-create"
+    },
+    {
+      "name": "imports-show",
+      "displayName": "Fetch an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-show"
+    },
+    {
+      "name": "imports-update",
+      "displayName": "Update an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-update"
+    },
+    {
+      "name": "imports-destroy",
+      "displayName": "Delete an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-destroy"
+    },
+    {
+      "name": "third-party-live-feed-items-create",
+      "displayName": "Create a live feed item",
+      "url": "https://developers.salesloft.com/docs/api/third-party-live-feed-items-create"
+    },
+    {
+      "name": "live-website-tracking-parameters-create",
+      "displayName": "Create an Live Website Tracking Parameter",
+      "url": "https://developers.salesloft.com/docs/api/live-website-tracking-parameters-create"
+    },
+    {
+      "name": "meetings-index",
+      "displayName": "List meetings",
+      "url": "https://developers.salesloft.com/docs/api/meetings-index"
+    },
+    {
+      "name": "meetings-update",
+      "displayName": "Update a meeting",
+      "url": "https://developers.salesloft.com/docs/api/meetings-update"
+    },
+    {
+      "name": "mime-email-payloads-show",
+      "displayName": "Fetch the MIME content for email",
+      "url": "https://developers.salesloft.com/docs/api/mime-email-payloads-show"
+    },
+    {
+      "name": "notes-index",
+      "displayName": "List notes",
+      "url": "https://developers.salesloft.com/docs/api/notes-index"
+    },
+    {
+      "name": "notes-create",
+      "displayName": "Create a note",
+      "url": "https://developers.salesloft.com/docs/api/notes-create"
+    },
+    {
+      "name": "notes-show",
+      "displayName": "Fetch a note",
+      "url": "https://developers.salesloft.com/docs/api/notes-show"
+    },
+    {
+      "name": "notes-update",
+      "displayName": "Update a note",
+      "url": "https://developers.salesloft.com/docs/api/notes-update"
+    },
+    {
+      "name": "notes-destroy",
+      "displayName": "Delete a note",
+      "url": "https://developers.salesloft.com/docs/api/notes-destroy"
+    },
+    {
+      "name": "ongoing-actions-create",
+      "displayName": "Create an ongoing action",
+      "url": "https://developers.salesloft.com/docs/api/ongoing-actions-create"
+    },
+    {
+      "name": "pending-emails-index",
+      "displayName": "List pending emails",
+      "url": "https://developers.salesloft.com/docs/api/pending-emails-index"
+    },
+    {
+      "name": "pending-emails-update",
+      "displayName": "Update a pending email",
+      "url": "https://developers.salesloft.com/docs/api/pending-emails-update"
+    },
+    {
+      "name": "people-index",
+      "displayName": "List people",
+      "url": "https://developers.salesloft.com/docs/api/people-index"
+    },
+    {
+      "name": "people-create",
+      "displayName": "Create a person",
+      "url": "https://developers.salesloft.com/docs/api/people-create"
+    },
+    {
+      "name": "people-show",
+      "displayName": "Fetch a person",
+      "url": "https://developers.salesloft.com/docs/api/people-show"
+    },
+    {
+      "name": "people-update",
+      "displayName": "Update a person",
+      "url": "https://developers.salesloft.com/docs/api/people-update"
+    },
+    {
+      "name": "people-destroy",
+      "displayName": "Delete a person",
+      "url": "https://developers.salesloft.com/docs/api/people-destroy"
+    },
+    {
+      "name": "data-control-people-soft-deletion-create",
+      "displayName": "Submit a people soft deletion request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-people-soft-deletion-create"
+    },
+    {
+      "name": "person-stages-index",
+      "displayName": "List person stages",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-index"
+    },
+    {
+      "name": "person-stages-create",
+      "displayName": "Create a person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-create"
+    },
+    {
+      "name": "person-stages-show",
+      "displayName": "Fetch a person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-show"
+    },
+    {
+      "name": "person-stages-update",
+      "displayName": "Update a person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-update"
+    },
+    {
+      "name": "person-stages-destroy",
+      "displayName": "Delete an person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-destroy"
+    },
+    {
+      "name": "person-upserts-create",
+      "displayName": "Upsert a person",
+      "url": "https://developers.salesloft.com/docs/api/person-upserts-create"
+    },
+    {
+      "name": "phone-number-assignments-index",
+      "displayName": "List phone number assignments",
+      "url": "https://developers.salesloft.com/docs/api/phone-number-assignments-index"
+    },
+    {
+      "name": "phone-number-assignments-show",
+      "displayName": "Fetch a phone number assignment",
+      "url": "https://developers.salesloft.com/docs/api/phone-number-assignments-show"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-update",
+      "displayName": "Update a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-update"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-show",
+      "displayName": "Show a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-show"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-destroy",
+      "displayName": "Delete a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-destroy"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-create",
+      "displayName": "Create a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-create"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-index",
+      "displayName": "List Play Registrations",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-index"
+    },
+    {
+      "name": "phone-numbers-recording-settings-show",
+      "displayName": "Fetch recording setting",
+      "url": "https://developers.salesloft.com/docs/api/phone-numbers-recording-settings-show"
+    },
+    {
+      "name": "data-control-requests-show",
+      "displayName": "Fetch a Request record",
+      "url": "https://developers.salesloft.com/docs/api/data-control-requests-show"
+    },
+    {
+      "name": "data-control-requests-index",
+      "displayName": "Retrieve a list of Requests",
+      "url": "https://developers.salesloft.com/docs/api/data-control-requests-index"
+    },
+    {
+      "name": "meetings-reschedule-links-show",
+      "displayName": "Fetch a reschedule meeting link",
+      "url": "https://developers.salesloft.com/docs/api/meetings-reschedule-links-show"
+    },
+    {
+      "name": "data-control-right-to-be-forgotten-create",
+      "displayName": "Submit a right to be forgotten request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-right-to-be-forgotten-create"
+    },
+    {
+      "name": "saved-list-views-index",
+      "displayName": "List saved list views",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-index"
+    },
+    {
+      "name": "saved-list-views-create",
+      "displayName": "Create a saved list view",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-create"
+    },
+    {
+      "name": "saved-list-views-show",
+      "displayName": "Fetch a saved list view",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-show"
+    },
+    {
+      "name": "saved-list-views-destroy",
+      "displayName": "Delete a saved list view",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-destroy"
+    },
+    {
+      "name": "saved-list-views-update",
+      "displayName": "Update a saved list view",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-update"
+    },
+    {
+      "name": "meetings-settings-searches-create",
+      "displayName": "List meeting settings",
+      "url": "https://developers.salesloft.com/docs/api/meetings-settings-searches-create"
+    },
+    {
+      "name": "meetings-settings-update",
+      "displayName": "Update a meeting setting",
+      "url": "https://developers.salesloft.com/docs/api/meetings-settings-update"
+    },
+    {
+      "name": "integrations-signals-registrations-update",
+      "displayName": "Update a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-update"
+    },
+    {
+      "name": "integrations-signals-registrations-show",
+      "displayName": "Fetch a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-show"
+    },
+    {
+      "name": "integrations-signals-registrations-destroy",
+      "displayName": "Deletes a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-destroy"
+    },
+    {
+      "name": "integrations-signals-registrations-create",
+      "displayName": "Create a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-create"
+    },
+    {
+      "name": "integrations-signals-registrations-index",
+      "displayName": "List Signal Registrations",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-index"
+    },
+    {
+      "name": "signals-create",
+      "displayName": "Create a Signal",
+      "url": "https://developers.salesloft.com/docs/api/signals-create"
+    },
+    {
+      "name": "steps-index",
+      "displayName": "List steps",
+      "url": "https://developers.salesloft.com/docs/api/steps-index"
+    },
+    {
+      "name": "steps-show",
+      "displayName": "Fetch a step",
+      "url": "https://developers.salesloft.com/docs/api/steps-show"
+    },
+    {
+      "name": "successes-index",
+      "displayName": "List successes",
+      "url": "https://developers.salesloft.com/docs/api/successes-index"
+    },
+    {
+      "name": "tags-index",
+      "displayName": "List team tags",
+      "url": "https://developers.salesloft.com/docs/api/tags-index"
+    },
+    {
+      "name": "tasks-create",
+      "displayName": "Create a Task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-create"
+    },
+    {
+      "name": "tasks-index",
+      "displayName": "List tasks",
+      "url": "https://developers.salesloft.com/docs/api/tasks-index"
+    },
+    {
+      "name": "tasks-show",
+      "displayName": "Fetch a task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-show"
+    },
+    {
+      "name": "tasks-update",
+      "displayName": "Update a Task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-update"
+    },
+    {
+      "name": "team-template-attachments-index",
+      "displayName": "List team template attachments",
+      "url": "https://developers.salesloft.com/docs/api/team-template-attachments-index"
+    },
+    {
+      "name": "team-templates-index",
+      "displayName": "List team templates",
+      "url": "https://developers.salesloft.com/docs/api/team-templates-index"
+    },
+    {
+      "name": "team-templates-show",
+      "displayName": "Fetch a team template",
+      "url": "https://developers.salesloft.com/docs/api/team-templates-show"
+    },
+    {
+      "name": "users-index",
+      "displayName": "List users",
+      "url": "https://developers.salesloft.com/docs/api/users-index"
+    },
+    {
+      "name": "users-show",
+      "displayName": "Fetch a user",
+      "url": "https://developers.salesloft.com/docs/api/users-show"
+    },
+    {
+      "name": "users-update",
+      "displayName": "Update a user",
+      "url": "https://developers.salesloft.com/docs/api/users-update"
+    },
+    {
+      "name": "webhook-subscriptions-update",
+      "displayName": "Update a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-update"
+    },
+    {
+      "name": "webhook-subscriptions-show",
+      "displayName": "Fetch a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-show"
+    },
+    {
+      "name": "webhook-subscriptions-destroy",
+      "displayName": "Delete a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-destroy"
+    },
+    {
+      "name": "webhook-subscriptions-create",
+      "displayName": "Create a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-create"
+    },
+    {
+      "name": "webhook-subscriptions-index",
+      "displayName": "List webhook subscriptions",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-index"
+    }
+  ]
+}

--- a/salesloft/metadata/schemas.json
+++ b/salesloft/metadata/schemas.json
@@ -1,0 +1,890 @@
+{
+  "data": {
+    "account-stages": {
+      "displayName": "List account stages",
+      "fields": {
+        "active": "active",
+        "created_at": "created_at",
+        "id": "id",
+        "name": "name",
+        "order": "order",
+        "updated_at": "updated_at"
+      }
+    },
+    "account-tiers": {
+      "displayName": "List Account Tiers",
+      "fields": {
+        "created_at": "created_at",
+        "id": "id",
+        "name": "name",
+        "order": "order",
+        "updated_at": "updated_at"
+      }
+    },
+    "accounts": {
+      "displayName": "List accounts",
+      "fields": {
+        "account_tier": "account_tier",
+        "archived_at": "archived_at",
+        "city": "city",
+        "company_stage": "company_stage",
+        "company_type": "company_type",
+        "conversational_name": "conversational_name",
+        "country": "country",
+        "counts": "counts",
+        "created_at": "created_at",
+        "creator": "creator",
+        "crm_id": "crm_id",
+        "crm_object_type": "crm_object_type",
+        "crm_url": "crm_url",
+        "custom_fields": "custom_fields",
+        "description": "description",
+        "do_not_contact": "do_not_contact",
+        "domain": "domain",
+        "founded": "founded",
+        "id": "id",
+        "industry": "industry",
+        "last_contacted_at": "last_contacted_at",
+        "last_contacted_by": "last_contacted_by",
+        "last_contacted_person": "last_contacted_person",
+        "last_contacted_type": "last_contacted_type",
+        "linkedin_url": "linkedin_url",
+        "locale": "locale",
+        "name": "name",
+        "owner": "owner",
+        "owner_crm_id": "owner_crm_id",
+        "phone": "phone",
+        "postal_code": "postal_code",
+        "revenue_range": "revenue_range",
+        "size": "size",
+        "state": "state",
+        "street": "street",
+        "tags": "tags",
+        "twitter_handle": "twitter_handle",
+        "updated_at": "updated_at",
+        "user_relationships": "user_relationships",
+        "website": "website"
+      }
+    },
+    "action-details-call-instructions": {
+      "displayName": "List call instructions",
+      "fields": {
+        "created_at": "created_at",
+        "id": "id",
+        "instructions": "instructions",
+        "updated_at": "updated_at"
+      }
+    },
+    "actions": {
+      "displayName": "List actions",
+      "fields": {
+        "action_details": "action_details",
+        "cadence": "cadence",
+        "created_at": "created_at",
+        "due": "due",
+        "due_on": "due_on",
+        "id": "id",
+        "multitouch_group_id": "multitouch_group_id",
+        "person": "person",
+        "status": "status",
+        "step": "step",
+        "task": "task",
+        "type": "type",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "activities-calls": {
+      "displayName": "List calls",
+      "fields": {
+        "action": "action",
+        "cadence": "cadence",
+        "called_person": "called_person",
+        "created_at": "created_at",
+        "crm_activity": "crm_activity",
+        "disposition": "disposition",
+        "duration": "duration",
+        "id": "id",
+        "note": "note",
+        "recordings": "recordings",
+        "sentiment": "sentiment",
+        "step": "step",
+        "task": "task",
+        "to": "to",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "activities-emails": {
+      "displayName": "List emails",
+      "fields": {
+        "action": "action",
+        "additional_recipients": "additional_recipients",
+        "body": "body",
+        "bounced": "bounced",
+        "cadence": "cadence",
+        "click_tracking": "click_tracking",
+        "counts": "counts",
+        "created_at": "created_at",
+        "crm_activity": "crm_activity",
+        "email_template": "email_template",
+        "error_message": "error_message",
+        "headers": "headers",
+        "id": "id",
+        "mailing": "mailing",
+        "personalization": "personalization",
+        "recipient": "recipient",
+        "recipient_email_address": "recipient_email_address",
+        "send_after": "send_after",
+        "sent_at": "sent_at",
+        "status": "status",
+        "step": "step",
+        "subject": "subject",
+        "task": "task",
+        "updated_at": "updated_at",
+        "user": "user",
+        "view_tracking": "view_tracking"
+      }
+    },
+    "activity-histories": {
+      "displayName": "List Past Activities",
+      "fields": {
+        "created_at": "created_at",
+        "dynamic_data": "dynamic_data",
+        "failed_dynamic_resources": "failed_dynamic_resources",
+        "id": "id",
+        "occurred_at": "occurred_at",
+        "pinned_at": "pinned_at",
+        "resource_id": "resource_id",
+        "resource_type": "resource_type",
+        "static_data": "static_data",
+        "tags": "tags",
+        "type": "type",
+        "updated_at": "updated_at",
+        "user_guid": "user_guid"
+      }
+    },
+    "bulk-jobs": {
+      "displayName": "List bulk jobs",
+      "fields": {
+        "created_at": "created_at",
+        "errors": "errors",
+        "finished_at": "finished_at",
+        "id": "id",
+        "marked_ready_at": "marked_ready_at",
+        "name": "name",
+        "processed": "processed",
+        "ready_to_execute": "ready_to_execute",
+        "scopes": "scopes",
+        "started_at": "started_at",
+        "state": "state",
+        "total": "total",
+        "type": "type",
+        "updated_at": "updated_at"
+      }
+    },
+    "bulk-jobs-job-data": {
+      "displayName": "List job data for a bulk job",
+      "fields": {
+        "error": "error",
+        "id": "id",
+        "record": "record",
+        "resource": "resource",
+        "status": "status"
+      }
+    },
+    "bulk-jobs-results": {
+      "displayName": "List job data for a completed bulk job.",
+      "fields": {
+        "error": "error",
+        "id": "id",
+        "record": "record",
+        "resource": "resource",
+        "status": "status"
+      }
+    },
+    "cadence-memberships": {
+      "displayName": "List cadence memberships",
+      "fields": {
+        "added_at": "added_at",
+        "cadence": "cadence",
+        "counts": "counts",
+        "created_at": "created_at",
+        "current_state": "current_state",
+        "currently_on_cadence": "currently_on_cadence",
+        "id": "id",
+        "latest_action": "latest_action",
+        "person": "person",
+        "person_deleted": "person_deleted",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "cadences": {
+      "displayName": "List cadences",
+      "fields": {
+        "added_stage": "added_stage",
+        "archived_at": "archived_at",
+        "bounced_stage": "bounced_stage",
+        "cadence_framework_id": "cadence_framework_id",
+        "cadence_function": "cadence_function",
+        "cadence_priority": "cadence_priority",
+        "counts": "counts",
+        "created_at": "created_at",
+        "creator": "creator",
+        "current_state": "current_state",
+        "draft": "draft",
+        "external_identifier": "external_identifier",
+        "finished_stage": "finished_stage",
+        "groups": "groups",
+        "id": "id",
+        "latest_active_date": "latest_active_date",
+        "name": "name",
+        "opt_out_link_included": "opt_out_link_included",
+        "override_contact_restrictions": "override_contact_restrictions",
+        "owner": "owner",
+        "remove_bounces_enabled": "remove_bounces_enabled",
+        "remove_replies_enabled": "remove_replies_enabled",
+        "replied_stage": "replied_stage",
+        "shared": "shared",
+        "tags": "tags",
+        "team_cadence": "team_cadence",
+        "updated_at": "updated_at"
+      }
+    },
+    "calendar-events": {
+      "displayName": "List calendar events",
+      "fields": {
+        "all_day": "all_day",
+        "attendees": "attendees",
+        "body_html": "body_html",
+        "busy": "busy",
+        "calendar_id": "calendar_id",
+        "canceled_at": "canceled_at",
+        "conference_data": "conference_data",
+        "created_at": "created_at",
+        "creator": "creator",
+        "description": "description",
+        "end_time": "end_time",
+        "extended_properties": "extended_properties",
+        "html_link": "html_link",
+        "i_cal_uid": "i_cal_uid",
+        "id": "id",
+        "last_occurrence_at": "last_occurrence_at",
+        "location": "location",
+        "organizer": "organizer",
+        "provider": "provider",
+        "recurrence": "recurrence",
+        "recurring": "recurring",
+        "recurring_interval": "recurring_interval",
+        "start_time": "start_time",
+        "status": "status",
+        "tenant_id": "tenant_id",
+        "title": "title",
+        "updated_at": "updated_at",
+        "user_guid": "user_guid"
+      }
+    },
+    "call-data-records": {
+      "displayName": "List call data records",
+      "fields": {
+        "call": "call",
+        "call_type": "call_type",
+        "call_uuid": "call_uuid",
+        "called_person": "called_person",
+        "created_at": "created_at",
+        "dialer_recording": "dialer_recording",
+        "direction": "direction",
+        "duration": "duration",
+        "ended_at": "ended_at",
+        "from": "from",
+        "id": "id",
+        "recording": "recording",
+        "started_at": "started_at",
+        "status": "status",
+        "to": "to",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "call-dispositions": {
+      "displayName": "List call dispositions",
+      "fields": {
+        "created_at": "created_at",
+        "id": "id",
+        "name": "name",
+        "updated_at": "updated_at"
+      }
+    },
+    "call-sentiments": {
+      "displayName": "List call sentiments",
+      "fields": {
+        "created_at": "created_at",
+        "id": "id",
+        "name": "name",
+        "updated_at": "updated_at"
+      }
+    },
+    "crm-activities": {
+      "displayName": "List crm activities",
+      "fields": {
+        "activity_type": "activity_type",
+        "created_at": "created_at",
+        "crm_id": "crm_id",
+        "custom_crm_fields": "custom_crm_fields",
+        "description": "description",
+        "error": "error",
+        "id": "id",
+        "person": "person",
+        "subject": "subject",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "crm-activity-fields": {
+      "displayName": "List crm activity fields",
+      "fields": {
+        "created_at": "created_at",
+        "crm_object_type": "crm_object_type",
+        "field": "field",
+        "field_type": "field_type",
+        "id": "id",
+        "picklist_values": "picklist_values",
+        "salesforce_object_type": "salesforce_object_type",
+        "source": "source",
+        "title": "title",
+        "updated_at": "updated_at",
+        "value": "value"
+      }
+    },
+    "crm-users": {
+      "displayName": "List crm users",
+      "fields": {
+        "created_at": "created_at",
+        "crm_id": "crm_id",
+        "first_name": "first_name",
+        "id": "id",
+        "last_name": "last_name",
+        "name": "name",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "custom-fields": {
+      "displayName": "List custom fields",
+      "fields": {
+        "created_at": "created_at",
+        "field_type": "field_type",
+        "id": "id",
+        "name": "name",
+        "updated_at": "updated_at",
+        "value_type": "value_type"
+      }
+    },
+    "custom-roles": {
+      "displayName": "List custom roles",
+      "fields": {
+        "id": "id",
+        "name": "name"
+      }
+    },
+    "data-control-requests": {
+      "displayName": "Retrieve a list of Requests",
+      "fields": {
+        "dry_run": "dry_run",
+        "events": "events",
+        "id": "id",
+        "metadata": "metadata",
+        "request_type": "request_type",
+        "team_id": "team_id",
+        "user_guid": "user_guid"
+      }
+    },
+    "email-template-attachments": {
+      "displayName": "List email template attachments",
+      "fields": {
+        "attachment_content_type": "attachment_content_type",
+        "attachment_file_size": "attachment_file_size",
+        "attachment_fingerprint": "attachment_fingerprint",
+        "attachment_id": "attachment_id",
+        "download_url": "download_url",
+        "email_template": "email_template",
+        "id": "id",
+        "name": "name",
+        "scanned": "scanned"
+      }
+    },
+    "email-templates": {
+      "displayName": "List email templates",
+      "fields": {
+        "_links": "_links",
+        "archived_at": "archived_at",
+        "body": "body",
+        "body_preview": "body_preview",
+        "cadence_template": "cadence_template",
+        "click_tracking_enabled": "click_tracking_enabled",
+        "counts": "counts",
+        "created_at": "created_at",
+        "groups": "groups",
+        "id": "id",
+        "last_used_at": "last_used_at",
+        "open_tracking_enabled": "open_tracking_enabled",
+        "shared": "shared",
+        "subject": "subject",
+        "tags": "tags",
+        "team_template": "team_template",
+        "template_owner": "template_owner",
+        "title": "title",
+        "updated_at": "updated_at"
+      }
+    },
+    "groups": {
+      "displayName": "List groups",
+      "fields": {
+        "accessible_groups": "accessible_groups",
+        "id": "id",
+        "name": "name",
+        "parent_id": "parent_id"
+      }
+    },
+    "imports": {
+      "displayName": "List imports",
+      "fields": {
+        "created_at": "created_at",
+        "current_people_count": "current_people_count",
+        "errors_list": "errors_list",
+        "id": "id",
+        "import_type": "import_type",
+        "imported_people_count": "imported_people_count",
+        "name": "name",
+        "updated_at": "updated_at",
+        "user_id": "user_id"
+      }
+    },
+    "integrations-signals-registrations": {
+      "displayName": "List Signal Registrations",
+      "fields": {
+        "attribution": "attribution",
+        "created_at": "created_at",
+        "data_shape": "data_shape",
+        "description": "description",
+        "globally_installed_at": "globally_installed_at",
+        "id": "id",
+        "indicators": "indicators",
+        "integration": "integration",
+        "integration_slug": "integration_slug",
+        "owner_user_guid": "owner_user_guid",
+        "type": "type"
+      }
+    },
+    "integrations-signals-registrations-plays": {
+      "displayName": "List Play Registrations",
+      "fields": {
+        "attributes": "attributes",
+        "created_at": "created_at",
+        "description": "description",
+        "enabled_at": "enabled_at",
+        "id": "id",
+        "identifier": "identifier",
+        "indicators": "indicators",
+        "integration": "integration",
+        "label": "label",
+        "name": "name",
+        "owner_tenant_id": "owner_tenant_id",
+        "owner_user_guid": "owner_user_guid",
+        "signal_registration": "signal_registration",
+        "signal_type": "signal_type",
+        "state": "state"
+      }
+    },
+    "me": {
+      "displayName": "Fetch current user",
+      "fields": {
+        "active": "active",
+        "bcc_email_address": "bcc_email_address",
+        "click_to_call_enabled": "click_to_call_enabled",
+        "created_at": "created_at",
+        "crm_connected": "crm_connected",
+        "email": "email",
+        "email_client_configured": "email_client_configured",
+        "email_client_email_address": "email_client_email_address",
+        "email_signature": "email_signature",
+        "email_signature_click_tracking_disabled": "email_signature_click_tracking_disabled",
+        "email_signature_type": "email_signature_type",
+        "external_feature_flags": "external_feature_flags",
+        "first_name": "first_name",
+        "from_address": "from_address",
+        "full_email_address": "full_email_address",
+        "group": "group",
+        "guid": "guid",
+        "id": "id",
+        "job_role": "job_role",
+        "last_name": "last_name",
+        "local_dial_enabled": "local_dial_enabled",
+        "locale_utc_offset": "locale_utc_offset",
+        "name": "name",
+        "phone_client": "phone_client",
+        "phone_number_assignment": "phone_number_assignment",
+        "role": "role",
+        "sending_email_address": "sending_email_address",
+        "slack_username": "slack_username",
+        "team": "team",
+        "team_admin": "team_admin",
+        "time_zone": "time_zone",
+        "twitter_handle": "twitter_handle",
+        "updated_at": "updated_at",
+        "work_country": "work_country"
+      }
+    },
+    "meetings": {
+      "displayName": "List meetings",
+      "fields": {
+        "account_id": "account_id",
+        "all_day": "all_day",
+        "attendees": "attendees",
+        "booked_by_meetings_settings": "booked_by_meetings_settings",
+        "booked_by_user": "booked_by_user",
+        "cadence": "cadence",
+        "calendar_id": "calendar_id",
+        "calendar_type": "calendar_type",
+        "canceled_at": "canceled_at",
+        "created_at": "created_at",
+        "crm": "crm",
+        "crm_custom_fields": "crm_custom_fields",
+        "crm_references": "crm_references",
+        "description": "description",
+        "end_time": "end_time",
+        "event_id": "event_id",
+        "event_source": "event_source",
+        "guests": "guests",
+        "i_cal_uid": "i_cal_uid",
+        "id": "id",
+        "last_occurrence_at": "last_occurrence_at",
+        "location": "location",
+        "meeting_type": "meeting_type",
+        "meeting_type_id": "meeting_type_id",
+        "no_show": "no_show",
+        "owned_by_meetings_settings": "owned_by_meetings_settings",
+        "owned_by_user": "owned_by_user",
+        "person": "person",
+        "recipient_email": "recipient_email",
+        "recipient_name": "recipient_name",
+        "recurrence": "recurrence",
+        "recurring": "recurring",
+        "recurring_interval": "recurring_interval",
+        "reschedule_guid": "reschedule_guid",
+        "reschedule_status": "reschedule_status",
+        "start_time": "start_time",
+        "status": "status",
+        "step": "step",
+        "strict_attribution": "strict_attribution",
+        "task_id": "task_id",
+        "title": "title",
+        "undo_completion_count": "undo_completion_count",
+        "updated_at": "updated_at"
+      }
+    },
+    "notes": {
+      "displayName": "List notes",
+      "fields": {
+        "associated_type": "associated_type",
+        "associated_with": "associated_with",
+        "call": "call",
+        "content": "content",
+        "created_at": "created_at",
+        "id": "id",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "pending-emails": {
+      "displayName": "List pending emails",
+      "fields": {
+        "id": "id",
+        "mailbox": "mailbox",
+        "mime_email_payload": "mime_email_payload"
+      }
+    },
+    "people": {
+      "displayName": "List people",
+      "fields": {
+        "account": "account",
+        "account_crm_id": "account_crm_id",
+        "bouncing": "bouncing",
+        "cadences": "cadences",
+        "city": "city",
+        "contact_restrictions": "contact_restrictions",
+        "country": "country",
+        "counts": "counts",
+        "created_at": "created_at",
+        "crm_id": "crm_id",
+        "crm_object_type": "crm_object_type",
+        "crm_url": "crm_url",
+        "custom_fields": "custom_fields",
+        "display_name": "display_name",
+        "do_not_contact": "do_not_contact",
+        "email_address": "email_address",
+        "eu_resident": "eu_resident",
+        "first_name": "first_name",
+        "full_email_address": "full_email_address",
+        "home_phone": "home_phone",
+        "id": "id",
+        "import": "import",
+        "job_seniority": "job_seniority",
+        "last_completed_step": "last_completed_step",
+        "last_completed_step_cadence": "last_completed_step_cadence",
+        "last_contacted_at": "last_contacted_at",
+        "last_contacted_by": "last_contacted_by",
+        "last_contacted_type": "last_contacted_type",
+        "last_name": "last_name",
+        "last_replied_at": "last_replied_at",
+        "linkedin_url": "linkedin_url",
+        "locale": "locale",
+        "locale_utc_offset": "locale_utc_offset",
+        "mobile_phone": "mobile_phone",
+        "most_recent_cadence": "most_recent_cadence",
+        "owner": "owner",
+        "owner_crm_id": "owner_crm_id",
+        "person_company_industry": "person_company_industry",
+        "person_company_name": "person_company_name",
+        "person_company_website": "person_company_website",
+        "person_stage": "person_stage",
+        "personal_email_address": "personal_email_address",
+        "personal_website": "personal_website",
+        "phone": "phone",
+        "phone_extension": "phone_extension",
+        "secondary_email_address": "secondary_email_address",
+        "starred": "starred",
+        "state": "state",
+        "success_count": "success_count",
+        "tags": "tags",
+        "title": "title",
+        "twitter_handle": "twitter_handle",
+        "untouched": "untouched",
+        "updated_at": "updated_at",
+        "work_city": "work_city",
+        "work_country": "work_country",
+        "work_state": "work_state"
+      }
+    },
+    "person-stages": {
+      "displayName": "List person stages",
+      "fields": {
+        "active": "active",
+        "created_at": "created_at",
+        "id": "id",
+        "name": "name",
+        "order": "order",
+        "updated_at": "updated_at"
+      }
+    },
+    "phone-number-assignments": {
+      "displayName": "List phone number assignments",
+      "fields": {
+        "id": "id",
+        "number": "number",
+        "user": "user"
+      }
+    },
+    "phone-numbers-caller-ids": {
+      "displayName": "List caller ids",
+      "fields": {
+        "account_name": "account_name",
+        "display_name": "display_name",
+        "person": "person",
+        "title": "title"
+      }
+    },
+    "saved-list-views": {
+      "displayName": "List saved list views",
+      "fields": {
+        "id": "id",
+        "is_default": "is_default",
+        "name": "name",
+        "shared": "shared",
+        "view": "view",
+        "view_params": "view_params"
+      }
+    },
+    "steps": {
+      "displayName": "List steps",
+      "fields": {
+        "cadence": "cadence",
+        "created_at": "created_at",
+        "day": "day",
+        "details": "details",
+        "disabled": "disabled",
+        "display_name": "display_name",
+        "id": "id",
+        "multitouch_enabled": "multitouch_enabled",
+        "name": "name",
+        "step_number": "step_number",
+        "type": "type",
+        "updated_at": "updated_at"
+      }
+    },
+    "successes": {
+      "displayName": "List successes",
+      "fields": {
+        "counts": "counts",
+        "created_at": "created_at",
+        "id": "id",
+        "latest_action": "latest_action",
+        "latest_cadence": "latest_cadence",
+        "latest_call": "latest_call",
+        "latest_email": "latest_email",
+        "latest_step": "latest_step",
+        "person": "person",
+        "succeeded_at": "succeeded_at",
+        "success_window_started_at": "success_window_started_at",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "tags": {
+      "displayName": "List team tags",
+      "fields": {
+        "id": "id",
+        "name": "name"
+      }
+    },
+    "tasks": {
+      "displayName": "List tasks",
+      "fields": {
+        "completed_at": "completed_at",
+        "completed_by": "completed_by",
+        "created_at": "created_at",
+        "created_by_user": "created_by_user",
+        "current_state": "current_state",
+        "description": "description",
+        "due_at": "due_at",
+        "due_date": "due_date",
+        "expires_after": "expires_after",
+        "id": "id",
+        "person": "person",
+        "remind_at": "remind_at",
+        "subject": "subject",
+        "task_type": "task_type",
+        "updated_at": "updated_at",
+        "user": "user"
+      }
+    },
+    "tasks-counts": {
+      "displayName": "Fetch task counts",
+      "fields": {
+        "call": "call",
+        "email": "email",
+        "general": "general",
+        "integration": "integration",
+        "total": "total"
+      }
+    },
+    "team": {
+      "displayName": "Fetch current team",
+      "fields": {
+        "allow_automated_email_steps": "allow_automated_email_steps",
+        "call_recording_disabled": "call_recording_disabled",
+        "click_tracking_default": "click_tracking_default",
+        "created_at": "created_at",
+        "custom_tracking_domain": "custom_tracking_domain",
+        "deactivated": "deactivated",
+        "dispositions_required": "dispositions_required",
+        "email_daily_limit": "email_daily_limit",
+        "group_privacy_setting": "group_privacy_setting",
+        "id": "id",
+        "license_limit": "license_limit",
+        "local_dial_enabled": "local_dial_enabled",
+        "name": "name",
+        "plan": "plan",
+        "plan_features": "plan_features",
+        "record_by_default": "record_by_default",
+        "sentiments_required": "sentiments_required",
+        "team_visibility_default": "team_visibility_default",
+        "updated_at": "updated_at"
+      }
+    },
+    "team-template-attachments": {
+      "displayName": "List team template attachments",
+      "fields": {
+        "attachment_file_size": "attachment_file_size",
+        "attachment_id": "attachment_id",
+        "download_url": "download_url",
+        "id": "id",
+        "name": "name",
+        "team_template": "team_template"
+      }
+    },
+    "team-templates": {
+      "displayName": "List team templates",
+      "fields": {
+        "_links": "_links",
+        "archived_at": "archived_at",
+        "body": "body",
+        "body_preview": "body_preview",
+        "click_tracking_enabled": "click_tracking_enabled",
+        "counts": "counts",
+        "created_at": "created_at",
+        "id": "id",
+        "last_modified_at": "last_modified_at",
+        "last_modified_user": "last_modified_user",
+        "last_used_at": "last_used_at",
+        "open_tracking_enabled": "open_tracking_enabled",
+        "subject": "subject",
+        "tags": "tags",
+        "title": "title",
+        "updated_at": "updated_at"
+      }
+    },
+    "users": {
+      "displayName": "List users",
+      "fields": {
+        "active": "active",
+        "bcc_email_address": "bcc_email_address",
+        "click_to_call_enabled": "click_to_call_enabled",
+        "created_at": "created_at",
+        "crm_connected": "crm_connected",
+        "email": "email",
+        "email_client_configured": "email_client_configured",
+        "email_client_email_address": "email_client_email_address",
+        "email_signature": "email_signature",
+        "email_signature_click_tracking_disabled": "email_signature_click_tracking_disabled",
+        "email_signature_type": "email_signature_type",
+        "external_feature_flags": "external_feature_flags",
+        "first_name": "first_name",
+        "from_address": "from_address",
+        "full_email_address": "full_email_address",
+        "group": "group",
+        "guid": "guid",
+        "id": "id",
+        "job_role": "job_role",
+        "last_name": "last_name",
+        "local_dial_enabled": "local_dial_enabled",
+        "locale_utc_offset": "locale_utc_offset",
+        "name": "name",
+        "phone_client": "phone_client",
+        "phone_number_assignment": "phone_number_assignment",
+        "role": "role",
+        "sending_email_address": "sending_email_address",
+        "slack_username": "slack_username",
+        "team": "team",
+        "team_admin": "team_admin",
+        "time_zone": "time_zone",
+        "twitter_handle": "twitter_handle",
+        "updated_at": "updated_at",
+        "work_country": "work_country"
+      }
+    },
+    "webhook-subscriptions": {
+      "displayName": "List webhook subscriptions",
+      "fields": {
+        "callback_token": "callback_token",
+        "callback_url": "callback_url",
+        "enabled": "enabled",
+        "event_type": "event_type",
+        "id": "id",
+        "tenant_id": "tenant_id",
+        "user_guid": "user_guid"
+      }
+    }
+  }
+}

--- a/salesloft/metadata/scrapping.go
+++ b/salesloft/metadata/scrapping.go
@@ -1,0 +1,27 @@
+package metadata
+
+import (
+	_ "embed"
+	"path/filepath"
+	"runtime"
+
+	"github.com/amp-labs/connectors/common/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+)
+
+type locator struct{}
+
+func (locator) AbsPathTo(filename string) string {
+	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
+	localDir := filepath.Dir(thisMethodsLocation)
+
+	return localDir + "/" + filename
+}

--- a/salesloft/metadata_test.go
+++ b/salesloft/metadata_test.go
@@ -1,0 +1,155 @@
+package salesloft
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scrapper"
+	"github.com/go-test/deep"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        []string
+		server       *httptest.Server
+		expected     *common.ListObjectMetadataResult
+		expectedErrs []error
+	}{
+		{
+			name:  "At least one object name must be queried",
+			input: nil,
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			name:  "Unknown object requested",
+			input: []string{"butterflies"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expectedErrs: []error{scrapper.ErrObjectNotFound},
+		},
+		{
+			name:  "Successfully describe one object with metadata",
+			input: []string{"bulk-jobs-results"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"bulk-jobs-results": {
+						DisplayName: "List job data for a completed bulk job.",
+						FieldsMap: map[string]string{
+							"error":    "error",
+							"id":       "id",
+							"record":   "record",
+							"resource": "resource",
+							"status":   "status",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			expectedErrs: nil,
+		},
+		{
+			name:  "Successfully describe multiple objects with metadata",
+			input: []string{"account-tiers", "actions"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"account-tiers": {
+						DisplayName: "List Account Tiers",
+						FieldsMap: map[string]string{
+							"created_at": "created_at",
+							"id":         "id",
+							"name":       "name",
+							"order":      "order",
+							"updated_at": "updated_at",
+						},
+					},
+					"actions": {
+						DisplayName: "List actions",
+						FieldsMap: map[string]string{
+							"action_details":      "action_details",
+							"cadence":             "cadence",
+							"created_at":          "created_at",
+							"due":                 "due",
+							"due_on":              "due_on",
+							"id":                  "id",
+							"multitouch_group_id": "multitouch_group_id",
+							"person":              "person",
+							"status":              "status",
+							"step":                "step",
+							"task":                "task",
+							"type":                "type",
+							"updated_at":          "updated_at",
+							"user":                "user",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tt.server.Close()
+
+			connector, err := NewConnector(
+				WithAuthenticatedClient(http.DefaultClient),
+			)
+			if err != nil {
+				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
+			}
+
+			// for testing we want to redirect calls to our mock server
+			connector.setBaseURL(tt.server.URL)
+
+			// start of tests
+			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
+			if err != nil {
+				if len(tt.expectedErrs) == 0 {
+					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
+				}
+			} else {
+				// check that missing error is what is expected
+				if len(tt.expectedErrs) != 0 {
+					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
+				}
+			}
+
+			// check every error
+			for _, expectedErr := range tt.expectedErrs {
+				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
+				}
+			}
+
+			if !reflect.DeepEqual(output, tt.expected) {
+				diff := deep.Equal(output, tt.expected)
+				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
+					tt.name, tt.expected, output, diff)
+			}
+		})
+	}
+}

--- a/scripts/scrapper/intercom/metadata/main.go
+++ b/scripts/scrapper/intercom/metadata/main.go
@@ -60,11 +60,11 @@ func createIndex() {
 		log.Printf("Index completed %.2f%%\n", getPercentage(i, len(sections))) // nolint:forbidigo
 	}
 
-	must(metadata.SaveIndex(registry))
+	must(metadata.FileManager.SaveIndex(registry))
 }
 
 func createSchemas() {
-	index, err := metadata.LoadIndex()
+	index, err := metadata.FileManager.LoadIndex()
 	must(err)
 
 	schemas := scrapper.NewObjectMetadataResult()
@@ -84,7 +84,7 @@ func createSchemas() {
 		log.Printf("Schemas completed %.2f%% [%v]\n", getPercentage(i, len(documents)), model.Name)
 	}
 
-	must(metadata.SaveSchemas(schemas))
+	must(metadata.FileManager.SaveSchemas(schemas))
 }
 
 func getSchemasForListEndpoints(index *scrapper.ModelURLRegistry) scrapper.ModelDocLinks {

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"log"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/amp-labs/connectors/common/scrapper"
+	"github.com/amp-labs/connectors/salesloft/metadata"
+)
+
+const (
+	// SalesloftDocsPrefixURL documentation root.
+	SalesloftDocsPrefixURL = "https://developers.salesloft.com"
+	// ModelIndexURL - on this page all links to dedicated Models can be found.
+	ModelIndexURL = "https://developers.salesloft.com/docs/api"
+)
+
+func main() {
+	// index will have URLs for every schema
+	createIndex()
+	// using index file collect response fields for every object
+	createSchemas()
+
+	log.Println("Completed.")
+}
+
+func createIndex() {
+	sections := getSectionLinks()
+
+	registry := scrapper.NewModelURLRegistry()
+
+	for i, section := range sections {
+		doc := scrapper.QueryHTML(SalesloftDocsPrefixURL + "/" + section)
+
+		doc.Find(".theme-doc-markdown article").Each(func(i int, s *goquery.Selection) {
+			cell := s.Find("a")
+			path, _ := cell.Attr("href")
+			name, _ := cell.Find("h2").Attr("title")
+			registry.Add(name, SalesloftDocsPrefixURL+path)
+		})
+		log.Printf("Index completed %.2f%%\n", getPercentage(i, len(sections))) // nolint:forbidigo
+	}
+
+	must(metadata.FileManager.SaveIndex(registry))
+}
+
+func createSchemas() {
+	index, err := metadata.FileManager.LoadIndex()
+	must(err)
+
+	schemas := scrapper.NewObjectMetadataResult()
+
+	filteredListDocs := getFilteredListDocs(index)
+	for i, model := range filteredListDocs { // nolint:varnamelen
+		doc := scrapper.QueryHTML(model.URL)
+
+		// There are 2 unordered lists that describe response schema
+		doc.Find(`.openapi-tabs__schema-container ul`).
+			Each(func(i int, list *goquery.Selection) {
+				list.Children().Each(func(i int, property *goquery.Selection) {
+					// Sometimes there are nested fields we ignore them
+					// Only the first most field represents top level fields of response payload
+					fieldName := property.Find(`strong`).First().Text()
+					if len(fieldName) != 0 {
+						schemas.Add(model.Name, model.DisplayName, fieldName)
+					}
+				})
+			})
+
+		log.Printf("Schemas completed %.2f%% [%v]\n", getPercentage(i, len(filteredListDocs)), model.Name)
+	}
+
+	must(metadata.FileManager.SaveSchemas(schemas))
+}
+
+/*
+Index file has these suffixes for model name (Total 134):
+  - destroy 2
+  - call 1 (create-conversations-call, should fall under create category)
+  - create 33
+  - index 48
+  - update 16
+  - show 34
+
+`Index` means List operation while `Show` is Singular get.
+We are only interested in List schemas (keeping `-index` documents).
+*/
+func getFilteredListDocs(index *scrapper.ModelURLRegistry) scrapper.ModelDocLinks {
+	list := make(scrapper.ModelDocLinks, 0)
+
+	for _, doc := range index.ModelDocs {
+		if name, found := strings.CutSuffix(doc.Name, "-index"); found {
+			list = append(list, scrapper.ModelDocLink{
+				Name:        name,
+				DisplayName: doc.DisplayName,
+				URL:         doc.URL,
+			})
+		}
+	}
+
+	return list
+}
+
+func getSectionLinks() []string {
+	doc := scrapper.QueryHTML(ModelIndexURL)
+
+	links := make([]string, 0)
+
+	doc.Find(".margin-top--lg article").Each(func(i int, s *goquery.Selection) {
+		cell := s.Find("a")
+		link, _ := cell.Attr("href")
+		links = append(links, link)
+	})
+
+	return links
+}
+
+func getPercentage(i int, i2 int) float64 {
+	return (float64(i+1) / float64(i2)) * 100 // nolint:gomnd
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/test/salesloft/metadata/main.go
+++ b/test/salesloft/metadata/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	msTest "github.com/amp-labs/connectors/test/salesloft"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+var (
+	objectNamePlural = "groups"
+)
+
+// we want to compare fields returned by read and schema properties provided by metadata methods
+// they must match for all such objects
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	filePath := os.Getenv("SALESLOFT_CRED_FILE")
+	if filePath == "" {
+		filePath = "./salesloft-creds.json"
+	}
+
+	conn := msTest.GetSalesloftConnector(ctx, filePath)
+	defer utils.Close(conn)
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectNamePlural,
+	})
+	if err != nil {
+		utils.Fail("error reading from Salesloft", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectNamePlural,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for Salesloft", "error", err)
+	}
+
+	fmt.Println("Compare object metadata against endpoint response:")
+
+	mismatchErr := compareFieldsMatch(metadata, response.Data[0].Raw)
+	if mismatchErr != nil {
+		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
+	} else {
+		fmt.Println("==> success fields match.")
+	}
+}
+
+func compareFieldsMatch(metadata *common.ListObjectMetadataResult, response map[string]any) error {
+	fields := make(map[string]bool)
+
+	for field := range response {
+		fields[field] = false
+	}
+
+	mismatch := make([]error, 0)
+
+	for name := range metadata.Result[objectNamePlural].FieldsMap {
+		if _, found := fields[name]; found {
+			fields[name] = true
+		}
+	}
+
+	// every field from Read must be known to ListObjectMetadata
+	for name, found := range fields {
+		if !found {
+			mismatch = append(mismatch, fmt.Errorf("metadata schema is missing field %v", name))
+		}
+	}
+
+	return errors.Join(mismatch...)
+}


### PR DESCRIPTION
Closes #370

# Scrapper

Every "square" is a section opening each we get a list of URLs that describe CRUD operations for that group.
![image](https://github.com/amp-labs/connectors/assets/60330780/3e4d77da-2394-4f77-9344-35953a91a711)

![image](https://github.com/amp-labs/connectors/assets/60330780/b0880902-a402-452e-b5a6-53f4fd154751)
Given index of URLs for every operation, open each and navigate to `Schema` section. This represenets response body. Save those fields under schemas.
![image](https://github.com/amp-labs/connectors/assets/60330780/88a82c41-98e5-4d78-a9d6-e1574f6e38e4)

# ListObjectMetadata
This method surfaces data stored under `salesloft/metadata/schemas.json`. This can be repopulated by scrapper tool.
![image](https://github.com/amp-labs/connectors/assets/60330780/d67fc024-2838-4aa5-af50-6bef0f764bb5)
