### PR TITLE
feat: Add Hunter auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -42,6 +42,7 @@ const (
 	GoogleContacts          Provider = "googleContacts"
 	HelpScoutMailbox        Provider = "helpScoutMailbox"
 	Hubspot                 Provider = "hubspot"
+	Hunter                  Provider = "hunter"
 	Instagram               Provider = "instagram"
 	Intercom                Provider = "intercom"
 	Ironclad                Provider = "ironclad"
@@ -2133,6 +2134,28 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		ApiKeyOpts: &ApiKeyOpts{
 			HeaderName: "Api-Key",
 			DocsURL:    "https://app.iterable.com/settings/apiKeys",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	// Hunter configuration
+	Hunter: {
+		AuthType: ApiKey,
+		BaseURL:  "https://api.hunter.io",
+		ApiKeyOpts: &ApiKeyOpts{
+			HeaderName: "X-API-KEY",
+			DocsURL:    "https://hunter.io/api-documentation/v2",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
Closes #304 

## Checklist
- [x] Ran Linter

## Catalog variables
None

## Notes
The API Key can be passed as either in the Header or Query Parameter

## Testing 
### GET 
<img width="1158" alt="Screenshot 2024-06-12 at 10 11 09" src="https://github.com/amp-labs/connectors/assets/52887226/0821c8b6-d97c-4e57-bd7f-a39c00fedb08">


### POST
<img width="1160" alt="Screenshot 2024-06-12 at 10 16 44" src="https://github.com/amp-labs/connectors/assets/52887226/be52d8be-68a0-4a01-bc56-1b328de61ac3">

### PUT
<img width="1146" alt="Screenshot 2024-06-12 at 10 17 35" src="https://github.com/amp-labs/connectors/assets/52887226/7c8ece1b-c55e-4b3a-902a-1c7952bfe452">

### DELETE
<img width="1149" alt="Screenshot 2024-06-12 at 10 28 47" src="https://github.com/amp-labs/connectors/assets/52887226/dd501243-68fa-430a-b748-28b30f5c728b">

## Pagination
Retrieving a paginated list of leads.
<img width="1147" alt="Screenshot 2024-06-12 at 10 26 59" src="https://github.com/amp-labs/connectors/assets/52887226/9485a98b-2150-4824-8b6d-0a20c5859163">

Requesting the next page values by using the `offset` value
<img width="1148" alt="Screenshot 2024-06-12 at 10 27 39" src="https://github.com/amp-labs/connectors/assets/52887226/2abc12b2-0fe5-4435-a2fb-168d2c27f6cb">
