### PR TITLE
feat: Add Pinterest Auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -47,6 +47,7 @@ const (
 	Mural                               Provider = "mural"
 	Notion                              Provider = "notion"
 	Outreach                            Provider = "outreach"
+	Pinterest                           Provider = "pinterest"
 	Pipedrive                           Provider = "pipedrive"
 	RingCentral                         Provider = "ringCentral"
 	Salesforce                          Provider = "salesforce"
@@ -1697,6 +1698,34 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenURL:                  "https://login.microsoftonline.com/common/oauth2/v2.0/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Pinterest configuration
+	Pinterest: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.pinterest.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://www.pinterest.com/oauth",
+			TokenURL:                  "https://api.pinterest.com/v5/oauth/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
## Checklist
- [ ] Ran Linter

## Catalog variables
Pinterest Provider = "pinterest"

## Notes
It supports pagination and batching

## Testing
### TOKEN RESPONSE
**SCRIPT:**
![image](https://github.com/amp-labs/connectors/assets/163011126/80583817-640b-4406-9ddf-43a6914db57a)

**POSTMAN:**
![image](https://github.com/amp-labs/connectors/assets/163011126/2a70683f-f7bf-4dde-bcf1-b6121c9f39b0)

### GET
URL: http://localhost:4444/v5/ad_accounts/549767715102/ads
![image](https://github.com/amp-labs/connectors/assets/163011126/221afca8-36f9-45c0-a8c0-3d830718e9bc)

### POST
URL: http://localhost:4444/v5/ad_accounts/549767715102/ads
![image](https://github.com/amp-labs/connectors/assets/163011126/9d46d890-e464-44d0-b6d6-e35582eaa4f8)

### PATCH
URL: http://localhost:4444/v5/ad_accounts/549767715102/ads
![image](https://github.com/amp-labs/connectors/assets/163011126/f3dd05f9-f0d8-44ad-a2e5-31999908bbac)

### DELETE
URL: http://localhost:4444/v5/pins/1054334962754985249
![image](https://github.com/amp-labs/connectors/assets/163011126/6102e320-fa67-46b4-8009-41cfe6fcaa48)

### Pagination
Requesting a paginated list of ads using page_size :
URL: http://localhost:4444/v5/ad_accounts/549767715102/ads?page_size=2
![image](https://github.com/amp-labs/connectors/assets/163011126/63b653f8-be80-48b5-93e4-0628aa36691e)

Requesting the next page using the bookmark value from the previous response
URL: http://localhost:4444/v5/ad_accounts/549767715102/ads?bookmark=P3A2ODcyNjY3NTk5NDF8MHwwfDEsMnwwfDExMzI4NDQzNzIzMTc0ODYqR1FMKnxlYTFhYTZjNDNjNmIwYzIyNGNlMGQzOWM4YzRjMGQ3MTQ1ZGY3YWNlYTVmNGFhZTk5NThhYzM3Y2E4OTk4OThmfE5FV3w=
![image](https://github.com/amp-labs/connectors/assets/163011126/cd7f911b-3ab8-4f69-b805-690bb6fa1cb6)

closes #386 
