### PR TITLE
feat: Add Zendesk Sunshine Conversations connector

### DIFF
--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -1,8 +1,9 @@
 package providers
 
 const (
-	ZendeskChat    Provider = "zendeskChat"
-	ZendeskSupport Provider = "zendeskSupport"
+	ZendeskChat     Provider = "zendeskChat"
+	ZendeskSupport  Provider = "zendeskSupport"
+	ZendeskSunshine Provider = "zendeskSunshineConversations"
 )
 
 func init() { // nolint:funlen
@@ -60,6 +61,34 @@ func init() { // nolint:funlen
 			},
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+
+	SetInfo(ZendeskSunshine, ProviderInfo{
+		DisplayName: "Zendesk Sunshine Conversations",
+		AuthType:    Basic,
+		BaseURL:     "https://{{.workspace}}.zendesk.com/sc",
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723143621/media/zendeskSunshineConversations_1723143620.png", // nolint:lll
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102329/media/zendeskSupport_1722102328.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723143621/media/zendeskSunshineConversations_1723143620.png", // nolint:lll
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722102362/media/zendeskSupport_1722102361.svg",
 			},
 		},


### PR DESCRIPTION
Closes #882 

# BLOCKED

Requires Workspace the same as Zendesk Support, but since this is non-oauth2 connector this is not yet supported.

Reference: https://docs.smooch.io/rest/#section/Introduction

# Configuration
URL would need AppId that can be found in Zendesk dashboard alongside username/password (API_KEY_ID, API_KEY_SECRET).

## Testing
### GET
URL: <http://localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

### POST
URL: <http://localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>

## Pagination
Please add screenshots that show successful pagination using the connector.

# Logo & Icons
Logos are copied over from other Zendesk connectors for dark and regular types respectively. Icon is sunset from below. The tool doesn't provide `Sunshine Conversations` text as part of image say in docs.
![image](https://github.com/user-attachments/assets/4ed5b2f8-ba31-465b-a6d8-af11a870d1d5)
![image](https://github.com/user-attachments/assets/9c63b459-f15f-43a7-8d13-c4e83431b726)

