### PR TITLE
Wrike auth connector update

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -306,13 +306,11 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: Oauth2,
 		BaseURL:  "https://www.wrike.com/api",
 		OauthOpts: OauthOpts{
+			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://www.wrike.com/oauth2/authorize",
 			TokenURL:                  "https://www.wrike.com/oauth2/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
-			TokenMetadataFields: TokenMetadataFields{
-				ScopesField: "scope",
-			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
Added Grant Type and removed Token Metadata scope field as it isn't returned in the token (see attached screenshot)

![Wrike - token raw](https://github.com/amp-labs/connectors/assets/95291462/8f90941c-47fc-4a0a-bdff-cb18b8059e16)


fixes #366 