### PR TITLE
fix: Add space between prefix and key

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -388,7 +388,7 @@ func createApiKeyHTTPClient( //nolint:ireturn
 	apiKey string,
 ) (common.AuthenticatedHTTPClient, error) {
 	if info.ApiKeyOpts.ValuePrefix != "" {
-		apiKey = info.ApiKeyOpts.ValuePrefix + apiKey
+		apiKey = info.ApiKeyOpts.ValuePrefix + " " + apiKey
 	}
 
 	opts := []common.HeaderAuthClientOption{


### PR DESCRIPTION
For Providers having a prefix in the API Key scheme, we need to add a space between the prefix and the token.