### PR TITLE
add: Logo - Zendesk Support

### DIFF
--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -1,11 +1,11 @@
 package providers
 
 const (
-	ZendeskChat    Provider = "zendeskChat"
+	ZendeskChat    Provider = "zendeskSupport"
 	ZendeskSupport Provider = "zendeskSupport"
 )
 
-func init() {
+func init() { // nolint:funlen
 	// Zendesk Support configuration
 	SetInfo(ZendeskSupport, ProviderInfo{
 		DisplayName: "Zendesk Support",
@@ -17,6 +17,16 @@ func init() {
 			TokenURL:                  "https://{{.workspace}}.zendesk.com/oauth/tokens",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102329/media/zendeskSupport_1722102328.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102329/media/zendeskSupport_1722102328.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -42,6 +52,16 @@ func init() {
 			TokenURL:                  "https://www.zopim.com/oauth2/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102329/media/zendeskSupport_1722102328.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102329/media/zendeskSupport_1722102328.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -1,7 +1,7 @@
 package providers
 
 const (
-	ZendeskChat    Provider = "zendeskSupport"
+	ZendeskChat    Provider = "zendeskChat"
 	ZendeskSupport Provider = "zendeskSupport"
 )
 


### PR DESCRIPTION
# Notes

Each mode shares the same logo, icon.
**Reason:** Icon looks better than logo (has no name).

**zendeskSupport** and **zendeskSupport** use identical Media. 2 providers though 1 company.

![Selection_648](https://github.com/user-attachments/assets/19e9cda6-5975-421a-9c1a-453344425bf2)


