### PR TITLE
Feat: Add media to Copper connector

### DIFF
--- a/providers/copper.go
+++ b/providers/copper.go
@@ -27,5 +27,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478129/media/copper_1722478128.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478062/media/copper_1722478061.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478129/media/copper_1722478128.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478080/media/copper_1722478079.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Copper connector.
Note: The icon has a background.
![Screenshot 2567-08-01 at 09 07 12](https://github.com/user-attachments/assets/2a06bd74-9f1e-4831-bd3a-2dda57983485)
![Screenshot 2567-08-01 at 09 07 32](https://github.com/user-attachments/assets/c4ef21c8-ee44-4828-bba9-92e581b373db)
