### PR TITLE
[ENG-1257] feat: Add WithWorkspace, connectors delegate to paramsbuilder

### DIFF
--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -78,6 +78,10 @@ func (p *Workspace) WithWorkspace(workspaceRef string) {
 	p.Name = workspaceRef
 }
 
+func (p *Workspace) Substitution() map[string]string {
+	return map[string]string{"workspace": p.Name}
+}
+
 // Module params adds suffix to URL controlling API versions.
 // This is relevant where there are several APIs for different product areas or sub-products, and the APIs
 // are versioned differently or have different ways of constructing URLs from object names.

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -28,13 +28,14 @@ func NewConnector(
 	// Create connector
 	conn = &Connector{
 		provider: params.provider,
-		Client:   &common.JSONHTTPClient{
+		Client: &common.JSONHTTPClient{
 			HTTPClient: params.Client.Caller,
 		},
 	}
 
 	// Read provider info & replace catalog variables with given substitutions, if any
 	substitution := params.Workspace.Substitution()
+
 	providerInfo, err := providers.ReadInfo(conn.provider, &substitution)
 	if err != nil {
 		return nil, err

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -15,30 +15,12 @@ func NewConnector(
 	provider providers.Provider,
 	opts ...Option,
 ) (conn *Connector, outErr error) {
-	defer func() {
-		if re := recover(); re != nil {
-			tmp, ok := re.(error)
-			if !ok {
-				panic(re)
-			}
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
 
-			outErr = tmp
-			conn = nil
-		}
-	}()
-
-	// Set up basic params
-	params := &connectorParams{}
-	params.provider = provider
-
-	// Apply options & verify
-	for _, opt := range opts {
-		opt(params)
-	}
-
-	var err error
-
-	params, err = params.prepare()
+	params, err := parameters{provider: provider}.FromOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,11 +28,14 @@ func NewConnector(
 	// Create connector
 	conn = &Connector{
 		provider: params.provider,
-		Client:   params.client,
+		Client:   &common.JSONHTTPClient{
+			HTTPClient: params.Client.Caller,
+		},
 	}
 
 	// Read provider info & replace catalog variables with given substitutions, if any
-	providerInfo, err := providers.ReadInfo(conn.provider, &params.substitutions)
+	substitution := params.Workspace.Substitution()
+	providerInfo, err := providers.ReadInfo(conn.provider, &substitution)
 	if err != nil {
 		return nil, err
 	}

--- a/connector/params.go
+++ b/connector/params.go
@@ -3,10 +3,10 @@ package connector
 import (
 	"context"
 	"errors"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )

--- a/docusign/connector.go
+++ b/docusign/connector.go
@@ -11,32 +11,20 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer func() {
-		if re := recover(); re != nil {
-			tmp, ok := re.(error)
-			if !ok {
-				panic(re)
-			}
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
 
-			outErr = tmp
-			conn = nil
-		}
-	}()
-
-	params := &docusignParams{}
-	for _, opt := range opts {
-		opt(params)
-	}
-
-	var err error
-
-	params, err = params.prepare()
+	params, err := parameters{}.FromOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	conn = &Connector{
-		Client: params.client,
+		Client: &common.JSONHTTPClient{
+			HTTPClient: params.Client.Caller,
+		},
 	}
 
 	// Read provider info

--- a/docusign/params.go
+++ b/docusign/params.go
@@ -2,53 +2,46 @@ package docusign
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"golang.org/x/oauth2"
 )
 
-type docusignParams struct {
-	client *common.JSONHTTPClient
+type Option func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
 }
 
-type Option func(params *docusignParams)
+func (p parameters) FromOptions(opts ...Option) (*parameters, error) {
+	params := &p
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return params, params.ValidateParams()
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+	)
+}
 
 // WithClient sets the http client to use for the connector. Saves some boilerplate.
-func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
-	opts ...common.OAuthOption,
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
-	return func(params *docusignParams) {
-		options := []common.OAuthOption{
-			common.WithOAuthClient(client),
-			common.WithOAuthConfig(config),
-			common.WithOAuthToken(token),
-		}
-
-		oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)
-		if err != nil {
-			panic(err) // caught in NewConnector
-		}
-
-		WithAuthenticatedClient(oauthClient)(params)
+	return func(params *parameters) {
+		params.WithClient(ctx, client, config, token, opts...)
 	}
 }
 
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
-	return func(params *docusignParams) {
-		params.client = &common.JSONHTTPClient{
-			HTTPClient: &common.HTTPClient{
-				Client:       client,
-				ErrorHandler: common.InterpretError,
-			},
-		}
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
 	}
-}
-
-func (params *docusignParams) prepare() (*docusignParams, error) {
-	if params.client == nil {
-		return nil, ErrMissingClient
-	}
-
-	return params, nil
 }

--- a/hubspot/modules.go
+++ b/hubspot/modules.go
@@ -1,40 +1,21 @@
 package hubspot
 
 import (
-	"fmt"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 )
 
-type APIModule struct {
-	Label   string // e.g. "crm"
-	Version string // e.g. "v3"
-}
-
 // ModuleCRM is the module used for accessing standard CRM objects.
-var ModuleCRM = APIModule{ // nolint: gochecknoglobals
+var ModuleCRM = paramsbuilder.APIModule{ // nolint: gochecknoglobals
 	Label:   "crm",
 	Version: "v3",
 }
 
 // ModuleEmpty is used for proxying requests through.
-var ModuleEmpty = APIModule{ // nolint: gochecknoglobals
+var ModuleEmpty = paramsbuilder.APIModule{ // nolint: gochecknoglobals
 	Label:   "",
 	Version: "",
 }
 
 // supportedModules represents currently working and supported modules within the Hubspot connector.
 // Any added module should be appended added here.
-var supportedModules = []APIModule{ModuleCRM} // nolint: gochecknoglobals
-
-func (a APIModule) String() string {
-	return fmt.Sprintf("%s/%s", a.Label, a.Version)
-}
-
-func supportsModule(module string) bool {
-	for _, mod := range supportedModules {
-		if module == mod.String() {
-			return true
-		}
-	}
-
-	return false
-}
+var supportedModules = []paramsbuilder.APIModule{ModuleCRM} // nolint: gochecknoglobals

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -17,17 +17,10 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer func() {
-		if re := recover(); re != nil {
-			tmp, ok := re.(error)
-			if !ok {
-				panic(re)
-			}
-
-			outErr = tmp
-			conn = nil
-		}
-	}()
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
 
 	params := &mockParams{
 		read: func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {

--- a/mock/params.go
+++ b/mock/params.go
@@ -23,8 +23,7 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 	return func(params *mockParams) {
 		params.client = &common.JSONHTTPClient{
 			HTTPClient: &common.HTTPClient{
-				Client:       client,
-				ErrorHandler: common.InterpretError,
+				Client: client,
 			},
 		}
 	}

--- a/salesforce/params.go
+++ b/salesforce/params.go
@@ -2,69 +2,55 @@ package salesforce
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"golang.org/x/oauth2"
 )
 
 // Option is a function which mutates the salesforce connector configuration.
-type Option func(params *sfParams)
+type Option func(params *parameters)
 
-// WithClient sets the http client to use for the connector. Saves some boilerplate.
-func WithClient(ctx context.Context, client *http.Client, config *oauth2.Config, token *oauth2.Token,
-	opts ...common.OAuthOption,
+// parameters is the internal configuration for the salesforce connector.
+type parameters struct {
+	paramsbuilder.Client
+	paramsbuilder.Workspace
+}
+
+func (p parameters) FromOptions(opts ...Option) (*parameters, error) {
+	params := &p
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return params, params.ValidateParams()
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+		p.Workspace.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
-	return func(params *sfParams) {
-		options := []common.OAuthOption{
-			common.WithOAuthClient(client),
-			common.WithOAuthConfig(config),
-			common.WithOAuthToken(token),
-		}
-
-		oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)
-		if err != nil {
-			panic(err) // caught in NewConnector
-		}
-
-		WithAuthenticatedClient(oauthClient)(params)
+	return func(params *parameters) {
+		params.WithClient(ctx, client, config, token, opts...)
 	}
 }
 
-// WithAuthenticatedClient sets the http client to use for the connector. Its usage is optional.
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
-	return func(params *sfParams) {
-		params.client = &common.JSONHTTPClient{
-			HTTPClient: &common.HTTPClient{
-				Client:       client,
-				ErrorHandler: common.InterpretError,
-			},
-		}
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
 	}
 }
 
-// WithWorkspace sets the salesforce workspace to use for the connector. It's required.
 func WithWorkspace(workspaceRef string) Option {
-	return func(params *sfParams) {
-		params.workspace = workspaceRef
+	return func(params *parameters) {
+		params.WithWorkspace(workspaceRef)
 	}
-}
-
-// sfParams is the internal configuration for the salesforce connector.
-type sfParams struct {
-	client    *common.JSONHTTPClient // required
-	workspace string                 // required
-}
-
-// prepare finalizes and validates the connector configuration, and returns an error if it's invalid.
-func (p *sfParams) prepare() (out *sfParams, err error) {
-	if p.client == nil {
-		return nil, ErrMissingClient
-	}
-
-	if len(p.workspace) == 0 {
-		return nil, ErrMissingWorkspace
-	}
-
-	return p, nil
 }


### PR DESCRIPTION
# Changes

* paramsbuilder.Workspace is used by relevant connectors, method returns substitutions map making usage concise
* Based on Hubstpot formulated behaviour of paramsbuilder.Module with fallback module
* all connectors delegate to paramsbuilder, shorter format