### PR TITLE
Feat: Add media to klaviyo connector

### DIFF
--- a/providers/klaviyo.go
+++ b/providers/klaviyo.go
@@ -30,5 +30,15 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722480320/media/klaviyo_1722480318.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722480320/media/klaviyo_1722480318.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722480368/media/klaviyo_1722480367.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722480352/media/klaviyo_1722480351.svg",
+			},
+		},
 	})
 }


### PR DESCRIPTION
Add Icon and Logo URLs to Klaviyo connector.
Note: Dark mode Icon is not available, used Logo instead.
![Screenshot 2567-08-01 at 09 51 37](https://github.com/user-attachments/assets/e9ab9450-9a54-4a49-acfb-badbd7a8d3f8)
