### PR TITLE
feat: Add media to CampaignMonitor

### DIFF
--- a/providers/campaignMonitor.go
+++ b/providers/campaignMonitor.go
@@ -15,6 +15,17 @@ func init() {
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
 		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722508734/media/const%20CampaignMonitor%20Provider%20%3D%20%22campaignMonitor%22_1722508735.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722508817/media/const%20CampaignMonitor%20Provider%20%3D%20%22campaignMonitor%22_1722508819.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722508734/media/const%20CampaignMonitor%20Provider%20%3D%20%22campaignMonitor%22_1722508735.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722508817/media/const%20CampaignMonitor%20Provider%20%3D%20%22campaignMonitor%22_1722508819.svg",
+			},
+		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
 				Insert: false,


### PR DESCRIPTION
Add Icon and Logo URLs to campaignMonitor connector.
![image](https://github.com/user-attachments/assets/2e16f6e0-b831-4d37-b062-436a59c663ce)

