### PR TITLE
fix: Enforce lower case ObjectName in metadata

### DIFF
--- a/common/naming/lowercase.go
+++ b/common/naming/lowercase.go
@@ -1,0 +1,43 @@
+package naming
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type LowerString struct {
+	text string
+}
+
+func NewLowerString(str string) LowerString {
+	return LowerString{text: strings.ToLower(str)}
+}
+
+func (s LowerString) String() string {
+	return s.text
+}
+
+func (s LowerString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.text)
+}
+
+func (s *LowerString) UnmarshalJSON(bytes []byte) error {
+	var text string
+
+	err := json.Unmarshal(bytes, &text)
+	if err != nil {
+		return err
+	}
+
+	s.text = NewLowerString(text).String()
+
+	return nil
+}
+
+func (s LowerString) MarshalText() ([]byte, error) {
+	return []byte(s.text), nil
+}
+
+func (s *LowerString) UnmarshalText(text []byte) error {
+	return s.UnmarshalJSON(text)
+}

--- a/tools/scrapper/convertors.go
+++ b/tools/scrapper/convertors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
 )
 
 var ErrObjectNotFound = errors.New("object not found")
@@ -16,10 +17,11 @@ func (r *ObjectMetadataResult) Select(objectNames []string) (*common.ListObjectM
 	}
 
 	// Convert and return only listed objects
-	for _, name := range objectNames {
+	for _, objectName := range objectNames {
+		name := naming.NewLowerString(objectName)
 		if v, ok := r.Result[name]; ok {
 			// move metadata from scrapper object to common object
-			list.Result[name] = common.ObjectMetadata{
+			list.Result[name.String()] = common.ObjectMetadata{
 				DisplayName: v.DisplayName,
 				FieldsMap:   v.FieldsMap,
 			}

--- a/tools/scrapper/models.go
+++ b/tools/scrapper/models.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/amp-labs/connectors/common/naming"
 )
 
 type ModelDocLinks []ModelDocLink
@@ -62,7 +64,7 @@ func (r *ModelURLRegistry) Sort() {
 
 type ObjectMetadataResult struct {
 	// Result is a map of object names to object metadata
-	Result map[string]ObjectMetadata `json:"data"`
+	Result map[naming.LowerString]ObjectMetadata `json:"data"`
 }
 
 type ObjectMetadata struct {
@@ -75,18 +77,20 @@ type ObjectMetadata struct {
 
 func NewObjectMetadataResult() *ObjectMetadataResult {
 	return &ObjectMetadataResult{
-		Result: make(map[string]ObjectMetadata),
+		Result: make(map[naming.LowerString]ObjectMetadata),
 	}
 }
 
 func (r *ObjectMetadataResult) Add(objectName string, objectDisplayName string, fieldName string) {
-	data, ok := r.Result[objectName]
+	name := naming.NewLowerString(objectName)
+
+	data, ok := r.Result[name]
 	if !ok {
 		data = ObjectMetadata{
 			DisplayName: objectDisplayName,
 			FieldsMap:   make(map[string]string),
 		}
-		r.Result[objectName] = data
+		r.Result[name] = data
 	}
 
 	data.FieldsMap[fieldName] = fieldName


### PR DESCRIPTION
After updating XML library in Salesforce I noticed that object names for ObjectMetadata are kept in lower case.

To be more consistent with generation of `schemas.json` files either by scrapping or parsing OpenAPI we should keep consistent case of Object Names.