### PR TITLE
fix: make OauthOpts optional, since not all providers need it

### DIFF
--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -66,7 +66,7 @@ type ProviderInfo struct {
 	// DisplayName The display name of the provider, if omitted, defaults to provider name.
 	DisplayName string     `json:"displayName,omitempty"`
 	Name        string     `json:"name"`
-	OauthOpts   *OauthOpts `json:"oauthOpts,omitempty" validate:"required"`
+	OauthOpts   *OauthOpts `json:"oauthOpts,omitempty"`
 
 	// PostAuthInfoNeeded If true, we require additional information after auth to start making requests.
 	PostAuthInfoNeeded bool         `json:"postAuthInfoNeeded,omitempty"`

--- a/providers/types.yaml
+++ b/providers/types.yaml
@@ -77,8 +77,6 @@ components:
 
     OauthOpts:
       type: object
-      x-oapi-codegen-extra-tags:
-        validate: required
       required:
           - grantType
           - tokenURL


### PR DESCRIPTION
See title. ReadProviders is failing because of this.