### PR TITLE
Add Adobe Sign Auth Connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -5,6 +5,7 @@ package providers
 // ================================================================================
 
 const (
+	AdobeSign                           Provider = "adobeSign"
 	Airtable                            Provider = "airtable"
 	AWeber                              Provider = "aWeber"
 	Asana                               Provider = "asana"
@@ -79,6 +80,36 @@ const (
 // ================================================================================
 
 var catalog = CatalogType{ // nolint:gochecknoglobals
+
+	// Adobe Sign configuration with substitution
+	AdobeSign: {
+		AuthType: Oauth2,
+		BaseURL:  "https://api.{{.shard}}.adobesign.com",
+		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://secure.{{.shard}}.adobesign.com/public/oauth/v2",
+			TokenURL:                  "https://api.{{.shard}}.echosign.com/oauth/v2/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: true,
+			TokenMetadataFields: TokenMetadataFields{
+				ConsumerRefField:  "api_access_point",
+				WorkspaceRefField: "web_access_point",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
 	// Salesforce configuration
 	Salesforce: {
 		AuthType: Oauth2,


### PR DESCRIPTION
Replacement of previous PR that wasn't merged due to shards addition and then removal. This version includes the shards as it was planned originally. 

## GET 
localhost:4444/api/rest/v6/users?pageSize=1
![adobe - get proxy ok](https://github.com/amp-labs/connectors/assets/95291462/b10a9993-7408-4ea7-937e-638516ae13c2)

## POST
localhost:4444/api/rest/v6/users
![adoby - post proxy ok](https://github.com/amp-labs/connectors/assets/95291462/bfbe4e13-4c72-4678-9384-83bcd247d3e8)

## Pagination

Cursor based pagination
![pagination_cursor](https://github.com/amp-labs/connectors/assets/95291462/f8caa3f5-73a6-43d6-a3fd-019d620054f7)

Next page
![pagination_next_page](https://github.com/amp-labs/connectors/assets/95291462/20343af0-9be6-41de-97de-a9b7812837dc)

fixes #366  
