### PR TITLE
Fix: nil reference error in Salesforce CreateMetadata when there's invalid token

### DIFF
--- a/salesforce/metadataApi.go
+++ b/salesforce/metadataApi.go
@@ -32,7 +32,7 @@ func (c *Connector) CreateMetadata(
 // CreateMetadataHelper is a recursive function that early exits when attemptsSoFar > 1.
 // This is a workaround for invalid token errors, because this is a SOAP API
 // the oauth2 library does not auto-refresh token the token in the first request,
-// but after a failed request, `tok` is updated, so we can retry again.
+// but after a failed request, `tok` is updated, so we can retry the request once.
 func (c *Connector) CreateMetadataHelper(
 	ctx context.Context,
 	metadata *xmldom.Node,

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -260,6 +260,7 @@ func createClientAuthParams(provider string) *ClientAuthParams {
 func getTokensFromRegistry() *oauth2.Token {
 	accessToken := registry.MustString("AccessToken")
 	refreshToken, err := registry.GetString("RefreshToken")
+
 	if err != nil {
 		// we are working without refresh token
 		return &oauth2.Token{


### PR DESCRIPTION
When there's an invalid access token used, `res` can actually be empty, so `res.StatusCode` results in a nil dereference error. 

<img width="1269" alt="Screenshot 2024-07-04 at 6 49 21 PM" src="https://github.com/amp-labs/connectors/assets/3990804/398fc610-8d0b-441c-b90a-72dd0938b756">

I revised the code to first check if `err` contains the string "invalid_grant" (see screenshot below for the printed `error` string)
<img width="1500" alt="Screenshot 2024-07-04 at 6 16 53 PM" src="https://github.com/amp-labs/connectors/assets/3990804/117eb243-1e93-4894-8e9b-7ba9d654b76e">

Then if err is nil and there's a non-200 response check the body. 

I also refactored the code to be a recursive function. 


