### PR TITLE
Iterable:add connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -47,6 +47,7 @@ const (
 	Ironclad                Provider = "ironclad"
 	IroncladDemo            Provider = "ironcladDemo"
 	IroncladEU              Provider = "ironcladEU"
+	Iterable                Provider = "iterable"
 	Keap                    Provider = "keap"
 	Klaviyo                 Provider = "klaviyo"
 	LinkedIn                Provider = "linkedIn"
@@ -2108,6 +2109,28 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Iterable API Key authentication
+	Iterable: {
+		AuthType: ApiKey,
+		BaseURL:  "https://api.iterable.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			HeaderName: "Api-Key",
+			DocsURL:    "https://app.iterable.com/settings/apiKeys",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
Closes #458 

## Checklist
- [x] Ran Linter
- [x] Created PR from non-main branch 

## Catalog variables
HeaderName: "Api-Key"

## Notes
API key type of authentication
use api instead of v2
Screenshot of a printed token is not available as it is generated on the platform

## Testing 
### GET 
URL: <localhost:4444/api/catalogs/catalogName/items/1> 
![Screenshot 2567-06-07 at 13 04 19](https://github.com/amp-labs/connectors/assets/103050835/3eb7f5fd-01a1-48c7-990a-75dd2bd4df02)

### POST
URL: <localhost:4444/api/catalogs/catalogName> 
![Screenshot 2567-06-07 at 12 59 06](https://github.com/amp-labs/connectors/assets/103050835/ef3b9e82-1917-4884-8d4a-cdd3d04fc524)

### PUT 
URL: <localhost:4444/api/catalogs/catalogName/items/1> 
![Screenshot 2567-06-07 at 13 02 57](https://github.com/amp-labs/connectors/assets/103050835/c9ff683b-ab40-406f-bd23-3c8a5dcecef6)

### PATCH 
URL: <localhost:4444/api/catalogs/catalogName/items/1> 
![Screenshot 2567-06-07 at 13 03 41](https://github.com/amp-labs/connectors/assets/103050835/bc3af4d6-8f0b-435b-a592-fb6d92f419b3)

### DELETE 
URL: <localhost:4444/api/catalogs/catalogName/items/1> 
![Screenshot 2567-06-07 at 13 16 03](https://github.com/amp-labs/connectors/assets/103050835/436efd37-bec2-45b7-accd-8c27ebfdc40b)

## Pagination
**Before pagination**
![Screenshot 2567-06-07 at 13 06 54](https://github.com/amp-labs/connectors/assets/103050835/36319cd0-226c-49a2-822b-e244e40f6833)
**After pagination**
`PageSize` and `Page` parameters added. The response includes `nextPageUrl` and `previousPageUrl`
![Screenshot 2567-06-07 at 13 08 43](https://github.com/amp-labs/connectors/assets/103050835/703a51b6-d108-4431-8605-f90d95f9e8e8)
