### PR TITLE
Feat Add Geckoboard Connector

### DIFF
--- a/providers/geckoboard.go
+++ b/providers/geckoboard.go
@@ -18,6 +18,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: true,
+		PostAuthInfoNeeded: false,
 	})
 }

--- a/providers/geckoboard.go
+++ b/providers/geckoboard.go
@@ -1,0 +1,23 @@
+package providers
+
+const Geckoboard Provider = "geckoboard"
+
+func init() {
+	SetInfo(Geckoboard, ProviderInfo{
+		AuthType: Basic,
+		BaseURL:  "https://api.geckoboard.com",
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		PostAuthInfoNeeded: true,
+	})
+}


### PR DESCRIPTION
Closes #523 

## Checklist
- [x] Ran Linter
- [x] Created PR from non-main branch 

## Catalog variables

## Notes
No version is required when making API calls
It was not possible to print the token as it is generated via the platform
No documentation on pagination but after testing, the limit param is supported

## Testing 
### GET 
URL: <localhost:4444/datasets> 
![Screenshot 2567-06-21 at 19 55 46](https://github.com/amp-labs/connectors/assets/103050835/a59ae772-d2be-42ed-8212-09ce45b2123c)

### POST
URL: <localhost:4444/v2/sales.by_year/data> 
![Screenshot 2567-06-21 at 19 59 57](https://github.com/amp-labs/connectors/assets/103050835/d30bcade-ed69-4c05-be48-45cead029893)

### PUT
URL: <localhost:4444/datasets/sales.by_year> 
![Screenshot 2567-06-21 at 19 58 48](https://github.com/amp-labs/connectors/assets/103050835/bf40b4ab-cffb-44c0-a87f-f18a4a342864)

### DELETE
URL: <localhost:4444/v2/datasets/sales.by_year> 
![Screenshot 2567-06-21 at 20 03 13](https://github.com/amp-labs/connectors/assets/103050835/292231ec-5c5a-4d1c-a234-5a861041533c)

## Pagination
**Before pagination**
![Screenshot 2567-06-21 at 19 55 46](https://github.com/amp-labs/connectors/assets/103050835/e231e17f-7c30-442d-ba7f-c3f94ad816be)
**After pagination**
![Screenshot 2567-06-21 at 20 02 32](https://github.com/amp-labs/connectors/assets/103050835/b765b91f-65d6-4b32-8e75-f48ce09c9e2a)
