### PR TITLE
Feat: Add media to Podium connector

### DIFF
--- a/providers/podium.go
+++ b/providers/podium.go
@@ -26,5 +26,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722330479/media/podium_1722330478.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722330479/media/podium_1722330478.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722330504/media/podium_1722330503.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722330504/media/podium_1722330503.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Podium connector.
Note: Neither regular nor dark-type icons were available for Podium. Logos were used instead.
![Screenshot 2567-07-30 at 16 09 04](https://github.com/user-attachments/assets/b53c9106-af94-4d6d-bf12-62dfef61a777)
