### PR TITLE
feat: Handle empty HTTP response

### DIFF
--- a/common/json_test.go
+++ b/common/json_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestUnmarshalJSON(t *testing.T) { // nolint:funlen
+	t.Parallel()
+
+	type Story struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+	}
+
+	tests := []struct {
+		name        string
+		input       []byte
+		expected    *Story
+		expectedErr error
+	}{
+		{
+			name:  "Nil body produces empty struct",
+			input: nil,
+			expected: &Story{
+				Title:       "",
+				Description: "",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "Empty body produces empty struct",
+			input: []byte(""),
+			expected: &Story{
+				Title:       "",
+				Description: "",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid JSON produces marshal error",
+			input:       []byte("2359"),
+			expected:    nil,
+			expectedErr: ErrFailedToUnmarshalBody,
+		},
+		{
+			name:  "Valid JSON values are mapped to struct fields",
+			input: []byte(`{"title": "Amazing", "description": "very long story"}`),
+			expected: &Story{
+				Title:       "Amazing",
+				Description: "very long story",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := UnmarshalJSON[Story](&JSONHTTPResponse{
+				bodyBytes: tt.input,
+			})
+			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
+		})
+	}
+}

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/spyzhov/ajson"
 )
 
@@ -123,7 +124,7 @@ func TestQueryInteger(t *testing.T) { // nolint:funlen
 			t.Parallel()
 
 			output, err := New(j, tt.input.zoom...).Integer(tt.input.key, tt.input.optional)
-			assertJSONManagerOutput(t, tt.name, tt.expected, tt.expectedErr, output, err)
+			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}
 }
@@ -218,7 +219,7 @@ func TestQueryString(t *testing.T) { // nolint:funlen
 			t.Parallel()
 
 			output, err := New(j, tt.input.zoom...).Str(tt.input.key, tt.input.optional)
-			assertJSONManagerOutput(t, tt.name, tt.expected, tt.expectedErr, output, err)
+			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}
 }
@@ -313,7 +314,7 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 			t.Parallel()
 
 			output, err := New(j, tt.input.zoom...).Bool(tt.input.key, tt.input.optional)
-			assertJSONManagerOutput(t, tt.name, tt.expected, tt.expectedErr, output, err)
+			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}
 }
@@ -518,19 +519,4 @@ func helperCreateJSON(t *testing.T, text string) *ajson.Node {
 	}
 
 	return jsonBody
-}
-
-func assertJSONManagerOutput(t *testing.T, name string, expected any, expectedErr error,
-	output any, err error,
-) {
-	t.Helper()
-
-	// check for actual error value
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("%s: expected: (%v), got: (%v)", name, expectedErr, err)
-	}
-
-	if !reflect.DeepEqual(output, expected) {
-		t.Fatalf("%s: expected: (%v), got: (%v)", name, expected, output)
-	}
 }

--- a/common/parse.go
+++ b/common/parse.go
@@ -25,16 +25,17 @@ func ParseResult(
 	marshalFunc func([]map[string]any, []string) ([]ReadResultRow, error),
 	fields []string,
 ) (*ReadResult, error) {
-	if resp == nil {
+	body, ok := resp.Body()
+	if !ok {
 		return nil, ErrEmptyJSONHTTPResponse
 	}
 
-	records, err := recordsFunc(resp.Body)
+	records, err := recordsFunc(body)
 	if err != nil {
 		return nil, err
 	}
 
-	nextPage, err := nextPageFunc(resp.Body)
+	nextPage, err := nextPageFunc(body)
 	if err != nil {
 		return nil, err
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -86,14 +86,14 @@ var (
 	// ErrEmptyJSONHTTPResponse is returned when the JSONHTTPResponse is nil.
 	ErrEmptyJSONHTTPResponse = errors.New("empty json http response")
 
-	// ErrEmptyResponse is returned when the response body is empty.
-	ErrEmptyResponse = errors.New("empty response body")
-
 	// ErrRecordDataNotJSON is returned when the record data in WriteParams is not JSON.
 	ErrRecordDataNotJSON = errors.New("record data is not JSON")
 
-	// ErrObjectNotSupported is returned when operation is not supported for this object.
+	// ErrOperationNotSupportedForObject is returned when operation is not supported for this object.
 	ErrOperationNotSupportedForObject = errors.New("operation is not supported for this object")
+
+	// ErrFailedToUnmarshalBody is returned when response body cannot be marshalled into some type.
+	ErrFailedToUnmarshalBody = errors.New("failed to unmarshal response body")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/examples/auth_connectors/adobe/adobe.go
+++ b/examples/auth_connectors/adobe/adobe.go
@@ -41,8 +41,13 @@ func adobeAuthExample(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", response.Code)
 	}
 
+	body, ok := response.Body()
+	if !ok {
+		return fmt.Errorf("empty response: %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
 	// The response body is already parsed (as JSON). You can access it like this:
-	nodes, err := response.Body.JSONPath("$.*.name")
+	nodes, err := body.JSONPath("$.*.name")
 	if err != nil {
 		return err
 	}

--- a/examples/auth_connectors/anthropic/anthropic.go
+++ b/examples/auth_connectors/anthropic/anthropic.go
@@ -50,8 +50,13 @@ func anthropicAuthExample(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", response.Code)
 	}
 
+	body, ok := response.Body()
+	if !ok {
+		return fmt.Errorf("cannot get messages: %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
 	// The response body is already parsed (as JSON). You can access it like this:
-	nodes, err := response.Body.JSONPath("$.model")
+	nodes, err := body.JSONPath("$.model")
 	if err != nil {
 		return err
 	}

--- a/examples/auth_connectors/blueshift/blueshift.go
+++ b/examples/auth_connectors/blueshift/blueshift.go
@@ -37,8 +37,13 @@ func blueshiftAuthExample(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", response.Code)
 	}
 
+	body, ok := response.Body()
+	if !ok {
+		return fmt.Errorf("cannot get campaigns %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
 	// The response body is already parsed (as JSON). You can access it like this:
-	nodes, err := response.Body.JSONPath("$.campaigns[0].name")
+	nodes, err := body.JSONPath("$.campaigns[0].name")
 	if err != nil {
 		return err
 	}

--- a/examples/auth_connectors/salesforce/salesforce.go
+++ b/examples/auth_connectors/salesforce/salesforce.go
@@ -53,8 +53,13 @@ func salesforceAuthExample(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", response.Code)
 	}
 
+	body, ok := response.Body()
+	if !ok {
+		return fmt.Errorf("cannot get limits %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
 	// The response body is already parsed (as JSON). You can access it like this:
-	nodes, err := response.Body.JSONPath("$.MassEmail.Max")
+	nodes, err := body.JSONPath("$.MassEmail.Max")
 	if err != nil {
 		return err
 	}

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -32,7 +32,14 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	return constructWriteResult(json.Body, config.ObjectName)
+	body, ok := json.Body()
+	if !ok {
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	return constructWriteResult(body, config.ObjectName)
 }
 
 func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult, error) {

--- a/providers/atlassian/authmetadata.go
+++ b/providers/atlassian/authmetadata.go
@@ -64,11 +64,12 @@ func (c *Connector) retrieveCloudId(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	if res.Body == nil {
-		return "", common.ErrEmptyJSONHTTPResponse
+	body, ok := res.Body()
+	if !ok {
+		return "", errors.Join(ErrContainerNotFound, common.ErrEmptyJSONHTTPResponse)
 	}
 
-	arr, err := res.Body.GetArray()
+	arr, err := body.GetArray()
 	if err != nil {
 		return "", err
 	}

--- a/providers/atlassian/metadata.go
+++ b/providers/atlassian/metadata.go
@@ -22,7 +22,12 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, _ []string) (*common
 		return nil, err
 	}
 
-	fields, err := c.parseFieldsJiraIssue(rsp.Body)
+	body, ok := rsp.Body()
+	if !ok {
+		return nil, errors.Join(ErrMissingMetadata, common.ErrEmptyJSONHTTPResponse)
+	}
+
+	fields, err := c.parseFieldsJiraIssue(body)
 	if err != nil {
 		return nil, errors.Join(ErrParsingMetadata, err)
 	}

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -36,7 +36,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				w.WriteHeader(http.StatusOK)
 				mockutils.WriteBody(w, ``)
 			})),
-			ExpectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{common.ErrEmptyJSONHTTPResponse},
 		},
 		{
 			Name:  "Server response must have at least one field",

--- a/providers/atlassian/write.go
+++ b/providers/atlassian/write.go
@@ -36,14 +36,15 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		return &common.WriteResult{
 			Success: true,
 		}, nil
 	}
 
 	// Write response has a reference to the resource but no payload data.
-	return constructWriteResult(res.Body)
+	return constructWriteResult(body)
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {

--- a/providers/docusign/metadata.go
+++ b/providers/docusign/metadata.go
@@ -22,10 +22,15 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 		return nil, err
 	}
 
+	body, ok := resp.Body()
+	if !ok {
+		return nil, errors.Join(ErrNoAccounts, common.ErrEmptyJSONHTTPResponse)
+	}
+
 	var postAuthInfo common.PostAuthInfo
 	postAuthInfo.RawResponse = resp
 
-	accounts, err := resp.Body.GetKey("accounts")
+	accounts, err := body.GetKey("accounts")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -41,7 +41,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte{})
+				_, _ = w.Write(responseContactsSchema)
 			})),
 			ExpectedErrs: []error{ErrObjectNotFound},
 		},

--- a/providers/dynamicscrm/read.go
+++ b/providers/dynamicscrm/read.go
@@ -2,6 +2,7 @@ package dynamicscrm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -75,9 +76,10 @@ func (c *Connector) performGetRequest(ctx context.Context, url *urlbuilder.URL) 
 		return nil, err
 	}
 
-	if rsp.Body == nil {
-		return nil, ErrObjectNotFound
+	body, ok := rsp.Body()
+	if !ok {
+		return nil, errors.Join(ErrObjectNotFound, common.ErrEmptyJSONHTTPResponse)
 	}
 
-	return rsp.Body, nil
+	return body, nil
 }

--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -93,7 +93,12 @@ func (c *Connector) describeObject(ctx context.Context, objectName string) (*com
 		return nil, fmt.Errorf("error fetching HubSpot fields: %w", err)
 	}
 
-	rawResponse, err := ajson.Marshal(rsp.Body)
+	body, ok := rsp.Body()
+	if !ok {
+		return nil, fmt.Errorf("cannot get HubSpot fields %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
+	rawResponse, err := ajson.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling object metadata response into byte array: %w", err)
 	}

--- a/providers/instantly/write.go
+++ b/providers/instantly/write.go
@@ -35,9 +35,11 @@ func (c *Connector) Write(
 	var write common.WriteMethod
 	if len(config.RecordId) == 0 {
 		write = c.Client.Post
+
 		constructURLPathCreate(config, url) // nolint:wsl
 	} else {
 		write = c.Client.Patch
+
 		constructURLPathUpdate(config, url)
 	}
 
@@ -46,7 +48,8 @@ func (c *Connector) Write(
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
@@ -56,7 +59,7 @@ func (c *Connector) Write(
 	recordIdNodePath := recordIdPaths[config.ObjectName]
 
 	// write response was with payload
-	return constructWriteResult(res.Body, recordIdNodePath)
+	return constructWriteResult(body, recordIdNodePath)
 }
 
 var recordIdPaths = map[string]*string{ // nolint:gochecknoglobals

--- a/providers/intercom/write.go
+++ b/providers/intercom/write.go
@@ -35,7 +35,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
@@ -43,7 +44,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	// write response was with payload
-	return constructWriteResult(res.Body)
+	return constructWriteResult(body)
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {

--- a/providers/outreach/write.go
+++ b/providers/outreach/write.go
@@ -2,7 +2,6 @@ package outreach
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -55,9 +54,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	var response WriteResponse
-
-	err = json.Unmarshal(res.Body.Source(), &response)
+	response, err := common.UnmarshalJSON[WriteResponse](res)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/pipeliner/write.go
+++ b/providers/pipeliner/write.go
@@ -35,15 +35,15 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
-		// it is unlikely to have no payload
+	body, ok := res.Body()
+	if !ok {
 		return &common.WriteResult{
 			Success: true,
 		}, nil
 	}
 
 	// write response was with payload
-	return constructWriteResult(res.Body)
+	return constructWriteResult(body)
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {

--- a/providers/salesforce/bulk.go
+++ b/providers/salesforce/bulk.go
@@ -314,7 +314,12 @@ func (c *Connector) bulkOperation(
 		return nil, fmt.Errorf("createJob failed: %w", err)
 	}
 
-	resObject, err := res.Body.GetObject()
+	body, ok := res.Body() // nolint:varnamelen
+	if !ok {
+		return nil, fmt.Errorf("createJob failed: %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
+	resObject, err := body.GetObject()
 	if err != nil {
 		return nil, fmt.Errorf(
 			"parsing result of createJob failed: %w",
@@ -358,7 +363,12 @@ func (c *Connector) bulkOperation(
 		return nil, fmt.Errorf("completeUpload failed: %w", err)
 	}
 
-	dataObject, err := data.Body.GetObject()
+	body, ok = data.Body()
+	if !ok {
+		return nil, fmt.Errorf("completeUpload failed: %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
+	dataObject, err := body.GetObject()
 	if err != nil {
 		return nil, fmt.Errorf("parsing result of completeUpload failed: %w", errors.Join(err, common.ErrParseError))
 	}

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -221,7 +221,12 @@ func (c *Connector) getOrganization(ctx context.Context) (map[string]*ajson.Node
 		return nil, err
 	}
 
-	return resp.Body.GetObject()
+	body, ok := resp.Body()
+	if !ok {
+		return nil, fmt.Errorf("cannot get organization %w", common.ErrEmptyJSONHTTPResponse)
+	}
+
+	return body.GetObject()
 }
 
 func (c *Connector) GetOrganizationId(ctx context.Context) (string, error) {
@@ -266,6 +271,10 @@ func (c *Connector) postToSFAPI(ctx context.Context, body any, path string, enti
 	}
 
 	res, err := common.UnmarshalJSON[SFAPIResponseBody](resp)
+	if err != nil {
+		return nil, err
+	}
+
 	if res.Warnings != nil && len(res.Warnings) > 0 {
 		slog.Warn(entity, "warnings", res.Warnings)
 	}

--- a/providers/salesforce/write.go
+++ b/providers/salesforce/write.go
@@ -35,24 +35,24 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 
 // parseWriteResult parses the response from writing to Salesforce API. A 2xx return type is assumed.
 func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error) {
-	// in case we got a 204 and empty array => unmarshal into nil ajson node
-	if rsp == nil || rsp.Body == nil {
+	body, ok := rsp.Body()
+	if !ok {
 		return &common.WriteResult{
 			Success: true,
 		}, nil
 	}
 
-	recordID, err := jsonquery.New(rsp.Body).Str("id", false)
+	recordID, err := jsonquery.New(body).Str("id", false)
 	if err != nil {
 		return nil, err
 	}
 
-	errors, err := getErrors(rsp.Body)
+	errors, err := getErrors(body)
 	if err != nil {
 		return nil, err
 	}
 
-	success, err := jsonquery.New(rsp.Body).Bool("success", false)
+	success, err := jsonquery.New(body).Bool("success", false)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -63,21 +63,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			},
 		},
 		{
-			Name:  "Write must act as a Create",
-			Input: common.WriteParams{ObjectName: "account"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					// cannot be update path
-					mockutils.RespondToMissingQueryParameters(w, r, []string{"_HttpMethod"}, func() {
-						w.WriteHeader(http.StatusOK)
-					})
-				})
-			})),
-			Expected:     &common.WriteResult{Success: true},
-			ExpectedErrs: nil,
-		},
-		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2"},
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -87,10 +72,16 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 						"_HttpMethod": []string{"PATCH"},
 					}, func() {
 						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(responseCreateOK)
 					})
 				})
 			})),
-			Expected:     &common.WriteResult{Success: true},
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "001ak00000OQTieAAH",
+				Errors:   []any{},
+				Data:     nil,
+			},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/salesloft/write.go
+++ b/providers/salesloft/write.go
@@ -36,7 +36,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
@@ -44,7 +45,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	// write response was with payload
-	return constructWriteResult(res.Body)
+	return constructWriteResult(body)
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {

--- a/providers/smartlead/write.go
+++ b/providers/smartlead/write.go
@@ -42,7 +42,8 @@ func (c *Connector) Write(
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
@@ -52,7 +53,7 @@ func (c *Connector) Write(
 	recordIdNodePath := recordIdPaths[config.ObjectName]
 
 	// write response was with payload
-	return constructWriteResult(res.Body, recordIdNodePath)
+	return constructWriteResult(body, recordIdNodePath)
 }
 
 var recordIdPaths = map[string]string{ // nolint:gochecknoglobals

--- a/providers/zendesksupport/write.go
+++ b/providers/zendesksupport/write.go
@@ -37,7 +37,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if res == nil || res.Body == nil {
+	body, ok := res.Body()
+	if !ok {
 		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
@@ -45,7 +46,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	// write response was with payload
-	return constructWriteResult(config, res.Body)
+	return constructWriteResult(config, body)
 }
 
 func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.WriteResult, error) {

--- a/test/apollo/metadata/metadata.go
+++ b/test/apollo/metadata/metadata.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-
 	ctx := context.Background()
 
 	conn := apollo.GetApolloConnector(ctx, "apollo-creds.json")

--- a/test/apollo/read/read.go
+++ b/test/apollo/read/read.go
@@ -41,7 +41,6 @@ func MainFn() int {
 }
 
 func testReadOpportunitiesSearch(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "opportunities",
 		Fields:     []string{"id"},
@@ -65,7 +64,6 @@ func testReadOpportunitiesSearch(ctx context.Context, conn *ap.Connector) error 
 }
 
 func testReadEmailAccounts(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "email_accounts",
 		Fields:     []string{"user_id", "id", "email"},
@@ -90,7 +88,6 @@ func testReadEmailAccounts(ctx context.Context, conn *ap.Connector) error {
 }
 
 func testReadCustomFields(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "typed_custom_fields",
 		Fields:     []string{"type", "id", "modality"},

--- a/test/apollo/search/search.go
+++ b/test/apollo/search/search.go
@@ -40,7 +40,6 @@ func MainFn() int {
 }
 
 func testReadContactsSearch(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "contacts",
 		Fields:     []string{"id"},
@@ -65,7 +64,6 @@ func testReadContactsSearch(ctx context.Context, conn *ap.Connector) error {
 }
 
 func testReadOpportunitiesSearch(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "opportunities",
 		Fields:     []string{"id"},
@@ -89,7 +87,6 @@ func testReadOpportunitiesSearch(ctx context.Context, conn *ap.Connector) error 
 }
 
 func testReadPeopleSearch(ctx context.Context, conn *ap.Connector) error {
-
 	params := common.ReadParams{
 		ObjectName: "mixed_people",
 		Fields:     []string{"id"},

--- a/test/utils/testutils/checks.go
+++ b/test/utils/testutils/checks.go
@@ -1,0 +1,23 @@
+package testutils
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func CheckOutputWithError(t *testing.T, name string,
+	expected any, expectedErr error,
+	actual any, actualErr error,
+) {
+	t.Helper()
+
+	// check for actual error value
+	if !errors.Is(actualErr, expectedErr) {
+		t.Fatalf("%s: expected: (%v), got: (%v)", name, expectedErr, actualErr)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("%s: expected: (%v), got: (%v)", name, expected, actual)
+	}
+}


### PR DESCRIPTION
# Problem
Any API call may return empty response. We are not explicit about it. And caller may forget to do nil check.

# Changes
I hid `common.JSONHTTPResponse.Body` field. It enforces access via `GetBody` which returns a flag indicating if response body was empty. This makes error handling explicit. Implementor of a deep connector must decide what empty response body signifies and how to address it.

# Result
The content of response body can be accessed 
* as *ajson.Node by calling `GetBody` (with flag check)
* or loaded into struct via `common.UnmarshalJSON` (empty body means empty struct, tests illustrate that)


# Review
Commits are grouped into related changes. Easier to review commit by commit.
