### PR TITLE
feat: Add OpenAI connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -57,6 +57,7 @@ const (
 	Monday                  Provider = "monday"
 	Mural                   Provider = "mural"
 	Notion                  Provider = "notion"
+	OpenAI                  Provider = "openAI"
 	Outreach                Provider = "outreach"
 	Pinterest               Provider = "pinterest"
 	Pipedrive               Provider = "pipedrive"
@@ -637,6 +638,28 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				Delete: false,
 			},
 			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	OpenAI: {
+		AuthType: ApiKey,
+		BaseURL:  "https://api.openai.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			HeaderName:  "Authorization",
+			ValuePrefix: "Bearer ",
+			DocsURL:     "https://platform.openai.com/docs/api-reference/api-keys",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -648,6 +648,7 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 		AuthType: ApiKey,
 		BaseURL:  "https://api.openai.com",
 		ApiKeyOpts: &ApiKeyOpts{
+			Type:        InHeader,
 			HeaderName:  "Authorization",
 			ValuePrefix: "Bearer ",
 			DocsURL:     "https://platform.openai.com/docs/api-reference/api-keys",


### PR DESCRIPTION
Closes #515 

## Checklist
- [x] Ran Linter


## Notes
All API is part of payed version!
Assistant is in beta  and doesn't look that it is payed.

## Testing
### GET
List AI modules.
URL: http://localhost:4444/v1/models

![image](https://github.com/amp-labs/connectors/assets/60330780/2248db51-0acb-4e22-8329-5dd9d7d9252a)

### POST
Create image using propmt text. (cost 2 cents)
URL: http://localhost:4444/v1/images/generations'

![image](https://github.com/amp-labs/connectors/assets/60330780/42cee7c9-ba49-4bea-bf5c-6ad1cc305e13)

Create assistant.
URL: http://localhost:4444/v1/assistants
With Header: OpenAI-Beta: assistants=v2
![image](https://github.com/amp-labs/connectors/assets/60330780/d1560c6a-16d7-42f2-b5e8-584c62abbf00)

There is no PUT or PATCH, modifications are done via POST, example:
![image](https://github.com/amp-labs/connectors/assets/60330780/d6cec0e8-6950-41c0-be30-94a041098d6f)

Also creating a speech out of text succeds. The output is in audio/mpeg format. (cost: 1 cent)
URL: http://localhost:4444/v1/audio/speech
![image](https://github.com/amp-labs/connectors/assets/60330780/f94d3730-0a2e-4ebd-8c2b-4987d3f85475)

### DELETE
Remove assitant.
URL: http://localhost:4444/v1/assistants/asst_zo1oGsgTtqwU4UPAe9d496Uj
![image](https://github.com/amp-labs/connectors/assets/60330780/c462452d-7b13-4484-a874-0e3c94733f82)



## Pagination
After creating 3 assistants, list them puting a limit of 2 items per page.

### First page
http://localhost:4444/v1/assistants?limit=2
![image](https://github.com/amp-labs/connectors/assets/60330780/c79abad5-db73-4ae9-a2a1-c57f43fd4a94)

### Second page
http://localhost:4444/v1/assistants?limit=2&after=asst_G7dvGM08Kl5bA3rW5Am6h8Pu
![image](https://github.com/amp-labs/connectors/assets/60330780/01c21c4b-5e7a-44c0-8d68-ebf5f2c1b2fe)

### Last empty page
http://localhost:4444/v1/assistants?limit=2&after=asst_zo1oGsgTtqwU4UPAe9d496Uj
![image](https://github.com/amp-labs/connectors/assets/60330780/7a1254f2-99c6-4ccb-a169-8a3fba25e594)

