### PR TITLE
feat: Add Customer.io Data Pipelines connector

### DIFF
--- a/providers/catalog.go
+++ b/providers/catalog.go
@@ -22,6 +22,7 @@ const (
 	Close                   Provider = "close"
 	ConstantContact         Provider = "constantContact"
 	Copper                  Provider = "copper"
+	CustomerDataPipelines   Provider = "customerDataPipelines"
 	Discord                 Provider = "discord"
 	Docusign                Provider = "docusign"
 	DocusignDeveloper       Provider = "docusignDeveloper"
@@ -360,6 +361,24 @@ var catalog = CatalogType{ // nolint:gochecknoglobals
 				Delete: false,
 			},
 			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	},
+
+	CustomerDataPipelines: {
+		AuthType: Basic,
+		BaseURL:  "https://cdp.customer.io/v1",
+		// DocsURL: https://customer.io/docs/api/cdp/#section/Authentication
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -224,8 +224,14 @@ func mainBasic(ctx context.Context, provider string, substitutionsMap map[string
 	user := registry.MustString("UserName")
 	pass := registry.MustString("Password")
 
-	if user == "" || pass == "" {
+	if len(user)+len(pass) == 0 {
 		log.Fatalf("Missing username or password")
+	}
+	if len(user) == 0 {
+		slog.Warn("no username for basic authentication, ensure that it is not required")
+	}
+	if len(pass) == 0 {
+		slog.Warn("no password for basic authentication, ensure that it is not required")
 	}
 
 	startBasicAuthProxy(ctx, provider, user, pass, substitutionsMap, DefaultPort)


### PR DESCRIPTION
Closes #514 

## Checklist
- [x] Ran Linter

## Catalog variables
Username is Track API Key
Password is empty.

## Notes
Changed code such that username and password are not required for basic authentication unless both are empty. Prints a warning instead of failing execution.

## Testing
### GET/PUT/DELETE
N/A

### POST
Tell customer.io to identify user. As the matter of fact any data or even no payload sent via any POST endpoint will always produce `{"success": true}`. All these endpoints are used for some kind of tracking those users. It is usefull to know which page a person opened and if user switched from anonymouse to registered and then associating this data.
URL: http://localhost:4444/identify
![image](https://github.com/amp-labs/connectors/assets/60330780/5c9f3bb6-8394-4ad7-b74a-81eefa96be4f)


## Pagination
N/A
