### PR TITLE
tidy: Mocktests to use Testroutines

### DIFF
--- a/atlassian/delete_test.go
+++ b/atlassian/delete_test.go
@@ -5,15 +5,14 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
@@ -21,104 +20,57 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseErrorFormat := testutils.DataFromFile(t, "delete-issue-not-found.json")
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:  "Write issue must include ID",
-			input: common.DeleteParams{},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write issue must include ID",
+			Input: common.DeleteParams{},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusTeapot)
 			})),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:  "Mime response header expected",
-			input: common.DeleteParams{RecordId: "10010"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Mime response header expected",
+			Input: common.DeleteParams{RecordId: "10010"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusTeapot)
 			})),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Not found returned on removing missing entry",
-			input: common.DeleteParams{RecordId: "10010"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Not found returned on removing missing entry",
+			Input: common.DeleteParams{RecordId: "10010"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write(responseErrorFormat)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Issue does not exist or you do not have permission to see it"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{RecordId: "10010"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{RecordId: "10010"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "DELETE")
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-				WithModule(ModuleJira),
-				WithMetadata(map[string]string{
-					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
-				}),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			if err != nil {
-				t.Fatalf("%s: failed to setup auth metadata connector %v", tt.name, err)
-			}
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/atlassian/metadata_test.go
+++ b/atlassian/metadata_test.go
@@ -5,16 +5,15 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
@@ -22,75 +21,68 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseIssueSchema := testutils.DataFromFile(t, "issue-metadata.json")
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		comparator   func(serverURL string, actual, expected *common.ListObjectMetadataResult) bool
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "Mime response header expected",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Server response must include array",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Server response must include array",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, ``)
 			})),
-			expectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{ErrParsingMetadata},
 		},
 		{
-			name:  "Server response must have at least one field",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Server response must have at least one field",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `[]`)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				ErrMissingMetadata,
 				ErrParsingMetadata,
 			},
 		},
 		{
-			name:  "Field response must have identifier",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Field response must have identifier",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `[{}]`)
 			})),
-			expectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{ErrParsingMetadata},
 		},
 		{
-			name:  "Field response must have display name",
-			input: []string{"butterflies"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Field response must have display name",
+			Input: []string{"butterflies"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `[{"id": "issuerestriction"}]`)
 			})),
-			expectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{ErrParsingMetadata},
 		},
 		{
-			name:  "Successfully describe Issue metadata",
-			input: []string{},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successfully describe Issue metadata",
+			Input: []string{},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseIssueSchema)
 			})),
-			comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
 				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
 			},
-			expected: &common.ListObjectMetadataResult{
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"issue": {
 						DisplayName: "Issue",
@@ -115,66 +107,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-				WithModule(ModuleJira),
-				WithMetadata(map[string]string{
-					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
-				}),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(tt.server.URL, output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/atlassian/write_test.go
+++ b/atlassian/write_test.go
@@ -5,16 +5,15 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -24,152 +23,95 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInvalidTypeError := testutils.DataFromFile(t, "create-issue-invalid-type.json")
 	createIssueResponse := testutils.DataFromFile(t, "create-issue.json")
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Error missing project during write",
-			input: common.WriteParams{RecordId: "10003"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error missing project during write",
+			Input: common.WriteParams{RecordId: "10003"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseInvalidProjectError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("project:Specify a valid project ID or key"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Error missing issue type during write",
-			input: common.WriteParams{RecordId: "10003"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error missing issue type during write",
+			Input: common.WriteParams{RecordId: "10003"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseInvalidTypeError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("issuetype:Specify an issue type"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{RecordId: "10003"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{RecordId: "10003"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PUT", func() {
 					w.WriteHeader(http.StatusNoContent)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of an Issue",
-			input: common.WriteParams{ObjectName: "accounts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of an Issue",
+			Input: common.WriteParams{ObjectName: "accounts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createIssueResponse)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "10004",
 				Errors:   nil,
 				Data:     nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-				WithModule(ModuleJira),
-				WithMetadata(map[string]string{
-					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
-				}),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			if err != nil {
-				t.Fatalf("%s: failed to setup auth metadata connector %v", tt.name, err)
-			}
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/gong/metadata_test.go
+++ b/gong/metadata_test.go
@@ -1,47 +1,36 @@
 package gong
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Unknown object requested",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{scrapper.ErrObjectNotFound},
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
 		},
 		{
-			name:   "Successfully describe one object with metadata",
-			input:  []string{"flows"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"flows"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"flows": {
 						DisplayName: "List Gong Engage flows (/v2/flows)",
@@ -57,13 +46,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:   "Successfully describe multiple objects with metadata",
-			input:  []string{"workspaces", "logs"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"workspaces", "logs"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"workspaces": {
 						DisplayName: "List all company workspaces (/v2/workspaces)",
@@ -90,53 +79,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
-					tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/intercom/delete_test.go
+++ b/intercom/delete_test.go
@@ -1,20 +1,18 @@
 package intercom
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
@@ -22,98 +20,60 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFound := testutils.DataFromFile(t, "resource-not-found.json")
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:         "Delete param object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Delete param object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Delete param object and its ID must be included",
-			input:        common.DeleteParams{ObjectName: "articles"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			Name:         "Delete param object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "articles"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write(responseNotFound)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("not_found[Resource Not Found]"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
 					mockutils.RespondNoContentForMethod(w, r, "DELETE")
 				})
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/intercom/metadata_test.go
+++ b/intercom/metadata_test.go
@@ -1,47 +1,36 @@
 package intercom
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Unknown object requested",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{scrapper.ErrObjectNotFound},
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
 		},
 		{
-			name:   "Successfully describe one object with metadata",
-			input:  []string{"help_centers"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"help_centers"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"help_centers": {
 						DisplayName: "Help Centers",
@@ -58,13 +47,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:   "Successfully describe multiple objects with metadata",
-			input:  []string{"data_events", "teams"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"data_events", "teams"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"data_events": {
 						DisplayName: "Data Events",
@@ -92,53 +81,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
-					tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/intercom/write_test.go
+++ b/intercom/write_test.go
@@ -1,20 +1,18 @@
 package intercom
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -25,93 +23,85 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	messageForInvalidSyntax := "There was a problem in the JSON you submitted [ddf8bfe97056e23f5d2b1ed92627ad07]: " +
 		"logged with error code"
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "signals"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "signals"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write(responseInvalidSyntax)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New(messageForInvalidSyntax), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "signals"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "signals"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PUT", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "API version header is passed as server request on POST",
-			input: common.WriteParams{ObjectName: "articles"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "API version header is passed as server request on POST",
+			Input: common.WriteParams{ObjectName: "articles"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createArticle)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return actual.Success == expected.Success
 			},
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of an article",
-			input: common.WriteParams{ObjectName: "articles"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of an article",
+			Input: common.WriteParams{ObjectName: "articles"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createArticle)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9333081",
 				Errors:   nil,
@@ -124,59 +114,19 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"url":          nil,
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/pipeliner/delete_test.go
+++ b/pipeliner/delete_test.go
@@ -1,20 +1,17 @@
 package pipeliner
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
@@ -22,35 +19,28 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseRemoveNote := testutils.DataFromFile(t, "delete-note.json")
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Write object and its ID must be included",
-			input:        common.DeleteParams{ObjectName: "quotes"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "quotes"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "DELETE", func() {
 					w.WriteHeader(http.StatusOK)
@@ -59,52 +49,20 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 					_, _ = w.Write(responseRemoveNote)
 				})
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/pipeliner/metadata_test.go
+++ b/pipeliner/metadata_test.go
@@ -1,47 +1,36 @@
 package pipeliner
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Unknown object requested",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{scrapper.ErrObjectNotFound},
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
 		},
 		{
-			name:   "Successfully describe one object with metadata",
-			input:  []string{"Notes"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"Notes"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Notes": {
 						DisplayName: "Notes",
@@ -73,13 +62,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:   "Successfully describe multiple objects with metadata",
-			input:  []string{"Phones", "Tags"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"Phones", "Tags"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Phones": {
 						DisplayName: "Phones",
@@ -120,54 +109,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
-					tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/pipeliner/write_test.go
+++ b/pipeliner/write_test.go
@@ -1,20 +1,18 @@
 package pipeliner
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -25,35 +23,27 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateNote := testutils.DataFromFile(t, "create-note.json")
 	responseUpdateNote := testutils.DataFromFile(t, "update-note.json")
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "notes"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "notes"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Error on failed entity validation",
-			input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error on failed entity validation",
+			Input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write(responseCreateFailedValidation)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New( // nolint:goerr113
 					"Non-null field 'Note'[01909781-5963-26bc-28ff-747e10a79a52].owner' is null or empty.",
@@ -61,56 +51,56 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			},
 		},
 		{
-			name:  "Error on invalid json body",
-			input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error on invalid json body",
+			Input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseCreateInvalidBody)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Missing or invalid JSON data."), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "notes"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "notes"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PATCH", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of a note",
-			input: common.WriteParams{ObjectName: "notes"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of a note",
+			Input: common.WriteParams{ObjectName: "notes"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(responseCreateNote)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",
 				Errors:   nil,
@@ -120,22 +110,22 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"note":       "important issue to resolve due 19th of July",
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid update of a note",
-			input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid update of a note",
+			Input: common.WriteParams{ObjectName: "notes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PATCH", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(responseUpdateNote)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",
 				Errors:   nil,
@@ -145,60 +135,19 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"note":       "Task due 19th of July",
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/salesforce/read_test.go
+++ b/salesforce/read_test.go
@@ -1,21 +1,19 @@
 package salesforce
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
@@ -25,66 +23,58 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseLeadsFirstPage := testutils.DataFromFile(t, "read-list-leads.json")
 	responseListContacts := testutils.DataFromFile(t, "read-list-contacts.json")
 
-	tests := []struct {
-		name         string
-		input        common.ReadParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(serverURL string, actual, expected *common.ReadResult) bool // custom comparison
-		expected     *common.ReadResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Read{
 		{
-			name:         "At least one field must be provided",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingFields},
+			Name:         "At least one field must be provided",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.ReadParams{Fields: []string{"Name"}},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.ReadParams{Fields: []string{"Name"}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.ReadParams{Fields: []string{"Name"}},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.ReadParams{Fields: []string{"Name"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseUnknownObject)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("sObject type 'Accout' is not supported"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Incorrect key in payload",
-			input: common.ReadParams{Fields: []string{"Name"}},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect key in payload",
+			Input: common.ReadParams{Fields: []string{"Name"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"garbage": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
-			name:  "Incorrect data type in payload",
-			input: common.ReadParams{Fields: []string{"Name"}},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect data type in payload",
+			Input: common.ReadParams{Fields: []string{"Name"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"records": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrNotArray},
+			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
-			name:  "Next page cursor may be missing in payload",
-			input: common.ReadParams{Fields: []string{"Name"}},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Next page cursor may be missing in payload",
+			Input: common.ReadParams{Fields: []string{"Name"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `
@@ -92,39 +82,39 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "records": []
 				}`)
 			})),
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{},
 				Done: true,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Next page URL is resolved, when provided with a string",
-			input: common.ReadParams{Fields: []string{"City"}},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Next page URL is resolved, when provided with a string",
+			Input: common.ReadParams{Fields: []string{"City"}},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseLeadsFirstPage)
 			})),
-			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.NextPage.String() == expected.NextPage.String()
 			},
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				NextPage: "/services/data/v59.0/query/01g3A00007lZwLKQA0-2000",
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name: "Successful read with chosen fields",
-			input: common.ReadParams{
+			Name: "Successful read with chosen fields",
+			Input: common.ReadParams{
 				Fields: []string{"Department", "AssistantName"},
 			},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseListContacts)
 			})),
-			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				// custom comparison focuses on subset of fields to keep the test short
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
@@ -132,7 +122,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					actual.Done == expected.Done &&
 					actual.Rows == expected.Rows
 			},
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Rows: 20,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
@@ -149,64 +139,34 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage: "",
 				Done:     true,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Read(ctx, tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(tt.server.URL, output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithWorkspace("test-workspace"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
 }

--- a/salesforce/write_test.go
+++ b/salesforce/write_test.go
@@ -1,21 +1,19 @@
 package salesforce
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -26,56 +24,48 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateOK := testutils.DataFromFile(t, "create-ok.json")
 	responseOKWithErrors := testutils.DataFromFile(t, "success-with-errors.json")
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "account"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "account"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Error response understood for creating with unknown field",
-			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error response understood for creating with unknown field",
+			Input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseUnknownField)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("No such column 'AccountNumer' on sobject of type Account"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Error response understood for updating reserved field",
-			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Error response understood for updating reserved field",
+			Input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseInvalidFieldUpsert)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Unable to create/update fields: MasterRecordId"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "account"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "account"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					// cannot be update path
@@ -84,13 +74,13 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					})
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					mockutils.RespondToQueryParameters(w, r, url.Values{
@@ -100,38 +90,38 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					})
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of account",
-			input: common.WriteParams{ObjectName: "accounts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of account",
+			Input: common.WriteParams{ObjectName: "accounts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(responseCreateOK)
 				})
 			})),
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "001ak00000OQTieAAH",
 				Errors:   []any{},
 				Data:     nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "OK Response, but with errors field",
-			input: common.WriteParams{ObjectName: "accounts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "OK Response, but with errors field",
+			Input: common.WriteParams{ObjectName: "accounts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(responseOKWithErrors)
 				})
 			})),
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  false,
 				RecordId: "001RM000003oLruYAE",
 				Errors: []any{map[string]any{
@@ -141,60 +131,19 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				}},
 				Data: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/salesloft/delete_test.go
+++ b/salesloft/delete_test.go
@@ -1,20 +1,18 @@
 package salesloft
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
@@ -22,96 +20,58 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	listSchema := testutils.DataFromFile(t, "write-signals-error.json")
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:         "Delete param object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Delete param object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Delete param object and its ID must be included",
-			input:        common.DeleteParams{ObjectName: "signals"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			Name:         "Delete param object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "signals"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write(listSchema)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("no Signal Registration found for integration id 5167 and given type"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "DELETE")
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/salesloft/metadata_test.go
+++ b/salesloft/metadata_test.go
@@ -1,47 +1,36 @@
 package salesloft
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Unknown object requested",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{scrapper.ErrObjectNotFound},
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
 		},
 		{
-			name:   "Successfully describe one object with metadata",
-			input:  []string{"bulk_jobs_results"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"bulk_jobs_results"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"bulk_jobs_results": {
 						DisplayName: "List job data for a completed bulk job.",
@@ -56,13 +45,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:   "Successfully describe multiple objects with metadata",
-			input:  []string{"account_tiers", "actions"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"account_tiers", "actions"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"account_tiers": {
 						DisplayName: "List Account Tiers",
@@ -96,53 +85,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
-					tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/salesloft/write_test.go
+++ b/salesloft/write_test.go
@@ -1,20 +1,18 @@
 package salesloft
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -24,77 +22,69 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	createAccountRes := testutils.DataFromFile(t, "write-create-account.json")
 	createTaskRes := testutils.DataFromFile(t, "write-create-task.json")
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "signals"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "signals"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write(listSchema)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("no Signal Registration found for integration id 5167 and given type"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "signals"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "signals"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PUT", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of account",
-			input: common.WriteParams{ObjectName: "accounts"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of account",
+			Input: common.WriteParams{ObjectName: "accounts"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createAccountRes)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1",
 				Errors:   nil,
@@ -106,22 +96,22 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"counts":      map[string]any{"people": 15.0},
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of a task",
-			input: common.WriteParams{ObjectName: "tasks"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of a task",
+			Input: common.WriteParams{ObjectName: "tasks"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createTaskRes)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "175204275",
 				Errors:   nil,
@@ -131,12 +121,12 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"task_type":     "call",
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid update of Saved List View",
-			input: common.WriteParams{ObjectName: "saved_list_views", RecordId: "22463"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid update of Saved List View",
+			Input: common.WriteParams{ObjectName: "saved_list_views", RecordId: "22463"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PUT", func() {
 					w.WriteHeader(http.StatusOK)
@@ -144,10 +134,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 							"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "22463",
 				Errors:   nil,
@@ -157,59 +147,19 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"view": "companies",
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/zendesksupport/delete_test.go
+++ b/zendesksupport/delete_test.go
@@ -1,20 +1,18 @@
 package zendesksupport
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
@@ -22,97 +20,58 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseServerError := testutils.DataFromFile(t, "server-error.json")
 
-	tests := []struct {
-		name         string
-		input        common.DeleteParams
-		server       *httptest.Server
-		connector    Connector
-		expected     *common.DeleteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Delete{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Write object and its ID must be included",
-			input:        common.DeleteParams{ObjectName: "brands"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingRecordID},
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "brands"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Internal server error in response",
-			input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Internal server error in response",
+			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write(responseServerError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrServer,
 				errors.New("Internal Server Error"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Successful delete",
-			input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Successful delete",
+			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondNoContentForMethod(w, r, "DELETE")
 			})),
-			expected:     &common.DeleteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Delete(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/zendesksupport/metadata_test.go
+++ b/zendesksupport/metadata_test.go
@@ -2,46 +2,37 @@ package zendesksupport
 
 import (
 	"context"
-	"errors"
 	"net/http"
-	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/go-test/deep"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		input        []string
-		server       *httptest.Server
-		expected     *common.ListObjectMetadataResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Metadata{
 		{
-			name:         "At least one object name must be queried",
-			input:        nil,
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Unknown object requested",
-			input:        []string{"butterflies"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{scrapper.ErrObjectNotFound},
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
 		},
 		{
-			name:   "Successfully describe one object with metadata",
-			input:  []string{"brands"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"brands"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"brands": {
 						DisplayName: "Brands",
@@ -67,13 +58,13 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:   "Successfully describe multiple objects with metadata",
-			input:  []string{"bookmarks", "ticket_audits"},
-			server: mockserver.Dummy(),
-			expected: &common.ListObjectMetadataResult{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"bookmarks", "ticket_audits"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"bookmarks": {
 						DisplayName: "Bookmarks",
@@ -99,54 +90,19 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Errors: nil,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.ListObjectMetadata(context.Background(), tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			if !reflect.DeepEqual(output, tt.expected) {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)",
-					tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }

--- a/zendesksupport/read_test.go
+++ b/zendesksupport/read_test.go
@@ -1,21 +1,19 @@
 package zendesksupport
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
@@ -27,124 +25,116 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseUsersEmptyPage := testutils.DataFromFile(t, "read-users-2-empty-page.json")
 	responseReadTickets := testutils.DataFromFile(t, "read-list-tickets.json")
 
-	tests := []struct {
-		name         string
-		input        common.ReadParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(serverURL string, actual, expected *common.ReadResult) bool // custom comparison
-		expected     *common.ReadResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Read{
 		{
-			name:         "Read object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.ReadParams{ObjectName: "triggers"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.ReadParams{ObjectName: "triggers"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Correct error message is understood from JSON response",
-			input: common.ReadParams{ObjectName: "triggers"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.ReadParams{ObjectName: "triggers"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write(responseErrorFormat)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("[InvalidEndpoint]Not found"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Forbidden error code and response",
-			input: common.ReadParams{ObjectName: "triggers"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Forbidden error code and response",
+			Input: common.ReadParams{ObjectName: "triggers"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusForbidden)
 				_, _ = w.Write(responseForbiddenError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrForbidden, errors.New("[Forbidden]You do not have access to this page"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Incorrect key in payload",
-			input: common.ReadParams{ObjectName: "triggers"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect key in payload",
+			Input: common.ReadParams{ObjectName: "triggers"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"garbage": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrKeyNotFound},
+			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
-			name:  "Incorrect data type in payload",
-			input: common.ReadParams{ObjectName: "triggers"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Incorrect data type in payload",
+			Input: common.ReadParams{ObjectName: "triggers"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, `{
 					"triggers": {}
 				}`)
 			})),
-			expectedErrs: []error{jsonquery.ErrNotArray},
+			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
-			name:  "Next page cursor may be missing in payload",
-			input: common.ReadParams{ObjectName: "users"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Next page cursor may be missing in payload",
+			Input: common.ReadParams{ObjectName: "users"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseUsersEmptyPage)
 			})),
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{},
 				Done: true,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Next page URL is resolved, when provided with a string",
-			input: common.ReadParams{ObjectName: "users"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Next page URL is resolved, when provided with a string",
+			Input: common.ReadParams{ObjectName: "users"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseUsersFirstPage)
 			})),
-			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.NextPage.String() == expected.NextPage.String()
 			},
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				NextPage: "https://d3v-ampersand.zendesk.com/api/v2/users" +
 					"?page%5Bafter%5D=eyJvIjoiaWQiLCJ2IjoiYVJOc1cwVDZGd0FBIn0%3D&page%5Bsize%5D=3",
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 		{
-			name: "Successful read with chosen fields",
-			input: common.ReadParams{
+			Name: "Successful read with chosen fields",
+			Input: common.ReadParams{
 				ObjectName: "tickets",
 				Fields:     []string{"type", "subject", "status"},
 			},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(responseReadTickets)
 			})),
-			comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				// custom comparison focuses on subset of fields to keep the test short
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
 					actual.NextPage.String() == expected.NextPage.String() &&
 					actual.Done == expected.Done
 			},
-			expected: &common.ReadResult{
+			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"type":    "incident",
@@ -162,64 +152,34 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"?page%5Bafter%5D=eyJvIjoibmljZV9pZCIsInYiOiJhUUVBQUFBQUFBQUEifQ%3D%3D&page%5Bsize%5D=1",
 				Done: false,
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our mock server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Read(ctx, tt.input)
-			if err != nil {
-				if len(tt.expectedErrs) == 0 {
-					t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-				}
-			} else {
-				// check that missing error is what is expected
-				if len(tt.expectedErrs) != 0 {
-					t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-				}
-			}
-
-			// check every error
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(tt.server.URL, output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithWorkspace("test-workspace"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
 }

--- a/zendesksupport/write_test.go
+++ b/zendesksupport/write_test.go
@@ -1,20 +1,18 @@
 package zendesksupport
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"github.com/go-test/deep"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
@@ -28,62 +26,54 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseRecordValidationError := testutils.DataFromFile(t, "record-validation.json")
 	createBrand := testutils.DataFromFile(t, "create-brand.json")
 
-	tests := []struct {
-		name         string
-		input        common.WriteParams
-		server       *httptest.Server
-		connector    Connector
-		comparator   func(actual, expected *common.WriteResult) bool // custom comparison
-		expected     *common.WriteResult
-		expectedErrs []error
-	}{
+	tests := []testroutines.Write{
 		{
-			name:         "Write object must be included",
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{common.ErrMissingObjects},
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			name:         "Mime response header expected",
-			input:        common.WriteParams{ObjectName: "signals"},
-			server:       mockserver.Dummy(),
-			expectedErrs: []error{interpreter.ErrMissingContentType},
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "signals"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			name:  "Missing write parameter",
-			input: common.WriteParams{ObjectName: "brands"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Missing write parameter",
+			Input: common.WriteParams{ObjectName: "brands"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseMissingParameterError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Parameter brands is required"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Record validation with single detail",
-			input: common.WriteParams{ObjectName: "brands"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Record validation with single detail",
+			Input: common.WriteParams{ObjectName: "brands"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseDuplicateError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("[RecordInvalid]Record validation errors"),               // nolint:goerr113
 				errors.New("[DuplicateValue]Subdomain: nk2 has already been taken"), // nolint:goerr113
 			},
 		},
 		{
-			name:  "Record validation with multiple details is split into dedicated errors",
-			input: common.WriteParams{ObjectName: "brands"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Record validation with multiple details is split into dedicated errors",
+			Input: common.WriteParams{ObjectName: "brands"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(responseRecordValidationError)
 			})),
-			expectedErrs: []error{
+			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("[RecordInvalid]Record validation errors"),        // nolint:goerr113
 				errors.New("[InvalidValue]Subdomain: is invalid"),            // nolint:goerr113
@@ -92,43 +82,43 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			},
 		},
 		{
-			name:  "Write must act as a Create",
-			input: common.WriteParams{ObjectName: "brands"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as a Create",
+			Input: common.WriteParams{ObjectName: "brands"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Write must act as an Update",
-			input: common.WriteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Write must act as an Update",
+			Input: common.WriteParams{ObjectName: "brands", RecordId: "31207417638931"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "PUT", func() {
 					w.WriteHeader(http.StatusOK)
 				})
 			})),
-			expected:     &common.WriteResult{Success: true},
-			expectedErrs: nil,
+			Expected:     &common.WriteResult{Success: true},
+			ExpectedErrs: nil,
 		},
 		{
-			name:  "Valid creation of a brand",
-			input: common.WriteParams{ObjectName: "brands"},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Name:  "Valid creation of a brand",
+			Input: common.WriteParams{ObjectName: "brands"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToMethod(w, r, "POST", func() {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write(createBrand)
 				})
 			})),
-			comparator: func(actual, expected *common.WriteResult) bool {
+			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
-			expected: &common.WriteResult{
+			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "31207417638931",
 				Errors:   nil,
@@ -141,60 +131,19 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					"default":   false,
 				},
 			},
-			expectedErrs: nil,
+			ExpectedErrs: nil,
 		},
 	}
 
-	for _, tt := range tests { // nolint:dupl
+	for _, tt := range tests {
 		// nolint:varnamelen
 		tt := tt // rebind, omit loop side effects for parallel goroutine
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			defer tt.server.Close()
-
-			ctx := context.Background()
-
-			connector, err := NewConnector(
-				WithAuthenticatedClient(http.DefaultClient),
-				WithWorkspace("test-workspace"),
-			)
-			if err != nil {
-				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)
-			}
-
-			// for testing we want to redirect calls to our server
-			connector.setBaseURL(tt.server.URL)
-
-			// start of tests
-			output, err := connector.Write(ctx, tt.input)
-			if len(tt.expectedErrs) == 0 && err != nil {
-				t.Fatalf("%s: expected no errors, got: (%v)", tt.name, err)
-			}
-
-			if len(tt.expectedErrs) != 0 && err == nil {
-				t.Fatalf("%s: expected errors (%v), but got nothing", tt.name, tt.expectedErrs)
-			}
-
-			for _, expectedErr := range tt.expectedErrs {
-				if !errors.Is(err, expectedErr) && !strings.Contains(err.Error(), expectedErr.Error()) {
-					t.Fatalf("%s: expected Error: (%v), got: (%v)", tt.name, expectedErr, err)
-				}
-			}
-
-			// compare desired output
-			var ok bool
-			if tt.comparator == nil {
-				// default comparison is concerned about all fields
-				ok = reflect.DeepEqual(output, tt.expected)
-			} else {
-				ok = tt.comparator(output, tt.expected)
-			}
-
-			if !ok {
-				diff := deep.Equal(output, tt.expected)
-				t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", tt.name, tt.expected, output, diff)
-			}
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
 		})
 	}
 }


### PR DESCRIPTION
@eberle1080 This is a follow up PR to https://github.com/amp-labs/connectors/pull/834

Every connector becomes shorter and consistent in testing Read/Write/ListObjectMetadata/Delete.

# Reviewing

Commits are split by connector.
Every test does rename and then points to `tesroutine.<METHOD_NAME>` struct. Then test execution is just a matter of calling one method on this struct.
