### PR TITLE
feat: Add media to Teamleader

### DIFF
--- a/providers/teamleader.go
+++ b/providers/teamleader.go
@@ -15,6 +15,17 @@ func init() {
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722418524/media/const%20Teamleader%20Provider%20%3D%20%22teamleader%22_1722418523.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722418524/media/const%20Teamleader%20Provider%20%3D%20%22teamleader%22_1722418523.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722418524/media/const%20Teamleader%20Provider%20%3D%20%22teamleader%22_1722418523.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722418524/media/const%20Teamleader%20Provider%20%3D%20%22teamleader%22_1722418523.png",
+			},
+		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
 				Insert: false,


### PR DESCRIPTION
Add Icon and Logo URLs to the Teamleader connector.
Note: Icon has been used for both logo and icon
![image](https://github.com/user-attachments/assets/953f9362-d58b-4d5f-a022-4de1c1bcff39)
