### PR TITLE
Remove Modules from Intercom connector

### DIFF
--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -79,6 +79,8 @@ func (p *Workspace) WithWorkspace(workspaceRef string) {
 }
 
 // Module params adds suffix to URL controlling API versions.
+// This is relevant where there are several APIs for different product areas or sub-products, and the APIs
+// are versioned differently or have different ways of constructing URLs from object names.
 type Module struct {
 	Suffix string
 }

--- a/intercom/connector.go
+++ b/intercom/connector.go
@@ -6,20 +6,14 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
 )
-
-var DefaultModule = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Version: "2.11",
-}
 
 const apiVersion = "2.11"
 
 type Connector struct {
 	BaseURL string
-	Module  string
 	Client  *common.JSONHTTPClient
 }
 
@@ -41,7 +35,6 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 
 	httpClient := params.Client.Caller
 	conn = &Connector{
-		Module: params.Module.Suffix,
 		Client: &common.JSONHTTPClient{
 			HTTPClient: httpClient,
 		},
@@ -60,7 +53,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.Module)
+	return fmt.Sprintf("%s.Connector", c.Provider())
 }
 
 // nolint:unused

--- a/intercom/connector.go
+++ b/intercom/connector.go
@@ -15,6 +15,8 @@ var DefaultModule = paramsbuilder.APIModule{ // nolint: gochecknoglobals
 	Version: "2.11",
 }
 
+const apiVersion = "2.11"
+
 type Connector struct {
 	BaseURL string
 	Module  string

--- a/intercom/params.go
+++ b/intercom/params.go
@@ -21,7 +21,6 @@ type Option func(params *parameters)
 // parameters Intercom supports auth client by delegation.
 type parameters struct {
 	paramsbuilder.Client
-	paramsbuilder.Module
 }
 
 func (p parameters) FromOptions(opts ...Option) (*parameters, error) {
@@ -36,7 +35,6 @@ func (p parameters) FromOptions(opts ...Option) (*parameters, error) {
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),
-		p.Module.ValidateParams(),
 	)
 }
 
@@ -51,11 +49,5 @@ func WithClient(ctx context.Context, client *http.Client,
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 	return func(params *parameters) {
 		params.WithAuthenticatedClient(client)
-	}
-}
-
-func WithModule(module paramsbuilder.APIModule) Option {
-	return func(params *parameters) {
-		params.WithModule(module)
 	}
 }

--- a/intercom/read.go
+++ b/intercom/read.go
@@ -2,6 +2,7 @@ package intercom
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/amp-labs/connectors/common"
@@ -14,9 +15,11 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	fmt.Println("[connector] MAKING GET REQUEST TO", link.String())
+
 	rsp, err := c.get(ctx, link.String(), common.Header{
 		Key:   "Intercom-Version",
-		Value: c.Module,
+		Value: apiVersion,
 	})
 	if err != nil {
 		return nil, err

--- a/intercom/read.go
+++ b/intercom/read.go
@@ -2,7 +2,6 @@ package intercom
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/amp-labs/connectors/common"
@@ -14,8 +13,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Println("[connector] MAKING GET REQUEST TO", link.String())
 
 	rsp, err := c.get(ctx, link.String(), common.Header{
 		Key:   "Intercom-Version",

--- a/test/intercom/connector.go
+++ b/test/intercom/connector.go
@@ -37,7 +37,6 @@ func GetIntercomConnector(ctx context.Context, filePath string) *intercom.Connec
 
 	conn, err := connectors.Intercom(
 		intercom.WithClient(ctx, http.DefaultClient, cfg, tok),
-		intercom.WithModule(intercom.DefaultModule),
 	)
 	if err != nil {
 		testUtils.Fail("error creating Intercom connector", "error", err)


### PR DESCRIPTION
We only want to have modules for products like Hubspot where there are several APIs for different product areas, and the APIs are versioned differently or have different ways of constructing URLs from object names. For Intercom, there's only a single REST API and there aren't sub-products. Requiring the connector to be initialized with a Module parameter (`intercom.WithModule(intercom.DefaultModule)`) adds unnecessary complexity and decreases usability. 

cc @Cobalt0s 