### PR TITLE
feat: Allow OAuth clients to be configured more easily

### DIFF
--- a/examples/utils/oauth2.go
+++ b/examples/utils/oauth2.go
@@ -78,13 +78,15 @@ func CreateOAuth2ClientCredentialsClient(ctx context.Context, info *providers.Pr
 		// If you have your own HTTP client, you can use it here.
 		Client: http.DefaultClient,
 
-		OAuth2ClientCreds: &clientcredentials.Config{
-			ClientID:       opts.OAuth2ClientId,
-			ClientSecret:   opts.OAuth2ClientSecret,
-			TokenURL:       info.Oauth2Opts.TokenURL,
-			Scopes:         opts.Scopes,
-			EndpointParams: opts.EndpointParams,
-			AuthStyle:      oauth2.AuthStyleInParams,
+		OAuth2ClientCreds: &providers.OAuth2ClientCredentialsParams{
+			Config: &clientcredentials.Config{
+				ClientID:       opts.OAuth2ClientId,
+				ClientSecret:   opts.OAuth2ClientSecret,
+				TokenURL:       info.Oauth2Opts.TokenURL,
+				Scopes:         opts.Scopes,
+				EndpointParams: opts.EndpointParams,
+				AuthStyle:      oauth2.AuthStyleInParams,
+			},
 		},
 	})
 	if err != nil {

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -460,8 +460,10 @@ func configureOAuthAuthCode(clientId, clientSecret string, scopes []string, prov
 
 func setupOAuth2ClientCredentialsHttpClient(ctx context.Context, prov *providers.ProviderInfo, cfg *clientcredentials.Config) common.AuthenticatedHTTPClient {
 	c, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug:             *debug,
-		OAuth2ClientCreds: cfg,
+		Debug: *debug,
+		OAuth2ClientCreds: &providers.OAuth2ClientCredentialsParams{
+			Config: cfg,
+		},
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
In the server, I need to set some additional oauth options, but I can't with the current client setup. This PR allows passing in arbitrary OAuth client options.

The goal here is to set a callback function so the server can see when a token is refreshed.