### PR TITLE
Feat: Add media to Bynder connector

### DIFF
--- a/providers/bynder.go
+++ b/providers/bynder.go
@@ -29,5 +29,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722329798/media/bynder_1722329797.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722329763/media/bynder_1722329761.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722329821/media/bynder_1722329820.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722329821/media/bynder_1722329820.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Bynder connector.
Note: The regular version of the icon was not available on the media uploader, therefore the logo was used instead.
![Screenshot 2567-07-30 at 15 55 21](https://github.com/user-attachments/assets/edc8f68e-7748-47ec-879a-44a73ebba390)
![Screenshot 2567-07-30 at 15 55 31](https://github.com/user-attachments/assets/de270b19-7e93-4298-95c9-cb5436d07531)
