### PR TITLE
fix: Scopes required: Seismic

### DIFF
--- a/providers/seismic.go
+++ b/providers/seismic.go
@@ -11,7 +11,7 @@ func init() {
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://auth.seismic.com/tenants/{{.workspace}}/connect/authorize",
 			TokenURL:                  "https://auth.seismic.com/tenants/{{.workspace}}/connect/token",
-			ExplicitScopesRequired:    false,
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
 		},
 		Media: &Media{


### PR DESCRIPTION
Seismic **requires scopes** to be passed.
Tried to generate token locally without scopes getting the same error.

![image](https://github.com/user-attachments/assets/7d6a2b24-f8c7-4a02-a897-1076539ae8a5)
