### PR TITLE
feat: Add Brevo auth connector

### DIFF
--- a/providers/brevo.go
+++ b/providers/brevo.go
@@ -1,0 +1,28 @@
+package providers
+
+const Brevo Provider = "brevo"
+
+func init() {
+	// Brevo(Sendinblue) configuration
+	SetInfo(Brevo, ProviderInfo{
+		AuthType: ApiKey,
+		BaseURL:  "https://api.brevo.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			Type:       InHeader,
+			HeaderName: "api-key",
+			DocsURL:    "https://developers.brevo.com/docs/getting-started",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
Closes #511 

## Checklist
- [x] Ran Linter

## Catalog variables
None

## Notes

## Testing 
### GET 
<img width="1151" alt="Screenshot 2024-06-18 at 11 59 01" src="https://github.com/amp-labs/connectors/assets/52887226/7b15923c-501a-49d7-940b-fa24bb480da8">

### POST
<img width="1156" alt="Screenshot 2024-06-18 at 12 00 03" src="https://github.com/amp-labs/connectors/assets/52887226/5dd894c7-7cd3-4479-8bd6-f09fb4125d71">

### DELETE
<img width="1155" alt="Screenshot 2024-06-18 at 12 03 26" src="https://github.com/amp-labs/connectors/assets/52887226/46855c99-2012-45f0-b89f-7fdc7855bd36">

### PUT
<img width="1150" alt="Screenshot 2024-06-18 at 12 02 15" src="https://github.com/amp-labs/connectors/assets/52887226/d64d83f1-d186-496c-8e4d-2839daebb56e">


## Pagination
Pagination uses `limit` and `offset` parameters. Requesting Contacts using the values.
<img width="1155" alt="Screenshot 2024-06-18 at 12 31 17" src="https://github.com/amp-labs/connectors/assets/52887226/04ad94f8-78b6-4c24-8330-214c74aa72e0">

Requesting the next offset value, and since limit+offset > `count`,  we have reached the last record. 
<img width="1150" alt="Screenshot 2024-06-18 at 12 25 38" src="https://github.com/amp-labs/connectors/assets/52887226/0f862dc7-bbf2-4986-aa86-014e2689e516">
