### PR TITLE
chore: update display name of Atlassian connector

### DIFF
--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -5,7 +5,7 @@ const Atlassian Provider = "atlassian"
 func init() {
 	// Atlassian Configuration
 	SetInfo(Atlassian, ProviderInfo{
-		DisplayName: "Atlassian (Jira, Confluence)",
+		DisplayName: "Atlassian",
 		AuthType:    Oauth2,
 		BaseURL:     "https://api.atlassian.com",
 		Oauth2Opts: &Oauth2Opts{

--- a/test/outreach/read/read.go
+++ b/test/outreach/read/read.go
@@ -34,7 +34,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }
 
 func testReadSequences(ctx context.Context, conn connectors.ReadConnector) error {


### PR DESCRIPTION
It was too long and looked awkward in the dashboard.