### PR TITLE
fix: Salesloft Metadata to match SnakeCase of ObjectName

### DIFF
--- a/intercom/metadata/index.json
+++ b/intercom/metadata/index.json
@@ -1,141 +1,6 @@
 {
   "data": [
     {
-      "name": "admin",
-      "displayName": "Admin",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Admins/admin"
-    },
-    {
-      "name": "article",
-      "displayName": "Article",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article"
-    },
-    {
-      "name": "article_list_item",
-      "displayName": "Articles",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_list_item"
-    },
-    {
-      "name": "article_search_highlights",
-      "displayName": "Article Search Highlights",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_search_highlights"
-    },
-    {
-      "name": "article_search_response",
-      "displayName": "Article Search Response",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_search_response"
-    },
-    {
-      "name": "company",
-      "displayName": "Company",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/company"
-    },
-    {
-      "name": "contact",
-      "displayName": "Contact",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Contacts/contact"
-    },
-    {
-      "name": "conversation",
-      "displayName": "Conversation",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Conversations/conversation"
-    },
-    {
-      "name": "data_attribute",
-      "displayName": "Data Attribute",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Attributes/data_attribute"
-    },
-    {
-      "name": "data_event",
-      "displayName": "Data Event",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Events/data_event"
-    },
-    {
-      "name": "data_export",
-      "displayName": "Data Export",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Export/data_export"
-    },
-    {
-      "name": "collection",
-      "displayName": "Collection",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/collection"
-    },
-    {
-      "name": "help_center",
-      "displayName": "Help Center",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/help_center"
-    },
-    {
-      "name": "help_center_list",
-      "displayName": "Help Centers",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/help_center_list"
-    },
-    {
-      "name": "message",
-      "displayName": "Message",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Messages/message"
-    },
-    {
-      "name": "news_item",
-      "displayName": "News Item",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/news_item"
-    },
-    {
-      "name": "newsfeed",
-      "displayName": "Newsfeed",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/newsfeed"
-    },
-    {
-      "name": "newsfeed_assignment",
-      "displayName": "Newsfeed Assignment",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/newsfeed_assignment"
-    },
-    {
-      "name": "note",
-      "displayName": "Note",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Notes/note"
-    },
-    {
-      "name": "segment",
-      "displayName": "Segment",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Segments/segment"
-    },
-    {
-      "name": "subscription_type",
-      "displayName": "Subscription Types",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Subscription-Types/subscription_type"
-    },
-    {
-      "name": "tag",
-      "displayName": "Tag",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tags/tag"
-    },
-    {
-      "name": "team",
-      "displayName": "Team",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Teams/team"
-    },
-    {
-      "name": "ticket",
-      "displayName": "Ticket",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket"
-    },
-    {
-      "name": "ticket_contacts",
-      "displayName": "Contacts",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_contacts"
-    },
-    {
-      "name": "ticket_part",
-      "displayName": "Ticket Part",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_part"
-    },
-    {
-      "name": "ticket_type",
-      "displayName": "Ticket Type",
-      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_type"
-    },
-    {
       "name": "activity_log",
       "displayName": "Activity Log",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/activity_log"
@@ -154,6 +19,11 @@
       "name": "addressable_list",
       "displayName": "Addressable List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/addressable_list"
+    },
+    {
+      "name": "admin",
+      "displayName": "Admin",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Admins/admin"
     },
     {
       "name": "admin_list",
@@ -186,6 +56,11 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/app"
     },
     {
+      "name": "article",
+      "displayName": "Article",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article"
+    },
+    {
       "name": "article_content",
       "displayName": "Article Content",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/article_content"
@@ -194,6 +69,21 @@
       "name": "article_list",
       "displayName": "Articles",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/article_list"
+    },
+    {
+      "name": "article_list_item",
+      "displayName": "Articles",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_list_item"
+    },
+    {
+      "name": "article_search_highlights",
+      "displayName": "Article Search Highlights",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_search_highlights"
+    },
+    {
+      "name": "article_search_response",
+      "displayName": "Article Search Response",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article_search_response"
     },
     {
       "name": "article_statistics",
@@ -221,9 +111,19 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/close_conversation_request"
     },
     {
+      "name": "collection",
+      "displayName": "Collection",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/collection"
+    },
+    {
       "name": "collection_list",
       "displayName": "Collections",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/collection_list"
+    },
+    {
+      "name": "company",
+      "displayName": "Company",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/company"
     },
     {
       "name": "company_attached_contacts",
@@ -244,6 +144,11 @@
       "name": "company_scroll",
       "displayName": "Company Scroll",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/company_scroll"
+    },
+    {
+      "name": "contact",
+      "displayName": "Contact",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Contacts/contact"
     },
     {
       "name": "contact_archived",
@@ -359,6 +264,11 @@
       "name": "content_sources_list",
       "displayName": "Content Source List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/content_sources_list"
+    },
+    {
+      "name": "conversation",
+      "displayName": "Conversation",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Conversations/conversation"
     },
     {
       "name": "conversation_attachment_files",
@@ -521,9 +431,19 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/customer_request"
     },
     {
+      "name": "data_attribute",
+      "displayName": "Data Attribute",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Attributes/data_attribute"
+    },
+    {
       "name": "data_attribute_list",
       "displayName": "Data Attribute List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/data_attribute_list"
+    },
+    {
+      "name": "data_event",
+      "displayName": "Data Event",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Events/data_event"
     },
     {
       "name": "data_event_list",
@@ -539,6 +459,11 @@
       "name": "data_event_summary_item",
       "displayName": "Data Event Summary Item",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/data_event_summary_item"
+    },
+    {
+      "name": "data_export",
+      "displayName": "Data Export",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Data-Export/data_export"
     },
     {
       "name": "data_export_csv",
@@ -591,6 +516,16 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/group_translated_content"
     },
     {
+      "name": "help_center",
+      "displayName": "Help Center",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/help_center"
+    },
+    {
+      "name": "help_center_list",
+      "displayName": "Help Centers",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/help_center_list"
+    },
+    {
       "name": "intercom_version",
       "displayName": "intercom_version",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/intercom_version"
@@ -611,14 +546,39 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/merge_contacts_request"
     },
     {
+      "name": "message",
+      "displayName": "Message",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Messages/message"
+    },
+    {
       "name": "multiple_filter_search_request",
       "displayName": "Multiple Filter Search Request",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/multiple_filter_search_request"
     },
     {
+      "name": "news_item",
+      "displayName": "News Item",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/news_item"
+    },
+    {
       "name": "news_item_request",
       "displayName": "Create News Item Request",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/news_item_request"
+    },
+    {
+      "name": "newsfeed",
+      "displayName": "Newsfeed",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/newsfeed"
+    },
+    {
+      "name": "newsfeed_assignment",
+      "displayName": "Newsfeed Assignment",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/News/newsfeed_assignment"
+    },
+    {
+      "name": "note",
+      "displayName": "Note",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Notes/note"
     },
     {
       "name": "note_list",
@@ -671,6 +631,11 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/search_request"
     },
     {
+      "name": "segment",
+      "displayName": "Segment",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Segments/segment"
+    },
+    {
       "name": "segment_list",
       "displayName": "Segment List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/segment_list"
@@ -701,9 +666,19 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/starting_after_paging"
     },
     {
+      "name": "subscription_type",
+      "displayName": "Subscription Types",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Subscription-Types/subscription_type"
+    },
+    {
       "name": "subscription_type_list",
       "displayName": "Subscription Types",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/subscription_type_list"
+    },
+    {
+      "name": "tag",
+      "displayName": "Tag",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tags/tag"
     },
     {
       "name": "tag_company_request",
@@ -726,6 +701,11 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/tags"
     },
     {
+      "name": "team",
+      "displayName": "Team",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Teams/team"
+    },
+    {
       "name": "team_list",
       "displayName": "Team List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/team_list"
@@ -736,6 +716,16 @@
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/team_priority_level"
     },
     {
+      "name": "ticket",
+      "displayName": "Ticket",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket"
+    },
+    {
+      "name": "ticket_contacts",
+      "displayName": "Contacts",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_contacts"
+    },
+    {
       "name": "ticket_custom_attributes",
       "displayName": "Ticket Attributes",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/ticket_custom_attributes"
@@ -744,6 +734,11 @@
       "name": "ticket_list",
       "displayName": "Ticket List",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/ticket_list"
+    },
+    {
+      "name": "ticket_part",
+      "displayName": "Ticket Part",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_part"
     },
     {
       "name": "ticket_part_author",
@@ -764,6 +759,11 @@
       "name": "ticket_request_custom_attributes",
       "displayName": "Ticket Attributes",
       "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/ticket_request_custom_attributes"
+    },
+    {
+      "name": "ticket_type",
+      "displayName": "Ticket Type",
+      "url": "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Tickets/ticket_type"
     },
     {
       "name": "ticket_type_attribute",

--- a/salesloft/metadata/index.json
+++ b/salesloft/metadata/index.json
@@ -1,21 +1,6 @@
 {
   "data": [
     {
-      "name": "me-index",
-      "displayName": "Fetch current user",
-      "url": "https://developers.salesloft.com/docs/api/me-index"
-    },
-    {
-      "name": "team-index",
-      "displayName": "Fetch current team",
-      "url": "https://developers.salesloft.com/docs/api/team-index"
-    },
-    {
-      "name": "data-control-account-redaction-create",
-      "displayName": "Execute an account redaction workflow",
-      "url": "https://developers.salesloft.com/docs/api/data-control-account-redaction-create"
-    },
-    {
       "name": "account-stages-index",
       "displayName": "List account stages",
       "url": "https://developers.salesloft.com/docs/api/account-stages-index"
@@ -41,19 +26,19 @@
       "url": "https://developers.salesloft.com/docs/api/account-upserts-create"
     },
     {
-      "name": "data-control-account-and-people-redaction-create",
-      "displayName": "Submit an account and people redaction  request",
-      "url": "https://developers.salesloft.com/docs/api/data-control-account-and-people-redaction-create"
+      "name": "accounts-create",
+      "displayName": "Create an account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-create"
+    },
+    {
+      "name": "accounts-destroy",
+      "displayName": "Delete an account",
+      "url": "https://developers.salesloft.com/docs/api/accounts-destroy"
     },
     {
       "name": "accounts-index",
       "displayName": "List accounts",
       "url": "https://developers.salesloft.com/docs/api/accounts-index"
-    },
-    {
-      "name": "accounts-create",
-      "displayName": "Create an account",
-      "url": "https://developers.salesloft.com/docs/api/accounts-create"
     },
     {
       "name": "accounts-show",
@@ -66,9 +51,14 @@
       "url": "https://developers.salesloft.com/docs/api/accounts-update"
     },
     {
-      "name": "accounts-destroy",
-      "displayName": "Delete an account",
-      "url": "https://developers.salesloft.com/docs/api/accounts-destroy"
+      "name": "action-details-call-instructions-index",
+      "displayName": "List call instructions",
+      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-index"
+    },
+    {
+      "name": "action-details-call-instructions-show",
+      "displayName": "Fetch a call instructions",
+      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-show"
     },
     {
       "name": "actions-index",
@@ -81,24 +71,39 @@
       "url": "https://developers.salesloft.com/docs/api/actions-show"
     },
     {
+      "name": "activities-calls-create",
+      "displayName": "Create a call",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-create"
+    },
+    {
+      "name": "activities-calls-index",
+      "displayName": "List calls",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-index"
+    },
+    {
+      "name": "activities-calls-show",
+      "displayName": "Fetch a call",
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-show"
+    },
+    {
       "name": "activities-create",
       "displayName": "Create an activity",
       "url": "https://developers.salesloft.com/docs/api/activities-create"
     },
     {
+      "name": "activities-emails-index",
+      "displayName": "List emails",
+      "url": "https://developers.salesloft.com/docs/api/activities-emails-index"
+    },
+    {
+      "name": "activities-emails-show",
+      "displayName": "Fetch an email",
+      "url": "https://developers.salesloft.com/docs/api/activities-emails-show"
+    },
+    {
       "name": "activity-histories-index",
       "displayName": "List Past Activities",
       "url": "https://developers.salesloft.com/docs/api/activity-histories-index"
-    },
-    {
-      "name": "bulk-jobs-update",
-      "displayName": "Update a bulk job",
-      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-update"
-    },
-    {
-      "name": "bulk-jobs-show",
-      "displayName": "Fetch a bulk job",
-      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-show"
     },
     {
       "name": "bulk-jobs-create",
@@ -126,6 +131,16 @@
       "url": "https://developers.salesloft.com/docs/api/bulk-jobs-results-index"
     },
     {
+      "name": "bulk-jobs-show",
+      "displayName": "Fetch a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-show"
+    },
+    {
+      "name": "bulk-jobs-update",
+      "displayName": "Update a bulk job",
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-update"
+    },
+    {
       "name": "bulk-reschedule-tasks-create",
       "displayName": "Reschedule many tasks at once",
       "url": "https://developers.salesloft.com/docs/api/bulk-reschedule-tasks-create"
@@ -141,24 +156,24 @@
       "url": "https://developers.salesloft.com/docs/api/cadence-imports-create"
     },
     {
-      "name": "cadence-memberships-index",
-      "displayName": "List cadence memberships",
-      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-index"
-    },
-    {
       "name": "cadence-memberships-create",
       "displayName": "Create a cadence membership",
       "url": "https://developers.salesloft.com/docs/api/cadence-memberships-create"
     },
     {
-      "name": "cadence-memberships-show",
-      "displayName": "Fetch a cadence membership",
-      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-show"
-    },
-    {
       "name": "cadence-memberships-destroy",
       "displayName": "Delete a cadence membership",
       "url": "https://developers.salesloft.com/docs/api/cadence-memberships-destroy"
+    },
+    {
+      "name": "cadence-memberships-index",
+      "displayName": "List cadence memberships",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-index"
+    },
+    {
+      "name": "cadence-memberships-show",
+      "displayName": "Fetch a cadence membership",
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-show"
     },
     {
       "name": "cadences-index",
@@ -171,14 +186,14 @@
       "url": "https://developers.salesloft.com/docs/api/cadences-show"
     },
     {
-      "name": "calendar-events-upsert-create",
-      "displayName": "Upsert a calendar event",
-      "url": "https://developers.salesloft.com/docs/api/calendar-events-upsert-create"
-    },
-    {
       "name": "calendar-events-index",
       "displayName": "List calendar events",
       "url": "https://developers.salesloft.com/docs/api/calendar-events-index"
+    },
+    {
+      "name": "calendar-events-upsert-create",
+      "displayName": "Upsert a calendar event",
+      "url": "https://developers.salesloft.com/docs/api/calendar-events-upsert-create"
     },
     {
       "name": "call-data-records-index",
@@ -196,49 +211,14 @@
       "url": "https://developers.salesloft.com/docs/api/call-dispositions-index"
     },
     {
-      "name": "action-details-call-instructions-index",
-      "displayName": "List call instructions",
-      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-index"
-    },
-    {
-      "name": "action-details-call-instructions-show",
-      "displayName": "Fetch a call instructions",
-      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-show"
-    },
-    {
       "name": "call-sentiments-index",
       "displayName": "List call sentiments",
       "url": "https://developers.salesloft.com/docs/api/call-sentiments-index"
     },
     {
-      "name": "phone-numbers-caller-ids-index",
-      "displayName": "List caller ids",
-      "url": "https://developers.salesloft.com/docs/api/phone-numbers-caller-ids-index"
-    },
-    {
-      "name": "activities-calls-index",
-      "displayName": "List calls",
-      "url": "https://developers.salesloft.com/docs/api/activities-calls-index"
-    },
-    {
-      "name": "activities-calls-create",
-      "displayName": "Create a call",
-      "url": "https://developers.salesloft.com/docs/api/activities-calls-create"
-    },
-    {
-      "name": "activities-calls-show",
-      "displayName": "Fetch a call",
-      "url": "https://developers.salesloft.com/docs/api/activities-calls-show"
-    },
-    {
       "name": "create-conversations-call",
       "displayName": "Create Conversations Call",
       "url": "https://developers.salesloft.com/docs/api/create-conversations-call"
-    },
-    {
-      "name": "tasks-counts-index",
-      "displayName": "Fetch task counts",
-      "url": "https://developers.salesloft.com/docs/api/tasks-counts-index"
     },
     {
       "name": "crm-activities-index",
@@ -261,9 +241,9 @@
       "url": "https://developers.salesloft.com/docs/api/crm-users-index"
     },
     {
-      "name": "custom-fields-show",
-      "displayName": "Fetch a custom field",
-      "url": "https://developers.salesloft.com/docs/api/custom-fields-show"
+      "name": "custom-fields-create",
+      "displayName": "Create a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-create"
     },
     {
       "name": "custom-fields-destroy",
@@ -276,9 +256,9 @@
       "url": "https://developers.salesloft.com/docs/api/custom-fields-index"
     },
     {
-      "name": "custom-fields-create",
-      "displayName": "Create a custom field",
-      "url": "https://developers.salesloft.com/docs/api/custom-fields-create"
+      "name": "custom-fields-show",
+      "displayName": "Fetch a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-show"
     },
     {
       "name": "custom-roles-index",
@@ -289,6 +269,36 @@
       "name": "custom-roles-show",
       "displayName": "Fetch a custom role",
       "url": "https://developers.salesloft.com/docs/api/custom-roles-show"
+    },
+    {
+      "name": "data-control-account-and-people-redaction-create",
+      "displayName": "Submit an account and people redaction  request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-account-and-people-redaction-create"
+    },
+    {
+      "name": "data-control-account-redaction-create",
+      "displayName": "Execute an account redaction workflow",
+      "url": "https://developers.salesloft.com/docs/api/data-control-account-redaction-create"
+    },
+    {
+      "name": "data-control-people-soft-deletion-create",
+      "displayName": "Submit a people soft deletion request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-people-soft-deletion-create"
+    },
+    {
+      "name": "data-control-requests-index",
+      "displayName": "Retrieve a list of Requests",
+      "url": "https://developers.salesloft.com/docs/api/data-control-requests-index"
+    },
+    {
+      "name": "data-control-requests-show",
+      "displayName": "Fetch a Request record",
+      "url": "https://developers.salesloft.com/docs/api/data-control-requests-show"
+    },
+    {
+      "name": "data-control-right-to-be-forgotten-create",
+      "displayName": "Submit a right to be forgotten request",
+      "url": "https://developers.salesloft.com/docs/api/data-control-right-to-be-forgotten-create"
     },
     {
       "name": "email-missing-tags-create",
@@ -311,16 +321,6 @@
       "url": "https://developers.salesloft.com/docs/api/email-templates-show"
     },
     {
-      "name": "activities-emails-index",
-      "displayName": "List emails",
-      "url": "https://developers.salesloft.com/docs/api/activities-emails-index"
-    },
-    {
-      "name": "activities-emails-show",
-      "displayName": "Fetch an email",
-      "url": "https://developers.salesloft.com/docs/api/activities-emails-show"
-    },
-    {
       "name": "external-emails-create",
       "displayName": "Create an External Email",
       "url": "https://developers.salesloft.com/docs/api/external-emails-create"
@@ -329,6 +329,11 @@
       "name": "groups-create",
       "displayName": "Create a group",
       "url": "https://developers.salesloft.com/docs/api/groups-create"
+    },
+    {
+      "name": "groups-destroy",
+      "displayName": "Deletes a Group by ID",
+      "url": "https://developers.salesloft.com/docs/api/groups-destroy"
     },
     {
       "name": "groups-index",
@@ -346,19 +351,19 @@
       "url": "https://developers.salesloft.com/docs/api/groups-update"
     },
     {
-      "name": "groups-destroy",
-      "displayName": "Deletes a Group by ID",
-      "url": "https://developers.salesloft.com/docs/api/groups-destroy"
+      "name": "imports-create",
+      "displayName": "Create an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-create"
+    },
+    {
+      "name": "imports-destroy",
+      "displayName": "Delete an import",
+      "url": "https://developers.salesloft.com/docs/api/imports-destroy"
     },
     {
       "name": "imports-index",
       "displayName": "List imports",
       "url": "https://developers.salesloft.com/docs/api/imports-index"
-    },
-    {
-      "name": "imports-create",
-      "displayName": "Create an import",
-      "url": "https://developers.salesloft.com/docs/api/imports-create"
     },
     {
       "name": "imports-show",
@@ -371,14 +376,54 @@
       "url": "https://developers.salesloft.com/docs/api/imports-update"
     },
     {
-      "name": "imports-destroy",
-      "displayName": "Delete an import",
-      "url": "https://developers.salesloft.com/docs/api/imports-destroy"
+      "name": "integrations-signals-registrations-create",
+      "displayName": "Create a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-create"
     },
     {
-      "name": "third-party-live-feed-items-create",
-      "displayName": "Create a live feed item",
-      "url": "https://developers.salesloft.com/docs/api/third-party-live-feed-items-create"
+      "name": "integrations-signals-registrations-destroy",
+      "displayName": "Deletes a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-destroy"
+    },
+    {
+      "name": "integrations-signals-registrations-index",
+      "displayName": "List Signal Registrations",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-index"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-create",
+      "displayName": "Create a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-create"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-destroy",
+      "displayName": "Delete a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-destroy"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-index",
+      "displayName": "List Play Registrations",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-index"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-show",
+      "displayName": "Show a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-show"
+    },
+    {
+      "name": "integrations-signals-registrations-plays-update",
+      "displayName": "Update a Play Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-update"
+    },
+    {
+      "name": "integrations-signals-registrations-show",
+      "displayName": "Fetch a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-show"
+    },
+    {
+      "name": "integrations-signals-registrations-update",
+      "displayName": "Update a Signal Registration",
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-update"
     },
     {
       "name": "live-website-tracking-parameters-create",
@@ -386,9 +431,29 @@
       "url": "https://developers.salesloft.com/docs/api/live-website-tracking-parameters-create"
     },
     {
+      "name": "me-index",
+      "displayName": "Fetch current user",
+      "url": "https://developers.salesloft.com/docs/api/me-index"
+    },
+    {
       "name": "meetings-index",
       "displayName": "List meetings",
       "url": "https://developers.salesloft.com/docs/api/meetings-index"
+    },
+    {
+      "name": "meetings-reschedule-links-show",
+      "displayName": "Fetch a reschedule meeting link",
+      "url": "https://developers.salesloft.com/docs/api/meetings-reschedule-links-show"
+    },
+    {
+      "name": "meetings-settings-searches-create",
+      "displayName": "List meeting settings",
+      "url": "https://developers.salesloft.com/docs/api/meetings-settings-searches-create"
+    },
+    {
+      "name": "meetings-settings-update",
+      "displayName": "Update a meeting setting",
+      "url": "https://developers.salesloft.com/docs/api/meetings-settings-update"
     },
     {
       "name": "meetings-update",
@@ -401,14 +466,19 @@
       "url": "https://developers.salesloft.com/docs/api/mime-email-payloads-show"
     },
     {
-      "name": "notes-index",
-      "displayName": "List notes",
-      "url": "https://developers.salesloft.com/docs/api/notes-index"
-    },
-    {
       "name": "notes-create",
       "displayName": "Create a note",
       "url": "https://developers.salesloft.com/docs/api/notes-create"
+    },
+    {
+      "name": "notes-destroy",
+      "displayName": "Delete a note",
+      "url": "https://developers.salesloft.com/docs/api/notes-destroy"
+    },
+    {
+      "name": "notes-index",
+      "displayName": "List notes",
+      "url": "https://developers.salesloft.com/docs/api/notes-index"
     },
     {
       "name": "notes-show",
@@ -419,11 +489,6 @@
       "name": "notes-update",
       "displayName": "Update a note",
       "url": "https://developers.salesloft.com/docs/api/notes-update"
-    },
-    {
-      "name": "notes-destroy",
-      "displayName": "Delete a note",
-      "url": "https://developers.salesloft.com/docs/api/notes-destroy"
     },
     {
       "name": "ongoing-actions-create",
@@ -441,14 +506,19 @@
       "url": "https://developers.salesloft.com/docs/api/pending-emails-update"
     },
     {
-      "name": "people-index",
-      "displayName": "List people",
-      "url": "https://developers.salesloft.com/docs/api/people-index"
-    },
-    {
       "name": "people-create",
       "displayName": "Create a person",
       "url": "https://developers.salesloft.com/docs/api/people-create"
+    },
+    {
+      "name": "people-destroy",
+      "displayName": "Delete a person",
+      "url": "https://developers.salesloft.com/docs/api/people-destroy"
+    },
+    {
+      "name": "people-index",
+      "displayName": "List people",
+      "url": "https://developers.salesloft.com/docs/api/people-index"
     },
     {
       "name": "people-show",
@@ -461,24 +531,19 @@
       "url": "https://developers.salesloft.com/docs/api/people-update"
     },
     {
-      "name": "people-destroy",
-      "displayName": "Delete a person",
-      "url": "https://developers.salesloft.com/docs/api/people-destroy"
+      "name": "person-stages-create",
+      "displayName": "Create a person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-create"
     },
     {
-      "name": "data-control-people-soft-deletion-create",
-      "displayName": "Submit a people soft deletion request",
-      "url": "https://developers.salesloft.com/docs/api/data-control-people-soft-deletion-create"
+      "name": "person-stages-destroy",
+      "displayName": "Delete an person stage",
+      "url": "https://developers.salesloft.com/docs/api/person-stages-destroy"
     },
     {
       "name": "person-stages-index",
       "displayName": "List person stages",
       "url": "https://developers.salesloft.com/docs/api/person-stages-index"
-    },
-    {
-      "name": "person-stages-create",
-      "displayName": "Create a person stage",
-      "url": "https://developers.salesloft.com/docs/api/person-stages-create"
     },
     {
       "name": "person-stages-show",
@@ -489,11 +554,6 @@
       "name": "person-stages-update",
       "displayName": "Update a person stage",
       "url": "https://developers.salesloft.com/docs/api/person-stages-update"
-    },
-    {
-      "name": "person-stages-destroy",
-      "displayName": "Delete an person stage",
-      "url": "https://developers.salesloft.com/docs/api/person-stages-destroy"
     },
     {
       "name": "person-upserts-create",
@@ -511,29 +571,9 @@
       "url": "https://developers.salesloft.com/docs/api/phone-number-assignments-show"
     },
     {
-      "name": "integrations-signals-registrations-plays-update",
-      "displayName": "Update a Play Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-update"
-    },
-    {
-      "name": "integrations-signals-registrations-plays-show",
-      "displayName": "Show a Play Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-show"
-    },
-    {
-      "name": "integrations-signals-registrations-plays-destroy",
-      "displayName": "Delete a Play Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-destroy"
-    },
-    {
-      "name": "integrations-signals-registrations-plays-create",
-      "displayName": "Create a Play Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-create"
-    },
-    {
-      "name": "integrations-signals-registrations-plays-index",
-      "displayName": "List Play Registrations",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-index"
+      "name": "phone-numbers-caller-ids-index",
+      "displayName": "List caller ids",
+      "url": "https://developers.salesloft.com/docs/api/phone-numbers-caller-ids-index"
     },
     {
       "name": "phone-numbers-recording-settings-show",
@@ -541,39 +581,9 @@
       "url": "https://developers.salesloft.com/docs/api/phone-numbers-recording-settings-show"
     },
     {
-      "name": "data-control-requests-show",
-      "displayName": "Fetch a Request record",
-      "url": "https://developers.salesloft.com/docs/api/data-control-requests-show"
-    },
-    {
-      "name": "data-control-requests-index",
-      "displayName": "Retrieve a list of Requests",
-      "url": "https://developers.salesloft.com/docs/api/data-control-requests-index"
-    },
-    {
-      "name": "meetings-reschedule-links-show",
-      "displayName": "Fetch a reschedule meeting link",
-      "url": "https://developers.salesloft.com/docs/api/meetings-reschedule-links-show"
-    },
-    {
-      "name": "data-control-right-to-be-forgotten-create",
-      "displayName": "Submit a right to be forgotten request",
-      "url": "https://developers.salesloft.com/docs/api/data-control-right-to-be-forgotten-create"
-    },
-    {
-      "name": "saved-list-views-index",
-      "displayName": "List saved list views",
-      "url": "https://developers.salesloft.com/docs/api/saved-list-views-index"
-    },
-    {
       "name": "saved-list-views-create",
       "displayName": "Create a saved list view",
       "url": "https://developers.salesloft.com/docs/api/saved-list-views-create"
-    },
-    {
-      "name": "saved-list-views-show",
-      "displayName": "Fetch a saved list view",
-      "url": "https://developers.salesloft.com/docs/api/saved-list-views-show"
     },
     {
       "name": "saved-list-views-destroy",
@@ -581,44 +591,19 @@
       "url": "https://developers.salesloft.com/docs/api/saved-list-views-destroy"
     },
     {
+      "name": "saved-list-views-index",
+      "displayName": "List saved list views",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-index"
+    },
+    {
+      "name": "saved-list-views-show",
+      "displayName": "Fetch a saved list view",
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-show"
+    },
+    {
       "name": "saved-list-views-update",
       "displayName": "Update a saved list view",
       "url": "https://developers.salesloft.com/docs/api/saved-list-views-update"
-    },
-    {
-      "name": "meetings-settings-searches-create",
-      "displayName": "List meeting settings",
-      "url": "https://developers.salesloft.com/docs/api/meetings-settings-searches-create"
-    },
-    {
-      "name": "meetings-settings-update",
-      "displayName": "Update a meeting setting",
-      "url": "https://developers.salesloft.com/docs/api/meetings-settings-update"
-    },
-    {
-      "name": "integrations-signals-registrations-update",
-      "displayName": "Update a Signal Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-update"
-    },
-    {
-      "name": "integrations-signals-registrations-show",
-      "displayName": "Fetch a Signal Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-show"
-    },
-    {
-      "name": "integrations-signals-registrations-destroy",
-      "displayName": "Deletes a Signal Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-destroy"
-    },
-    {
-      "name": "integrations-signals-registrations-create",
-      "displayName": "Create a Signal Registration",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-create"
-    },
-    {
-      "name": "integrations-signals-registrations-index",
-      "displayName": "List Signal Registrations",
-      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-index"
     },
     {
       "name": "signals-create",
@@ -646,14 +631,9 @@
       "url": "https://developers.salesloft.com/docs/api/tags-index"
     },
     {
-      "name": "tasks-show",
-      "displayName": "Fetch a task",
-      "url": "https://developers.salesloft.com/docs/api/tasks-show"
-    },
-    {
-      "name": "tasks-update",
-      "displayName": "Update a Task",
-      "url": "https://developers.salesloft.com/docs/api/tasks-update"
+      "name": "tasks-counts-index",
+      "displayName": "Fetch task counts",
+      "url": "https://developers.salesloft.com/docs/api/tasks-counts-index"
     },
     {
       "name": "tasks-create",
@@ -664,6 +644,21 @@
       "name": "tasks-index",
       "displayName": "List tasks",
       "url": "https://developers.salesloft.com/docs/api/tasks-index"
+    },
+    {
+      "name": "tasks-show",
+      "displayName": "Fetch a task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-show"
+    },
+    {
+      "name": "tasks-update",
+      "displayName": "Update a Task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-update"
+    },
+    {
+      "name": "team-index",
+      "displayName": "Fetch current team",
+      "url": "https://developers.salesloft.com/docs/api/team-index"
     },
     {
       "name": "team-template-attachments-index",
@@ -681,6 +676,11 @@
       "url": "https://developers.salesloft.com/docs/api/team-templates-show"
     },
     {
+      "name": "third-party-live-feed-items-create",
+      "displayName": "Create a live feed item",
+      "url": "https://developers.salesloft.com/docs/api/third-party-live-feed-items-create"
+    },
+    {
       "name": "users-index",
       "displayName": "List users",
       "url": "https://developers.salesloft.com/docs/api/users-index"
@@ -696,14 +696,9 @@
       "url": "https://developers.salesloft.com/docs/api/users-update"
     },
     {
-      "name": "webhook-subscriptions-update",
-      "displayName": "Update a webhook subscription",
-      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-update"
-    },
-    {
-      "name": "webhook-subscriptions-show",
-      "displayName": "Fetch a webhook subscription",
-      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-show"
+      "name": "webhook-subscriptions-create",
+      "displayName": "Create a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-create"
     },
     {
       "name": "webhook-subscriptions-destroy",
@@ -711,14 +706,19 @@
       "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-destroy"
     },
     {
-      "name": "webhook-subscriptions-create",
-      "displayName": "Create a webhook subscription",
-      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-create"
-    },
-    {
       "name": "webhook-subscriptions-index",
       "displayName": "List webhook subscriptions",
       "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-index"
+    },
+    {
+      "name": "webhook-subscriptions-show",
+      "displayName": "Fetch a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-show"
+    },
+    {
+      "name": "webhook-subscriptions-update",
+      "displayName": "Update a webhook subscription",
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-update"
     }
   ]
 }

--- a/salesloft/metadata/index.json
+++ b/salesloft/metadata/index.json
@@ -261,16 +261,6 @@
       "url": "https://developers.salesloft.com/docs/api/crm-users-index"
     },
     {
-      "name": "custom-fields-index",
-      "displayName": "List custom fields",
-      "url": "https://developers.salesloft.com/docs/api/custom-fields-index"
-    },
-    {
-      "name": "custom-fields-create",
-      "displayName": "Create a custom field",
-      "url": "https://developers.salesloft.com/docs/api/custom-fields-create"
-    },
-    {
       "name": "custom-fields-show",
       "displayName": "Fetch a custom field",
       "url": "https://developers.salesloft.com/docs/api/custom-fields-show"
@@ -279,6 +269,16 @@
       "name": "custom-fields-destroy",
       "displayName": "Delete a custom field",
       "url": "https://developers.salesloft.com/docs/api/custom-fields-destroy"
+    },
+    {
+      "name": "custom-fields-index",
+      "displayName": "List custom fields",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-index"
+    },
+    {
+      "name": "custom-fields-create",
+      "displayName": "Create a custom field",
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-create"
     },
     {
       "name": "custom-roles-index",
@@ -646,16 +646,6 @@
       "url": "https://developers.salesloft.com/docs/api/tags-index"
     },
     {
-      "name": "tasks-create",
-      "displayName": "Create a Task",
-      "url": "https://developers.salesloft.com/docs/api/tasks-create"
-    },
-    {
-      "name": "tasks-index",
-      "displayName": "List tasks",
-      "url": "https://developers.salesloft.com/docs/api/tasks-index"
-    },
-    {
       "name": "tasks-show",
       "displayName": "Fetch a task",
       "url": "https://developers.salesloft.com/docs/api/tasks-show"
@@ -664,6 +654,16 @@
       "name": "tasks-update",
       "displayName": "Update a Task",
       "url": "https://developers.salesloft.com/docs/api/tasks-update"
+    },
+    {
+      "name": "tasks-create",
+      "displayName": "Create a Task",
+      "url": "https://developers.salesloft.com/docs/api/tasks-create"
+    },
+    {
+      "name": "tasks-index",
+      "displayName": "List tasks",
+      "url": "https://developers.salesloft.com/docs/api/tasks-index"
     },
     {
       "name": "team-template-attachments-index",

--- a/salesloft/metadata/schemas.json
+++ b/salesloft/metadata/schemas.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "account-stages": {
+    "account_stages": {
       "displayName": "List account stages",
       "fields": {
         "active": "active",
@@ -11,7 +11,7 @@
         "updated_at": "updated_at"
       }
     },
-    "account-tiers": {
+    "account_tiers": {
       "displayName": "List Account Tiers",
       "fields": {
         "created_at": "created_at",
@@ -66,7 +66,7 @@
         "website": "website"
       }
     },
-    "action-details-call-instructions": {
+    "action_details_call_instructions": {
       "displayName": "List call instructions",
       "fields": {
         "created_at": "created_at",
@@ -94,7 +94,7 @@
         "user": "user"
       }
     },
-    "activities-calls": {
+    "activities_calls": {
       "displayName": "List calls",
       "fields": {
         "action": "action",
@@ -115,7 +115,7 @@
         "user": "user"
       }
     },
-    "activities-emails": {
+    "activities_emails": {
       "displayName": "List emails",
       "fields": {
         "action": "action",
@@ -127,6 +127,7 @@
         "counts": "counts",
         "created_at": "created_at",
         "crm_activity": "crm_activity",
+        "draft_with_ai": "draft_with_ai",
         "email_template": "email_template",
         "error_message": "error_message",
         "headers": "headers",
@@ -146,7 +147,7 @@
         "view_tracking": "view_tracking"
       }
     },
-    "activity-histories": {
+    "activity_histories": {
       "displayName": "List Past Activities",
       "fields": {
         "created_at": "created_at",
@@ -164,7 +165,7 @@
         "user_guid": "user_guid"
       }
     },
-    "bulk-jobs": {
+    "bulk_jobs": {
       "displayName": "List bulk jobs",
       "fields": {
         "created_at": "created_at",
@@ -183,7 +184,7 @@
         "updated_at": "updated_at"
       }
     },
-    "bulk-jobs-job-data": {
+    "bulk_jobs_job_data": {
       "displayName": "List job data for a bulk job",
       "fields": {
         "error": "error",
@@ -193,7 +194,7 @@
         "status": "status"
       }
     },
-    "bulk-jobs-results": {
+    "bulk_jobs_results": {
       "displayName": "List job data for a completed bulk job.",
       "fields": {
         "error": "error",
@@ -203,7 +204,7 @@
         "status": "status"
       }
     },
-    "cadence-memberships": {
+    "cadence_memberships": {
       "displayName": "List cadence memberships",
       "fields": {
         "added_at": "added_at",
@@ -252,7 +253,7 @@
         "updated_at": "updated_at"
       }
     },
-    "calendar-events": {
+    "calendar_events": {
       "displayName": "List calendar events",
       "fields": {
         "all_day": "all_day",
@@ -285,7 +286,7 @@
         "user_guid": "user_guid"
       }
     },
-    "call-data-records": {
+    "call_data_records": {
       "displayName": "List call data records",
       "fields": {
         "call": "call",
@@ -307,7 +308,7 @@
         "user": "user"
       }
     },
-    "call-dispositions": {
+    "call_dispositions": {
       "displayName": "List call dispositions",
       "fields": {
         "created_at": "created_at",
@@ -316,7 +317,7 @@
         "updated_at": "updated_at"
       }
     },
-    "call-sentiments": {
+    "call_sentiments": {
       "displayName": "List call sentiments",
       "fields": {
         "created_at": "created_at",
@@ -325,7 +326,7 @@
         "updated_at": "updated_at"
       }
     },
-    "crm-activities": {
+    "crm_activities": {
       "displayName": "List crm activities",
       "fields": {
         "activity_type": "activity_type",
@@ -341,7 +342,7 @@
         "user": "user"
       }
     },
-    "crm-activity-fields": {
+    "crm_activity_fields": {
       "displayName": "List crm activity fields",
       "fields": {
         "created_at": "created_at",
@@ -357,7 +358,7 @@
         "value": "value"
       }
     },
-    "crm-users": {
+    "crm_users": {
       "displayName": "List crm users",
       "fields": {
         "created_at": "created_at",
@@ -370,7 +371,7 @@
         "user": "user"
       }
     },
-    "custom-fields": {
+    "custom_fields": {
       "displayName": "List custom fields",
       "fields": {
         "created_at": "created_at",
@@ -381,14 +382,14 @@
         "value_type": "value_type"
       }
     },
-    "custom-roles": {
+    "custom_roles": {
       "displayName": "List custom roles",
       "fields": {
         "id": "id",
         "name": "name"
       }
     },
-    "data-control-requests": {
+    "data_control_requests": {
       "displayName": "Retrieve a list of Requests",
       "fields": {
         "dry_run": "dry_run",
@@ -400,7 +401,7 @@
         "user_guid": "user_guid"
       }
     },
-    "email-template-attachments": {
+    "email_template_attachments": {
       "displayName": "List email template attachments",
       "fields": {
         "attachment_content_type": "attachment_content_type",
@@ -414,7 +415,7 @@
         "scanned": "scanned"
       }
     },
-    "email-templates": {
+    "email_templates": {
       "displayName": "List email templates",
       "fields": {
         "_links": "_links",
@@ -461,7 +462,7 @@
         "user_id": "user_id"
       }
     },
-    "integrations-signals-registrations": {
+    "integrations_signals_registrations": {
       "displayName": "List Signal Registrations",
       "fields": {
         "attribution": "attribution",
@@ -477,7 +478,7 @@
         "type": "type"
       }
     },
-    "integrations-signals-registrations-plays": {
+    "integrations_signals_registrations_plays": {
       "displayName": "List Play Registrations",
       "fields": {
         "attributes": "attributes",
@@ -522,6 +523,7 @@
         "last_name": "last_name",
         "local_dial_enabled": "local_dial_enabled",
         "locale_utc_offset": "locale_utc_offset",
+        "manager_user_guid": "manager_user_guid",
         "name": "name",
         "phone_client": "phone_client",
         "phone_number_assignment": "phone_number_assignment",
@@ -597,7 +599,7 @@
         "user": "user"
       }
     },
-    "pending-emails": {
+    "pending_emails": {
       "displayName": "List pending emails",
       "fields": {
         "id": "id",
@@ -667,7 +669,7 @@
         "work_state": "work_state"
       }
     },
-    "person-stages": {
+    "person_stages": {
       "displayName": "List person stages",
       "fields": {
         "active": "active",
@@ -678,7 +680,7 @@
         "updated_at": "updated_at"
       }
     },
-    "phone-number-assignments": {
+    "phone_number_assignments": {
       "displayName": "List phone number assignments",
       "fields": {
         "id": "id",
@@ -686,7 +688,7 @@
         "user": "user"
       }
     },
-    "phone-numbers-caller-ids": {
+    "phone_numbers_caller_ids": {
       "displayName": "List caller ids",
       "fields": {
         "account_name": "account_name",
@@ -695,7 +697,7 @@
         "title": "title"
       }
     },
-    "saved-list-views": {
+    "saved_list_views": {
       "displayName": "List saved list views",
       "fields": {
         "id": "id",
@@ -769,13 +771,14 @@
         "user": "user"
       }
     },
-    "tasks-counts": {
+    "tasks_counts": {
       "displayName": "Fetch task counts",
       "fields": {
         "call": "call",
         "email": "email",
         "general": "general",
         "integration": "integration",
+        "other": "other",
         "total": "total"
       }
     },
@@ -803,7 +806,7 @@
         "updated_at": "updated_at"
       }
     },
-    "team-template-attachments": {
+    "team_template_attachments": {
       "displayName": "List team template attachments",
       "fields": {
         "attachment_file_size": "attachment_file_size",
@@ -814,7 +817,7 @@
         "team_template": "team_template"
       }
     },
-    "team-templates": {
+    "team_templates": {
       "displayName": "List team templates",
       "fields": {
         "_links": "_links",
@@ -860,6 +863,7 @@
         "last_name": "last_name",
         "local_dial_enabled": "local_dial_enabled",
         "locale_utc_offset": "locale_utc_offset",
+        "manager_user_guid": "manager_user_guid",
         "name": "name",
         "phone_client": "phone_client",
         "phone_number_assignment": "phone_number_assignment",
@@ -874,7 +878,7 @@
         "work_country": "work_country"
       }
     },
-    "webhook-subscriptions": {
+    "webhook_subscriptions": {
       "displayName": "List webhook subscriptions",
       "fields": {
         "callback_token": "callback_token",

--- a/salesloft/metadata_test.go
+++ b/salesloft/metadata_test.go
@@ -42,13 +42,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		},
 		{
 			name:  "Successfully describe one object with metadata",
-			input: []string{"bulk-jobs-results"},
+			input: []string{"bulk_jobs_results"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusTeapot)
 			})),
 			expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
-					"bulk-jobs-results": {
+					"bulk_jobs_results": {
 						DisplayName: "List job data for a completed bulk job.",
 						FieldsMap: map[string]string{
 							"error":    "error",
@@ -65,13 +65,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		},
 		{
 			name:  "Successfully describe multiple objects with metadata",
-			input: []string{"account-tiers", "actions"},
+			input: []string{"account_tiers", "actions"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusTeapot)
 			})),
 			expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
-					"account-tiers": {
+					"account_tiers": {
 						DisplayName: "List Account Tiers",
 						FieldsMap: map[string]string{
 							"created_at": "created_at",

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/amp-labs/connectors/salesloft/metadata"
 	"github.com/amp-labs/connectors/tools/scrapper"
+	"github.com/iancoleman/strcase"
 )
 
 const (
@@ -56,6 +57,8 @@ func createSchemas() {
 		doc := scrapper.QueryHTML(model.URL)
 
 		// There are 2 unordered lists that describe response schema
+		modelName := strcase.ToSnake(model.Name)
+
 		doc.Find(`.openapi-tabs__schema-container ul`).
 			Each(func(i int, list *goquery.Selection) {
 				list.Children().Each(func(i int, property *goquery.Selection) {
@@ -63,12 +66,12 @@ func createSchemas() {
 					// Only the first most field represents top level fields of response payload
 					fieldName := property.Find(`strong`).First().Text()
 					if len(fieldName) != 0 {
-						schemas.Add(model.Name, model.DisplayName, fieldName)
+						schemas.Add(modelName, model.DisplayName, fieldName)
 					}
 				})
 			})
 
-		log.Printf("Schemas completed %.2f%% [%v]\n", getPercentage(i, len(filteredListDocs)), model.Name)
+		log.Printf("Schemas completed %.2f%% [%v]\n", getPercentage(i, len(filteredListDocs)), modelName)
 	}
 
 	must(metadata.FileManager.SaveSchemas(schemas))

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -59,5 +59,6 @@ func headerIsSubset(superset, subset http.Header) (string, bool) {
 			}
 		}
 	}
+
 	return "", true
 }

--- a/tools/scrapper/files.go
+++ b/tools/scrapper/files.go
@@ -26,6 +26,8 @@ func NewMetadataFileManager(schemas []byte, locator MetadataFileLocator) *Metada
 }
 
 func (m MetadataFileManager) SaveIndex(index *ModelURLRegistry) error {
+	index.Sort()
+
 	return FlushToFile(m.locator.AbsPathTo(IndexFile), index)
 }
 

--- a/tools/scrapper/models.go
+++ b/tools/scrapper/models.go
@@ -1,6 +1,7 @@
 package scrapper
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -46,6 +47,12 @@ func (r *ModelURLRegistry) Add(displayName, url string) {
 		DisplayName: displayName,
 		Name:        name,
 		URL:         url,
+	})
+}
+
+func (r *ModelURLRegistry) Sort() {
+	sort.Slice(r.ModelDocs, func(i, j int) bool {
+		return r.ModelDocs[i].Name < r.ModelDocs[j].Name
 	})
 }
 


### PR DESCRIPTION
# Actions taken:

* Salesloft object names use kebab case from Docs, modified that to snake case which is used in URL path. This turns `saved-list-views` into the `saved_list_views` (making read and metadata use the same object name).
* Index of HTML Docs used for Metadata are sorted in order to ensure consistent output. (I ran scrapper for Intercom as well). No functional change.