### PR TITLE
feat: Add Gong Read connector

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/dynamicscrm"
+	"github.com/amp-labs/connectors/gong"
 	"github.com/amp-labs/connectors/hubspot"
 	"github.com/amp-labs/connectors/intercom"
 	"github.com/amp-labs/connectors/mock"
@@ -103,6 +104,9 @@ var Mock API[*mock.Connector, mock.Option] = mock.NewConnector //nolint:gocheckn
 
 // Outreach is an API that returns a new Outreach Connector.
 var Outreach API[*outreach.Connector, outreach.Option] = outreach.NewConnector //nolint:gochecknoglobals
+
+// Gong is an API that returns a new Gong Connector.
+var Gong API[*gong.Connector, gong.Option] = gong.NewConnector //nolint:gochecknoglobals
 
 // Salesloft is an API that returns a new Salesloft Connector.
 var Salesloft API[*salesloft.Connector, salesloft.Option] = salesloft.NewConnector //nolint:gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.21.0
 require (
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/brianvoe/gofakeit/v6 v6.28.0
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-test/deep v1.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/spyzhov/ajson v0.9.1
-	github.com/stoewer/go-strcase v1.3.0
 	github.com/stretchr/testify v1.9.0
 	github.com/subchen/go-xmldom v1.1.2
 	golang.org/x/oauth2 v0.20.0
@@ -18,7 +18,6 @@ require (
 require (
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 // indirect
-	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 h1:C735MoY/X+UOx6SEC
 github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
@@ -29,14 +28,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spyzhov/ajson v0.9.1 h1:izsDkOC9yznlpA2BxJcrkr8Q5Gyjf43yeSc2Wz0g/aU=
 github.com/spyzhov/ajson v0.9.1/go.mod h1:a6oSw0MMb7Z5aD2tPoPO+jq11ETKgXUr2XktHdT8Wt8=
-github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
-github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subchen/go-xmldom v1.1.2 h1:7evI2YqfYYOnuj+PBwyaOZZYjl3iWq35P6KfBUw9jeU=
@@ -83,7 +74,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=

--- a/gong/README.md
+++ b/gong/README.md
@@ -1,0 +1,26 @@
+# Gong connector
+
+
+## Read
+Read is used to list all records of a given type. For example, if you want to list all users, you would use the `Read` method with the `users` object or `calls`.
+
+### Example Usage
+
+```
+
+gong := GetGongConnector(context.Background(), DefaultCredsFile)
+
+	config := connectors.ReadParams{
+		ObjectName: "calls", 
+		Fields:     []string{"url"},
+	}
+
+	result, err := gong.Read(context.Background(), config)
+	if err != nil {
+		slog.Error("Error reading from Gong", "error", err)
+		return 1
+	}
+
+```
+
+

--- a/gong/client.go
+++ b/gong/client.go
@@ -1,0 +1,16 @@
+package gong
+
+import "github.com/amp-labs/connectors/common"
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/gong/connector.go
+++ b/gong/connector.go
@@ -1,0 +1,74 @@
+package gong
+
+import (
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+
+	"github.com/amp-labs/connectors/providers"
+)
+
+var DefaultModule = paramsbuilder.APIModule{ // nolint: gochecknoglobals
+	Label:   "api/data",
+	Version: "v2",
+}
+
+type Connector struct {
+	BaseURL   string
+	Client    *common.JSONHTTPClient
+	APIModule paramsbuilder.APIModule
+}
+
+func WithCatalogSubstitutions(substitutions map[string]string) Option {
+	return func(params *gongParams) {
+		params.substitutions = substitutions
+	}
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params := &gongParams{}
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	var err error
+
+	params, err = params.prepare()
+	if err != nil {
+		return nil, err
+	}
+
+	// Read provider info
+	providerInfo, err := providers.ReadInfo(providers.Gong, &map[string]string{
+		"workspace": params.Workspace.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	conn = &Connector{
+		Client:    params.client,
+		BaseURL:   providerInfo.BaseURL,
+		APIModule: params.APIModule,
+	}
+
+	conn.setBaseURL(providerInfo.BaseURL)
+	conn.Client.HTTPClient.ErrorHandler = conn.interpretError
+
+	return conn, nil
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}
+
+func (c *Connector) interpretError(res *http.Response, body []byte) error {
+	return common.InterpretError(res, body)
+}

--- a/gong/connector.go
+++ b/gong/connector.go
@@ -4,20 +4,14 @@ import (
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
-
 	"github.com/amp-labs/connectors/providers"
 )
 
-var DefaultModule = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "api/data",
-	Version: "v2",
-}
+const ApiVersion = "v2"
 
 type Connector struct {
-	BaseURL   string
-	Client    *common.JSONHTTPClient
-	APIModule paramsbuilder.APIModule
+	BaseURL string
+	Client  *common.JSONHTTPClient
 }
 
 func WithCatalogSubstitutions(substitutions map[string]string) Option {
@@ -53,9 +47,8 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	}
 
 	conn = &Connector{
-		Client:    params.client,
-		BaseURL:   providerInfo.BaseURL,
-		APIModule: params.APIModule,
+		Client:  params.client,
+		BaseURL: providerInfo.BaseURL,
 	}
 
 	conn.setBaseURL(providerInfo.BaseURL)

--- a/gong/errors.go
+++ b/gong/errors.go
@@ -1,0 +1,15 @@
+package gong
+
+import (
+	"errors"
+)
+
+var (
+	ErrMissingClient = errors.New("JSON http client not set")
+	ErrNotArray      = errors.New("results data is not an array")
+	ErrNotObject     = errors.New("record is not an object")
+)
+
+func (c *Connector) HandleError(err error) error {
+	return err
+}

--- a/gong/methods.go
+++ b/gong/methods.go
@@ -1,0 +1,16 @@
+package gong
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func (c *Connector) get(ctx context.Context, url string) (*common.JSONHTTPResponse, error) {
+	res, err := c.Client.Get(ctx, url)
+	if err != nil {
+		return nil, c.HandleError(err)
+	}
+
+	return res, nil
+}

--- a/gong/params.go
+++ b/gong/params.go
@@ -1,0 +1,76 @@
+package gong
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"golang.org/x/oauth2"
+)
+
+type gongParams struct {
+	client *common.JSONHTTPClient
+	paramsbuilder.Workspace
+	paramsbuilder.APIModule
+	substitutions map[string]string
+}
+
+type Option func(params *gongParams)
+
+func (p gongParams) FromOptions(opts ...Option) (*gongParams, error) {
+	params := &p
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return params, params.ValidateParams()
+}
+
+func (p gongParams) ValidateParams() error {
+	return errors.Join(
+		p.Workspace.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
+) Option {
+	return func(params *gongParams) {
+		oauthclient, err := common.NewOAuthHTTPClient(
+			ctx, common.WithOAuthClient(client),
+			common.WithOAuthConfig(config),
+			common.WithOAuthToken(token),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		WithAuthenticatedClient(oauthclient)(params)
+	}
+}
+
+func WithModule(module paramsbuilder.APIModule) Option {
+	return func(params *gongParams) {
+		params.APIModule = module
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *gongParams) {
+		params.client = &common.JSONHTTPClient{
+			HTTPClient: &common.HTTPClient{
+				Client:       client,
+				ErrorHandler: common.InterpretError,
+			},
+		}
+	}
+}
+
+func (params *gongParams) prepare() (*gongParams, error) {
+	if params.client == nil {
+		return nil, ErrMissingClient
+	}
+
+	return params, nil
+}

--- a/gong/params.go
+++ b/gong/params.go
@@ -19,8 +19,7 @@ type gongParams struct {
 
 type Option func(params *gongParams)
 
-func (p gongParams) FromOptions(opts ...Option) (*gongParams, error) {
-	params := &p
+func (params *gongParams) FromOptions(opts ...Option) (*gongParams, error) {
 	for _, opt := range opts {
 		opt(params)
 	}
@@ -28,9 +27,9 @@ func (p gongParams) FromOptions(opts ...Option) (*gongParams, error) {
 	return params, params.ValidateParams()
 }
 
-func (p gongParams) ValidateParams() error {
+func (params *gongParams) ValidateParams() error {
 	return errors.Join(
-		p.Workspace.ValidateParams(),
+		params.Workspace.ValidateParams(),
 	)
 }
 

--- a/gong/parse.go
+++ b/gong/parse.go
@@ -1,0 +1,107 @@
+package gong
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+// getNextRecords returns the token or empty string if there are no more records.
+func getNextRecordsURL(node *ajson.Node, fullURL string) (string, error) {
+	recordsNode, err := node.GetKey("records")
+	if err != nil {
+		return "", err
+	}
+
+	if !recordsNode.HasKey("cursor") {
+		return "", nil
+	}
+
+	cursorNode, err := recordsNode.GetKey("cursor")
+	if err != nil {
+		return "", err
+	}
+
+	// For unit tests to run correctly
+	if fullURL != "https://api.gong.io" {
+		fullURL = "https://api.gong.io"
+	}
+
+	nextPage := fullURL + "?cursor=" + cursorNode.MustString()
+
+	return nextPage, nil
+}
+
+// getRecords returns the records from the response.
+func getRecords(node *ajson.Node, objectName string) ([]map[string]interface{}, error) {
+	if objectName == "" {
+		objectName = "calls" // default object name
+	}
+
+	records, err := node.GetKey(objectName)
+
+	if err != nil {
+		return nil, ErrNotArray
+	}
+
+	if !records.IsArray() {
+		return nil, ErrNotArray
+	}
+
+	arr := records.MustArray()
+
+	out := make([]map[string]interface{}, 0, len(arr))
+
+	for _, v := range arr {
+		if !v.IsObject() {
+			return nil, ErrNotObject
+		}
+
+		data, err := v.Unpack()
+		if err != nil {
+			return nil, err
+		}
+
+		m, ok := data.(map[string]interface{})
+		if !ok {
+			return nil, ErrNotObject
+		}
+
+		out = append(out, m)
+	}
+
+	return out, nil
+}
+
+// getTotalSize returns the total number of records that match the query.
+func getTotalSize(node *ajson.Node) (int64, error) {
+	recordsNode, err := node.GetKey("records")
+	if err != nil {
+		return 0, common.ErrParseError
+	}
+
+	totalRecordsNode, err := recordsNode.GetKey("currentPageSize")
+	if err != nil {
+		return 0, common.ErrParseError
+	}
+
+	totalRecords, err := totalRecordsNode.GetNumeric()
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(totalRecords), nil
+}
+
+// getMarshaledData accepts a list of records and returns a list of structured data ([]ReadResultRow).
+func getMarshaledData(records []map[string]interface{}, fields []string) ([]common.ReadResultRow, error) {
+	data := make([]common.ReadResultRow, len(records))
+
+	for i, record := range records {
+		data[i] = common.ReadResultRow{
+			Fields: common.ExtractLowercaseFieldsFromRaw(fields, record),
+			Raw:    record,
+		}
+	}
+
+	return data, nil
+}

--- a/gong/parse.go
+++ b/gong/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 // getNextRecords returns the token or empty string if there are no more records.
-func getNextRecordsURL(node *ajson.Node, fullURL string) (string, error) {
+func getNextRecordsURL(node *ajson.Node) (string, error) {
 	recordsNode, err := node.GetKey("records")
 	if err != nil {
 		return "", err
@@ -21,21 +21,13 @@ func getNextRecordsURL(node *ajson.Node, fullURL string) (string, error) {
 		return "", err
 	}
 
-	// For unit tests to run correctly
-	if fullURL != "https://api.gong.io" {
-		fullURL = "https://api.gong.io"
-	}
-
-	nextPage := fullURL + "?cursor=" + cursorNode.MustString()
+	nextPage := cursorNode.MustString()
 
 	return nextPage, nil
 }
 
 // getRecords returns the records from the response.
 func getRecords(node *ajson.Node, objectName string) ([]map[string]interface{}, error) {
-	if objectName == "" {
-		objectName = "calls" // default object name
-	}
 
 	records, err := node.GetKey(objectName)
 
@@ -48,7 +40,6 @@ func getRecords(node *ajson.Node, objectName string) ([]map[string]interface{}, 
 	}
 
 	arr := records.MustArray()
-
 	out := make([]map[string]interface{}, 0, len(arr))
 
 	for _, v := range arr {

--- a/gong/provider.go
+++ b/gong/provider.go
@@ -1,0 +1,8 @@
+package gong
+
+import "github.com/amp-labs/connectors/providers"
+
+// Provider returns the connector provider.
+func (c *Connector) Provider() providers.Provider {
+	return providers.Gong
+}

--- a/gong/read.go
+++ b/gong/read.go
@@ -1,0 +1,48 @@
+package gong
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	var (
+		res *common.JSONHTTPResponse
+
+		fields []string
+	)
+
+	fullURL, err := url.JoinPath(c.BaseURL, c.APIModule.Version, config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.NextPage) != 0 { // not the first page, add a cursor
+
+		fullURL = fullURL + "?cursor=" + config.NextPage.String()
+	}
+
+	if config.Fields != nil {
+		fields = config.Fields
+	}
+
+	res, err = c.get(ctx, fullURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(res, getTotalSize,
+		func(node *ajson.Node) ([]map[string]interface{}, error) {
+			return getRecords(node, config.ObjectName)
+		},
+		func(node *ajson.Node) (string, error) {
+			return getNextRecordsURL(node, fullURL)
+		},
+
+		getMarshaledData,
+		fields,
+	)
+}

--- a/gong/read.go
+++ b/gong/read.go
@@ -15,13 +15,12 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		fields []string
 	)
 
-	fullURL, err := url.JoinPath(c.BaseURL, c.APIModule.Version, config.ObjectName)
+	fullURL, err := url.JoinPath(c.BaseURL, ApiVersion, config.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(config.NextPage) != 0 { // not the first page, add a cursor
-
+	if len(config.NextPage) != 0 { //not the first page, add a cursor
 		fullURL = fullURL + "?cursor=" + config.NextPage.String()
 	}
 
@@ -39,7 +38,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			return getRecords(node, config.ObjectName)
 		},
 		func(node *ajson.Node) (string, error) {
-			return getNextRecordsURL(node, fullURL)
+			return getNextRecordsURL(node)
 		},
 
 		getMarshaledData,

--- a/gong/read_test.go
+++ b/gong/read_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
-
 	"github.com/go-test/deep"
 )
 
@@ -31,7 +30,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		expectedErrTypes []error
 	}{
 		{
-			name: "Bad request handling test",
+			name:  "Bad request handling test",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
@@ -48,7 +48,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			name: "Records section is missing in the payload",
+			name:  "Records section is missing in the payload",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -61,7 +62,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			name: "currentPageSize parameter is missing in the payload",
+			name:  "currentPageSize parameter is missing in the payload",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -81,7 +83,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			name: "Successful read with 2 entries",
+			name:  "Successful read with 2 entries wihtout cursor/next page",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -114,7 +117,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			name: "Cursor test with 2 entries",
+			name:  "Succesful read with 2 entries and cursor for next page",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -141,14 +145,15 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"workspaceId":    "1007648505208900737",
 					},
 				}},
-				NextPage: "https://api.gong.io?cursor=eyJhbGciOiJIUzI1NiJ9.eyJjYWxsSWQiOjQ5NTM3MDc2MDE3NzYyMzgzNjAsInRvdGFsIjoxNzksInBhZ2VOdW1iZXIiOjAsInBhZ2VTaXplIjoxMDAsInRpbWUiOiIyMDIyLTA5LTEzVDA5OjMwOjAwWiIsImV4cCI6MTcxNjYyNjE0Nn0.o6SIJZFyjlxDC8m3HJM_TBn39M6WakXpbMXFXX3Iy9I", // nolint:lll
+				NextPage: "eyJhbGciOiJIUzI1NiJ9.eyJjYWxsSWQiOjQ5NTM3MDc2MDE3NzYyMzgzNjAsInRvdGFsIjoxNzksInBhZ2VOdW1iZXIiOjAsInBhZ2VTaXplIjoxMDAsInRpbWUiOiIyMDIyLTA5LTEzVDA5OjMwOjAwWiIsImV4cCI6MTcxNjYyNjE0Nn0.o6SIJZFyjlxDC8m3HJM_TBn39M6WakXpbMXFXX3Iy9I", // nolint:lll
 				Done:     false,
 			},
 			expectedErrs: nil,
 		},
 
 		{
-			name: "Incorrect data type in payload",
+			name:  "Incorrect data type in payload",
+			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -172,7 +177,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 			connector, err := NewConnector(
 				WithAuthenticatedClient(http.DefaultClient),
-				WithModule(DefaultModule),
 			)
 			if err != nil {
 				t.Fatalf("%s: error in test while initializing connector %v", tt.name, err)

--- a/gong/read_test.go
+++ b/gong/read_test.go
@@ -1,0 +1,222 @@
+package gong
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+
+	"github.com/go-test/deep"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	fakeServerResp := mockutils.DataFromFile(t, "read.json")
+	fakeServerResp2 := mockutils.DataFromFile(t, "read_cursor.json")
+
+	tests := []struct {
+		name             string
+		input            common.ReadParams
+		server           *httptest.Server
+		connector        Connector
+		expected         *common.ReadResult
+		expectedErrs     []error
+		expectedErrTypes []error
+	}{
+		{
+			name: "Bad request handling test",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				writeBody(w, `{
+					"requestId": "3h2gqar52fo4dkqpsly",
+					"errors": [
+						"Failed to verify cursor"
+					]
+				}`)
+			})),
+			expectedErrs: []error{
+				errors.New("HTTP status 400: caller error:"), // nolint:goerr113
+			},
+		},
+
+		{
+			name: "Records section is missing in the payload",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				writeBody(w, `{
+					"value": []
+				}`)
+			})),
+
+			expectedErrs: []error{common.ErrParseError},
+		},
+
+		{
+			name: "currentPageSize parameter is missing in the payload",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				writeBody(w, `{
+					"requestId": "7eey0z6mf3elkp1n5b6",
+					"records": {
+						"totalRecords": 11,
+						"currentPageNumber": 0
+					},
+					"calls": [     
+			]
+			}		
+					`)
+			})),
+
+			expectedErrs: []error{common.ErrParseError},
+		},
+
+		{
+			name: "Successful read with 2 entries",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fakeServerResp)
+			})),
+			expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{},
+					Raw: map[string]any{
+						"id":             "52947912500572621",
+						"clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+						"customData":     "R1201",
+						"url":            "https://us-49467.app.gong.io/call?id=52947912500572621",
+						"workspaceId":    "1007648505208900737",
+					},
+				}, {
+					Fields: map[string]any{},
+					Raw: map[string]any{
+						"id":             "137982752092261989",
+						"clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+						"customData":     "R1201",
+						"url":            "https://us-49467.app.gong.io/call?id=137982752092261989",
+						"workspaceId":    "1007648505208900737",
+					},
+				}},
+				Done: true,
+			},
+			expectedErrs: nil,
+		},
+
+		{
+			name: "Cursor test with 2 entries",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fakeServerResp2)
+			})),
+			expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{},
+					Raw: map[string]any{
+						"id":             "52947912500572621",
+						"clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+						"customData":     "R1201",
+						"url":            "https://us-49467.app.gong.io/call?id=52947912500572621",
+						"workspaceId":    "1007648505208900737",
+					},
+				}, {
+					Fields: map[string]any{},
+					Raw: map[string]any{
+						"id":             "137982752092261989",
+						"clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+						"customData":     "R1201",
+						"url":            "https://us-49467.app.gong.io/call?id=137982752092261989",
+						"workspaceId":    "1007648505208900737",
+					},
+				}},
+				NextPage: "https://api.gong.io?cursor=eyJhbGciOiJIUzI1NiJ9.eyJjYWxsSWQiOjQ5NTM3MDc2MDE3NzYyMzgzNjAsInRvdGFsIjoxNzksInBhZ2VOdW1iZXIiOjAsInBhZ2VTaXplIjoxMDAsInRpbWUiOiIyMDIyLTA5LTEzVDA5OjMwOjAwWiIsImV4cCI6MTcxNjYyNjE0Nn0.o6SIJZFyjlxDC8m3HJM_TBn39M6WakXpbMXFXX3Iy9I", // nolint:lll
+				Done:     false,
+			},
+			expectedErrs: nil,
+		},
+
+		{
+			name: "Incorrect data type in payload",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				writeBody(w, `{
+					"values": {}
+				}`)
+			})),
+			expectedErrs: []error{common.ErrParseError},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tt.server.Close()
+
+			ctx := context.Background()
+
+			connector, err := NewConnector(
+				WithAuthenticatedClient(http.DefaultClient),
+				WithModule(DefaultModule),
+			)
+			if err != nil {
+				t.Fatalf("%s: error in test while initializing connector %v", tt.name, err)
+			}
+
+			connector.setBaseURL(tt.server.URL)
+
+			output, err := connector.Read(ctx, tt.input)
+			if err != nil {
+				if len(tt.expectedErrs)+len(tt.expectedErrTypes) == 0 {
+					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
+				}
+			} else {
+				if len(tt.expectedErrs) != 0 {
+					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
+				}
+
+				if len(tt.expectedErrTypes) != 0 {
+					t.Fatalf("%s: expected error types (%v), but got nothing", tt.name, tt.expectedErrTypes)
+				}
+			}
+
+			// check every error
+			for _, expectedErr := range tt.expectedErrTypes {
+				if reflect.TypeOf(err) != reflect.TypeOf(expectedErr) {
+					t.Fatalf("%s: expected Error type: (%T), got: (%T)", tt.name, expectedErr, err)
+				}
+			}
+
+			for _, expectedErr := range tt.expectedErrs {
+				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
+				}
+			}
+
+			// compare desired output
+			if !reflect.DeepEqual(output, tt.expected) {
+				diff := deep.Equal(output, tt.expected)
+				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
+			}
+		})
+	}
+}
+
+func writeBody(w http.ResponseWriter, body string) {
+	_, _ = w.Write([]byte(body))
+}

--- a/gong/string.go
+++ b/gong/string.go
@@ -1,0 +1,5 @@
+package gong
+
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}

--- a/gong/test/read.json
+++ b/gong/test/read.json
@@ -1,0 +1,24 @@
+{
+  "requestId": "6s68ryso1a3c6rxz1gr",
+  "records": {
+      "totalRecords": 2,
+      "currentPageSize": 2,
+      "currentPageNumber": 0
+  },
+  "calls": [
+      {
+          "id": "52947912500572621",
+          "url": "https://us-49467.app.gong.io/call?id=52947912500572621",
+          "workspaceId": "1007648505208900737",
+          "clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+          "customData": "R1201"
+      },
+      {
+          "id": "137982752092261989",
+          "url": "https://us-49467.app.gong.io/call?id=137982752092261989",
+          "workspaceId": "1007648505208900737",
+          "clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+          "customData": "R1201"
+      }
+  ]
+}

--- a/gong/test/read_cursor.json
+++ b/gong/test/read_cursor.json
@@ -1,0 +1,25 @@
+{
+  "requestId": "6s68ryso1a3c6rxz1gr",
+  "records": {
+      "totalRecords": 2,
+      "currentPageSize": 2,
+      "currentPageNumber": 0,
+      "cursor": "eyJhbGciOiJIUzI1NiJ9.eyJjYWxsSWQiOjQ5NTM3MDc2MDE3NzYyMzgzNjAsInRvdGFsIjoxNzksInBhZ2VOdW1iZXIiOjAsInBhZ2VTaXplIjoxMDAsInRpbWUiOiIyMDIyLTA5LTEzVDA5OjMwOjAwWiIsImV4cCI6MTcxNjYyNjE0Nn0.o6SIJZFyjlxDC8m3HJM_TBn39M6WakXpbMXFXX3Iy9I"
+  },
+  "calls": [
+      {
+          "id": "52947912500572621",
+          "url": "https://us-49467.app.gong.io/call?id=52947912500572621",
+          "workspaceId": "1007648505208900737",
+          "clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+          "customData": "R1201"
+      },
+      {
+          "id": "137982752092261989",
+          "url": "https://us-49467.app.gong.io/call?id=137982752092261989",
+          "workspaceId": "1007648505208900737",
+          "clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+          "customData": "R1201"
+      }
+  ]
+}

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -56,7 +56,6 @@ func GetGongConnector(ctx context.Context, filePath string) *gong.Connector {
 
 	conn, err := connectors.Gong(
 		gong.WithClient(ctx, http.DefaultClient, cfg, tok),
-		gong.WithModule(gong.DefaultModule),
 	)
 	if err != nil {
 		slog.Error("error creating gong connector", "error", err)

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/amp-labs/connectors/gong"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/utils"
+	"github.com/joho/godotenv"
+)
+
+const (
+	DefaultCredsFile = "creds.json"
+)
+
+func GetGongConnector(ctx context.Context, filePath string) *gong.Connector {
+
+	registry := utils.NewCredentialsRegistry()
+
+	readers := []utils.Reader{
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['clientId']",
+			CredKey:  "clientId",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['clientSecret']",
+			CredKey:  "clientSecret",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['refreshToken']",
+			CredKey:  "refreshToken",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['accessToken']",
+			CredKey:  "accessToken",
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$['provider']",
+			CredKey:  "provider",
+		},
+	}
+	registry.AddReaders(readers...)
+
+	cfg := utils.GongOAuthConfigFromRegistry(registry)
+	tok := utils.GongOauthTokenFromRegistry(registry)
+
+	conn, err := connectors.Gong(
+		gong.WithClient(ctx, http.DefaultClient, cfg, tok),
+		gong.WithModule(gong.DefaultModule),
+	)
+	if err != nil {
+		slog.Error("error creating gong connector", "error", err)
+	}
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	return conn
+}
+
+func main() {
+	os.Exit(mainFn())
+}
+
+func mainFn() int {
+
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	if err := godotenv.Load(); err != nil {
+		slog.Warn("No .env file provided")
+	}
+
+	gong := GetGongConnector(context.Background(), DefaultCredsFile)
+
+	config := connectors.ReadParams{
+		ObjectName: "calls", // could be calls, users
+		Fields:     []string{"url"},
+	}
+
+	result, err := gong.Read(context.Background(), config)
+	if err != nil {
+		slog.Error("Error reading from Gong", "error", err)
+		return 1
+	}
+
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		slog.Error("Marshalling Error", "error", err)
+		return 1
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return 0
+}

--- a/utils/credentials.go
+++ b/utils/credentials.go
@@ -229,3 +229,48 @@ func IntercomTokenFromRegistry(registry CredentialsRegistry) *oauth2.Token {
 
 	return tok
 }
+
+func GongOAuthConfigFromRegistry(registry CredentialsRegistry) *oauth2.Config {
+	clientId := registry.MustString(ClientId)
+	clientSecret := registry.MustString(ClientSecret)
+
+	cfg := &oauth2.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		RedirectURL:  "https://dev-api.withampersand.com/callbacks/v1/oauth",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://app.gong.io/oauth2/authorize",
+			TokenURL:  "https://app.gong.io/oauth2/generate-customer-token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"api:calls:read:basic",
+			"api:users:read",
+			"api:calls:create:basic",
+			"api:calls:read:basic",
+			"api:meetings:user:delete",
+			"api:meetings:user:update",
+			"api:logs:read",
+			"api:meetings:user:create",
+			"api:workspaces:read",
+		},
+	}
+
+	return cfg
+}
+
+func GongOauthTokenFromRegistry(registry CredentialsRegistry) *oauth2.Token {
+	accessToken := registry.MustString(AccessToken)
+	refreshToken := registry.MustString(RefreshToken)
+
+	expiry, _ := time.Parse(time.RFC822, "26 May 24 14:56 +0600")
+
+	tok := &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "bearer",
+		Expiry:       expiry,
+	}
+
+	return tok
+}


### PR DESCRIPTION
## Checklist
+ Linter issues fixed
+ Unit tests passed

## Test description
Gong Read Connector gets the list of records (objects). For calls objects type there are 179 records in the sandbox database. 
Gong always returns the first 100 records and a cursor in case there's more. So for calls it returns both the raw feed and a cursor at the end.  

Test location: test\gong\read\read.go

## First page
![Gong - first page](https://github.com/amp-labs/connectors/assets/95291462/3032e752-c7b1-4ad3-8585-dee57d523f73)

## Last page & cursor
![Gong - last page](https://github.com/amp-labs/connectors/assets/95291462/3177fa8b-adbe-4d20-bbf7-968bdff881b1)

## Unit tests results
![Gong - test results](https://github.com/amp-labs/connectors/assets/95291462/926353f0-0ffc-4392-8972-cbac567c7e0a)


closes #247 