### PR TITLE
feat: set the connector cloudID for Atlassian once its retrieved by GetPostAuthInfo

### DIFF
--- a/atlassian/authmetadata.go
+++ b/atlassian/authmetadata.go
@@ -19,6 +19,8 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 		return nil, errors.Join(ErrDiscoveryFailure, err)
 	}
 
+	c.cloudId = cloudId
+
 	return &common.PostAuthInfo{
 		CatalogVars: AuthMetadataVars{
 			CloudId: cloudId,


### PR DESCRIPTION
Internally memoize the cloudID field so it can be used for subsequent calls using the same connector instance.


