### PR TITLE
Feat: Add media to Freshservice

### DIFF
--- a/providers/freshservice.go
+++ b/providers/freshservice.go
@@ -20,5 +20,15 @@ func init() {
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326054/media/freshservice_1722326053.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326028/media/freshservice_1722326026.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326054/media/freshservice_1722326053.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326085/media/freshservice_1722326084.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Freshservice connector.
Note: Freshservice is a part of Freshworks platform and, therefore, is sharing Freshworks icons as per the media uploader.
![Screenshot 2567-07-30 at 14 53 05](https://github.com/user-attachments/assets/e3fc8227-ac85-495b-b6e0-ab90b9d0d7df)
![Screenshot 2567-07-30 at 14 53 34](https://github.com/user-attachments/assets/a08a5764-5802-497f-8ace-6fce8eec0f13)
