### PR TITLE
feat: Deep connector Jira (Metadata)

### DIFF
--- a/atlassian/metadata.go
+++ b/atlassian/metadata.go
@@ -30,7 +30,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, _ []string) (*common
 	// Read response is flattened exposing only important fields which happen to not have id.
 	// To mitigate this API response the Read method will attach id.
 	// Therefore, metadata must include it too.
-	fields["id"] = "Identifier"
+	fields["id"] = "Id"
 
 	return &common.ListObjectMetadataResult{
 		Result: map[string]common.ObjectMetadata{

--- a/atlassian/metadata.go
+++ b/atlassian/metadata.go
@@ -1,0 +1,44 @@
+package atlassian
+
+import (
+	"context"
+	"errors"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// ListObjectMetadata lists builtin and custom fields.
+// Supports only Issue object. Therefore, objectNames argument is ignored.
+// API Reference:
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-fields/#api-rest-api-2-field-get
+func (c *Connector) ListObjectMetadata(ctx context.Context, _ []string) (*common.ListObjectMetadataResult, error) {
+	url, err := c.getJiraRestApiURL("field")
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	fields, err := c.parseFieldsJiraIssue(rsp.Body)
+	if err != nil {
+		return nil, errors.Join(ErrParsingMetadata, err)
+	}
+
+	// Read response is flattened exposing only important fields which happen to not have id.
+	// To mitigate this API response the Read method will attach id.
+	// Therefore, metadata must include it too.
+	fields["id"] = "Identifier"
+
+	return &common.ListObjectMetadataResult{
+		Result: map[string]common.ObjectMetadata{
+			"issue": {
+				DisplayName: "Issue",
+				FieldsMap:   fields,
+			},
+		},
+		Errors: nil,
+	}, nil
+}

--- a/atlassian/metadataFields.go
+++ b/atlassian/metadataFields.go
@@ -1,0 +1,43 @@
+package atlassian
+
+import (
+	"errors"
+
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+var (
+	ErrParsingMetadata = errors.New("couldn't parse metadata")
+	ErrMissingMetadata = errors.New("there is no metadata for object")
+)
+
+// Converts API response into the fields' registry.
+func (c *Connector) parseFieldsJiraIssue(node *ajson.Node) (map[string]string, error) {
+	arr, err := node.GetArray()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(arr) == 0 {
+		return nil, ErrMissingMetadata
+	}
+
+	fieldsMap := make(map[string]string)
+
+	for _, item := range arr {
+		name, err := jsonquery.New(item).Str("id", false)
+		if err != nil {
+			return nil, err
+		}
+
+		displayName, err := jsonquery.New(item).Str("name", false)
+		if err != nil {
+			return nil, err
+		}
+
+		fieldsMap[*name] = *displayName
+	}
+
+	return fieldsMap, nil
+}

--- a/atlassian/metadata_test.go
+++ b/atlassian/metadata_test.go
@@ -96,7 +96,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						DisplayName: "Issue",
 						FieldsMap: map[string]string{
 							// Manually attached fields:
-							"id": "Identifier",
+							"id": "Id",
 							// Fields coming from server response:
 							"issuekey":                      "Key",
 							"priority":                      "Priority",
@@ -132,7 +132,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				WithWorkspace("test-workspace"),
 				WithModule(ModuleJira),
 				WithMetadata(map[string]string{
-					"cloudID": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // it doesn't matter for the test
+					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
 				}),
 			)
 			if err != nil {
@@ -176,5 +176,23 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
 			}
 		})
+	}
+}
+
+func TestListObjectMetadataWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithWorkspace("test-workspace"),
+		WithModule(ModuleJira),
+	)
+	if err != nil {
+		t.Fatal("failed to create connector")
+	}
+
+	_, err = connector.ListObjectMetadata(context.Background(), nil)
+	if !errors.Is(err, ErrMissingCloudId) {
+		t.Fatalf("expected ListObjectMetadata method to complain about missing cloud id")
 	}
 }

--- a/atlassian/metadata_test.go
+++ b/atlassian/metadata_test.go
@@ -1,0 +1,180 @@
+package atlassian
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+	"github.com/go-test/deep"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	responseIssueSchema := testutils.DataFromFile(t, "issue-metadata.json")
+
+	tests := []struct {
+		name         string
+		input        []string
+		server       *httptest.Server
+		comparator   func(serverURL string, actual, expected *common.ListObjectMetadataResult) bool
+		expected     *common.ListObjectMetadataResult
+		expectedErrs []error
+	}{
+		{
+			name:         "Mime response header expected",
+			input:        []string{"butterflies"},
+			server:       mockserver.Dummy(),
+			expectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			name:  "Server response must include array",
+			input: []string{"butterflies"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, ``)
+			})),
+			expectedErrs: []error{ErrParsingMetadata},
+		},
+		{
+			name:  "Server response must have at least one field",
+			input: []string{"butterflies"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `[]`)
+			})),
+			expectedErrs: []error{
+				ErrMissingMetadata,
+				ErrParsingMetadata,
+			},
+		},
+		{
+			name:  "Field response must have identifier",
+			input: []string{"butterflies"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `[{}]`)
+			})),
+			expectedErrs: []error{ErrParsingMetadata},
+		},
+		{
+			name:  "Field response must have display name",
+			input: []string{"butterflies"},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `[{"id": "issuerestriction"}]`)
+			})),
+			expectedErrs: []error{ErrParsingMetadata},
+		},
+		{
+			name:  "Successfully describe Issue metadata",
+			input: []string{},
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(responseIssueSchema)
+			})),
+			comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
+				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
+			},
+			expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"issue": {
+						DisplayName: "Issue",
+						FieldsMap: map[string]string{
+							// Manually attached fields:
+							"id": "Identifier",
+							// Fields coming from server response:
+							"issuekey":                      "Key",
+							"priority":                      "Priority",
+							"creator":                       "Creator",
+							"worklog":                       "Log Work",
+							"issuetype":                     "Issue Type",
+							"issuelinks":                    "Linked Issues",
+							"fixVersions":                   "Fix versions",
+							"issuerestriction":              "Restrict to",
+							"statuscategorychangedate":      "Status Category Changed",
+							"aggregatetimeoriginalestimate": "Σ Original Estimate",
+							"customfield_10028":             "Submitted forms",
+							"customfield_10035":             "Project overview key",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer tt.server.Close()
+
+			connector, err := NewConnector(
+				WithAuthenticatedClient(http.DefaultClient),
+				WithWorkspace("test-workspace"),
+				WithModule(ModuleJira),
+				WithMetadata(map[string]string{
+					"cloudID": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // it doesn't matter for the test
+				}),
+			)
+			if err != nil {
+				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
+			}
+
+			// for testing we want to redirect calls to our mock server
+			connector.setBaseURL(tt.server.URL)
+
+			// start of tests
+			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
+			if err != nil {
+				if len(tt.expectedErrs) == 0 {
+					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
+				}
+			} else {
+				// check that missing error is what is expected
+				if len(tt.expectedErrs) != 0 {
+					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
+				}
+			}
+
+			// check every error
+			for _, expectedErr := range tt.expectedErrs {
+				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
+				}
+			}
+
+			// compare desired output
+			var ok bool
+			if tt.comparator == nil {
+				// default comparison is concerned about all fields
+				ok = reflect.DeepEqual(output, tt.expected)
+			} else {
+				ok = tt.comparator(tt.server.URL, output, tt.expected)
+			}
+
+			if !ok {
+				diff := deep.Equal(output, tt.expected)
+				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
+			}
+		})
+	}
+}

--- a/atlassian/test/issue-metadata.json
+++ b/atlassian/test/issue-metadata.json
@@ -1,0 +1,197 @@
+[
+  {
+    "id": "issuekey",
+    "key": "issuekey",
+    "name": "Key",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": false,
+    "clauseNames": [
+      "id",
+      "issue",
+      "issuekey",
+      "key"
+    ]
+  },
+  {
+    "id": "priority",
+    "key": "priority",
+    "name": "Priority",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "priority"
+    ],
+    "schema": {
+      "type": "priority",
+      "system": "priority"
+    }
+  },
+  {
+    "id": "creator",
+    "key": "creator",
+    "name": "Creator",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "creator"
+    ],
+    "schema": {
+      "type": "user",
+      "system": "creator"
+    }
+  },
+  {
+    "id": "worklog",
+    "key": "worklog",
+    "name": "Log Work",
+    "custom": false,
+    "orderable": true,
+    "navigable": false,
+    "searchable": true,
+    "clauseNames": [],
+    "schema": {
+      "type": "array",
+      "items": "worklog",
+      "system": "worklog"
+    }
+  },
+  {
+    "id": "issuetype",
+    "key": "issuetype",
+    "name": "Issue Type",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "issuetype",
+      "type"
+    ],
+    "schema": {
+      "type": "issuetype",
+      "system": "issuetype"
+    }
+  },
+  {
+    "id": "issuelinks",
+    "key": "issuelinks",
+    "name": "Linked Issues",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "issueLink"
+    ],
+    "schema": {
+      "type": "array",
+      "items": "issuelinks",
+      "system": "issuelinks"
+    }
+  },
+  {
+    "id": "fixVersions",
+    "key": "fixVersions",
+    "name": "Fix versions",
+    "custom": false,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "fixVersion"
+    ],
+    "schema": {
+      "type": "array",
+      "items": "version",
+      "system": "fixVersions"
+    }
+  },
+  {
+    "id": "issuerestriction",
+    "key": "issuerestriction",
+    "name": "Restrict to",
+    "custom": false,
+    "orderable": true,
+    "navigable": false,
+    "searchable": true,
+    "clauseNames": [],
+    "schema": {
+      "type": "issuerestriction",
+      "system": "issuerestriction"
+    }
+  },
+  {
+    "id": "statuscategorychangedate",
+    "key": "statuscategorychangedate",
+    "name": "Status Category Changed",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "statusCategoryChangedDate"
+    ],
+    "schema": {
+      "type": "datetime",
+      "system": "statuscategorychangedate"
+    }
+  },
+  {
+    "id": "aggregatetimeoriginalestimate",
+    "key": "aggregatetimeoriginalestimate",
+    "name": "Σ Original Estimate",
+    "custom": false,
+    "orderable": false,
+    "navigable": true,
+    "searchable": false,
+    "clauseNames": [],
+    "schema": {
+      "type": "number",
+      "system": "aggregatetimeoriginalestimate"
+    }
+  },
+  {
+    "id": "customfield_10028",
+    "key": "customfield_10028",
+    "name": "Submitted forms",
+    "untranslatedName": "Submitted forms",
+    "custom": true,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "cf[10028]",
+      "Submitted forms"
+    ],
+    "schema": {
+      "type": "number",
+      "custom": "com.atlassian.jira.plugins.proforma-managed-fields:forms-submitted-field-cftype",
+      "customId": 10028
+    }
+  },
+  {
+    "id": "customfield_10035",
+    "key": "com.atlassian.atlas.jira__project-key",
+    "name": "Project overview key",
+    "untranslatedName": "Project overview key",
+    "custom": true,
+    "orderable": true,
+    "navigable": true,
+    "searchable": true,
+    "clauseNames": [
+      "cf[10035]",
+      "Project overview key"
+    ],
+    "schema": {
+      "type": "string",
+      "custom": "read-only-string-issue-field",
+      "customId": 10035
+    }
+  }
+]

--- a/test/atlassian/metadata/main.go
+++ b/test/atlassian/metadata/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+)
+
+var (
+	objectName = "issue" // nolint: gochecknoglobals
+)
+
+// We want to compare fields returned by read and schema properties provided by metadata methods.
+// Properties from read must all be present in schema definition.
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAtlassianConnector(ctx)
+	defer utils.Close(conn)
+
+	response, err := conn.Read(ctx, common.ReadParams{})
+	if err != nil {
+		utils.Fail("error reading from Atlassian", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	metadata, err := conn.ListObjectMetadata(ctx, nil)
+	if err != nil {
+		utils.Fail("error listing metadata for Atlassian", "error", err)
+	}
+
+	slog.Info("Compare object metadata against endpoint response:")
+
+	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
+	if mismatchErr != nil {
+		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
+	} else {
+		slog.Info("==> success fields match.")
+	}
+}


### PR DESCRIPTION
Closes #709 

# Description

Implemented ListObjectMetadata by making an API call to `field` endpoint which returns fields of Jira issue.
Reference: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-fields/#api-rest-api-2-field-get

# Testing

![image](https://github.com/user-attachments/assets/c441f245-9eac-49b4-a041-0f9024b1e308)
