### PR TITLE
feat: Add SendGrid auth connector

### DIFF
--- a/providers/sendGrid.go
+++ b/providers/sendGrid.go
@@ -1,0 +1,29 @@
+package providers
+
+const SendGrid Provider = "sendGrid"
+
+func init() {
+	// SendGrid configuration
+	SetInfo(SendGrid, ProviderInfo{
+		AuthType: ApiKey,
+		BaseURL:  "https://api.sendgrid.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			Type:        InHeader,
+			HeaderName:  "Authorization",
+			ValuePrefix: "Bearer ",
+			DocsURL:     "https://www.twilio.com/docs/sendgrid",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
Closes #510 

## Checklist
- [x] Ran Linter

## Catalog variables
None

## Notes

## Testing 
### GET 
<img width="1162" alt="Screenshot 2024-06-20 at 12 04 41" src="https://github.com/amp-labs/connectors/assets/52887226/74c4295a-3ac2-406f-97d7-c9915e4930da">


### POST
<img width="1155" alt="Screenshot 2024-06-20 at 12 17 01" src="https://github.com/amp-labs/connectors/assets/52887226/e13b9460-1d32-403b-8d39-c4b6f57471c0">


### PATCH
<img width="1145" alt="Screenshot 2024-06-20 at 12 11 45" src="https://github.com/amp-labs/connectors/assets/52887226/1d84c8f1-b200-4e5b-be41-3e83159c67b4">


### DELETE
<img width="1151" alt="Screenshot 2024-06-20 at 12 10 17" src="https://github.com/amp-labs/connectors/assets/52887226/445b831f-d57d-45ac-afa3-da475a426498">


## Pagination
Requesting a paginated list of templates.
<img width="1141" alt="Screenshot 2024-06-20 at 12 05 54" src="https://github.com/amp-labs/connectors/assets/52887226/7e8a3df9-b2bd-43cb-a650-10f980e98f98">


Using the `next` in `_metadata` to retrieve the next page token.
<img width="1146" alt="Screenshot 2024-06-20 at 12 09 50" src="https://github.com/amp-labs/connectors/assets/52887226/91084f26-84a2-45e1-ac40-e019a7dd750e">

