### PR TITLE
feat: Add Crunchbase auth connector

### DIFF
--- a/providers/crunchbase.go
+++ b/providers/crunchbase.go
@@ -8,9 +8,11 @@ func init() {
 		AuthType: ApiKey,
 		BaseURL:  "https://api.crunchbase.com",
 		ApiKeyOpts: &ApiKeyOpts{
-			Type:       InHeader,
-			HeaderName: "X-cb-user-key",
-			DocsURL:    "https://data.crunchbase.com/docs/getting-started",
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name: "X-cb-user-key",
+			},
+			DocsURL: "https://data.crunchbase.com/docs/getting-started",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/crunchbase.go
+++ b/providers/crunchbase.go
@@ -1,0 +1,28 @@
+package providers
+
+const Crunchbase Provider = "crunchbase"
+
+func init() {
+	// Crunchbase configuration
+	SetInfo(Crunchbase, ProviderInfo{
+		AuthType: ApiKey,
+		BaseURL:  "https://api.crunchbase.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			Type:       InHeader,
+			HeaderName: "X-cb-user-key",
+			DocsURL:    "https://data.crunchbase.com/docs/getting-started",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
Closes #622 

## Checklist
- [x] Ran Linter

## Catalog variables
None

## Notes
Crunchbase rest API is a read-only API.

## Testing 
### GET 
<img width="1153" alt="Screenshot 2024-07-01 at 12 35 05" src="https://github.com/amp-labs/connectors/assets/52887226/21a73923-1871-4fb9-9703-26e5b8dda1c4">


### POST (Reading data as well)
<img width="1152" alt="Screenshot 2024-07-01 at 12 23 50" src="https://github.com/amp-labs/connectors/assets/52887226/4d9f13d8-da2e-4b7d-b664-6b2f7984b464">


## Pagination
Searching for organizations with certain criterias. default limit = 100 
<img width="1149" alt="Screenshot 2024-07-01 at 13 19 39" src="https://github.com/amp-labs/connectors/assets/52887226/eed083c8-d69c-4177-a36b-6be1d8798771">

Using the last item uuid in the response for the next request.
<img width="1151" alt="Screenshot 2024-07-01 at 13 20 53" src="https://github.com/amp-labs/connectors/assets/52887226/5e52e67d-505f-490c-8af5-517fc68ac358">

NOTE: We'd have to do this until we get an empty response or understand that we have iterated through all records using the `count` key.

