### PR TITLE
fix: do not return error in ReadInfo if there are no substitution variables

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -130,6 +130,11 @@ func (c CustomCatalog) ReadInfo(provider Provider, vars ...paramsbuilder.Catalog
 		return nil, ErrProviderNotFound
 	}
 
+	// No substitution needed
+	if len(vars) == 0 {
+		return &pInfo, nil
+	}
+
 	// Clone before modifying
 	providerInfo, err := clone[ProviderInfo](pInfo)
 	if err != nil {

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -113,7 +113,7 @@ func SetInfo(provider Provider, info ProviderInfo) {
 }
 
 // ReadInfo reads the information from the catalog for specific provider. It also performs string substitution
-// on the values in the config that are surrounded by {{}}.
+// on the values in the config that are surrounded by {{}}, if vars are provided.
 // The catalog variable will be applied such that `{{.VAR_NAME}}` string will be replaced with `VAR_VALUE`.
 func ReadInfo(provider Provider, vars ...paramsbuilder.CatalogVariable) (*ProviderInfo, error) {
 	return NewCustomCatalog().ReadInfo(provider, vars...)

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -106,7 +106,7 @@ func TestReadInfo(t *testing.T) { // nolint:funlen
 		expectedErrs []error
 	}{
 		{
-			name: "Custom catalog has missing provider",
+			name: "Returns missing provider error",
 			input: inType{
 				options:  customTestCatalogOption,
 				provider: "nobody knows",
@@ -116,17 +116,22 @@ func TestReadInfo(t *testing.T) { // nolint:funlen
 			expectedErrs: []error{ErrProviderNotFound},
 		},
 		{
-			name: "Provider requires substitution",
+			name: "Works without substitution",
 			input: inType{
 				options:  customTestCatalogOption,
 				provider: "test",
 				vars:     nil,
 			},
-			expected:     nil,
-			expectedErrs: []error{ErrSubstitutionFailure},
+			expected: &ProviderInfo{
+				AuthType:    Oauth2,
+				Name:        "test",
+				BaseURL:     "https://{{.workspace}}.test.com",
+				DisplayName: "Super Test",
+			},
+			expectedErrs: nil,
 		},
 		{
-			name: "Provider requires substitution",
+			name: "Works with substitution",
 			input: inType{
 				options:  customTestCatalogOption,
 				provider: "test",

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -14,7 +14,7 @@ var (
 	testCatalog CatalogType = map[string]ProviderInfo{ // nolint:gochecknoglobals
 		"test": {
 			AuthType:    Oauth2,
-			Name:        "Tester Testerson",
+			Name:        "test",
 			BaseURL:     "https://{{.workspace}}.test.com",
 			DisplayName: "Super Test",
 		},


### PR DESCRIPTION
Sometimes the server needs to read providerInfo without doing any variable substitutions (e.g. in GetProvider API call), we should not error out, otherwise the UI library will fail to work for providers that have substitution variables (such as Salesforce) because the UI library needs to call GetProvider first to see if it needs to render a workspace entry box. 