### PR TITLE
feat: Add Anthropic connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -9,6 +9,7 @@ const (
 	Aha                     Provider = "aha"
 	Aircall                 Provider = "aircall"
 	Airtable                Provider = "airtable"
+	Anthropic               Provider = "anthropic"
 	Asana                   Provider = "asana"
 	Atlassian               Provider = "atlassian"
 	Attio                   Provider = "attio"
@@ -1102,6 +1103,28 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
 			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	Anthropic: {
+		AuthType: ApiKey,
+		BaseURL:  "https://api.anthropic.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			Type:       InHeader,
+			HeaderName: "x-api-key",
+			DocsURL:    "https://docs.anthropic.com/en/api/getting-started#authentication",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
Closes #512

## Checklist
- [x] Ran Linter

## Catalog variables
N/A

## Notes
Only one endpoint exists to send messages. It is a conversation with AI chat bot.
Version header must be provided for a request to succeed.

## Testing

### POST
Proxy can pass version header and POSTing a message succeeds:
```
curl --location --request POST 'http://localhost:4444/v1/messages' \
--header 'anthropic-version: 2023-06-01' \
--header 'Content-Type: application/json' \
--data-raw '{
    "model": "claude-3-opus-20240229",
    "max_tokens": 1024,
    "messages": [
        {
            "role": "user",
            "content": "Hello, world"
        }
    ]
}'
```
![image](https://github.com/amp-labs/connectors/assets/60330780/7387637e-60e1-4b4c-a826-5cc69c56ea7c)

### Errors

Without version header we get error 400:
```
{
    "type": "error",
    "error": {
        "type": "invalid_request_error",
        "message": "anthropic-version: header is required"
    }
}
```

