### PR TITLE
test: mock Salesforce Write method

### DIFF
--- a/common/jsonquery/converters.go
+++ b/common/jsonquery/converters.go
@@ -24,12 +24,27 @@ func (convertor) ArrayToMap(arr []*ajson.Node) ([]map[string]any, error) {
 			return nil, err
 		}
 
-		m, ok := data.(map[string]interface{})
+		m, ok := data.(map[string]any)
 		if !ok {
 			return nil, ErrNotObject
 		}
 
 		output = append(output, m)
+	}
+
+	return output, nil
+}
+
+func (convertor) ArrayToObjects(arr []*ajson.Node) ([]any, error) {
+	output := make([]any, 0, len(arr))
+
+	for _, v := range arr {
+		data, err := v.Unpack()
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, data)
 	}
 
 	return output, nil

--- a/common/jsonquery/defaults.go
+++ b/common/jsonquery/defaults.go
@@ -25,3 +25,16 @@ func (q *Query) StrWithDefault(key string, defaultValue string) (string, error) 
 
 	return *result, nil
 }
+
+func (q *Query) BoolWithDefault(key string, defaultValue bool) (bool, error) {
+	result, err := q.Bool(key, true)
+	if err != nil {
+		return false, err
+	}
+
+	if result == nil {
+		return defaultValue, nil
+	}
+
+	return *result, nil
+}

--- a/common/jsonquery/errors.go
+++ b/common/jsonquery/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrNotArray    = errors.New("JSON value is not an array")
 	ErrNotObject   = errors.New("JSON value is not an object")
 	ErrNotString   = errors.New("JSON value is not a string")
+	ErrNotBool     = errors.New("JSON value is not a boolean")
 	ErrNotNumeric  = errors.New("JSON value is not a numeric")
 	ErrNotInteger  = errors.New("JSON value is not an integer")
 	ErrUnpacking   = errors.New("failed to unpack ajson node")

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -97,6 +97,28 @@ func (q *Query) Str(key string, optional bool) (*string, error) {
 	return &txt, nil
 }
 
+func (q *Query) Bool(key string, optional bool) (*bool, error) {
+	node, err := q.getInnerKey(key, optional)
+	if err != nil {
+		return nil, err
+	}
+
+	if node == nil {
+		return nil, nil // nolint:nilnil
+	}
+
+	if node.IsNull() {
+		return nil, handleNullNode(key, optional)
+	}
+
+	flag, err := node.GetBool()
+	if err != nil {
+		return nil, ErrNotBool
+	}
+
+	return &flag, nil
+}
+
 func (q *Query) Array(key string, optional bool) ([]*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {

--- a/common/types.go
+++ b/common/types.go
@@ -162,9 +162,9 @@ type WriteResult struct {
 	// RecordId is the ID of the written record.
 	RecordId string `json:"recordId,omitempty"` // optional
 	// Errors is list of error record returned by the API.
-	Errors []interface{} `json:"errors,omitempty"` // optional
+	Errors []any `json:"errors,omitempty"` // optional
 	// Data is a JSON node containing data about the properties that were updated.
-	Data map[string]interface{} `json:"data,omitempty"` // optional
+	Data map[string]any `json:"data,omitempty"` // optional
 }
 
 // DeleteResult is what's returned from deleting data via the Delete call.

--- a/salesforce/errors.go
+++ b/salesforce/errors.go
@@ -13,10 +13,7 @@ import (
 
 var (
 	ErrNotArray           = errors.New("records is not an array")
-	ErrNotObject          = errors.New("record isn't an object")
 	ErrNotString          = errors.New("nextRecordsUrl isn't a string")
-	ErrNotBool            = errors.New("done isn't a boolean")
-	ErrNotNumeric         = errors.New("totalSize isn't numeric")
 	ErrCannotReadMetadata = errors.New("cannot read object metadata, it is possible you don't have the correct permissions set") // nolint:lll
 )
 
@@ -54,6 +51,10 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error { 
 		case "REQUEST_LIMIT_EXCEEDED":
 			return createError(common.ErrLimitExceeded, sfErr)
 		case "INVALID_TYPE":
+			fallthrough
+		case "INVALID_FIELD_FOR_INSERT_UPDATE":
+			fallthrough
+		case "INVALID_FIELD":
 			return createError(common.ErrBadRequest, sfErr)
 		default:
 			continue

--- a/salesforce/test/create-ok.json
+++ b/salesforce/test/create-ok.json
@@ -1,0 +1,5 @@
+{
+  "id": "001ak00000OQTieAAH",
+  "success": true,
+  "errors": []
+}

--- a/salesforce/test/invalid-field-upsert.json
+++ b/salesforce/test/invalid-field-upsert.json
@@ -1,0 +1,9 @@
+[
+  {
+    "message": "Unable to create/update fields: MasterRecordId. Please check the security settings of this field and verify that it is read/write for your profile or permission set.",
+    "errorCode": "INVALID_FIELD_FOR_INSERT_UPDATE",
+    "fields": [
+      "MasterRecordId"
+    ]
+  }
+]

--- a/salesforce/test/success-with-errors.json
+++ b/salesforce/test/success-with-errors.json
@@ -1,0 +1,11 @@
+{
+  "id": "001RM000003oLruYAE",
+  "success": false,
+  "errors": [
+    {
+      "statusCode": "MALFORMED_ID",
+      "message": "malformed id 001RM000003oLrB000",
+      "fields": []
+    }
+  ]
+}

--- a/salesforce/test/unknown-field.json
+++ b/salesforce/test/unknown-field.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "No such column 'AccountNumer' on sobject of type Account",
+    "errorCode": "INVALID_FIELD"
+  }
+]

--- a/salesforce/write.go
+++ b/salesforce/write.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/spyzhov/ajson"
 )
 
 // Write will write data to Salesforce.
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+	if len(config.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
 	url, err := c.getRestApiURL("sobjects", config.ObjectName)
 	if err != nil {
 		return nil, err
@@ -37,7 +42,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 		}, nil
 	}
 
-	createdRecordId, err := getCreatedRecordId(rsp.Body)
+	recordID, err := jsonquery.New(rsp.Body).Str("id", false)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +52,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 		return nil, err
 	}
 
-	success, err := getSuccess(rsp.Body)
+	success, err := jsonquery.New(rsp.Body).Bool("success", false)
 	if err != nil {
 		return nil, err
 	}
@@ -55,66 +60,23 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 	// Salesforce does not return record data upon successful write so we do not populate
 	// the corresponding result field
 	return &common.WriteResult{
-		RecordId: createdRecordId,
+		RecordId: *recordID,
 		Errors:   errors,
-		Success:  success,
+		Success:  *success,
 	}, nil
 }
 
 // getErrors returns the errors from the response.
 func getErrors(node *ajson.Node) ([]any, error) {
-	errors, err := node.GetKey("errors")
+	arr, err := jsonquery.New(node).Array("errors", true)
 	if err != nil {
 		return nil, err
 	}
 
-	if !errors.IsArray() {
-		return nil, ErrNotArray
-	}
-
-	arr := errors.MustArray()
-
-	out := make([]any, 0, len(arr))
-
-	for _, v := range arr {
-		if !v.IsString() {
-			return nil, ErrNotString
-		}
-
-		data, err := v.Unpack()
-		if err != nil {
-			return nil, err
-		}
-
-		m, ok := data.(string)
-		if !ok {
-			return nil, ErrNotString
-		}
-
-		out = append(out, m)
-	}
-
-	return out, nil
-}
-
-func getCreatedRecordId(node *ajson.Node) (string, error) {
-	idNode, err := node.GetKey("id")
+	objects, err := jsonquery.Convertor.ArrayToObjects(arr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return idNode.MustString(), nil
-}
-
-func getSuccess(node *ajson.Node) (bool, error) {
-	successNode, err := node.GetKey("success")
-	if err != nil {
-		return false, err
-	}
-
-	if !successNode.IsBool() {
-		return false, ErrNotBool
-	}
-
-	return successNode.MustBool(), nil
+	return objects, nil
 }

--- a/salesforce/write_test.go
+++ b/salesforce/write_test.go
@@ -1,0 +1,202 @@
+package salesforce
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/go-test/deep"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseUnknownField := mockutils.DataFromFile(t, "unknown-field.json")
+	responseInvalidFieldUpsert := mockutils.DataFromFile(t, "invalid-field-upsert.json")
+	responseCreateOK := mockutils.DataFromFile(t, "create-ok.json")
+	responseOKWithErrors := mockutils.DataFromFile(t, "success-with-errors.json")
+
+	tests := []struct {
+		name         string
+		input        common.WriteParams
+		server       *httptest.Server
+		connector    Connector
+		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
+		expected     *common.WriteResult
+		expectedErrs []error
+	}{
+		{
+			name: "Write object must be included",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			name:  "Mime response header expected",
+			input: common.WriteParams{ObjectName: "account"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			})),
+			expectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			name:  "Error response understood for creating with unknown field",
+			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(responseUnknownField)
+			})),
+			expectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("No such column 'AccountNumer' on sobject of type Account"), // nolint:goerr113
+			},
+		},
+		{
+			name:  "Error response understood for updating reserved field",
+			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(responseInvalidFieldUpsert)
+			})),
+			expectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Unable to create/update fields: MasterRecordId"), // nolint:goerr113
+			},
+		},
+		{
+			name:  "Write must act as a Create",
+			input: common.WriteParams{ObjectName: "account"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToMethod(w, r, "POST", func() {
+					// cannot be update path
+					mockutils.RespondToMissingQueryParameters(w, r, []string{"_HttpMethod"}, func() {
+						w.WriteHeader(http.StatusOK)
+					})
+				})
+			})),
+			expected:     &common.WriteResult{Success: true},
+			expectedErrs: nil,
+		},
+		{
+			name:  "Write must act as an Update",
+			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToMethod(w, r, "POST", func() {
+					mockutils.RespondToQueryParameters(w, r, url.Values{
+						"_HttpMethod": []string{"PATCH"},
+					}, func() {
+						w.WriteHeader(http.StatusOK)
+					})
+				})
+			})),
+			expected:     &common.WriteResult{Success: true},
+			expectedErrs: nil,
+		},
+		{
+			name:  "Valid creation of account",
+			input: common.WriteParams{ObjectName: "accounts"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToMethod(w, r, "POST", func() {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(responseCreateOK)
+				})
+			})),
+			expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "001ak00000OQTieAAH",
+				Errors:   []any{},
+				Data:     nil,
+			},
+			expectedErrs: nil,
+		},
+		{
+			name:  "OK Response, but with errors field",
+			input: common.WriteParams{ObjectName: "accounts"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToMethod(w, r, "POST", func() {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(responseOKWithErrors)
+				})
+			})),
+			expected: &common.WriteResult{
+				Success:  false,
+				RecordId: "001RM000003oLruYAE",
+				Errors: []any{map[string]any{
+					"statusCode": "MALFORMED_ID",
+					"message":    "malformed id 001RM000003oLrB000",
+					"fields":     []any{},
+				}},
+				Data: nil,
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tt.server.Close()
+
+			ctx := context.Background()
+
+			connector, err := NewConnector(
+				WithAuthenticatedClient(http.DefaultClient),
+				WithWorkspace("test-workspace"),
+			)
+			if err != nil {
+				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
+			}
+
+			// for testing we want to redirect calls to our server
+			connector.setBaseURL(tt.server.URL)
+
+			// start of tests
+			output, err := connector.Write(ctx, tt.input)
+			if len(tt.expectedErrs) == 0 && err != nil {
+				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
+			}
+
+			if len(tt.expectedErrs) != 0 && err == nil {
+				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
+			}
+
+			for _, expectedErr := range tt.expectedErrs {
+				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
+				}
+			}
+
+			// compare desired output
+			var ok bool
+			if tt.comparator == nil {
+				// default comparison is concerned about all fields
+				ok = reflect.DeepEqual(output, tt.expected)
+			} else {
+				ok = tt.comparator(output, tt.expected)
+			}
+
+			if !ok {
+				diff := deep.Equal(output, tt.expected)
+				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Mock Tests

Write seems to have had an issue when parsing errors during StatusOK. General convertor to golang data types is utilised as errors item has a free structure. This example again was taken from documentation as I failed to produce this case. (I would end up with real error -- non 2xx response codes).
```
{
  "id": "001RM000003oLruYAE",
  "success": false,
  "errors": [
    {
      "statusCode": "MALFORMED_ID",
      "message": "malformed id 001RM000003oLrB000",
      "fields": []
    }
  ]
}
```
Enforced required ObjectName.

# Manual Tests

Manual test for Saleforce which does Read+Write is still passing.
![image](https://github.com/amp-labs/connectors/assets/60330780/8faee455-74c5-4181-ba88-d8932647cbee)
