### PR TITLE
feat: Add providers.SetInfo

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -42,6 +42,14 @@ func ReadCatalog() (CatalogType, error) {
 	return catalog, nil
 }
 
+// SetInfo sets the information for a specific provider in the catalog.
+// This is useful to enable experimental providers or to override the default
+// provider information. As a general rule, don't ever call this function
+// in production code unless you have a compelling reason to do so.
+func SetInfo(provider Provider, info ProviderInfo) {
+	catalog[provider] = info
+}
+
 // ReadInfo reads the information from the catalog for specific provider. It also performs string substitution
 // on the values in the config that are surrounded by {{}}.
 func ReadInfo(provider Provider, substitutions *map[string]string) (*ProviderInfo, error) {


### PR DESCRIPTION
There have been several instances where it would have been nice to override the providers in the connectors repo. As an example, testing out the proxy logic without needing to open a PR in connectors -> open a PR in server -> deploy preview environment. This is excessive for what amounts to changing a bool from false to true.

This PR allows us to override providers from the server repo. The general use-case here is for testing, but theoretically we could use it to disable problematic features in prod (e.g. a feature we marked as stable which turns out to have a show-stopping bug). Obviously we'd need to be very selective about when it's used, in general the source of truth should still live in the connectors repo. However being able to override is useful.
