### PR TITLE
Feat: Add media to Shopify connector

### DIFF
--- a/providers/shopify.go
+++ b/providers/shopify.go
@@ -26,5 +26,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326919/media/shopify_1722326918.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326847/media/shopify_1722326845.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326881/media/shopify_1722326880.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326881/media/shopify_1722326880.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Shopify connector.
Note: No logo for the regular mode
![Screenshot 2567-07-30 at 15 07 14](https://github.com/user-attachments/assets/68665803-1003-4679-9551-c203d5ff9dd9)
