### PR TITLE
feat: Add MessageBird auth connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -53,6 +53,7 @@ const (
 	Keap                    Provider = "keap"
 	Klaviyo                 Provider = "klaviyo"
 	LinkedIn                Provider = "linkedIn"
+	MessageBird             Provider = "messageBird"
 	Microsoft               Provider = "microsoft"
 	Miro                    Provider = "miro"
 	Mixmax                  Provider = "mixmax"
@@ -2211,5 +2212,29 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+	},
+
+	// MessageBird configuration
+	MessageBird: {
+		AuthType: ApiKey,
+		BaseURL:  "https://api.bird.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			Type:        InHeader,
+			HeaderName:  "Authorization",
+			ValuePrefix: "AccessKey ",
+			DocsURL:     "https://docs.bird.com/api",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
 	},
 }


### PR DESCRIPTION
Closes #509 

## Checklist
- [x] Ran Linter

## Catalog variables
None

## Notes
Uses API Key scheme, InHeader. 

## Testing 
### GET 
<img width="1145" alt="Screenshot 2024-06-13 at 10 09 55" src="https://github.com/amp-labs/connectors/assets/52887226/5dd032e7-335a-4076-bf88-099ee759c743">


### POST
<img width="1150" alt="Screenshot 2024-06-13 at 10 17 23" src="https://github.com/amp-labs/connectors/assets/52887226/bd8c85e2-ff85-4b02-9774-a5edcbbfc328">


### PATCH
<img width="1145" alt="Screenshot 2024-06-13 at 10 46 22" src="https://github.com/amp-labs/connectors/assets/52887226/72d73ed8-e5b9-482b-8677-a89d7377e27b">

### DELETE
<img width="1152" alt="Screenshot 2024-06-13 at 10 42 13" src="https://github.com/amp-labs/connectors/assets/52887226/58b85d86-1308-41d0-ad12-ce44adcd39cb">


## Pagination
Requesting a paginated list of contacts
<img width="1154" alt="Screenshot 2024-06-13 at 10 54 51" src="https://github.com/amp-labs/connectors/assets/52887226/e0686fea-e498-4bec-8002-51e40998f7e2">

Using the `nextPageToken` to request next page contacts. As observed no more pages, as there is no `nextPageToken`
<img width="1149" alt="Screenshot 2024-06-13 at 10 41 18" src="https://github.com/amp-labs/connectors/assets/52887226/c6ee5d93-8478-45f1-97b5-1eb83756f759">
