### PR TITLE
fix: Panic thrown by DynamicsCRM.Metadata, change XML lib

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/proxy_connector.md
+++ b/.github/PULL_REQUEST_TEMPLATE/proxy_connector.md
@@ -1,3 +1,5 @@
+Closes #<issue-number>
+
 ## Testing
 ### GET
 URL: <localhost:4444/v2/some-api-call>

--- a/common/xml.go
+++ b/common/xml.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/amp-labs/connectors/common/xquery"
 	"github.com/go-playground/validator"
-	"github.com/subchen/go-xmldom"
 )
 
 const (
@@ -23,7 +22,6 @@ const (
 var (
 	//nolint:gochecknoglobals
 	validate          = validator.New()
-	ErrNoXMLRoot      = errors.New("xml document has no root")
 	ErrNotXMLChildren = errors.New("children must be of type 'XMLData' or 'XMLString'")
 	ErrNoSelfClosing  = errors.New("selfClosing cannot be true if children are not present")
 	ErrNoParens       = errors.New("value cannot contain < or >")
@@ -46,15 +44,7 @@ type XMLHTTPResponse struct {
 	Headers http.Header
 
 	// Body is the unmarshalled response body in XML form. Content is the same as bodyBytes
-	Body *xmldom.Document
-}
-
-func (r XMLHTTPResponse) GetRoot() (*xmldom.Node, error) {
-	if r.Body == nil || r.Body.Root == nil {
-		return nil, ErrNoXMLRoot
-	}
-
-	return r.Body.Root, nil
+	Body *xquery.XML
 }
 
 // Get makes a GET request to the given URL and returns the response body as a XML object.
@@ -90,7 +80,7 @@ func parseXMLResponse(res *http.Response, body []byte) (*XMLHTTPResponse, error)
 	}
 
 	// Unmarshall the response body into XML
-	xmlBody, err := xmldom.Parse(bytes.NewReader(body))
+	xmlBody, err := xquery.NewXML(body)
 	if err != nil {
 		return nil, NewHTTPStatusError(res.StatusCode, fmt.Errorf("failed to unmarshall response body into XML: %w", err))
 	}

--- a/common/xquery/queries.go
+++ b/common/xquery/queries.go
@@ -1,0 +1,96 @@
+package xquery
+
+import (
+	"bytes"
+
+	xq "github.com/antchfx/xmlquery"
+)
+
+// XML is a wrapper of xmlquery.XML. It has additional safety incorporated when querying the contents.
+// This also serves as an abstraction from real implementation which can change.
+// In fact library was changed, this should limit disruption in the future if such issue arises again.
+type XML struct {
+	delegate *xq.Node
+}
+
+func NewXML(data []byte) (*XML, error) {
+	node, err := xq.Parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	return newXML(node), nil
+}
+
+func newXML(node *xq.Node) *XML {
+	return &XML{delegate: node}
+}
+
+func (x *XML) IsEmpty() bool {
+	// this check allows to abide to Null Object pattern
+	return x.delegate == nil
+}
+
+func (x *XML) FindOne(expr string) (output *XML) {
+	if x.IsEmpty() {
+		return x
+	}
+
+	defer panicRecovery(func(cause error) { // nolint:unparam
+		output = newXML(nil)
+	})
+
+	node := xq.FindOne(x.delegate, expr)
+
+	return newXML(node)
+}
+
+func (x *XML) FindMany(expr string) (output []*XML) {
+	if x.IsEmpty() {
+		return []*XML{}
+	}
+
+	defer panicRecovery(func(cause error) { // nolint:unparam
+		output = []*XML{}
+	})
+
+	nodes := xq.Find(x.delegate, expr)
+	output = make([]*XML, len(nodes))
+
+	for i, node := range nodes {
+		output[i] = newXML(node)
+	}
+
+	return output
+}
+
+func (x *XML) Parent() *XML {
+	if x.IsEmpty() {
+		return x
+	}
+
+	return newXML(x.delegate.Parent)
+}
+
+func (x *XML) Attr(name string) string {
+	if x.IsEmpty() {
+		return ""
+	}
+
+	return x.delegate.SelectAttr(name)
+}
+
+func (x *XML) HasChildren() bool {
+	return x.delegate.FirstChild != nil
+}
+
+func panicRecovery(wrapup func(cause error)) {
+	if re := recover(); re != nil {
+		err, ok := re.(error)
+		if !ok {
+			panic(re)
+		}
+
+		wrapup(err)
+	}
+}

--- a/dynamicscrm/metadata.go
+++ b/dynamicscrm/metadata.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/subchen/go-xmldom"
+	"github.com/amp-labs/connectors/common/xquery"
 )
 
 var (
@@ -37,12 +37,7 @@ func (c *Connector) ListObjectMetadata(
 		return nil, err
 	}
 
-	root, err := rsp.GetRoot()
-	if err != nil {
-		return nil, err
-	}
-
-	entities, err := extractEntities(root)
+	entities, err := extractEntities(rsp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -59,44 +54,46 @@ func (c *Connector) ListObjectMetadata(
 }
 
 // collects field properties and groups them in entities, other data in XML is ignored.
-func extractEntities(root *xmldom.Node) (EntitySet, error) {
-	querySchema := fmt.Sprintf("/DataServices/Schema[@Namespace='%v']", CRMMetadataSchemaName)
+func extractEntities(root *xquery.XML) (EntitySet, error) {
+	querySchema := fmt.Sprintf("//edmx:DataServices/Schema[@Namespace='%v']", CRMMetadataSchemaName)
 
-	schema := root.QueryOne(querySchema)
-	if schema == nil {
+	schema := root.FindOne(querySchema)
+	if schema.IsEmpty() {
 		return nil, ErrMissingSchema
 	}
 
 	entities := NewEntitySet()
 	// List all field properties that exist for current schema
 	queryListAllSchemaProperties := fmt.Sprintf(
-		"/DataServices/Schema[@Namespace='%v']/EntityType[*]/Property/@Name", CRMMetadataSchemaName)
-	root.QueryEach(queryListAllSchemaProperties, func(index int, property *xmldom.Node) {
+		"//edmx:DataServices/Schema[@Namespace='%v']/EntityType[*]/Property/@Name", CRMMetadataSchemaName)
+	for _, nameAttr := range root.FindMany(queryListAllSchemaProperties) {
 		// parent of a property is an Entity.
 		// Entity may inherit properties from a parent
 		// We save entity name and the name of its parent, so later we can infer all properties by denormalisation
-		entityName := property.Parent.GetAttributeValue("Name")
-		parentName := property.Parent.GetAttributeValue("BaseType")
+		property := nameAttr.Parent()
+		entityObj := property.Parent()
+		entityName := entityObj.Attr("Name")
+		parentName := entityObj.Attr("BaseType")
 		entity := entities.GetOrCreate(entityName, parentName)
-		propertyName := property.GetAttributeValue("Name")
+		propertyName := property.Attr("Name")
 		entity.AddProperty(propertyName)
-	})
+	}
 
 	queryListAbstractEntities := fmt.Sprintf(
-		"/DataServices/Schema[@Namespace='%v']/EntityType[@Abstract='true']", CRMMetadataSchemaName)
-	root.QueryEach(queryListAbstractEntities, func(index int, abstractEntity *xmldom.Node) {
-		if len(abstractEntity.Children) == 0 {
+		"//edmx:DataServices/Schema[@Namespace='%v']/EntityType[@Abstract='true']", CRMMetadataSchemaName)
+	for _, abstractEntity := range root.FindMany(queryListAbstractEntities) {
+		if !abstractEntity.HasChildren() {
 			// these entities were not included by previous query as they have no properties
 			// we programmatically find these special types, which are "primary values" but for structs
 			// Ex: crmbaseentity, crmmodelbaseentity,
-			entityName := abstractEntity.GetAttributeValue("Name")
+			entityName := abstractEntity.Attr("Name")
 			// effectively only create
 			_ = entities.GetOrCreate(entityName, "")
 		}
-	})
+	}
 
 	// link every child with parent completing hierarchy
-	schemaAlias := schema.GetAttributeValue("Alias")
+	schemaAlias := schema.Attr("Alias")
 	if err := entities.MatchParentsWithChildren(schemaAlias); err != nil {
 		return nil, errors.Join(ErrMetadataProcessing, err)
 	}

--- a/dynamicscrm/metadata_test.go
+++ b/dynamicscrm/metadata_test.go
@@ -56,16 +56,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			expectedErrs: []error{common.ErrNotXML},
 		},
 		{
-			name:  "Missing XML root",
-			input: []string{"msfp_surveyinvite"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/xml")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `<?xml version="1.0" encoding="utf-8"?>`)
-			})),
-			expectedErrs: []error{common.ErrNoXMLRoot},
-		},
-		{
 			name:  "Server response without CRM Schema",
 			input: []string{"msfp_surveyinvite"},
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.9.2
+	github.com/antchfx/xmlquery v1.4.0
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-playground/validator v9.31.0+incompatible
@@ -20,10 +21,11 @@ require (
 
 require (
 	github.com/andybalholm/cascadia v1.3.2 // indirect
-	github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 // indirect
+	github.com/antchfx/xpath v1.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,11 @@ github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
-github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 h1:C735MoY/X+UOx6SECmHk5pVOj51h839Ph13pEoY8UmU=
+github.com/antchfx/xmlquery v1.4.0 h1:xg2HkfcRK2TeTbdb0m1jxCYnvsPaGY/oeZWTGqX/0hA=
+github.com/antchfx/xmlquery v1.4.0/go.mod h1:Ax2aeaeDjfIw3CwXKDQ0GkwZ6QlxoChlIBP+mGnDFjI=
 github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/antchfx/xpath v1.3.0 h1:nTMlzGAK3IJ0bPpME2urTuFL76o4A96iYvoKFHRXJgc=
+github.com/antchfx/xpath v1.3.0/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -25,6 +28,8 @@ github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -100,6 +105,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
 golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=

--- a/providers/dynamics.go
+++ b/providers/dynamics.go
@@ -48,6 +48,9 @@ func init() {
 			// TODO: flip this to false once we implement the ability to get workspace
 			// information post-auth.
 			ExplicitWorkspaceRequired: true,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -56,7 +59,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/salesforce/metadataApi.go
+++ b/salesforce/metadataApi.go
@@ -19,7 +19,6 @@ import (
 var (
 	ErrCreateMetadata  = errors.New("error in CreateMetadata")
 	ErrCreatingRequest = errors.New("error in creating request")
-	ErrBadRequest      = errors.New("bad request")
 )
 
 func (c *Connector) CreateMetadata(

--- a/test/dynamicscrm/connector.go
+++ b/test/dynamicscrm/connector.go
@@ -16,37 +16,43 @@ func GetMSDynamics365CRMConnector(ctx context.Context, filePath string) *dynamic
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_ID",
-			CredKey:  "clientId",
+			CredKey:  utils.ClientId,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_SECRET",
-			CredKey:  "clientSecret",
+			CredKey:  utils.ClientSecret,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.ACCESS_TOKEN",
-			CredKey:  "accessToken",
+			CredKey:  utils.AccessToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.REFRESH_TOKEN",
-			CredKey:  "refreshToken",
+			CredKey:  utils.RefreshToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.PROVIDER",
-			CredKey:  "provider",
+			CredKey:  utils.Provider,
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.WORKSPACE",
+			CredKey:  utils.WorkspaceRef,
 		},
 	}
 	_ = registry.AddReaders(readers...)
 
 	cfg := utils.MSDynamics365CRMConfigFromRegistry(registry)
 	tok := utils.MSDynamics365CRMTokenFromRegistry(registry)
+	workspace := registry.MustString(utils.WorkspaceRef)
 
 	conn, err := dynamicscrm.NewConnector(
 		dynamicscrm.WithClient(ctx, http.DefaultClient, cfg, tok),
-		dynamicscrm.WithWorkspace(utils.MSDynamics365CRMWorkspace),
+		dynamicscrm.WithWorkspace(workspace),
 	)
 	if err != nil {
 		testUtils.Fail("error creating microsoft CRM connector", "error", err)

--- a/test/dynamicscrm/metadata/main.go
+++ b/test/dynamicscrm/metadata/main.go
@@ -79,6 +79,7 @@ func sanitizeReadResponse(response map[string]any) map[string]any {
 		// ignore all fields that are OData annotations
 		// they are not part of ObjectMetadata
 		lower := strings.ToLower(field)
+
 		isAnnotation := strings.Contains(lower, "@odata") || strings.Contains(lower, "@microsoft.dynamics.crm")
 		if !isAnnotation {
 			crucialFields[field] = v

--- a/test/dynamicscrm/metadata/main.go
+++ b/test/dynamicscrm/metadata/main.go
@@ -78,7 +78,9 @@ func sanitizeReadResponse(response map[string]any) map[string]any {
 	for field, v := range response {
 		// ignore all fields that are OData annotations
 		// they are not part of ObjectMetadata
-		if !strings.HasPrefix(field, "@") {
+		lower := strings.ToLower(field)
+		isAnnotation := strings.Contains(lower, "@odata") || strings.Contains(lower, "@microsoft.dynamics.crm")
+		if !isAnnotation {
 			crucialFields[field] = v
 		}
 	}

--- a/tools/connectorgen/template/test/connector.go.tmpl
+++ b/tools/connectorgen/template/test/connector.go.tmpl
@@ -17,27 +17,32 @@ func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Pack
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_ID",
-			CredKey:  "clientId",
+			CredKey:  utils.ClientId,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.CLIENT_SECRET",
-			CredKey:  "clientSecret",
+			CredKey:  utils.ClientSecret,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.ACCESS_TOKEN",
-			CredKey:  "accessToken",
+			CredKey:  utils.AccessToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.REFRESH_TOKEN",
-			CredKey:  "refreshToken",
+			CredKey:  utils.RefreshToken,
 		},
 		&utils.JSONReader{
 			FilePath: filePath,
 			JSONPath: "$.PROVIDER",
-			CredKey:  "provider",
+			CredKey:  utils.Provider,
+		},
+		&utils.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.WORKSPACE",
+			CredKey:  utils.WorkspaceRef,
 		},
 	}
 	_ = registry.AddReaders(readers...)
@@ -45,11 +50,12 @@ func Get{{ .Provider }}Connector(ctx context.Context, filePath string) *{{ .Pack
 	// TODO create config and token registries
 	cfg := utils.{{ .Provider }}ConfigFromRegistry(registry)
 	tok := utils.{{ .Provider }}TokenFromRegistry(registry)
+	workspace := registry.MustString(utils.WorkspaceRef)
 
 	// TODO provide required options
 	conn, err := connectors.{{ .Provider }}(
 		{{ .Package }}.WithClient(ctx, http.DefaultClient, cfg, tok),
-		{{ .Package }}.WithWorkspace(utils.{{ .Provider }}Workspace),
+		{{ .Package }}.WithWorkspace(workspace),
 	)
 	if err != nil {
 		testUtils.Fail("error creating connector", "error", err)

--- a/utils/credentials.go
+++ b/utils/credentials.go
@@ -90,11 +90,10 @@ func HubspotOAuthConfigFromRegistry(registry CredentialsRegistry) *oauth2.Config
 	return cfg
 }
 
-var MSDynamics365CRMWorkspace = "org5bd08fdd" //nolint:gochecknoglobals
-
 func MSDynamics365CRMConfigFromRegistry(registry CredentialsRegistry) *oauth2.Config {
 	clientId := registry.MustString(ClientId)
 	clientSecret := registry.MustString(ClientSecret)
+	workspace := registry.MustString(WorkspaceRef)
 
 	cfg := &oauth2.Config{
 		ClientID:     clientId,
@@ -106,7 +105,7 @@ func MSDynamics365CRMConfigFromRegistry(registry CredentialsRegistry) *oauth2.Co
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
 		Scopes: []string{
-			fmt.Sprintf("https://%v.crm.dynamics.com/user_impersonation", MSDynamics365CRMWorkspace),
+			fmt.Sprintf("https://%v.crm.dynamics.com/user_impersonation", workspace),
 			"offline_access",
 		},
 	}


### PR DESCRIPTION
Based on https://github.com/amp-labs/connectors/pull/535

# Bug

xmldom depends on xpath. Updating xpath to lates breaks the former. Panic is thrown by method that returns single values.
Xpath syntax worked before with older version.
![image](https://github.com/amp-labs/connectors/assets/60330780/d3085371-578e-4271-8280-1517a144e118)

# Fix

Xpath library suggests query libraries for use which seem to be better updated. Switching to `antchfx/xmlquery` does the trick.
Also this library is wrapped to better handle panics and nil cases with NullObject pattern.

Library [Documentation](https://github.com/antchfx/xmlquery):
![image](https://github.com/amp-labs/connectors/assets/60330780/d4bc1ba7-4937-4dba-8025-7f72545364ef)


# Enable Proxy
Dynamics CRM proxy is enabled. The code changes from this PR https://github.com/amp-labs/connectors/pull/535 are fully covered in this PR. This part closes #206 