### PR TITLE
Feat: Add media to Keap connector

### DIFF
--- a/providers/keap.go
+++ b/providers/keap.go
@@ -27,5 +27,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722479751/media/keap_1722479749.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722479751/media/keap_1722479749.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722479775/media/keap_1722479774.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722479775/media/keap_1722479774.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Keap connector.
Note: Icons not available for both dark and regular modes, logos were used instead.
![Screenshot 2567-08-01 at 09 40 34](https://github.com/user-attachments/assets/a7576c6f-8668-4600-946c-085bd6fc3935)
