### PR TITLE
build: re-enable linter in Github actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
           go-version: ">=1.21.0"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v3
         continue-on-error: false
         with:
           version: latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,9 +10,8 @@ jobs:
         with:
           go-version: ">=1.21.0"
           cache: false
-          version: v1.54
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         continue-on-error: false
         with:
-          version: latest
+          version: v1.54

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
           go-version: ">=1.21.0"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        continue-on-error: true
+        uses: golangci/golangci-lint-action@v6
+        continue-on-error: false
         with:
           version: latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           go-version: ">=1.21.0"
           cache: false
+          version: v1.54
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         continue-on-error: false

--- a/gong/parse.go
+++ b/gong/parse.go
@@ -28,9 +28,7 @@ func getNextRecordsURL(node *ajson.Node) (string, error) {
 
 // getRecords returns the records from the response.
 func getRecords(node *ajson.Node, objectName string) ([]map[string]interface{}, error) {
-
 	records, err := node.GetKey(objectName)
-
 	if err != nil {
 		return nil, ErrNotArray
 	}

--- a/gong/read.go
+++ b/gong/read.go
@@ -20,7 +20,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	if len(config.NextPage) != 0 { //not the first page, add a cursor
+	if len(config.NextPage) != 0 { // not the first page, add a cursor
 		fullURL = fullURL + "?cursor=" + config.NextPage.String()
 	}
 
@@ -37,10 +37,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		func(node *ajson.Node) ([]map[string]interface{}, error) {
 			return getRecords(node, config.ObjectName)
 		},
-		func(node *ajson.Node) (string, error) {
-			return getNextRecordsURL(node)
-		},
-
+		getNextRecordsURL,
 		getMarshaledData,
 		fields,
 	)

--- a/gong/read_test.go
+++ b/gong/read_test.go
@@ -117,7 +117,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			name:  "Succesful read with 2 entries and cursor for next page",
+			name:  "Successful read with 2 entries and cursor for next page",
 			input: common.ReadParams{ObjectName: "calls"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/amp-labs/connectors/gong"
-
 	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/gong"
 	"github.com/amp-labs/connectors/utils"
 	"github.com/joho/godotenv"
 )
@@ -19,7 +18,6 @@ const (
 )
 
 func GetGongConnector(ctx context.Context, filePath string) *gong.Connector {
-
 	registry := utils.NewCredentialsRegistry()
 
 	readers := []utils.Reader{
@@ -73,7 +71,6 @@ func main() {
 }
 
 func mainFn() int {
-
 	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})


### PR DESCRIPTION
The linter was somehow set to `continue-on-error: true` before, so the CI passes even when the linter fails. This PR re-enables the linter and also fixes existing lint issues. 

I also pinned golangci to v1.54 (same version we use in the server), not latest. 