### PR TITLE
fix: Gong remove options, add error handler

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -6,7 +6,11 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-type NextPageFunc func(*ajson.Node) (string, error)
+type (
+	ListSizeFunc func(*ajson.Node) (int64, error)
+	NextPageFunc func(*ajson.Node) (string, error)
+	RecordsFunc  func(*ajson.Node) ([]map[string]any, error)
+)
 
 // ParseResult parses the response from a provider into a ReadResult. A 2xx return type is assumed.
 // The sizeFunc, recordsFunc, nextPageFunc, and marshalFunc are used to extract the relevant data from the response.

--- a/gong/errors.go
+++ b/gong/errors.go
@@ -15,14 +15,7 @@ func (*Connector) interpretJSONError(res *http.Response, body []byte) error { //
 		return fmt.Errorf("interpretJSONError general: %w %w", interpreter.ErrUnmarshal, err)
 	}
 
-	return payload.CombineErr(statusCodeMapping(res, body))
-}
-
-func statusCodeMapping(res *http.Response, body []byte) error {
-	switch res.StatusCode { // nolint:gocritic
-	default:
-		return interpreter.DefaultStatusCodeMappingToErr(res, body)
-	}
+	return payload.CombineErr(interpreter.DefaultStatusCodeMappingToErr(res, body))
 }
 
 type ResponseError struct {

--- a/gong/params.go
+++ b/gong/params.go
@@ -10,16 +10,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type gongParams struct {
-	client *common.JSONHTTPClient
-	paramsbuilder.Workspace
-	paramsbuilder.APIModule
-	substitutions map[string]string
+// Option is a function which mutates the connector configuration.
+type Option func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
 }
 
-type Option func(params *gongParams)
-
-func (params *gongParams) FromOptions(opts ...Option) (*gongParams, error) {
+func (p parameters) FromOptions(opts ...Option) (*parameters, error) {
+	params := &p
 	for _, opt := range opts {
 		opt(params)
 	}
@@ -27,49 +26,22 @@ func (params *gongParams) FromOptions(opts ...Option) (*gongParams, error) {
 	return params, params.ValidateParams()
 }
 
-func (params *gongParams) ValidateParams() error {
+func (p parameters) ValidateParams() error {
 	return errors.Join(
-		params.Workspace.ValidateParams(),
+		p.Client.ValidateParams(),
 	)
 }
 
-func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
-	return func(params *gongParams) {
-		oauthclient, err := common.NewOAuthHTTPClient(
-			ctx, common.WithOAuthClient(client),
-			common.WithOAuthConfig(config),
-			common.WithOAuthToken(token),
-		)
-		if err != nil {
-			panic(err)
-		}
-
-		WithAuthenticatedClient(oauthclient)(params)
-	}
-}
-
-func WithModule(module paramsbuilder.APIModule) Option {
-	return func(params *gongParams) {
-		params.APIModule = module
+	return func(params *parameters) {
+		params.WithClient(ctx, client, config, token, opts...)
 	}
 }
 
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
-	return func(params *gongParams) {
-		params.client = &common.JSONHTTPClient{
-			HTTPClient: &common.HTTPClient{
-				Client:       client,
-				ErrorHandler: common.InterpretError,
-			},
-		}
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
 	}
-}
-
-func (params *gongParams) prepare() (*gongParams, error) {
-	if params.client == nil {
-		return nil, ErrMissingClient
-	}
-
-	return params, nil
 }

--- a/gong/read.go
+++ b/gong/read.go
@@ -2,43 +2,30 @@ package gong
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/spyzhov/ajson"
 )
 
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
-	var (
-		res *common.JSONHTTPResponse
-
-		fields []string
-	)
-
-	fullURL, err := url.JoinPath(c.BaseURL, ApiVersion, config.ObjectName)
+	url, err := c.getURL(config.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(config.NextPage) != 0 { // not the first page, add a cursor
-		fullURL = fullURL + "?cursor=" + config.NextPage.String()
+		url.WithQueryParam("cursor", config.NextPage.String())
 	}
 
-	if config.Fields != nil {
-		fields = config.Fields
-	}
-
-	res, err = c.Client.Get(ctx, fullURL)
+	res, err := c.Client.Get(ctx, url.String())
 	if err != nil {
 		return nil, err
 	}
 
-	return common.ParseResult(res, getTotalSize,
-		func(node *ajson.Node) ([]map[string]interface{}, error) {
-			return getRecords(node, config.ObjectName)
-		},
+	return common.ParseResult(res,
+		makeGetTotalSize(config.ObjectName),
+		makeGetRecords(config.ObjectName),
 		getNextRecordsURL,
 		getMarshaledData,
-		fields,
+		config.Fields,
 	)
 }

--- a/gong/url.go
+++ b/gong/url.go
@@ -1,0 +1,18 @@
+package gong
+
+import "github.com/amp-labs/connectors/common/urlbuilder"
+
+var queryEncodingExceptions = map[string]string{ //nolint:gochecknoglobals
+	// none
+}
+
+func constructURL(base string) (*urlbuilder.URL, error) {
+	link, err := urlbuilder.New(base)
+	if err != nil {
+		return nil, err
+	}
+
+	link.AddEncodingExceptions(queryEncodingExceptions)
+
+	return link, nil
+}

--- a/test/gong/connector.go
+++ b/test/gong/connector.go
@@ -1,15 +1,15 @@
-package {{ .Package }}
+package gong
 
 import (
 	"context"
 	"net/http"
 
-	"github.com/amp-labs/connectors/{{ .Package }}"
+	"github.com/amp-labs/connectors/gong"
 	testUtils "github.com/amp-labs/connectors/test/utils"
 	"github.com/amp-labs/connectors/utils"
 )
 
-func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Package }}.Connector {
+func GetGongConnector(ctx context.Context, filePath string) *gong.Connector {
 	registry := utils.NewCredentialsRegistry()
 
 	readers := []utils.Reader{
@@ -38,23 +38,14 @@ func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Pack
 			JSONPath: "$.provider",
 			CredKey:  utils.Provider,
 		},
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.workspace",
-			CredKey:  utils.WorkspaceRef,
-		},
 	}
 	_ = registry.AddReaders(readers...)
 
-	// TODO create config and token registries
-	cfg := utils.{{ .Provider }}ConfigFromRegistry(registry)
-	tok := utils.{{ .Provider }}TokenFromRegistry(registry)
-	workspace := registry.MustString(utils.WorkspaceRef)
+	cfg := utils.GongOAuthConfigFromRegistry(registry)
+	tok := utils.GongOauthTokenFromRegistry(registry)
 
-	// TODO provide required options
-	conn, err := {{ .Package }}.NewConnector(
-		{{ .Package }}.WithClient(ctx, http.DefaultClient, cfg, tok),
-		{{ .Package }}.WithWorkspace(workspace),
+	conn, err := gong.NewConnector(
+		gong.WithClient(ctx, http.DefaultClient, cfg, tok),
 	)
 	if err != nil {
 		testUtils.Fail("error creating connector", "error", err)

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -4,67 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"net/http"
 	"os"
 
 	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/gong"
-	"github.com/amp-labs/connectors/utils"
+	connTest "github.com/amp-labs/connectors/test/gong"
 	"github.com/joho/godotenv"
 )
 
 const (
 	DefaultCredsFile = "creds.json"
 )
-
-func GetGongConnector(ctx context.Context, filePath string) *gong.Connector {
-	registry := utils.NewCredentialsRegistry()
-
-	readers := []utils.Reader{
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$['clientId']",
-			CredKey:  "clientId",
-		},
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$['clientSecret']",
-			CredKey:  "clientSecret",
-		},
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$['refreshToken']",
-			CredKey:  "refreshToken",
-		},
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$['accessToken']",
-			CredKey:  "accessToken",
-		},
-		&utils.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$['provider']",
-			CredKey:  "provider",
-		},
-	}
-	registry.AddReaders(readers...)
-
-	cfg := utils.GongOAuthConfigFromRegistry(registry)
-	tok := utils.GongOauthTokenFromRegistry(registry)
-
-	conn, err := gong.NewConnector(
-		gong.WithClient(ctx, http.DefaultClient, cfg, tok),
-	)
-	if err != nil {
-		slog.Error("error creating gong connector", "error", err)
-	}
-
-	defer func() {
-		_ = conn.Close()
-	}()
-
-	return conn
-}
 
 func main() {
 	os.Exit(mainFn())
@@ -82,14 +31,14 @@ func mainFn() int {
 		slog.Warn("No .env file provided")
 	}
 
-	gong := GetGongConnector(context.Background(), DefaultCredsFile)
+	conn := connTest.GetGongConnector(context.Background(), DefaultCredsFile)
 
 	config := connectors.ReadParams{
 		ObjectName: "calls", // could be calls, users
 		Fields:     []string{"url"},
 	}
 
-	result, err := gong.Read(context.Background(), config)
+	result, err := conn.Read(context.Background(), config)
 	if err != nil {
 		slog.Error("Error reading from Gong", "error", err)
 		return 1

--- a/tools/connectorgen/template/base/connector.go.tmpl
+++ b/tools/connectorgen/template/base/connector.go.tmpl
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
 )


### PR DESCRIPTION
# Changes

* Parse error in the format that gong utilises
* Method `count number of records` - counts records manually, because currentPageSize doesn't reflect this
* Removed Workspace and APIModule options
* Response parsing to use `jsonquery` for a shorter form, adapted tests respectively
* Tiny changes to connector gen template files
* Pull connector instantiation for testing that can be used by other 'Methods'

Making request using existing `Read` test returns output as expected.
![image](https://github.com/amp-labs/connectors/assets/60330780/a9654a31-8c48-4969-b670-fabf7f946f7b)
