### PR TITLE
feat: Enable proxy: ActiveCampaign

### DIFF
--- a/providers/activeCampaign.go
+++ b/providers/activeCampaign.go
@@ -31,7 +31,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
Closes #848

# BLOCKED
Workspace is not supported for non-oauth2 connectors, cannot proceed with testing.

## Testing
### GET
URL: <localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

### POST
URL: <localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>

### Invalid requests
Wrong verb applied, invalid path.


## Pagination
Please add screenshots that show successful pagination using the connector. 

## Successful console operation (operation & events)

## Failed console operation (operation & events)

## Raw token response