### PR TITLE
chore: Add explicit ref to checkout step in action

### DIFF
--- a/.github/workflows/generate-json-catalog.yaml
+++ b/.github/workflows/generate-json-catalog.yaml
@@ -14,6 +14,9 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
 
       - name: Check for changes in providers/catalog.go
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Adding this explicitly is what makes the commit actually work and not reject the update. I don't know why because the checkout is supposed to work off the latest commit anyway.

### Testing
I tweaked this action on [a test PR ](https://github.com/amp-labs/connectors/pull/663)to commit the file to the PR ref, and it successfully generated and committed the update json file. I assume the same should now carry over to main.

### Permissions
Also, adding the ops account to the 'Allow bypassing branch protection' list isn't the full picture. You also have to create a custom role with the 'bypass branch protection' permission and assign it to the ops account. 