### PR TITLE
add: Basic auth client as connector option

### DIFF
--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -35,6 +35,7 @@ func Apply[P ParamAssurance](params P, opts []func(params *P)) (*P, error) {
 
 // Client params sets up authenticated proxy HTTP client
 // This can be reused among other param builders by composition.
+// There are many types of authentication, where only one must be chosen. Ex: oauth2.
 type Client struct {
 	Caller *common.HTTPClient
 }
@@ -47,7 +48,8 @@ func (p *Client) ValidateParams() error {
 	return nil
 }
 
-func (p *Client) WithClient(
+// WithOauthClient option that sets up client that utilises Oauth2 authentication.
+func (p *Client) WithOauthClient(
 	ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token,
 	opts ...common.OAuthOption,
@@ -64,6 +66,24 @@ func (p *Client) WithClient(
 	}
 
 	p.WithAuthenticatedClient(oauthClient)
+}
+
+// WithBasicClient option that sets up client that utilises Basic (username, password) authentication.
+func (p *Client) WithBasicClient(
+	ctx context.Context, client *http.Client,
+	user, pass string,
+	opts ...common.HeaderAuthClientOption,
+) {
+	options := []common.HeaderAuthClientOption{
+		common.WithHeaderClient(client),
+	}
+
+	basicClient, err := common.NewBasicAuthHTTPClient(ctx, user, pass, append(options, opts...)...)
+	if err != nil {
+		panic(err) // caught in NewConnector
+	}
+
+	p.WithAuthenticatedClient(basicClient)
 }
 
 func (p *Client) WithAuthenticatedClient(client common.AuthenticatedHTTPClient) {

--- a/common/scanning/credscanning/provider.go
+++ b/common/scanning/credscanning/provider.go
@@ -87,7 +87,7 @@ func createProviderCreds(
 
 func selectReader(field Field, filePath string, providerName string) scanning.Reader { // nolint:ireturn
 	if len(filePath) != 0 {
-		return field.GetJSONReader(filePath)
+		return field.GetJSONReader(filePath) // nolint:ireturn
 	}
 
 	return field.GetENVReader(providerName)

--- a/connector/params.go
+++ b/connector/params.go
@@ -44,7 +44,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/docusign/params.go
+++ b/docusign/params.go
@@ -27,7 +27,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/dynamicscrm/params.go
+++ b/dynamicscrm/params.go
@@ -35,7 +35,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/gong/params.go
+++ b/gong/params.go
@@ -27,7 +27,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/hubspot/params.go
+++ b/hubspot/params.go
@@ -36,7 +36,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/intercom/params.go
+++ b/intercom/params.go
@@ -33,7 +33,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/outreach/params.go
+++ b/outreach/params.go
@@ -26,7 +26,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/salesforce/params.go
+++ b/salesforce/params.go
@@ -30,7 +30,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/salesloft/params.go
+++ b/salesloft/params.go
@@ -33,7 +33,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 

--- a/zendesksupport/params.go
+++ b/zendesksupport/params.go
@@ -35,7 +35,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
 ) Option {
 	return func(params *parameters) {
-		params.WithClient(ctx, client, config, token, opts...)
+		params.WithOauthClient(ctx, client, config, token, opts...)
 	}
 }
 


### PR DESCRIPTION
As we are moving towards implementing **non oauth2** deep connectors there should be an option of selecting other auth clients used by connector.
`paramsbuilder.Client` is a parameter that now has 2 choices of either using Oauth2 or Basic authentication.

Every connector sets up parameters by delegation so their methods on the surface are not affected. Every connector will still use `WithClient` method making the naming predictable, however the passed arguments will differ.