### PR TITLE
feat: Add media to Sellsy

### DIFF
--- a/providers/sellsy.go
+++ b/providers/sellsy.go
@@ -27,5 +27,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722470945/media/sellsy_1722470945.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722471161/media/sellsy_1722471161.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722470988/media/sellsy_1722470988.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722471227/media/sellsy_1722471226.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Sellsy connector.
<img width="1440" alt="Screenshot 2024-08-01 at 12 16 08 AM" src="https://github.com/user-attachments/assets/7ae97f84-5f48-4d66-87a8-8129381255aa">
