### PR TITLE
feat: Enable proxy: Dynamics CRM

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/proxy_connector.md
+++ b/.github/PULL_REQUEST_TEMPLATE/proxy_connector.md
@@ -1,3 +1,5 @@
+Closes #<issue-number>
+
 ## Testing
 ### GET
 URL: <localhost:4444/v2/some-api-call>

--- a/providers/dynamics.go
+++ b/providers/dynamics.go
@@ -48,6 +48,9 @@ func init() {
 			// TODO: flip this to false once we implement the ability to get workspace
 			// information post-auth.
 			ExplicitWorkspaceRequired: true,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -56,7 +59,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/test/dynamicscrm/connector.go
+++ b/test/dynamicscrm/connector.go
@@ -16,37 +16,43 @@ func GetMSDynamics365CRMConnector(ctx context.Context, filePath string) *dynamic
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_ID",
-			CredKey:  "clientId",
+			CredKey:  utils.ClientId,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_SECRET",
-			CredKey:  "clientSecret",
+			CredKey:  utils.ClientSecret,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.ACCESS_TOKEN",
-			CredKey:  "accessToken",
+			CredKey:  utils.AccessToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.REFRESH_TOKEN",
-			CredKey:  "refreshToken",
+			CredKey:  utils.RefreshToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.PROVIDER",
-			CredKey:  "provider",
+			CredKey:  utils.Provider,
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.WORKSPACE",
+			CredKey:  utils.WorkspaceRef,
 		},
 	}
 	_ = registry.AddReaders(readers...)
 
 	cfg := utils.MSDynamics365CRMConfigFromRegistry(registry)
 	tok := utils.MSDynamics365CRMTokenFromRegistry(registry)
+	workspace := registry.MustString(utils.WorkspaceRef)
 
 	conn, err := dynamicscrm.NewConnector(
 		dynamicscrm.WithClient(ctx, http.DefaultClient, cfg, tok),
-		dynamicscrm.WithWorkspace(utils.MSDynamics365CRMWorkspace),
+		dynamicscrm.WithWorkspace(workspace),
 	)
 	if err != nil {
 		testUtils.Fail("error creating microsoft CRM connector", "error", err)

--- a/test/dynamicscrm/metadata/main.go
+++ b/test/dynamicscrm/metadata/main.go
@@ -78,7 +78,9 @@ func sanitizeReadResponse(response map[string]any) map[string]any {
 	for field, v := range response {
 		// ignore all fields that are OData annotations
 		// they are not part of ObjectMetadata
-		if !strings.HasPrefix(field, "@") {
+		lower := strings.ToLower(field)
+		isAnnotation := strings.Contains(lower, "@odata") || strings.Contains(lower, "@microsoft.dynamics.crm")
+		if !isAnnotation {
 			crucialFields[field] = v
 		}
 	}

--- a/tools/connectorgen/template/test/connector.go.tmpl
+++ b/tools/connectorgen/template/test/connector.go.tmpl
@@ -17,27 +17,32 @@ func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Pack
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_ID",
-			CredKey:  "clientId",
+			CredKey:  utils.ClientId,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_SECRET",
-			CredKey:  "clientSecret",
+			CredKey:  utils.ClientSecret,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.ACCESS_TOKEN",
-			CredKey:  "accessToken",
+			CredKey:  utils.AccessToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.REFRESH_TOKEN",
-			CredKey:  "refreshToken",
+			CredKey:  utils.RefreshToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.PROVIDER",
-			CredKey:  "provider",
+			CredKey:  utils.Provider,
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.WORKSPACE",
+			CredKey:  utils.WorkspaceRef,
 		},
 	}
 	_ = registry.AddReaders(readers...)
@@ -45,11 +50,12 @@ func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Pack
 	// TODO create config and token registries
 	cfg := utils.{{ .Provider }}ConfigFromRegistry(registry)
 	tok := utils.{{ .Provider }}TokenFromRegistry(registry)
+	workspace := registry.MustString(utils.WorkspaceRef)
 
 	// TODO provide required options
 	conn, err := connectors.{{ .Provider }}(
 		{{ .Package }}.WithClient(ctx, http.DefaultClient, cfg, tok),
-		{{ .Package }}.WithWorkspace(utils.{{ .Provider }}Workspace),
+		{{ .Package }}.WithWorkspace(workspace),
 	)
 	if err != nil {
 		testUtils.Fail("error creating connector", "error", err)

--- a/utils/credentials.go
+++ b/utils/credentials.go
@@ -90,11 +90,10 @@ func HubspotOAuthConfigFromRegistry(registry CredentialsRegistry) *oauth2.Config
 	return cfg
 }
 
-var MSDynamics365CRMWorkspace = "org5bd08fdd" //nolint:gochecknoglobals
-
 func MSDynamics365CRMConfigFromRegistry(registry CredentialsRegistry) *oauth2.Config {
 	clientId := registry.MustString(ClientId)
 	clientSecret := registry.MustString(ClientSecret)
+	workspace := registry.MustString(WorkspaceRef)
 
 	cfg := &oauth2.Config{
 		ClientID:     clientId,
@@ -106,7 +105,7 @@ func MSDynamics365CRMConfigFromRegistry(registry CredentialsRegistry) *oauth2.Co
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
 		Scopes: []string{
-			fmt.Sprintf("https://%v.crm.dynamics.com/user_impersonation", MSDynamics365CRMWorkspace),
+			fmt.Sprintf("https://%v.crm.dynamics.com/user_impersonation", workspace),
 			"offline_access",
 		},
 	}


### PR DESCRIPTION
Closes #206 

# Changes
All manual tests are passing for MS with new credentials.
* DynamicsCRM, proxy toggled on.
* Domain for Ampersand company was changed affecting URLs and Scopes which utilise URLs, ex:
```
"scopes": "https://org5a07f924.crm.dynamics.com/user_impersonation,offline_access"
```
* Workspace was hard coded into tests which is wrong, now it is coming from credentials file. 
* Github PR template for proxy PRs to include mention of Github issue.
* TokenMetadataFields - to include `scope`.

## Testing
### GET
List contacts.
```
curl --location --request GET 'https://proxy.withampersand.com/v9.2/contacts?$select=fullname' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/c78f31dc-68aa-45ac-9ec3-76e85507fda5)


### POST
Create lead.
```
curl --location --request POST 'https://proxy.withampersand.com/v9.2/leads' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "subject": "New Balance, 2000s running-inspired design",
    "firstname": "William",
    "lastname": "Riley"
}'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/aeb92abe-60de-4946-948d-3d54b55ebb1b)


### PATCH
Update lead.
```
curl --location --request PATCH 'https://proxy.withampersand.com/v9.2/leads(af0d06d0-1f30-ef11-8409-6045bd0881b3)' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "subject": "New Balance, Athletics Hoodies",
    "firstname": "Joe",
    "lastname": "Preston"
}'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/65954134-1121-46ea-b081-e79faede300a)

### DELETE
Remove lead.
```
curl --location --request DELETE 'https://proxy.withampersand.com/v9.2/leads(af0d06d0-1f30-ef11-8409-6045bd0881b3)' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/ce1af73d-2638-4b78-a285-75b948774de1)


### Invalid requests
Wrong verb applied (POST on a singular object):
![image](https://github.com/amp-labs/connectors/assets/60330780/d862cd35-5fc6-466e-8976-a9bd61846c00)
Invalid path:
![image](https://github.com/amp-labs/connectors/assets/60330780/30a6396c-4b99-4077-b7f7-adc567f1d0ed)


## Pagination

### First Page
List leads by providing `prefer` page size header.
```
curl --location --request GET 'https://proxy.withampersand.com/v9.2/leads?$select=subject' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>' \
--header 'Prefer: odata.maxpagesize=2' 
```
![image](https://github.com/amp-labs/connectors/assets/60330780/9ec12acb-05f8-4adc-9a6a-5d0b483db3e6)

### Second Page
Follow cursor.
```
curl --location --request GET 'https://proxy.withampersand.com/v9.2/leads?$select=subject&$skiptoken=%3Ccookie%20pagenumber=%222%22%20pagingcookie=%22%253ccookie%2520page%253d%25221%2522%253e%253cleadid%2520last%253d%2522%257b41B9F0C8-1F30-EF11-8409-6045BD0881B3%257d%2522%2520first%253d%2522%257bE42CC18F-1F30-EF11-8409-6045BD0881B3%257d%2522%2520%252f%253e%253c%252fcookie%253e%22%20istracking=%22False%22%20/%3E' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: a3949605-654b-4a01-9ab4-ff8790fbc6b8' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>' \
--header 'Prefer: odata.maxpagesize=2'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/59eb71bf-db31-4bc5-b8a4-b0f4933238df)


## Successful console operation (operation & events)
![image](https://github.com/amp-labs/connectors/assets/60330780/a353de55-790d-4681-9061-d3fe57740540)


## Failed console operation (operation & events)
![image](https://github.com/amp-labs/connectors/assets/60330780/e291725c-419b-431d-9e93-40eceb0e75c8)


## Raw token response
```
{
  "token_type": "Bearer",
  "scope": "https://org5a07f924.crm.dynamics.com/user_impersonation",
  "expires_in": 4561,
  "ext_expires_in": 4561,
  "access_token": "....",
  "refresh_token": ".....",
}
```