### PR TITLE
feat: Add media to ChargeOver

### DIFF
--- a/providers/chargeOver.go
+++ b/providers/chargeOver.go
@@ -20,5 +20,15 @@ func init() {
 			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460983/media/chargeover_1722460983.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722461005/media/chargeover_1722461004.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460983/media/chargeover_1722460983.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722461005/media/chargeover_1722461004.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Miro connector.
<img width="1440" alt="Screenshot 2024-07-31 at 9 31 45 PM" src="https://github.com/user-attachments/assets/4694c06c-d4e1-4494-a0a8-7a0e597cff7b">
