### PR TITLE
fix: avoid panics incase nil response

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -24,7 +24,7 @@ func ParseResult(
 	fields []string,
 ) (*ReadResult, error) {
 	if resp == nil {
-		return &ReadResult{}, nil
+		return nil, ErrEmptyResponse
 	}
 
 	totalSize, err := sizeFunc(resp.Body)

--- a/common/parse.go
+++ b/common/parse.go
@@ -24,7 +24,7 @@ func ParseResult(
 	fields []string,
 ) (*ReadResult, error) {
 	if resp == nil {
-		return nil, ErrEmptyResponse
+		return nil, ErrEmptyJSONHTTPResponse
 	}
 
 	totalSize, err := sizeFunc(resp.Body)

--- a/common/parse.go
+++ b/common/parse.go
@@ -23,6 +23,10 @@ func ParseResult(
 	marshalFunc func([]map[string]any, []string) ([]ReadResultRow, error),
 	fields []string,
 ) (*ReadResult, error) {
+	if resp == nil {
+		return &ReadResult{}, nil
+	}
+
 	totalSize, err := sizeFunc(resp.Body)
 	if err != nil {
 		return nil, err

--- a/common/types.go
+++ b/common/types.go
@@ -82,6 +82,9 @@ var (
 
 	// ErrMetadataLoadFailure is returned when files that contain metadata for a connector cannot be loaded.
 	ErrMetadataLoadFailure = errors.New("cannot load metadata")
+
+	// ErrEmptyResponse is returned when the jsonResponse is nil
+	ErrEmptyResponse = errors.New("empty http response error")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/common/types.go
+++ b/common/types.go
@@ -83,8 +83,8 @@ var (
 	// ErrMetadataLoadFailure is returned when files that contain metadata for a connector cannot be loaded.
 	ErrMetadataLoadFailure = errors.New("cannot load metadata")
 
-	// ErrEmptyResponse is returned when the jsonResponse is nil
-	ErrEmptyResponse = errors.New("empty http response error")
+	// ErrEmptyResponse is returned when the jsonResponse is nil.
+	ErrEmptyJSONHTTPResponse = errors.New("empty json http response")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.


### PR DESCRIPTION
We are allowing returning nil in parseJSONResponse, this will cause panics in parseResult function. This fixes that.