### PR TITLE
feat: Deep connector Jira (Read)

### DIFF
--- a/atlassian/authmetadata.go
+++ b/atlassian/authmetadata.go
@@ -79,12 +79,12 @@ func (c *Connector) retrieveCloudId(ctx context.Context) (string, error) {
 
 		if *workspaceName == c.workspace {
 			// names match, select this container.
-			cloudID, err := jsonquery.New(item).Str("id", false)
+			cloudId, err := jsonquery.New(item).Str("id", false)
 			if err != nil {
 				return "", err
 			}
 
-			return *cloudID, nil
+			return *cloudId, nil
 		}
 	}
 

--- a/atlassian/connector.go
+++ b/atlassian/connector.go
@@ -1,6 +1,7 @@
 package atlassian
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
@@ -9,6 +10,9 @@ import (
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
 )
+
+// ErrMissingCloudId happens when cloud id was not provided via WithMetadata.
+var ErrMissingCloudId = errors.New("connector missing cloud id")
 
 type Connector struct {
 	Client  *common.JSONHTTPClient
@@ -66,6 +70,17 @@ func (c *Connector) String() string {
 	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.Module)
 }
 
+// URL format follows structure applicable to Oauth2 Atlassian apps.
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/#other-integrations
+func (c *Connector) getJiraRestApiURL(arg string) (*urlbuilder.URL, error) {
+	cloudId, err := c.getCloudId()
+	if err != nil {
+		return nil, err
+	}
+
+	return constructURL(c.BaseURL, "ex/jira", cloudId, c.Module, arg)
+}
+
 // URL allows to get list of sites associated with auth token.
 // https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/#3-1-get-the-cloudid-for-your-site
 func (c *Connector) getAccessibleSitesURL() (*urlbuilder.URL, error) {
@@ -75,4 +90,12 @@ func (c *Connector) getAccessibleSitesURL() (*urlbuilder.URL, error) {
 func (c *Connector) setBaseURL(newURL string) {
 	c.BaseURL = newURL
 	c.Client.HTTPClient.Base = newURL
+}
+
+func (c *Connector) getCloudId() (string, error) {
+	if len(c.cloudId) == 0 {
+		return "", ErrMissingCloudId
+	}
+
+	return c.cloudId, nil
 }

--- a/atlassian/parse.go
+++ b/atlassian/parse.go
@@ -1,0 +1,109 @@
+package atlassian
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+func getTotalSize(node *ajson.Node) (int64, error) {
+	return jsonquery.New(node).ArraySize("issues")
+}
+
+/*
+Records cannot be returned as is from the API. Extra processing is described below.
+ 1. First of all, main properties are located under "fields" key.
+ 2. Secondly, item id is not mirrored under "fields" property, which means
+    unwrapping is not enough, we must attach "id" property.
+
+Visual example of what will happen to each property:
+
+	{
+		"id": "", 					=> preserved
+		"expand": "",				=> removed
+		"self": "",					=> removed
+		"key": "",					=> removed
+		"fields": {					=> unwrapped/flattened
+			"project": "",			=> moved outside
+			"lastViewed": ""		=> moved outside
+			...						...
+			...						=> moved outside
+		}
+	}
+*/
+func getRecords(node *ajson.Node) ([]map[string]any, error) {
+	arr, err := jsonquery.New(node).Array("issues", false)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]map[string]any, len(arr))
+
+	for index, item := range arr {
+		fieldsObject, err := jsonquery.New(item).Object("fields", false)
+		if err != nil {
+			return nil, errors.Join(common.ErrParseError, err)
+		}
+
+		fields, err := jsonquery.Convertor.ObjectToMap(fieldsObject)
+		if err != nil {
+			return nil, errors.Join(common.ErrParseError, err)
+		}
+
+		id, err := jsonquery.New(item).Str("id", false)
+		if err != nil {
+			return nil, errors.Join(common.ErrParseError, err)
+		}
+
+		// Enhance response with id property.
+		fields["id"] = *id
+		list[index] = fields
+	}
+
+	return list, nil
+}
+
+// Next starting page index is calculated base on current index and array size.
+func getNextRecords(node *ajson.Node) (string, error) {
+	size, err := getTotalSize(node)
+	if err != nil {
+		return "", err
+	}
+
+	if size == 0 {
+		// No elements returned for the current page.
+		// There is no need to go further, definitely we are at the end.
+		return "", nil
+	}
+
+	startAt, err := jsonquery.New(node).Integer("startAt", true)
+	if err != nil {
+		return "", err
+	}
+
+	if startAt == nil {
+		// we cannot determine the next page
+		return "", nil
+	}
+
+	// StartAt starts from zero
+	nextStartIndex := *startAt + size
+
+	return strconv.FormatInt(nextStartIndex, 10), nil
+}
+
+func getMarshaledData(records []map[string]any, fields []string) ([]common.ReadResultRow, error) {
+	data := make([]common.ReadResultRow, len(records))
+
+	for i, record := range records {
+		data[i] = common.ReadResultRow{
+			Fields: common.ExtractLowercaseFieldsFromRaw(fields, record),
+			Raw:    record,
+		}
+	}
+
+	return data, nil
+}

--- a/atlassian/read.go
+++ b/atlassian/read.go
@@ -1,0 +1,62 @@
+package atlassian
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// Read only returns a list of Jira Issues.
+// You can provide the following values:
+// * ObjectName - ignored.
+// * NextPage - to get next page which may have no elements left.
+// * Since - to scope the time frame, precision is in minutes.
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	link, err := c.buildReadURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := c.Client.Get(ctx, link.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		rsp,
+		getTotalSize,
+		getRecords,
+		getNextRecords,
+		getMarshaledData,
+		config.Fields,
+	)
+}
+
+func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
+	url, err := c.getJiraRestApiURL("search")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.NextPage) != 0 {
+		url.WithQueryParam("startAt", config.NextPage.String())
+	}
+
+	if !config.Since.IsZero() {
+		// Read URL supports time scoping. common.ReadParams.Since is used to get relative time frame.
+		// Here is an API example on how to request issues that were updated in the last 30 minutes.
+		// search?jql=updated > "-30m"
+		// The reason we use minutes is that it is the most granular API permits.
+		diff := time.Since(config.Since)
+
+		minutes := int64(diff.Minutes())
+		if minutes > 0 {
+			url.WithQueryParam("jql", fmt.Sprintf(`updated > "-%vm"`, minutes))
+		}
+	}
+
+	return url, nil
+}

--- a/atlassian/read_test.go
+++ b/atlassian/read_test.go
@@ -1,0 +1,373 @@
+package atlassian
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+	"github.com/go-test/deep"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseErrorFormat := testutils.DataFromFile(t, "jql-error.json")
+	responseIssuesFirstPage := testutils.DataFromFile(t, "read-issues.json")
+	responsePathNotFoundError := testutils.DataFromFile(t, "path-not-found.json")
+
+	tests := []struct {
+		name         string
+		input        common.ReadParams
+		server       *httptest.Server
+		connector    Connector
+		comparator   func(serverURL string, actual, expected *common.ReadResult) bool // custom comparison
+		expected     *common.ReadResult
+		expectedErrs []error
+	}{
+		{
+			name:         "Mime response header expected",
+			server:       mockserver.Dummy(),
+			expectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			name: "Correct error message is understood from JSON response",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(responseErrorFormat)
+			})),
+			expectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Date value '-53s' for field 'updated' is invalid"), // nolint:goerr113
+			},
+		},
+		{
+			name: "Invalid path understood as not found error",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write(responsePathNotFoundError)
+			})),
+			expectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Not Found - No message available"), // nolint:goerr113
+			},
+		},
+		{
+			name: "Incorrect key in payload",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{
+					"garbage": {}
+				}`)
+			})),
+			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+		},
+		{
+			name: "Incorrect data type in payload",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{
+					"issues": {}
+				}`)
+			})),
+			expectedErrs: []error{jsonquery.ErrNotArray},
+		},
+		{
+			name: "Empty array produces no next page",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `
+				{
+				  "startAt": 6,
+				  "issues": []
+				}`)
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return nextPageComparator(actual, expected)
+			},
+			expected: &common.ReadResult{
+				Rows:     0,
+				NextPage: "",
+				Done:     true,
+			},
+			expectedErrs: nil,
+		},
+		{
+			name: "Issue must have fields property",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `
+				{
+				  "issues": [{}]
+				}`)
+			})),
+			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+		},
+		{
+			name: "Issue must have id property",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `
+				{
+				  "issues": [{"fields":{}}]
+				}`)
+			})),
+			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+		},
+		{
+			name: "Missing starting index produces no next page",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `
+				{
+				  "issues": [
+					{"fields":{}, "id": "0"},
+					{"fields":{}, "id": "1"}
+				]}`)
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return nextPageComparator(actual, expected)
+			},
+			expected: &common.ReadResult{
+				Rows:     2,
+				NextPage: "",
+				Done:     true,
+			},
+			expectedErrs: nil,
+		},
+		{
+			name: "Next page is implied from start index and issues size",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `
+				{
+				  "startAt": 6,
+				  "issues": [
+					{"fields":{}, "id": "0"},
+					{"fields":{}, "id": "1"}
+				]}`)
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return nextPageComparator(actual, expected)
+			},
+			expected: &common.ReadResult{
+				Rows:     2,
+				NextPage: "8",
+				Done:     false,
+			},
+			expectedErrs: nil,
+		},
+		{
+			name: "Since rounds to minute time frame",
+			input: common.ReadParams{
+				Since: time.Now().Add(-5 * time.Minute),
+			},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.RespondToQueryParameters(w, r, url.Values{
+					// server was asked to get issues that occurred in the last 5 min
+					"jql": []string{`updated > "-5m"`},
+				}, func() {
+					mockutils.WriteBody(w, `
+					{
+					  "startAt": 0,
+					  "issues": [{"fields":{}, "id": "0"}]
+					}`)
+				})
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return actual.Rows == expected.Rows
+			},
+			expected: &common.ReadResult{
+				Rows: 1,
+			},
+			expectedErrs: nil, // there must be no errors.
+		},
+		{
+			name: "Next page is propagated in query params",
+			input: common.ReadParams{
+				NextPage: "17",
+			},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.RespondToQueryParameters(w, r, url.Values{
+					"startAt": []string{"17"},
+				}, func() {
+					mockutils.WriteBody(w, `
+					{
+					  "startAt": 17,
+					  "issues": [
+						{"fields":{}, "id": "0"},
+						{"fields":{}, "id": "1"},
+						{"fields":{}, "id": "2"}
+					]}`)
+				})
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return actual.Rows == expected.Rows
+			},
+			expected: &common.ReadResult{
+				Rows: 3,
+			},
+			expectedErrs: nil, // there must be no errors
+		},
+		{
+			name: "Successful list of rows",
+			input: common.ReadParams{
+				Fields: []string{"id", "summary"},
+			},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(responseIssuesFirstPage)
+			})),
+			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+					actual.NextPage.String() == expected.NextPage.String() &&
+					actual.Rows == expected.Rows &&
+					actual.Done == expected.Done
+			},
+			expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"id":      "10001",
+						"summary": "Another one",
+					},
+					Raw: map[string]any{
+						"id":                       "10001",
+						"description":              nil,
+						"created":                  "2024-07-22T22:41:48.474+0300",
+						"statuscategorychangedate": "2024-07-22T22:41:48.686+0300",
+					},
+				}, {
+					Fields: map[string]any{
+						"id":      "10000",
+						"summary": "First Issue on Jira",
+					},
+					Raw: map[string]any{
+						"id":                       "10000",
+						"description":              nil,
+						"created":                  "2024-07-22T22:41:35.069+0300",
+						"statuscategorychangedate": "2024-07-22T22:41:35.326+0300",
+					},
+				}},
+				NextPage: "2",
+				Done:     false,
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tt.server.Close()
+
+			ctx := context.Background()
+
+			connector, err := NewConnector(
+				WithAuthenticatedClient(http.DefaultClient),
+				WithWorkspace("test-workspace"),
+				WithModule(ModuleJira),
+				WithMetadata(map[string]string{
+					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
+				}),
+			)
+			if err != nil {
+				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
+			}
+
+			// for testing we want to redirect calls to our mock server
+			connector.setBaseURL(tt.server.URL)
+
+			if err != nil {
+				t.Fatalf("%s: failed to setup auth metadata connector %v", tt.name, err)
+			}
+
+			// start of tests
+			output, err := connector.Read(ctx, tt.input)
+			if err != nil {
+				if len(tt.expectedErrs) == 0 {
+					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
+				}
+			} else {
+				// check that missing error is what is expected
+				if len(tt.expectedErrs) != 0 {
+					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
+				}
+			}
+
+			// check every error
+			for _, expectedErr := range tt.expectedErrs {
+				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
+				}
+			}
+
+			// compare desired output
+			var ok bool
+			if tt.comparator == nil {
+				// default comparison is concerned about all fields
+				ok = reflect.DeepEqual(output, tt.expected)
+			} else {
+				ok = tt.comparator(tt.server.URL, output, tt.expected)
+			}
+
+			if !ok {
+				diff := deep.Equal(output, tt.expected)
+				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
+			}
+		})
+	}
+}
+
+func TestReadWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithWorkspace("test-workspace"),
+		WithModule(ModuleJira),
+	)
+	if err != nil {
+		t.Fatal("failed to create connector")
+	}
+
+	_, err = connector.Read(context.Background(), common.ReadParams{})
+	if !errors.Is(err, ErrMissingCloudId) {
+		t.Fatalf("expected Read method to complain about missing cloud id")
+	}
+}
+
+func nextPageComparator(actual *common.ReadResult, expected *common.ReadResult) bool {
+	return actual.NextPage.String() == expected.NextPage.String() &&
+		actual.Rows == expected.Rows &&
+		actual.Done == expected.Done
+}

--- a/atlassian/test/jql-error.json
+++ b/atlassian/test/jql-error.json
@@ -1,0 +1,6 @@
+{
+  "errorMessages": [
+    "Date value '-53s' for field 'updated' is invalid. Valid formats include: 'yyyy/MM/dd HH:mm', 'yyyy-MM-dd HH:mm', 'yyyy/MM/dd', 'yyyy-MM-dd', or a period format e.g. '-5d', '4w 2d'."
+  ],
+  "warningMessages": []
+}

--- a/atlassian/test/path-not-found.json
+++ b/atlassian/test/path-not-found.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2024-07-29T11:56:50.846388822Z",
+  "status": 404,
+  "error": "Not Found",
+  "message": "No message available",
+  "path": "/ex/jira/ebc887b2-1e61-4059-ab35-71f15cc16e12/rest/api/3/issue"
+}

--- a/atlassian/test/read-issues.json
+++ b/atlassian/test/read-issues.json
@@ -1,0 +1,332 @@
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 2,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,customfield_10010.requestTypePractice,renderedFields",
+      "id": "10001",
+      "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/10001",
+      "key": "AM-2",
+      "fields": {
+        "statuscategorychangedate": "2024-07-22T22:41:48.686+0300",
+        "issuetype": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issuetype/10005",
+          "id": "10005",
+          "description": "A small, distinct piece of work.",
+          "iconUrl": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+          "name": "Task",
+          "subtask": false,
+          "avatarId": 10318,
+          "entityId": "4c981554-a7aa-4b63-bb3a-7c9d61ba2f78",
+          "hierarchyLevel": 0
+        },
+        "timespent": null,
+        "customfield_10030": null,
+        "project": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/project/10001",
+          "id": "10001",
+          "key": "AM",
+          "name": "AmpProject",
+          "projectTypeKey": "business",
+          "simplified": true,
+          "avatarUrls": {
+            "48x48": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409",
+            "24x24": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=small",
+            "16x16": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=xsmall",
+            "32x32": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=medium"
+          }
+        },
+        "customfield_10032": null,
+        "customfield_10033": null,
+        "fixVersions": [],
+        "aggregatetimespent": null,
+        "resolution": null,
+        "customfield_10027": null,
+        "customfield_10028": null,
+        "customfield_10029": null,
+        "resolutiondate": null,
+        "workratio": -1,
+        "watches": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/AM-2/watchers",
+          "watchCount": 1,
+          "isWatching": true
+        },
+        "lastViewed": null,
+        "created": "2024-07-22T22:41:48.474+0300",
+        "customfield_10020": null,
+        "customfield_10021": null,
+        "customfield_10022": null,
+        "priority": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/priority/3",
+          "iconUrl": "https://second-proj.atlassian.net/images/icons/priorities/medium.svg",
+          "name": "Medium",
+          "id": "3"
+        },
+        "customfield_10023": null,
+        "customfield_10024": null,
+        "customfield_10025": null,
+        "customfield_10026": null,
+        "labels": [],
+        "customfield_10016": null,
+        "customfield_10017": null,
+        "customfield_10018": {
+          "hasEpicLinkFieldDependency": false,
+          "showField": false,
+          "nonEditableReason": {
+            "reason": "PLUGIN_LICENSE_ERROR",
+            "message": "The Parent Link is only available to Jira Premium users."
+          }
+        },
+        "customfield_10019": "0|i00007:",
+        "timeestimate": null,
+        "aggregatetimeoriginalestimate": null,
+        "versions": [],
+        "issuelinks": [],
+        "assignee": null,
+        "updated": "2024-07-22T22:41:48.713+0300",
+        "status": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/status/10003",
+          "description": "",
+          "iconUrl": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/",
+          "name": "To Do",
+          "id": "10003",
+          "statusCategory": {
+            "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        },
+        "components": [],
+        "timeoriginalestimate": null,
+        "description": null,
+        "customfield_10010": null,
+        "customfield_10014": null,
+        "customfield_10015": null,
+        "customfield_10005": null,
+        "customfield_10006": null,
+        "customfield_10007": null,
+        "security": null,
+        "customfield_10008": null,
+        "aggregatetimeestimate": null,
+        "customfield_10009": null,
+        "summary": "Another one",
+        "creator": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/user?accountId=70121%3A05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "accountId": "70121:05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "emailAddress": "somebody@gmail.com",
+          "avatarUrls": {
+            "48x48": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "24x24": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "16x16": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "32x32": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png"
+          },
+          "displayName": "Bob",
+          "active": true,
+          "timeZone": "America/Vancouver",
+          "accountType": "atlassian"
+        },
+        "subtasks": [],
+        "reporter": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/user?accountId=70121%3A05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "accountId": "70121:05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "emailAddress": "somebody@gmail.com",
+          "avatarUrls": {
+            "48x48": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "24x24": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "16x16": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "32x32": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png"
+          },
+          "displayName": "Bob",
+          "active": true,
+          "timeZone": "America/Vancouver",
+          "accountType": "atlassian"
+        },
+        "aggregateprogress": {
+          "progress": 0,
+          "total": 0
+        },
+        "customfield_10001": null,
+        "customfield_10002": [],
+        "customfield_10003": null,
+        "customfield_10004": null,
+        "environment": null,
+        "duedate": null,
+        "progress": {
+          "progress": 0,
+          "total": 0
+        },
+        "votes": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/AM-2/votes",
+          "votes": 0,
+          "hasVoted": false
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,customfield_10010.requestTypePractice,renderedFields",
+      "id": "10000",
+      "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/10000",
+      "key": "AM-1",
+      "fields": {
+        "statuscategorychangedate": "2024-07-22T22:41:35.326+0300",
+        "issuetype": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issuetype/10005",
+          "id": "10005",
+          "description": "A small, distinct piece of work.",
+          "iconUrl": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+          "name": "Task",
+          "subtask": false,
+          "avatarId": 10318,
+          "entityId": "4c981554-a7aa-4b63-bb3a-7c9d61ba2f78",
+          "hierarchyLevel": 0
+        },
+        "timespent": null,
+        "customfield_10030": null,
+        "project": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/project/10001",
+          "id": "10001",
+          "key": "AM",
+          "name": "AmpProject",
+          "projectTypeKey": "business",
+          "simplified": true,
+          "avatarUrls": {
+            "48x48": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409",
+            "24x24": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=small",
+            "16x16": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=xsmall",
+            "32x32": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/universal_avatar/view/type/project/avatar/10409?size=medium"
+          }
+        },
+        "customfield_10032": null,
+        "fixVersions": [],
+        "customfield_10033": null,
+        "aggregatetimespent": null,
+        "resolution": null,
+        "customfield_10027": null,
+        "customfield_10028": null,
+        "customfield_10029": null,
+        "resolutiondate": null,
+        "workratio": -1,
+        "lastViewed": null,
+        "watches": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/AM-1/watchers",
+          "watchCount": 1,
+          "isWatching": true
+        },
+        "created": "2024-07-22T22:41:35.069+0300",
+        "customfield_10020": null,
+        "customfield_10021": null,
+        "customfield_10022": null,
+        "customfield_10023": null,
+        "priority": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/priority/3",
+          "iconUrl": "https://second-proj.atlassian.net/images/icons/priorities/medium.svg",
+          "name": "Medium",
+          "id": "3"
+        },
+        "customfield_10024": null,
+        "customfield_10025": null,
+        "customfield_10026": null,
+        "labels": [],
+        "customfield_10016": null,
+        "customfield_10017": null,
+        "customfield_10018": {
+          "hasEpicLinkFieldDependency": false,
+          "showField": false,
+          "nonEditableReason": {
+            "reason": "PLUGIN_LICENSE_ERROR",
+            "message": "The Parent Link is only available to Jira Premium users."
+          }
+        },
+        "customfield_10019": "0|hzzzzz:",
+        "aggregatetimeoriginalestimate": null,
+        "timeestimate": null,
+        "versions": [],
+        "issuelinks": [],
+        "assignee": null,
+        "updated": "2024-07-22T22:41:35.358+0300",
+        "status": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/status/10003",
+          "description": "",
+          "iconUrl": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/",
+          "name": "To Do",
+          "id": "10003",
+          "statusCategory": {
+            "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        },
+        "components": [],
+        "timeoriginalestimate": null,
+        "description": null,
+        "customfield_10010": null,
+        "customfield_10014": null,
+        "customfield_10015": null,
+        "customfield_10005": null,
+        "customfield_10006": null,
+        "security": null,
+        "customfield_10007": null,
+        "customfield_10008": null,
+        "aggregatetimeestimate": null,
+        "customfield_10009": null,
+        "summary": "First Issue on Jira",
+        "creator": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/user?accountId=70121%3A05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "accountId": "70121:05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "emailAddress": "somebody@gmail.com",
+          "avatarUrls": {
+            "48x48": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "24x24": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "16x16": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "32x32": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png"
+          },
+          "displayName": "Bob",
+          "active": true,
+          "timeZone": "America/Vancouver",
+          "accountType": "atlassian"
+        },
+        "subtasks": [],
+        "reporter": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/user?accountId=70121%3A05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "accountId": "70121:05d32b6e-71d6-4198-a358-6a2dcdc6aa47",
+          "emailAddress": "somebody@gmail.com",
+          "avatarUrls": {
+            "48x48": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "24x24": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "16x16": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png",
+            "32x32": "https://secure.gravatar.com/avatar/58a5d67b49ad16b8f012790ad9411d06?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCK-2.png"
+          },
+          "displayName": "Bob",
+          "active": true,
+          "timeZone": "America/Vancouver",
+          "accountType": "atlassian"
+        },
+        "aggregateprogress": {
+          "progress": 0,
+          "total": 0
+        },
+        "customfield_10001": null,
+        "customfield_10002": [],
+        "customfield_10003": null,
+        "customfield_10004": null,
+        "environment": null,
+        "duedate": null,
+        "progress": {
+          "progress": 0,
+          "total": 0
+        },
+        "votes": {
+          "self": "https://api.atlassian.com/ex/jira/ebc887b2-7e61-4059-ab35-71f15cc16e12/rest/api/3/issue/AM-1/votes",
+          "votes": 0,
+          "hasVoted": false
+        }
+      }
+    }
+  ]
+}

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -38,5 +38,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		PostAuthInfoNeeded: true,
 	})
 }

--- a/test/atlassian/auth-metadata/main.go
+++ b/test/atlassian/auth-metadata/main.go
@@ -28,11 +28,11 @@ func main() {
 	}
 
 	metadata := atlassian.NewAuthMetadataVars(*info.CatalogVars)
-	cloudID := metadata.CloudId
+	cloudId := metadata.CloudId
 
-	if len(cloudID) == 0 {
+	if len(cloudId) == 0 {
 		utils.Fail("missing cloud id in post authentication metadata")
 	}
 
-	slog.Info("retrieved auth metadata", "cloud id", cloudID)
+	slog.Info("retrieved auth metadata", "cloud id", cloudId)
 }

--- a/test/atlassian/read/main.go
+++ b/test/atlassian/read/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAtlassianConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		Fields: []string{
+			"id", "summary", "status",
+		},
+		// Below is the example to get issues that were updated in the last 15 min.
+		// Since: time.Now().Add(-15 * time.Minute),
+	})
+	if err != nil {
+		utils.Fail("error reading from Atlassian", "error", err)
+	}
+
+	fmt.Println("Reading issue..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
Closes #709 

# Description

Read operation uses search API endpoint to return Jira issues.
The data returned from `issue endpoint` is not returned untouched.

Fields property contains data of interest, the gist of it.
Id property is manually attached. This is the only relevant property outside of fields.


# Testing

Manual script to retrieve list of issues.
![image](https://github.com/user-attachments/assets/eb11ad25-aa4b-4337-84c1-2f7011252fef)


