### PR TITLE
feat: jsonquery: Empty key behaves as itself reference

### DIFF
--- a/common/handy/pointers.go
+++ b/common/handy/pointers.go
@@ -15,6 +15,11 @@ func (pointers) Bool(input bool) *bool {
 	return &input
 }
 
+// Int64 returns a pointer to the given integer.
+func (pointers) Int64(input int64) *int64 {
+	return &input
+}
+
 // IsTrue checks boolean pointer was set and is true.
 func (pointers) IsTrue(input *bool) bool {
 	if input == nil {

--- a/common/jsonquery/nested.go
+++ b/common/jsonquery/nested.go
@@ -41,6 +41,16 @@ func (q *Query) getInnerKey(targetKey string, optional bool) (*ajson.Node, error
 		return nil, err
 	}
 
+	// Empty key means we are referencing current node.
+	if len(targetKey) == 0 {
+		targetNode := zoomed
+		if targetNode.IsNull() {
+			return nil, handleNullNode(targetKey, optional)
+		}
+
+		return targetNode, nil
+	}
+
 	if !zoomed.HasKey(targetKey) {
 		if optional {
 			// null value in payload is allowed

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -10,9 +10,10 @@ import (
 //
 // Usage examples, where node is JSON parsed via ajson library:
 //
-//	->	Must get *int64:	jsonquery.New(node).Integer("num", false)
-//	->	Optional *string:	jsonquery.New(node).String("text", true)
-//	->	Nested array:		jsonquery.New(node, "your", "path", "to", "array").Array("list", false)
+//	->	Must get *int64:					jsonquery.New(node).Integer("num", false)
+//	->	Optional *string:					jsonquery.New(node).String("text", true)
+//	->	Nested array:						jsonquery.New(node, "your", "path", "to", "array").Array("list", false)
+//	->	Convert current obj to list:		jsonquery.New(node).Array("", false)
 type Query struct {
 	node *ajson.Node
 	zoom []string
@@ -26,6 +27,9 @@ func New(node *ajson.Node, zoom ...string) *Query {
 	}
 }
 
+// Object returns json object.
+// Optional argument set to false will create error in case of missing value.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) Object(key string, optional bool) (*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
@@ -47,6 +51,9 @@ func (q *Query) Object(key string, optional bool) (*ajson.Node, error) {
 	return node, nil
 }
 
+// Integer returns integer.
+// Optional argument set to false will create error in case of missing value.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) Integer(key string, optional bool) (*int64, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
@@ -75,6 +82,9 @@ func (q *Query) Integer(key string, optional bool) (*int64, error) {
 	return &result, nil
 }
 
+// Str returns string.
+// Optional argument set to false will create error in case of missing value.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) Str(key string, optional bool) (*string, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
@@ -97,6 +107,9 @@ func (q *Query) Str(key string, optional bool) (*string, error) {
 	return &txt, nil
 }
 
+// Bool returns boolean.
+// Optional argument set to false will create error in case of missing value.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) Bool(key string, optional bool) (*bool, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
@@ -119,6 +132,9 @@ func (q *Query) Bool(key string, optional bool) (*bool, error) {
 	return &flag, nil
 }
 
+// Array returns list of nodes.
+// Optional argument set to false will create error in case of missing value.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) Array(key string, optional bool) ([]*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
@@ -141,6 +157,9 @@ func (q *Query) Array(key string, optional bool) ([]*ajson.Node, error) {
 	return arr, nil
 }
 
+// ArraySize returns the array size located under key.
+// It is assumed that array value must be not null and present.
+// Empty key is interpreter as "this", in other words current node.
 func (q *Query) ArraySize(key string) (int64, error) {
 	arr, err := q.Array(key, false)
 	if err != nil {

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/amp-labs/connectors/common/handy"
 	"github.com/spyzhov/ajson"
 )
 
@@ -25,7 +26,7 @@ var testJSONData = `{
 			"display_time": "yesterday"
 		}}`
 
-func TestQuery_Integer(t *testing.T) { // nolint:funlen
+func TestQueryInteger(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	j := helperCreateJSON(t, testJSONData) // nolint:varnamelen
@@ -84,7 +85,7 @@ func TestQuery_Integer(t *testing.T) { // nolint:funlen
 			input: inType{
 				key: "count",
 			},
-			expected: ptrInt64(38),
+			expected: handy.Pointers.Int64(38),
 		},
 		{
 			name: "Reaching for nested integer",
@@ -93,7 +94,16 @@ func TestQuery_Integer(t *testing.T) { // nolint:funlen
 				optional: false,
 				zoom:     []string{"payload", "notes", "body"},
 			},
-			expected: ptrInt64(359),
+			expected: handy.Pointers.Int64(359),
+		},
+		{
+			name: "Reaching for nested integer using self reference",
+			input: inType{
+				key:      "", // empty string acts as 'self'
+				optional: false,
+				zoom:     []string{"payload", "notes", "body", "amount"},
+			},
+			expected: handy.Pointers.Int64(359),
 		},
 		{
 			name: "Non existent zoom path is ok for optional integer",
@@ -170,7 +180,7 @@ func TestQueryString(t *testing.T) { // nolint:funlen
 			input: inType{
 				key: "text",
 			},
-			expected: ptrString("Hello World"),
+			expected: handy.Pointers.Str("Hello World"),
 		},
 		{
 			name: "Reaching for nested string",
@@ -179,7 +189,16 @@ func TestQueryString(t *testing.T) { // nolint:funlen
 				optional: false,
 				zoom:     []string{"payload", "notes", "body"},
 			},
-			expected: ptrString("Some notes"),
+			expected: handy.Pointers.Str("Some notes"),
+		},
+		{
+			name: "Reaching for nested string using self reference",
+			input: inType{
+				key:      "", // empty string acts as 'self'
+				optional: false,
+				zoom:     []string{"payload", "notes", "body", "text"},
+			},
+			expected: handy.Pointers.Str("Some notes"),
 		},
 		{
 			name: "Non existent zoom path is ok for optional string",
@@ -256,7 +275,7 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 			input: inType{
 				key: "inProgress",
 			},
-			expected: ptrBool(false),
+			expected: handy.Pointers.Bool(false),
 		},
 		{
 			name: "Reaching for nested bool",
@@ -265,7 +284,16 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 				optional: false,
 				zoom:     []string{"payload", "notes", "body"},
 			},
-			expected: ptrBool(true),
+			expected: handy.Pointers.Bool(true),
+		},
+		{
+			name: "Reaching for nested bool using self reference",
+			input: inType{
+				key:      "", // empty string acts as 'self'
+				optional: false,
+				zoom:     []string{"payload", "notes", "body", "purchased"},
+			},
+			expected: handy.Pointers.Bool(true),
 		},
 		{
 			name: "Non existent zoom path is ok for optional bool",
@@ -290,7 +318,7 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 	}
 }
 
-func TestQuery_Array(t *testing.T) { // nolint:funlen
+func TestQueryArray(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	j := helperCreateJSON(t, testJSONData) // nolint:varnamelen
@@ -359,6 +387,15 @@ func TestQuery_Array(t *testing.T) { // nolint:funlen
 			expectedSize: 5,
 		},
 		{
+			name: "Reaching for nested array using self reference",
+			input: inType{
+				key:      "", // empty string acts as 'self'
+				optional: false,
+				zoom:     []string{"payload", "notes", "nested_arr"},
+			},
+			expectedSize: 5,
+		},
+		{
 			name: "Non existent zoom path is ok for optional arr",
 			input: inType{
 				key:      "street",
@@ -390,7 +427,7 @@ func TestQuery_Array(t *testing.T) { // nolint:funlen
 	}
 }
 
-func TestQuery_Object(t *testing.T) { // nolint:funlen
+func TestQueryObject(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	j := helperCreateJSON(t, testJSONData) // nolint:varnamelen
@@ -435,6 +472,14 @@ func TestQuery_Object(t *testing.T) { // nolint:funlen
 			input: inType{
 				key:  "body",
 				zoom: []string{"payload", "notes"},
+			},
+			expectedErr: nil, // success
+		},
+		{
+			name: "Valid nested object using self reference",
+			input: inType{
+				key:  "", // empty string acts as 'self'
+				zoom: []string{"payload", "notes", "body"},
 			},
 			expectedErr: nil, // success
 		},
@@ -488,16 +533,4 @@ func assertJSONManagerOutput(t *testing.T, name string, expected any, expectedEr
 	if !reflect.DeepEqual(output, expected) {
 		t.Fatalf("%s: expected: (%v), got: (%v)", name, expected, output)
 	}
-}
-
-func ptrInt64(num int64) *int64 {
-	return &num
-}
-
-func ptrString(text string) *string {
-	return &text
-}
-
-func ptrBool(flag bool) *bool {
-	return &flag
 }

--- a/gong/read.go
+++ b/gong/read.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if len(config.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
 	url, err := c.getURL(config.ObjectName)
 	if err != nil {
 		return nil, err

--- a/gong/read_test.go
+++ b/gong/read_test.go
@@ -24,12 +24,19 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	tests := []testroutines.Read{
 		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
 			Name:         "Mime response header expected",
+			Input:        common.ReadParams{ObjectName: "calls"},
 			Server:       mockserver.Dummy(),
 			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
-			Name: "Incorrect key in payload",
+			Name:  "Incorrect key in payload",
+			Input: common.ReadParams{ObjectName: "calls"},
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
#Background

jsonquery package has utility methods for querying JSON fields.
The key is assumed to be non empty string.


# Problem

There is no way to reference itself, the current node. All utils assume that you want to reach for nested fields. As it turns out it is not always the case.

Example: you have a json node holding `[{}, {}, {}]`. Calculating the size would require calling ajson node in similiar steps to what is already done by jsonquery - redundancy.

# Solution

getInnerKey is a shared method among all query calls which resolves zoom path.
Special case of empty string is handled as tautology.

As a side effect (not my direct intent) these statements will act identically:
```go
jsonquery.New(node, "flags").Bool("enabled", false)

jsonquery.New(node, "flags", "enabled").Bool("", false)
```

