### PR TITLE
feat: Add media to pipeliner

### DIFF
--- a/providers/pipeliner.go
+++ b/providers/pipeliner.go
@@ -9,6 +9,17 @@ func init() {
 		DisplayName: "Pipeliner",
 		AuthType:    Basic,
 		BaseURL:     "https://eu-central.api.pipelinersales.com",
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722409690/media/const%20Pipeliner%20Provider%20%3D%20%22pipeliner%22_1722409689.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722409690/media/const%20Pipeliner%20Provider%20%3D%20%22pipeliner%22_1722409689.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722409690/media/const%20Pipeliner%20Provider%20%3D%20%22pipeliner%22_1722409689.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722409690/media/const%20Pipeliner%20Provider%20%3D%20%22pipeliner%22_1722409689.png",
+			},
+		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
 				Insert: false,


### PR DESCRIPTION
Add Icon and Logo URLs to Pipeliner connector.
Note: Neither regular nor dark-type icons were available for Pipeliner. Logos were used instead.
![image](https://github.com/user-attachments/assets/c7f397e6-1601-4f64-86ab-a2f6c819b1ca)
