### PR TITLE
Feat: Add media to Dixa

### DIFF
--- a/providers/dixa.go
+++ b/providers/dixa.go
@@ -26,5 +26,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327729/media/dixa_1722327728.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327706/media/dixa_1722327704.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327746/media/dixa_1722327745.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327746/media/dixa_1722327745.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Dixa connector.
Note: Regular type of icon is not available on the uploader. Used regular Logo instead.
![Screenshot 2567-07-30 at 15 23 32](https://github.com/user-attachments/assets/a007f318-f88f-41f9-952c-47ce2f46d26a)
![Screenshot 2567-07-30 at 15 23 16](https://github.com/user-attachments/assets/57a6d3c6-457c-4645-9c4e-f49e01672de5)
