### PR TITLE
scrapper: Salesloft, collect Statistics on query params

### DIFF
--- a/salesloft/metadata/queryParamStats.json
+++ b/salesloft/metadata/queryParamStats.json
@@ -1,0 +1,308 @@
+{
+  "meta": {
+    "totalObjects": 48,
+    "collectedAt": "2024-06-10"
+  },
+  "queryParams": [
+    {
+      "name": "updated_at[gt]",
+      "frequency": 0.3125,
+      "totalObjects": 15,
+      "objects": [
+        "account_stages",
+        "accounts",
+        "actions",
+        "activities_calls",
+        "activities_emails",
+        "activity_histories",
+        "cadence_memberships",
+        "cadences",
+        "crm_activities",
+        "email_templates",
+        "notes",
+        "people",
+        "successes",
+        "tasks",
+        "team_templates"
+      ]
+    },
+    {
+      "name": "updated_at[gte]",
+      "frequency": 0.3125,
+      "totalObjects": 15,
+      "objects": [
+        "account_stages",
+        "accounts",
+        "actions",
+        "activities_calls",
+        "activities_emails",
+        "activity_histories",
+        "cadence_memberships",
+        "cadences",
+        "crm_activities",
+        "email_templates",
+        "notes",
+        "people",
+        "successes",
+        "tasks",
+        "team_templates"
+      ]
+    },
+    {
+      "name": "updated_at[lt]",
+      "frequency": 0.3125,
+      "totalObjects": 15,
+      "objects": [
+        "account_stages",
+        "accounts",
+        "actions",
+        "activities_calls",
+        "activities_emails",
+        "activity_histories",
+        "cadence_memberships",
+        "cadences",
+        "crm_activities",
+        "email_templates",
+        "notes",
+        "people",
+        "successes",
+        "tasks",
+        "team_templates"
+      ]
+    },
+    {
+      "name": "updated_at[lte]",
+      "frequency": 0.3125,
+      "totalObjects": 15,
+      "objects": [
+        "account_stages",
+        "accounts",
+        "actions",
+        "activities_calls",
+        "activities_emails",
+        "activity_histories",
+        "cadence_memberships",
+        "cadences",
+        "crm_activities",
+        "email_templates",
+        "notes",
+        "people",
+        "successes",
+        "tasks",
+        "team_templates"
+      ]
+    },
+    {
+      "name": "created_at[gt]",
+      "frequency": 0.1041,
+      "totalObjects": 5,
+      "objects": [
+        "accounts",
+        "activities_calls",
+        "imports",
+        "meetings",
+        "people"
+      ]
+    },
+    {
+      "name": "created_at[gte]",
+      "frequency": 0.1041,
+      "totalObjects": 5,
+      "objects": [
+        "accounts",
+        "activities_calls",
+        "imports",
+        "meetings",
+        "people"
+      ]
+    },
+    {
+      "name": "created_at[lt]",
+      "frequency": 0.1041,
+      "totalObjects": 5,
+      "objects": [
+        "accounts",
+        "activities_calls",
+        "imports",
+        "meetings",
+        "people"
+      ]
+    },
+    {
+      "name": "created_at[lte]",
+      "frequency": 0.1041,
+      "totalObjects": 5,
+      "objects": [
+        "accounts",
+        "activities_calls",
+        "imports",
+        "meetings",
+        "people"
+      ]
+    },
+    {
+      "name": "last_contacted[gt]",
+      "frequency": 0.0416,
+      "totalObjects": 2,
+      "objects": [
+        "accounts",
+        "people"
+      ]
+    },
+    {
+      "name": "last_contacted[gte]",
+      "frequency": 0.0416,
+      "totalObjects": 2,
+      "objects": [
+        "accounts",
+        "people"
+      ]
+    },
+    {
+      "name": "last_contacted[lt]",
+      "frequency": 0.0416,
+      "totalObjects": 2,
+      "objects": [
+        "accounts",
+        "people"
+      ]
+    },
+    {
+      "name": "last_contacted[lte]",
+      "frequency": 0.0416,
+      "totalObjects": 2,
+      "objects": [
+        "accounts",
+        "people"
+      ]
+    },
+    {
+      "name": "due_on[gt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "actions"
+      ]
+    },
+    {
+      "name": "due_on[gte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "actions"
+      ]
+    },
+    {
+      "name": "due_on[lt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "actions"
+      ]
+    },
+    {
+      "name": "due_on[lte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "actions"
+      ]
+    },
+    {
+      "name": "occurred_at[gt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activity_histories"
+      ]
+    },
+    {
+      "name": "occurred_at[gte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activity_histories"
+      ]
+    },
+    {
+      "name": "occurred_at[lt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activity_histories"
+      ]
+    },
+    {
+      "name": "occurred_at[lte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activity_histories"
+      ]
+    },
+    {
+      "name": "sent_at[gt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activities_emails"
+      ]
+    },
+    {
+      "name": "sent_at[gte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activities_emails"
+      ]
+    },
+    {
+      "name": "sent_at[lt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activities_emails"
+      ]
+    },
+    {
+      "name": "sent_at[lte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "activities_emails"
+      ]
+    },
+    {
+      "name": "start_time[gt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "meetings"
+      ]
+    },
+    {
+      "name": "start_time[gte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "meetings"
+      ]
+    },
+    {
+      "name": "start_time[lt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "meetings"
+      ]
+    },
+    {
+      "name": "start_time[lte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "meetings"
+      ]
+    }
+  ]
+}

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -200,6 +200,7 @@ func (a *OAuthApp) processCallback(writer http.ResponseWriter, request *http.Req
 func (a *OAuthApp) Run() error {
 	if a.GrantType == providers.ClientCredentials {
 		src := a.ClientCredsConfig.TokenSource(context.Background())
+
 		tok, err := src.Token()
 		if err != nil {
 			return err

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -236,6 +236,7 @@ func mainBasic(ctx context.Context, provider string, substitutionsMap map[string
 func getTokensFromRegistry() *oauth2.Token {
 	accessToken := registry.MustString("AccessToken")
 	refreshToken, err := registry.GetString("RefreshToken")
+
 	if err != nil {
 		// we are working without refresh token
 		return &oauth2.Token{

--- a/tools/scrapper/files.go
+++ b/tools/scrapper/files.go
@@ -3,8 +3,9 @@ package scrapper
 import "encoding/json"
 
 const (
-	IndexFile   = "index.json"
-	SchemasFile = "schemas.json"
+	IndexFile           = "index.json"
+	SchemasFile         = "schemas.json"
+	QueryParamStatsFile = "queryParamStats.json"
 )
 
 // MetadataFileLocator locates index and schema files.
@@ -55,4 +56,8 @@ func (m MetadataFileManager) LoadSchemas() (*ObjectMetadataResult, error) {
 	}
 
 	return result, nil
+}
+
+func (m MetadataFileManager) SaveQueryParamStats(stats *QueryParamStats) error {
+	return FlushToFile(m.locator.AbsPathTo(QueryParamStatsFile), stats)
 }


### PR DESCRIPTION
# Description

Salesloft has some query parameters that can be used for performing Read method using `Since` qurying.

Added a method that can be executed at any time to see stats on frequency usage of query params in Salesloft APIs.