### PR TITLE
Feat: Add media to Freshsales connector

### DIFF
--- a/providers/freshsales.go
+++ b/providers/freshsales.go
@@ -27,5 +27,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722324573/media/freshsales_1722324572.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722324555/media/freshsales_1722324554.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722324573/media/freshsales_1722324572.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722325347/media/freshsales_1722325345.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Freshsales.
Note: Freshsales is a part of the Freshworks platform and therefore will share the Freshworks Icon and Logo as per the media generator.
![Screenshot 2567-07-30 at 14 44 13](https://github.com/user-attachments/assets/a4bd2e9e-943f-464d-8779-8c121fc84c70)
![Screenshot 2567-07-30 at 14 44 29](https://github.com/user-attachments/assets/79373ddb-b143-4630-8fc4-56665e482aed)
