### PR TITLE
Feat: Add media to Maxio connector

### DIFF
--- a/providers/maxio.go
+++ b/providers/maxio.go
@@ -20,5 +20,15 @@ func init() {
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328568/media/maxio_1722328567.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328550/media/maxio_1722328549.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328600/media/maxio_1722328599.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328600/media/maxio_1722328599.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Maxio connector.
Note: There is no regular type of Icon, therefore a regular logo was used instead.
![Screenshot 2567-07-30 at 15 35 33](https://github.com/user-attachments/assets/86bddfa2-7aa0-4e88-ad70-7c440df2c479)
![Screenshot 2567-07-30 at 15 35 41](https://github.com/user-attachments/assets/d3f57889-55ea-4ed4-a399-4d0db7ca15ec)
