### PR TITLE
add: Package testroutines

### DIFF
--- a/dynamicscrm/delete_test.go
+++ b/dynamicscrm/delete_test.go
@@ -1,53 +1,44 @@
 package dynamicscrm
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/go-test/deep"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Write object and its ID must be included",
-			input:        common.DeleteParams{ObjectName: "fax"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "fax"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				mockutils.WriteBody(w, `{
@@ -57,64 +48,32 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 					}
 				}`)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Resource not found for the segment 'conacs'"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "DELETE")
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/dynamicscrm/metadata_test.go
+++ b/dynamicscrm/metadata_test.go
@@ -1,20 +1,18 @@
 package dynamicscrm
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
@@ -24,41 +22,33 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	// Attributes file is a shorter form of real Microsoft server response.
 	responseContactsAttributes := testutils.DataFromFile(t, "contacts-attributes.json")
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(serverURL string, actual, expected *common.ListObjectMetadataResult) bool
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        []string{"accounts"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        []string{"accounts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Schema endpoint is not available for object",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Schema endpoint is not available for object",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte{})
 			})),
-			expectedErrs: []error{ErrObjectNotFound},
+			ExpectedErrs: []error{ErrObjectNotFound},
 		},
 		{
-			name:  "Attributes endpoint is not available for object",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Attributes endpoint is not available for object",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				switch path := r.URL.Path; {
@@ -68,12 +58,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					_, _ = w.Write([]byte{})
 				}
 			})),
-			expectedErrs: []error{ErrObjectNotFound},
+			ExpectedErrs: []error{ErrObjectNotFound},
 		},
 		{
-			name:  "Object doesn't have attributes",
-			input: []string{"accounts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Object doesn't have attributes",
+			Input: []string{"accounts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				switch path := r.URL.Path; {
@@ -85,12 +75,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					_, _ = w.Write([]byte{})
 				}
 			})),
-			expectedErrs: []error{ErrObjectMissingAttributes},
+			ExpectedErrs: []error{ErrObjectMissingAttributes},
 		},
 		{
-			name:  "Correctly list metadata for account leads and invite contact",
-			input: []string{"contacts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correctly list metadata for account leads and invite contact",
+			Input: []string{"contacts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				// server will be called 2 times
@@ -103,10 +93,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					_, _ = w.Write([]byte{})
 				}
 			})),
-			comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
 				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
 			},
-			expected: &common.ListObjectMetadataResult{
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
 						DisplayName: "contacts",
@@ -127,62 +117,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(tt.server.URL, output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/dynamicscrm/read.go
+++ b/dynamicscrm/read.go
@@ -14,6 +14,10 @@ import (
 // Microsoft API supports other capabilities like filtering, grouping, and sorting which we can potentially tap into later.
 // See https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query-data-web-api#odata-query-options
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if len(config.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
 	link, err := c.buildReadURL(config)
 	if err != nil {
 		return nil, err

--- a/dynamicscrm/read_test.go
+++ b/dynamicscrm/read_test.go
@@ -1,21 +1,19 @@
 package dynamicscrm
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
@@ -23,22 +21,23 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseContactsGet := testutils.DataFromFile(t, "contacts-read.json")
 
-	tests := []struct {
-		name         string
-		input        common.ReadParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.ReadResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Read{
 		{
-			name:         "Mime response header expected",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name: "Correct error message is understood from JSON response",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:         "Mime response header expected",
+			Input:        common.ReadParams{ObjectName: "contact"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.ReadParams{ObjectName: "contact"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				mockutils.WriteBody(w, `{
@@ -48,55 +47,59 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					}
 				}`)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("Resource not found for the segment 'conacs'"), // nolint:goerr113
 			},
 		},
 		{
-			name: "Incorrect key in payload",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect key in payload",
+			Input: common.ReadParams{ObjectName: "contact"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"garbage": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
-			name: "Incorrect data type in payload",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect data type in payload",
+			Input: common.ReadParams{ObjectName: "contact"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"value": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrNotArray},
+			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
-			name: "Next page cursor may be missing in payload",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Next page cursor may be missing in payload",
+			Input: common.ReadParams{ObjectName: "contact"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"value": []
 				}`)
 			})),
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{},
 				Done: true,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name: "Successful read with 2 entries",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful read with 2 entries",
+			Input: common.ReadParams{ObjectName: "contact"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseContactsGet)
 			})),
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{},
@@ -124,19 +127,17 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				NextPage: "https://org5bd08fdd.api.crm.dynamics.com/api/data/v9.2/contacts?$select=fullname,emailaddress1,fax,familystatuscode&$skiptoken=%3Ccookie%20pagenumber=%222%22%20pagingcookie=%22%253ccookie%2520page%253d%25221%2522%253e%253ccontactid%2520last%253d%2522%257b9FD4A450-CB0C-EA11-A813-000D3A1B1223%257d%2522%2520first%253d%2522%257bCDCFA450-CB0C-EA11-A813-000D3A1B1223%257d%2522%2520%252f%253e%253c%252fcookie%253e%22%20istracking=%22False%22%20/%3E", // nolint:lll
 				Done:     false,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name: "Successful read with chosen fields",
-			input: common.ReadParams{
-				Fields: []string{"fullname", "fax"},
-			},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful read with chosen fields",
+			Input: common.ReadParams{ObjectName: "contact", Fields: []string{"fullname", "fax"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseContactsGet)
 			})),
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
@@ -170,56 +171,34 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				NextPage: "https://org5bd08fdd.api.crm.dynamics.com/api/data/v9.2/contacts?$select=fullname,emailaddress1,fax,familystatuscode&$skiptoken=%3Ccookie%20pagenumber=%222%22%20pagingcookie=%22%253ccookie%2520page%253d%25221%2522%253e%253ccontactid%2520last%253d%2522%257b9FD4A450-CB0C-EA11-A813-000D3A1B1223%257d%2522%2520first%253d%2522%257bCDCFA450-CB0C-EA11-A813-000D3A1B1223%257d%2522%2520%252f%253e%253c%252fcookie%253e%22%20istracking=%22False%22%20/%3E", // nolint:lll
 				Done:     false,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Read(ctx, tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithWorkspace("test-workspace"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
 }

--- a/dynamicscrm/write_test.go
+++ b/dynamicscrm/write_test.go
@@ -1,47 +1,39 @@
 package dynamicscrm
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/go-test/deep"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Input:        common.WriteParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "fax"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "fax"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.WriteParams{ObjectName: "fax"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.WriteParams{ObjectName: "fax"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				mockutils.WriteBody(w, `{
@@ -51,74 +43,42 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					}
 				}`)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Resource not found for the segment 'conacs'"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "fax"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "fax"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "POST")
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "PATCH")
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -1,0 +1,11 @@
+// Package testroutines holds a collection of common test procedures.
+// They provide a framework to write mock tests.
+package testroutines
+
+import (
+	"github.com/amp-labs/connectors"
+)
+
+// ConnectorBuilder is a callback method to construct and configure connector for testing.
+// This is a factory method called for every test suite.
+type ConnectorBuilder[C connectors.Connector] func() (C, error)

--- a/test/utils/testroutines/delete.go
+++ b/test/utils/testroutines/delete.go
@@ -1,0 +1,46 @@
+package testroutines
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Delete is a test suite useful for testing connectors.DeleteConnector interface.
+type Delete struct {
+	Name  string
+	Input common.DeleteParams
+	// dependencies
+	Server *httptest.Server
+	// custom comparison
+	Comparator func(serverURL string, actual, expected *common.DeleteResult) bool
+	// output
+	Expected     *common.DeleteResult
+	ExpectedErrs []error
+}
+
+func (d Delete) getOutline() suiteOutline[common.DeleteResult] {
+	return suiteOutline[common.DeleteResult]{
+		Name:         d.Name,
+		Server:       d.Server,
+		Comparator:   d.Comparator,
+		Expected:     d.Expected,
+		ExpectedErrs: d.ExpectedErrs,
+	}
+}
+
+// Run provides a procedure to test connectors.DeleteConnector
+func (d Delete) Run(t *testing.T, builder ConnectorBuilder[connectors.DeleteConnector]) {
+	defer d.Server.Close()
+
+	conn, err := builder()
+	if err != nil {
+		t.Fatalf("%s: error in test while constructing connector %v", d.Name, err)
+	}
+
+	output, err := conn.Delete(context.Background(), d.Input)
+	d.getOutline().Validate(t, err, output)
+}

--- a/test/utils/testroutines/metadata.go
+++ b/test/utils/testroutines/metadata.go
@@ -1,0 +1,48 @@
+package testroutines
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Metadata is a test suite useful for testing connectors.ObjectMetadataConnector interface.
+type Metadata struct {
+	Name  string
+	Input []string
+	// dependencies
+	Server *httptest.Server
+	// custom comparison
+	Comparator func(serverURL string, actual, expected *common.ListObjectMetadataResult) bool
+	// output
+	Expected     *common.ListObjectMetadataResult
+	ExpectedErrs []error
+}
+
+func (m Metadata) getOutline() suiteOutline[common.ListObjectMetadataResult] {
+	return suiteOutline[common.ListObjectMetadataResult]{
+		Name:         m.Name,
+		Server:       m.Server,
+		Comparator:   m.Comparator,
+		Expected:     m.Expected,
+		ExpectedErrs: m.ExpectedErrs,
+	}
+}
+
+// Run provides a procedure to test connectors.ObjectMetadataConnector
+func (m Metadata) Run(t *testing.T,
+	builder ConnectorBuilder[connectors.ObjectMetadataConnector],
+) {
+	defer m.Server.Close()
+
+	conn, err := builder()
+	if err != nil {
+		t.Fatalf("%s: error in test while constructing connector %v", m.Name, err)
+	}
+
+	output, err := conn.ListObjectMetadata(context.Background(), m.Input)
+	m.getOutline().Validate(t, err, output)
+}

--- a/test/utils/testroutines/outline.go
+++ b/test/utils/testroutines/outline.go
@@ -1,0 +1,72 @@
+package testroutines
+
+import (
+	"errors"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+// suiteOutline describes major components that are used to test any Connector methods.
+// It is universal and generic `V` value represents the data type of the expected output.
+type suiteOutline[V any] struct {
+	// Name of the test suite.
+	Name string
+	// Mock Server which connector will call.
+	Server *httptest.Server
+	// Custom Comparator of how expected output agrees with actual output.
+	Comparator func(serverURL string, actual, expected *V) bool
+	// Expected return value.
+	Expected *V
+	// ExpectedErrs is a list of errors that must be present in error output.
+	ExpectedErrs []error
+}
+
+// Validate checks if supplied input conforms to the test intention.
+func (o suiteOutline[V]) Validate(t *testing.T, err error, output *V) {
+	defer o.Server.Close()
+
+	// performs validation of error output using described test suite outline.
+	o.checkError(t, err)
+	// performs validation of data output using described test suite outline.
+	o.checkValue(t, output)
+}
+
+func (o suiteOutline[V]) checkError(t *testing.T, err error) {
+	if err != nil {
+		if len(o.ExpectedErrs) == 0 {
+			t.Fatalf("%s: expected no errors, got: (%v)", o.Name, err)
+		}
+	} else {
+		// check that missing error is what is expected
+		if len(o.ExpectedErrs) != 0 {
+			t.Fatalf("%s: expected errors (%v), but got nothing", o.Name, o.ExpectedErrs)
+		}
+	}
+
+	// check every error
+	for _, expectedErr := range o.ExpectedErrs {
+		if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
+			t.Fatalf("%s: expected Error: (%v), got: (%v)", o.Name, expectedErr, err)
+		}
+	}
+}
+
+func (o suiteOutline[V]) checkValue(t *testing.T, output *V) {
+	// compare desired output
+	var ok bool
+	if o.Comparator == nil {
+		// default comparison is concerned about all fields
+		ok = reflect.DeepEqual(output, o.Expected)
+	} else {
+		ok = o.Comparator(o.Server.URL, output, o.Expected)
+	}
+
+	if !ok {
+		diff := deep.Equal(output, o.Expected)
+		t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", o.Name, o.Expected, output, diff)
+	}
+}

--- a/test/utils/testroutines/read.go
+++ b/test/utils/testroutines/read.go
@@ -1,0 +1,48 @@
+package testroutines
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Read is a test suite useful for testing connectors.ReadConnector interface.
+type Read struct {
+	Name  string
+	Input common.ReadParams
+	// dependencies
+	Server *httptest.Server
+	// custom comparison
+	Comparator func(serverURL string, actual, expected *common.ReadResult) bool
+	// output
+	Expected     *common.ReadResult
+	ExpectedErrs []error
+}
+
+func (r Read) getOutline() suiteOutline[common.ReadResult] {
+	// It is better to create suiteOutline on a fly then store it directly on Read struct.
+	// Nested objects make the test ugly. Better this function then all test files.
+	return suiteOutline[common.ReadResult]{
+		Name:         r.Name,
+		Server:       r.Server,
+		Comparator:   r.Comparator,
+		Expected:     r.Expected,
+		ExpectedErrs: r.ExpectedErrs,
+	}
+}
+
+// Run provides a procedure to test connectors.ReadConnector
+func (r Read) Run(t *testing.T, builder ConnectorBuilder[connectors.ReadConnector]) {
+	defer r.Server.Close()
+
+	conn, err := builder()
+	if err != nil {
+		t.Fatalf("%s: error in test while constructing connector %v", r.Name, err)
+	}
+
+	output, err := conn.Read(context.Background(), r.Input)
+	r.getOutline().Validate(t, err, output)
+}

--- a/test/utils/testroutines/write.go
+++ b/test/utils/testroutines/write.go
@@ -1,0 +1,46 @@
+package testroutines
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Write is a test suite useful for testing connectors.WriteConnector interface.
+type Write struct {
+	Name  string
+	Input common.WriteParams
+	// dependencies
+	Server *httptest.Server
+	// custom comparison
+	Comparator func(serverURL string, actual, expected *common.WriteResult) bool
+	// output
+	Expected     *common.WriteResult
+	ExpectedErrs []error
+}
+
+func (w Write) getOutline() suiteOutline[connectors.WriteResult] {
+	return suiteOutline[connectors.WriteResult]{
+		Name:         w.Name,
+		Server:       w.Server,
+		Comparator:   w.Comparator,
+		Expected:     w.Expected,
+		ExpectedErrs: w.ExpectedErrs,
+	}
+}
+
+// Run provides a procedure to test connectors.WriteConnector
+func (w Write) Run(t *testing.T, builder ConnectorBuilder[connectors.WriteConnector]) {
+	defer w.Server.Close()
+
+	conn, err := builder()
+	if err != nil {
+		t.Fatalf("%s: error in test while constructing connector %v", w.Name, err)
+	}
+
+	output, err := conn.Write(context.Background(), w.Input)
+	w.getOutline().Validate(t, err, output)
+}


### PR DESCRIPTION
# Reviewing

Changes are grouped by commits. The first two are the most important to understand the change. 
Commits named `add: Define <METHOD> testing, dynamicsCRM` are mirroring each other.

# Description

Introduces `testroutines` package that will remove repetitive, long test setup.

This defines common test structure for Read/Write/ListObjectMetadata/Delete.
The boilerplate is removed with generics and appropriate calls to connectors method.

The test needs to check output expectations, error expectations.
They must not differ. This code is copied over and over with no changes.

# Usage

Declaring test suites:
``` go
tests := []testroutines.Write{
  {
    Name:  "Test name",
    Input: common.WriteParams{},
    ExpectedErrs: []error{common.ErrBadRequest}
  }
}
```
Running test suite (within for loop):
``` go
testSuite.Run(t, func() (connectors.WriteConnector, error) {
    return constructTestConnector(tt.Server.URL)
})
```
# Note
DynamicsCRM connector is used for demonstration.
The file changes look big while it is doing struct replacement. As an example `testroutines.Read` has the same fields but only public (capitalized).

