### PR TITLE
feat: Add media to Braintree

### DIFF
--- a/providers/braintree.go
+++ b/providers/braintree.go
@@ -21,5 +21,15 @@ func init() {
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460381/media/braintree_1722460380.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460341/media/braintree_1722460339.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460381/media/braintree_1722460380.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460360/media/braintree_1722460359.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Miro connector.
<img width="1440" alt="Screenshot 2024-07-31 at 9 15 33 PM" src="https://github.com/user-attachments/assets/19a9d409-5d08-4c31-86e8-dd98a9ebee3a">
