### PR TITLE
feat: paramsbuilder: API Key client

### DIFF
--- a/common/apiKey.go
+++ b/common/apiKey.go
@@ -7,14 +7,15 @@ import (
 // NewApiKeyHeaderAuthHTTPClient returns a new http client, with automatic API key
 // authentication. Specifically this means that the client will automatically
 // add the API key (as a header) to every request.
+// HeaderValue must be in the correct format. This sometimes means adding prefix to the API Key.
 func NewApiKeyHeaderAuthHTTPClient( //nolint:ireturn
 	ctx context.Context,
-	headerName, apiKey string,
+	headerName, headerValue string,
 	opts ...HeaderAuthClientOption,
 ) (AuthenticatedHTTPClient, error) {
 	return NewHeaderAuthHTTPClient(ctx, append(opts, WithHeaders(Header{
 		Key:   headerName,
-		Value: apiKey,
+		Value: headerValue,
 	}))...)
 }
 

--- a/common/paramsbuilder/client.go
+++ b/common/paramsbuilder/client.go
@@ -20,7 +20,13 @@ type Client struct {
 }
 
 func (p *Client) ValidateParams() error {
+	// http client must be defined.
 	if p.Caller == nil {
+		return ErrMissingClient
+	}
+
+	// authentication client should be present.
+	if p.Caller.Client == nil {
 		return ErrMissingClient
 	}
 
@@ -58,6 +64,50 @@ func (p *Client) WithBasicClient(
 	}
 
 	basicClient, err := common.NewBasicAuthHTTPClient(ctx, user, pass, append(options, opts...)...)
+	if err != nil {
+		panic(err) // caught in NewConnector
+	}
+
+	p.WithAuthenticatedClient(basicClient)
+}
+
+// WithApiKeyHeaderClient option sets up client that utilises API Key authentication.
+// Passed via Header.
+func (p *Client) WithApiKeyHeaderClient(
+	ctx context.Context, client *http.Client,
+	headerName, headerValue string,
+	opts ...common.HeaderAuthClientOption,
+) {
+	options := []common.HeaderAuthClientOption{
+		common.WithHeaderClient(client),
+	}
+
+	basicClient, err := common.NewApiKeyHeaderAuthHTTPClient(ctx,
+		headerName, headerValue,
+		append(options, opts...)...,
+	)
+	if err != nil {
+		panic(err) // caught in NewConnector
+	}
+
+	p.WithAuthenticatedClient(basicClient)
+}
+
+// WithApiKeyQueryParamClient option sets up client that utilises API Key authentication.
+// Passed via Query Param.
+func (p *Client) WithApiKeyQueryParamClient(
+	ctx context.Context, client *http.Client,
+	queryParamName, apiKey string,
+	opts ...common.QueryParamAuthClientOption,
+) {
+	options := []common.QueryParamAuthClientOption{
+		common.WithQueryParamClient(client),
+	}
+
+	basicClient, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx,
+		queryParamName, apiKey,
+		append(options, opts...)...,
+	)
 	if err != nil {
 		panic(err) // caught in NewConnector
 	}

--- a/common/paramsbuilder/client.go
+++ b/common/paramsbuilder/client.go
@@ -82,7 +82,7 @@ func (p *Client) WithApiKeyHeaderClient(
 		common.WithHeaderClient(client),
 	}
 
-	basicClient, err := common.NewApiKeyHeaderAuthHTTPClient(ctx,
+	apiKeyClient, err := common.NewApiKeyHeaderAuthHTTPClient(ctx,
 		headerName, headerValue,
 		append(options, opts...)...,
 	)
@@ -90,7 +90,7 @@ func (p *Client) WithApiKeyHeaderClient(
 		panic(err) // caught in NewConnector
 	}
 
-	p.WithAuthenticatedClient(basicClient)
+	p.WithAuthenticatedClient(apiKeyClient)
 }
 
 // WithApiKeyQueryParamClient option sets up client that utilises API Key authentication.
@@ -104,7 +104,7 @@ func (p *Client) WithApiKeyQueryParamClient(
 		common.WithQueryParamClient(client),
 	}
 
-	basicClient, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx,
+	apiKeyClient, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx,
 		queryParamName, apiKey,
 		append(options, opts...)...,
 	)
@@ -112,7 +112,7 @@ func (p *Client) WithApiKeyQueryParamClient(
 		panic(err) // caught in NewConnector
 	}
 
-	p.WithAuthenticatedClient(basicClient)
+	p.WithAuthenticatedClient(apiKeyClient)
 }
 
 // WithAuthenticatedClient sets up an HTTP client that uses your implementation of authentication.


### PR DESCRIPTION
# Background

Deep connectors support 2 types of Clients during connector initialization: Oauth2 and Basic password.

# Changes

* paramsbuilder exposes Clients supporting API key authentication
  * via Header
  * via Query param
* ProviderInfo has 2 new methods fullfiling required arguments of paramsbuilder
  * GetApiKeyQueryParamName - programatically figure out what is query param name by looking up the catalog
  * GetApiKeyHeader - from catalog get header name, header value prefix
