### PR TITLE
fix: Fix failing catalog.json action

### DIFF
--- a/.github/workflows/generate-json-catalog.yaml
+++ b/.github/workflows/generate-json-catalog.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +35,6 @@ jobs:
           git add providers/catalog.json
           git commit -m "Update catalog.json"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git push
+          git push origin HEAD:main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The action is failing with the following logs - 
```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

 git push origin HEAD:<name-of-remote-branch>
```
and 

```
remote: Permission to amp-labs/connectors.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/amp-labs/connectors/': The requested URL returned error: 403
```