### PR TITLE
fix: pass API version Header for all Intercom methods

### DIFF
--- a/intercom/connector.go
+++ b/intercom/connector.go
@@ -12,6 +12,11 @@ import (
 
 const apiVersion = "2.11"
 
+var apiVersionHeader = common.Header{ // nolint:gochecknoglobals
+	Key:   "Intercom-Version",
+	Value: apiVersion,
+}
+
 type Connector struct {
 	BaseURL string
 	Client  *common.JSONHTTPClient

--- a/intercom/delete.go
+++ b/intercom/delete.go
@@ -24,7 +24,7 @@ func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*co
 
 	// Server usually responds with data indicating resource id that was just removed,
 	// or it returns the same payload as during Get/Post/Put requests
-	_, err = c.Client.Delete(ctx, url.String())
+	_, err = c.Client.Delete(ctx, url.String(), apiVersionHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/intercom/delete_test.go
+++ b/intercom/delete_test.go
@@ -69,7 +69,9 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "DELETE")
+				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
+					mockutils.RespondNoContentForMethod(w, r, "DELETE")
+				})
 			})),
 			expected:     &common.DeleteResult{Success: true},
 			expectedErrs: nil,

--- a/intercom/read.go
+++ b/intercom/read.go
@@ -14,10 +14,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	rsp, err := c.Client.Get(ctx, link.String(), common.Header{
-		Key:   "Intercom-Version",
-		Value: apiVersion,
-	})
+	rsp, err := c.Client.Get(ctx, link.String(), apiVersionHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/intercom/write.go
+++ b/intercom/write.go
@@ -30,7 +30,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		url.AddPath(config.RecordId)
 	}
 
-	res, err := write(ctx, url.String(), config.RecordData)
+	res, err := write(ctx, url.String(), config.RecordData, apiVersionHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/intercom/write_test.go
+++ b/intercom/write_test.go
@@ -85,6 +85,22 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			expectedErrs: nil,
 		},
 		{
+			name:  "API version header is passed as server request on POST",
+			input: common.WriteParams{ObjectName: "articles"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(createArticle)
+				})
+			})),
+			comparator: func(actual, expected *common.WriteResult) bool {
+				return actual.Success == expected.Success
+			},
+			expected:     &common.WriteResult{Success: true},
+			expectedErrs: nil,
+		},
+		{
 			name:  "Valid creation of an article",
 			input: common.WriteParams{ObjectName: "articles"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -22,11 +22,42 @@ func RespondToMethod(w http.ResponseWriter, r *http.Request, methodName string, 
 		WriteBody(w, fmt.Sprintf(`{
 			"error": {
 				"code": "from test",
-				"message":"test server expected %v request"
+				"message": "test server expected %v request"
 			}}`, methodName))
+	}
+}
+
+func RespondToHeader(w http.ResponseWriter, r *http.Request, header http.Header, onSuccess func()) {
+	// if some headers are missing we return error code so the test will fail
+	if missingHeader, ok := headerIsSubset(r.Header, header); ok {
+		// if method is matching headers
+		onSuccess()
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+		WriteBody(w, fmt.Sprintf(`{
+			"error": {
+				"code": "from test",
+				"message": "test server mismatching [%v] header"
+			}}`, missingHeader))
 	}
 }
 
 func WriteBody(w http.ResponseWriter, body string) {
 	_, _ = w.Write([]byte(body))
+}
+
+func headerIsSubset(superset, subset http.Header) (string, bool) {
+	for name, values := range subset {
+		superValues := make(map[string]bool)
+		for _, v := range superset.Values(name) {
+			superValues[v] = true
+		}
+		// every value of this header must be part of superset
+		for _, value := range values {
+			if _, found := superValues[value]; !found {
+				return name, false
+			}
+		}
+	}
+	return "", true
 }


### PR DESCRIPTION
As I recall from the documentation their server defaults to some API version. Since we are passing it to one method all other methods should be consistent.

Linter: https://github.com/amp-labs/connectors/pull/480