### PR TITLE
feat: enable proxy marketo

### DIFF
--- a/providers/marketo.go
+++ b/providers/marketo.go
@@ -35,7 +35,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Testing
### GET
<img width="1153" alt="Screenshot 2024-08-13 at 10 33 41" src="https://github.com/user-attachments/assets/baa606d8-4890-4ac9-b47e-0a96e52e8456">


### POST
<img width="1148" alt="Screenshot 2024-08-13 at 10 39 40" src="https://github.com/user-attachments/assets/20ce28b8-88d0-4b65-88ba-6dfa6246b0aa">

### DELETE
<img width="1149" alt="Screenshot 2024-08-13 at 10 41 17" src="https://github.com/user-attachments/assets/f4c05113-81e9-4649-9f83-35dc587b9c69">


### Invalid requests
Wrong verb applied, 
<img width="1152" alt="Screenshot 2024-08-13 at 10 56 28" src="https://github.com/user-attachments/assets/583e94ac-8fc0-4d00-9e7f-d6d6ad10220e">


invalid path.
<img width="1149" alt="Screenshot 2024-08-13 at 10 29 13" src="https://github.com/user-attachments/assets/7b981c88-63d1-4dea-85ae-4327c063d684">



## Pagination
Retrieve paginationToken first.
<img width="1147" alt="Screenshot 2024-08-13 at 10 46 12" src="https://github.com/user-attachments/assets/89882ec9-47c0-4641-a006-0094f8398b1f">

Using the paginationToken to retrieve data.
<img width="1142" alt="Screenshot 2024-08-13 at 10 48 15" src="https://github.com/user-attachments/assets/e5f64bdf-05d6-4725-8990-3f740d1c0684">

As observed above `moreResults` is `true` thus we have more data to retrieve.
<img width="1145" alt="Screenshot 2024-08-13 at 10 49 14" src="https://github.com/user-attachments/assets/ec86a8d0-3300-4219-96fb-7af9ee7ed7de">


All Success and Failed Operations will show a success in the console, Although some will be failures and some will be success. This is because Marketo returns a 200 OK status code for all events. The difference is the value of the `success` and `errors` keys in the responses.

<img width="967" alt="Screenshot 2024-08-13 at 11 02 30" src="https://github.com/user-attachments/assets/a27cff9a-4683-43c4-bb3b-ef8d89e65a0e">
