### PR TITLE
add: Region, new catalog variable

### DIFF
--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -20,6 +20,7 @@ var (
 	ErrMissingClient     = errors.New("http client not set")
 	ErrMissingWorkspace  = errors.New("missing workspace name")
 	ErrNoSupportedModule = errors.New("no supported module was chosen")
+	ErrMissingRegion     = errors.New("missing region name")
 )
 
 // Create will apply options to construct a ready to go set of parameters.
@@ -174,4 +175,28 @@ func (a APIModule) String() string {
 	}
 
 	return fmt.Sprintf("%s/%s", a.Label, a.Version)
+}
+
+// Region param sets up varying regions, part of the world.
+type Region struct {
+	Name string
+}
+
+func (r *Region) ValidateParams() error {
+	if len(r.Name) == 0 {
+		return ErrMissingRegion
+	}
+
+	return nil
+}
+
+func (r *Region) WithRegion(region string) {
+	r.Name = region
+}
+
+func (r *Region) GetSubstitutionPlan() SubstitutionPlan {
+	return SubstitutionPlan{
+		From: variableRegion,
+		To:   r.Name,
+	}
 }

--- a/common/paramsbuilder/variables.go
+++ b/common/paramsbuilder/variables.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	variableWorkspace = "workspace"
+	variableRegion    = "region"
 )
 
 // CatalogVariable allows dynamically to replace variables represented with `{{VAR_NAME}}` string.
@@ -43,6 +44,8 @@ func NewCatalogVariables[V substitutions.RegistryValue](registry substitutions.R
 		switch key {
 		case variableWorkspace:
 			result = append(result, &Workspace{Name: name})
+		case variableRegion:
+			result = append(result, &Region{Name: name})
 		default:
 			slog.Info("unknown substitution SubstitutionPlan for catalog", key, value)
 		}

--- a/common/scanning/credscanning/fields.go
+++ b/common/scanning/credscanning/fields.go
@@ -29,6 +29,7 @@ var Fields = struct { // nolint:gochecknoglobals
 	ApiKey Field
 	// Catalog variables
 	Workspace Field
+	Region    Field
 }{
 	Provider: Field{
 		Name:      "provider",
@@ -84,6 +85,11 @@ var Fields = struct { // nolint:gochecknoglobals
 		Name:      "workspace",
 		PathJSON:  "substitutions.workspace",
 		SuffixENV: "WORKSPACE",
+	},
+	Region: Field{
+		Name:      "region",
+		PathJSON:  "substitutions.region",
+		SuffixENV: "REGION",
 	},
 }
 
@@ -142,6 +148,12 @@ func getFields(info providers.ProviderInfo, withAccessToken bool) (handy.Lists[F
 			lists.Add(requiredType, Fields.Workspace)
 		}
 	}
+
+	// FIXME provider information should have flag for region.
+	// This will allow to validate user input is sufficient for this provider.
+	// If info has Region enabled, then add it as required for scanning.
+	// For now read as optional.
+	lists.Add(optionalType, Fields.Region)
 
 	return lists, nil
 }

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -35,7 +35,10 @@ func NewConnector(
 	}
 
 	// Read provider info & replace catalog variables with given substitutions, if any
-	providerInfo, err := providers.ReadInfo(conn.provider, &params.Workspace)
+	providerInfo, err := providers.ReadInfo(conn.provider,
+		&params.Workspace,
+		&params.Region,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/connector/params.go
+++ b/connector/params.go
@@ -25,6 +25,7 @@ type parameters struct {
 	provider providers.Provider
 	paramsbuilder.Client
 	paramsbuilder.Workspace
+	paramsbuilder.Region
 }
 
 func (p parameters) ValidateParams() error {
@@ -33,6 +34,7 @@ func (p parameters) ValidateParams() error {
 	}
 
 	// workspace is optional
+	// region is optional
 
 	return errors.Join(
 		p.Client.ValidateParams(),


### PR DESCRIPTION
Introducing new connector parameter - Region.

Additionaly this happens to be a catalog variable. This value in turn will be used during automatic substitution of vars found in catalog provider.