### PR TITLE
Feat: Add media to Freshdesk

### DIFF
--- a/providers/freshdesk.go
+++ b/providers/freshdesk.go
@@ -20,5 +20,15 @@ func init() {
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321939/media/freshdesk_1722321938.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321905/media/freshdesk_1722321903.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321939/media/freshdesk_1722321938.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321995/media/freshdesk_1722321994.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add logo and icon URLs to Freshdesk connector

Note: Freshdesk is a part of the Freshworks platform and therefore will share the Freshworks Icon and Logo as per the media generator. 
![Screenshot 2567-07-30 at 13 40 34](https://github.com/user-attachments/assets/852d7a4a-3c53-47ec-b354-946b1b787cc9)
![Screenshot 2567-07-30 at 13 47 02](https://github.com/user-attachments/assets/0703ec11-f996-45d0-b49a-07857a9165a7)
