### PR TITLE
feat: Enable proxy: ServiceNow connector

### DIFF
--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -25,7 +25,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
Updated pull request for ServiceNow
Old PR - https://github.com/amp-labs/connectors/pull/487

## Checklist
- [x] Ran Linter
- [x] Created PR from non-main branch

## Notes
No fishy behaviour was observed. All the requests/responses were parsed correctly.

## Catelog variables
ServiceNow Provider = "serviceNow"

## Testing
### TOKEN RESPONSE
**SCRIPT:**
![image](https://github.com/user-attachments/assets/b3abc0b0-e00f-4aba-a918-d891d56cdc6f)

**POSTMAN:**
![image](https://github.com/user-attachments/assets/7604a5c8-199e-4ddf-b591-6221cbf644ec)

### GET
URL: https://proxy.withampersand.com/api/now/table/sys_user
![image](https://github.com/user-attachments/assets/2fa84a1c-82c9-4fb2-9c96-8467a10ccdbe)

### POST
URL: https://proxy.withampersand.com/api/now/table/incident
![image](https://github.com/user-attachments/assets/fd49c225-4003-4917-8e46-076f9c23a5a5)

### Pagination
Requesting a paginated list of users using limit:
URL: https://proxy.withampersand.com/api/now/table/sys_user?sysparm_limit=1
![image](https://github.com/user-attachments/assets/65dbde1d-8a3b-411f-ab5d-13bd0a5820f3)

### Invalid request
![image](https://github.com/user-attachments/assets/b46d6885-2855-4922-9bac-b9cd6485f12e)

### Success Console Operation
![image](https://github.com/user-attachments/assets/82e6da35-e1e8-4f7d-a561-bfb5b636454a)

### Failure Console Operation
![image](https://github.com/user-attachments/assets/c938ac45-30e7-4273-a7aa-7d5817c84c6b)

closes #384 