### PR TITLE
add: Docs URLs to static Metadata schemas

### DIFF
--- a/salesloft/metadata/index.json
+++ b/salesloft/metadata/index.json
@@ -176,6 +176,11 @@
       "url": "https://developers.salesloft.com/docs/api/cadence-memberships-show"
     },
     {
+      "name": "cadence-stats-show",
+      "displayName": "Fetch stats for a cadence",
+      "url": "https://developers.salesloft.com/docs/api/cadence-stats-show"
+    },
+    {
       "name": "cadences-index",
       "displayName": "List cadences",
       "url": "https://developers.salesloft.com/docs/api/cadences-index"
@@ -216,9 +221,49 @@
       "url": "https://developers.salesloft.com/docs/api/call-sentiments-index"
     },
     {
-      "name": "create-conversations-call",
-      "displayName": "Create Conversations Call",
-      "url": "https://developers.salesloft.com/docs/api/create-conversations-call"
+      "name": "conversations-calls-create",
+      "displayName": "Create a new call",
+      "url": "https://developers.salesloft.com/docs/api/conversations-calls-create"
+    },
+    {
+      "name": "conversations-find-all",
+      "displayName": "Fetch conversations",
+      "url": "https://developers.salesloft.com/docs/api/conversations-find-all"
+    },
+    {
+      "name": "conversations-find-one",
+      "displayName": "Fetch a conversation",
+      "url": "https://developers.salesloft.com/docs/api/conversations-find-one"
+    },
+    {
+      "name": "conversations-find-one-conversation-recording",
+      "displayName": "Fetch Conversation media",
+      "url": "https://developers.salesloft.com/docs/api/conversations-find-one-conversation-recording"
+    },
+    {
+      "name": "conversations-find-one-extensive",
+      "displayName": "Fetch an extensive conversation",
+      "url": "https://developers.salesloft.com/docs/api/conversations-find-one-extensive"
+    },
+    {
+      "name": "conversations-transcriptions-find-all-transcripts",
+      "displayName": "List Transcriptions",
+      "url": "https://developers.salesloft.com/docs/api/conversations-transcriptions-find-all-transcripts"
+    },
+    {
+      "name": "conversations-transcriptions-find-one-transcript",
+      "displayName": "Fetch a Transcription",
+      "url": "https://developers.salesloft.com/docs/api/conversations-transcriptions-find-one-transcript"
+    },
+    {
+      "name": "conversations-transcriptions-find-one-transcript-artifact",
+      "displayName": "Fetch a Transcription Artifact",
+      "url": "https://developers.salesloft.com/docs/api/conversations-transcriptions-find-one-transcript-artifact"
+    },
+    {
+      "name": "conversations-transcriptions-find-one-transcript-sentences",
+      "displayName": "Fetch a Transcription's sentences",
+      "url": "https://developers.salesloft.com/docs/api/conversations-transcriptions-find-one-transcript-sentences"
     },
     {
       "name": "crm-activities-index",
@@ -311,6 +356,11 @@
       "url": "https://developers.salesloft.com/docs/api/email-template-attachments-index"
     },
     {
+      "name": "email-templates-create",
+      "displayName": "Create Personal Email Template",
+      "url": "https://developers.salesloft.com/docs/api/email-templates-create"
+    },
+    {
       "name": "email-templates-index",
       "displayName": "List email templates",
       "url": "https://developers.salesloft.com/docs/api/email-templates-index"
@@ -321,9 +371,44 @@
       "url": "https://developers.salesloft.com/docs/api/email-templates-show"
     },
     {
+      "name": "email-templates-update",
+      "displayName": "Update Personal Email Template",
+      "url": "https://developers.salesloft.com/docs/api/email-templates-update"
+    },
+    {
+      "name": "external-configurations-create",
+      "displayName": "Create a configuration",
+      "url": "https://developers.salesloft.com/docs/api/external-configurations-create"
+    },
+    {
+      "name": "external-configurations-destroy",
+      "displayName": "Delete a configuration",
+      "url": "https://developers.salesloft.com/docs/api/external-configurations-destroy"
+    },
+    {
+      "name": "external-configurations-index",
+      "displayName": "List team configurations",
+      "url": "https://developers.salesloft.com/docs/api/external-configurations-index"
+    },
+    {
       "name": "external-emails-create",
       "displayName": "Create an External Email",
       "url": "https://developers.salesloft.com/docs/api/external-emails-create"
+    },
+    {
+      "name": "external-mappings-create",
+      "displayName": "Create a mapping",
+      "url": "https://developers.salesloft.com/docs/api/external-mappings-create"
+    },
+    {
+      "name": "external-mappings-destroy",
+      "displayName": "Delete a mapping",
+      "url": "https://developers.salesloft.com/docs/api/external-mappings-destroy"
+    },
+    {
+      "name": "external-mappings-index",
+      "displayName": "List team mappings",
+      "url": "https://developers.salesloft.com/docs/api/external-mappings-index"
     },
     {
       "name": "groups-create",
@@ -407,7 +492,7 @@
     },
     {
       "name": "integrations-signals-registrations-plays-show",
-      "displayName": "Show a Play Registration",
+      "displayName": "Fetch a Play Registration",
       "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-show"
     },
     {
@@ -666,6 +751,11 @@
       "url": "https://developers.salesloft.com/docs/api/team-template-attachments-index"
     },
     {
+      "name": "team-templates-create",
+      "displayName": "Create Team Email Template",
+      "url": "https://developers.salesloft.com/docs/api/team-templates-create"
+    },
+    {
       "name": "team-templates-index",
       "displayName": "List team templates",
       "url": "https://developers.salesloft.com/docs/api/team-templates-index"
@@ -674,6 +764,11 @@
       "name": "team-templates-show",
       "displayName": "Fetch a team template",
       "url": "https://developers.salesloft.com/docs/api/team-templates-show"
+    },
+    {
+      "name": "team-templates-update",
+      "displayName": "Update Team Email Template",
+      "url": "https://developers.salesloft.com/docs/api/team-templates-update"
     },
     {
       "name": "third-party-live-feed-items-create",

--- a/salesloft/metadata/queryParamStats.json
+++ b/salesloft/metadata/queryParamStats.json
@@ -1,13 +1,13 @@
 {
   "meta": {
     "totalObjects": 48,
-    "collectedAt": "2024-06-10"
+    "collectedAt": "2024-08-13"
   },
   "queryParams": [
     {
       "name": "updated_at[gt]",
-      "frequency": 0.3125,
-      "totalObjects": 15,
+      "frequency": 0.3333,
+      "totalObjects": 16,
       "objects": [
         "account_stages",
         "accounts",
@@ -21,6 +21,7 @@
         "email_templates",
         "notes",
         "people",
+        "steps",
         "successes",
         "tasks",
         "team_templates"
@@ -28,8 +29,8 @@
     },
     {
       "name": "updated_at[gte]",
-      "frequency": 0.3125,
-      "totalObjects": 15,
+      "frequency": 0.3333,
+      "totalObjects": 16,
       "objects": [
         "account_stages",
         "accounts",
@@ -43,6 +44,7 @@
         "email_templates",
         "notes",
         "people",
+        "steps",
         "successes",
         "tasks",
         "team_templates"
@@ -50,8 +52,8 @@
     },
     {
       "name": "updated_at[lt]",
-      "frequency": 0.3125,
-      "totalObjects": 15,
+      "frequency": 0.3333,
+      "totalObjects": 16,
       "objects": [
         "account_stages",
         "accounts",
@@ -65,6 +67,7 @@
         "email_templates",
         "notes",
         "people",
+        "steps",
         "successes",
         "tasks",
         "team_templates"
@@ -72,8 +75,8 @@
     },
     {
       "name": "updated_at[lte]",
-      "frequency": 0.3125,
-      "totalObjects": 15,
+      "frequency": 0.3333,
+      "totalObjects": 16,
       "objects": [
         "account_stages",
         "accounts",
@@ -87,6 +90,7 @@
         "email_templates",
         "notes",
         "people",
+        "steps",
         "successes",
         "tasks",
         "team_templates"
@@ -206,6 +210,38 @@
       "totalObjects": 1,
       "objects": [
         "actions"
+      ]
+    },
+    {
+      "name": "include_counts_acted_on[gt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "tasks"
+      ]
+    },
+    {
+      "name": "include_counts_acted_on[gte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "tasks"
+      ]
+    },
+    {
+      "name": "include_counts_acted_on[lt]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "tasks"
+      ]
+    },
+    {
+      "name": "include_counts_acted_on[lte]",
+      "frequency": 0.0208,
+      "totalObjects": 1,
+      "objects": [
+        "tasks"
       ]
     },
     {

--- a/salesloft/metadata/schemas.json
+++ b/salesloft/metadata/schemas.json
@@ -9,17 +9,20 @@
         "name": "name",
         "order": "order",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/account-stages-index"
     },
     "account_tiers": {
       "displayName": "List Account Tiers",
       "fields": {
+        "active": "active",
         "created_at": "created_at",
         "id": "id",
         "name": "name",
         "order": "order",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/account-tiers-index"
     },
     "accounts": {
       "displayName": "List accounts",
@@ -64,7 +67,8 @@
         "updated_at": "updated_at",
         "user_relationships": "user_relationships",
         "website": "website"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/accounts-index"
     },
     "action_details_call_instructions": {
       "displayName": "List call instructions",
@@ -73,7 +77,8 @@
         "id": "id",
         "instructions": "instructions",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/action-details-call-instructions-index"
     },
     "actions": {
       "displayName": "List actions",
@@ -92,7 +97,8 @@
         "type": "type",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/actions-index"
     },
     "activities_calls": {
       "displayName": "List calls",
@@ -113,7 +119,8 @@
         "to": "to",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/activities-calls-index"
     },
     "activities_emails": {
       "displayName": "List emails",
@@ -145,7 +152,8 @@
         "updated_at": "updated_at",
         "user": "user",
         "view_tracking": "view_tracking"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/activities-emails-index"
     },
     "activity_histories": {
       "displayName": "List Past Activities",
@@ -163,7 +171,8 @@
         "type": "type",
         "updated_at": "updated_at",
         "user_guid": "user_guid"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/activity-histories-index"
     },
     "bulk_jobs": {
       "displayName": "List bulk jobs",
@@ -182,7 +191,8 @@
         "total": "total",
         "type": "type",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-index"
     },
     "bulk_jobs_job_data": {
       "displayName": "List job data for a bulk job",
@@ -192,7 +202,8 @@
         "record": "record",
         "resource": "resource",
         "status": "status"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-job-data-index"
     },
     "bulk_jobs_results": {
       "displayName": "List job data for a completed bulk job.",
@@ -202,7 +213,8 @@
         "record": "record",
         "resource": "resource",
         "status": "status"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/bulk-jobs-results-index"
     },
     "cadence_memberships": {
       "displayName": "List cadence memberships",
@@ -219,13 +231,16 @@
         "person_deleted": "person_deleted",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/cadence-memberships-index"
     },
     "cadences": {
       "displayName": "List cadences",
       "fields": {
         "added_stage": "added_stage",
+        "archived": "archived",
         "archived_at": "archived_at",
+        "archived_by": "archived_by",
         "bounced_stage": "bounced_stage",
         "cadence_framework_id": "cadence_framework_id",
         "cadence_function": "cadence_function",
@@ -251,7 +266,8 @@
         "tags": "tags",
         "team_cadence": "team_cadence",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/cadences-index"
     },
     "calendar_events": {
       "displayName": "List calendar events",
@@ -284,7 +300,8 @@
         "title": "title",
         "updated_at": "updated_at",
         "user_guid": "user_guid"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/calendar-events-index"
     },
     "call_data_records": {
       "displayName": "List call data records",
@@ -306,7 +323,8 @@
         "to": "to",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/call-data-records-index"
     },
     "call_dispositions": {
       "displayName": "List call dispositions",
@@ -315,7 +333,8 @@
         "id": "id",
         "name": "name",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/call-dispositions-index"
     },
     "call_sentiments": {
       "displayName": "List call sentiments",
@@ -324,7 +343,8 @@
         "id": "id",
         "name": "name",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/call-sentiments-index"
     },
     "crm_activities": {
       "displayName": "List crm activities",
@@ -340,7 +360,8 @@
         "subject": "subject",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/crm-activities-index"
     },
     "crm_activity_fields": {
       "displayName": "List crm activity fields",
@@ -356,7 +377,8 @@
         "title": "title",
         "updated_at": "updated_at",
         "value": "value"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/crm-activity-fields-index"
     },
     "crm_users": {
       "displayName": "List crm users",
@@ -369,7 +391,8 @@
         "name": "name",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/crm-users-index"
     },
     "custom_fields": {
       "displayName": "List custom fields",
@@ -380,14 +403,16 @@
         "name": "name",
         "updated_at": "updated_at",
         "value_type": "value_type"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/custom-fields-index"
     },
     "custom_roles": {
       "displayName": "List custom roles",
       "fields": {
         "id": "id",
         "name": "name"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/custom-roles-index"
     },
     "data_control_requests": {
       "displayName": "Retrieve a list of Requests",
@@ -399,7 +424,8 @@
         "request_type": "request_type",
         "team_id": "team_id",
         "user_guid": "user_guid"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/data-control-requests-index"
     },
     "email_template_attachments": {
       "displayName": "List email template attachments",
@@ -413,7 +439,8 @@
         "id": "id",
         "name": "name",
         "scanned": "scanned"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/email-template-attachments-index"
     },
     "email_templates": {
       "displayName": "List email templates",
@@ -437,7 +464,34 @@
         "template_owner": "template_owner",
         "title": "title",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/email-templates-index"
+    },
+    "external_configurations": {
+      "displayName": "List team configurations",
+      "fields": {
+        "deleted": "deleted",
+        "external_type": "external_type",
+        "id": "id",
+        "object_type": "object_type",
+        "source_id": "source_id",
+        "source_type": "source_type"
+      },
+      "url": "https://developers.salesloft.com/docs/api/external-configurations-index"
+    },
+    "external_mappings": {
+      "displayName": "List team mappings",
+      "fields": {
+        "deleted": "deleted",
+        "external_id": "external_id",
+        "external_type": "external_type",
+        "id": "id",
+        "inserted_at": "inserted_at",
+        "object_id": "object_id",
+        "object_type": "object_type",
+        "tenant_id": "tenant_id"
+      },
+      "url": "https://developers.salesloft.com/docs/api/external-mappings-index"
     },
     "groups": {
       "displayName": "List groups",
@@ -446,7 +500,8 @@
         "id": "id",
         "name": "name",
         "parent_id": "parent_id"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/groups-index"
     },
     "imports": {
       "displayName": "List imports",
@@ -460,7 +515,8 @@
         "name": "name",
         "updated_at": "updated_at",
         "user_id": "user_id"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/imports-index"
     },
     "integrations_signals_registrations": {
       "displayName": "List Signal Registrations",
@@ -476,7 +532,8 @@
         "integration_slug": "integration_slug",
         "owner_user_guid": "owner_user_guid",
         "type": "type"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-index"
     },
     "integrations_signals_registrations_plays": {
       "displayName": "List Play Registrations",
@@ -496,47 +553,18 @@
         "signal_registration": "signal_registration",
         "signal_type": "signal_type",
         "state": "state"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-plays-index"
     },
     "me": {
       "displayName": "Fetch current user",
       "fields": {
-        "active": "active",
-        "bcc_email_address": "bcc_email_address",
-        "click_to_call_enabled": "click_to_call_enabled",
-        "created_at": "created_at",
-        "crm_connected": "crm_connected",
         "email": "email",
-        "email_client_configured": "email_client_configured",
-        "email_client_email_address": "email_client_email_address",
-        "email_signature": "email_signature",
-        "email_signature_click_tracking_disabled": "email_signature_click_tracking_disabled",
-        "email_signature_type": "email_signature_type",
-        "external_feature_flags": "external_feature_flags",
-        "first_name": "first_name",
-        "from_address": "from_address",
-        "full_email_address": "full_email_address",
-        "group": "group",
         "guid": "guid",
         "id": "id",
-        "job_role": "job_role",
-        "last_name": "last_name",
-        "local_dial_enabled": "local_dial_enabled",
-        "locale_utc_offset": "locale_utc_offset",
-        "manager_user_guid": "manager_user_guid",
-        "name": "name",
-        "phone_client": "phone_client",
-        "phone_number_assignment": "phone_number_assignment",
-        "role": "role",
-        "sending_email_address": "sending_email_address",
-        "slack_username": "slack_username",
-        "team": "team",
-        "team_admin": "team_admin",
-        "time_zone": "time_zone",
-        "twitter_handle": "twitter_handle",
-        "updated_at": "updated_at",
-        "work_country": "work_country"
-      }
+        "name": "name"
+      },
+      "url": "https://developers.salesloft.com/docs/api/me-index"
     },
     "meetings": {
       "displayName": "List meetings",
@@ -584,7 +612,8 @@
         "title": "title",
         "undo_completion_count": "undo_completion_count",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/meetings-index"
     },
     "notes": {
       "displayName": "List notes",
@@ -597,7 +626,8 @@
         "id": "id",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/notes-index"
     },
     "pending_emails": {
       "displayName": "List pending emails",
@@ -605,7 +635,8 @@
         "id": "id",
         "mailbox": "mailbox",
         "mime_email_payload": "mime_email_payload"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/pending-emails-index"
     },
     "people": {
       "displayName": "List people",
@@ -667,7 +698,8 @@
         "work_city": "work_city",
         "work_country": "work_country",
         "work_state": "work_state"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/people-index"
     },
     "person_stages": {
       "displayName": "List person stages",
@@ -678,7 +710,8 @@
         "name": "name",
         "order": "order",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/person-stages-index"
     },
     "phone_number_assignments": {
       "displayName": "List phone number assignments",
@@ -686,7 +719,8 @@
         "id": "id",
         "number": "number",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/phone-number-assignments-index"
     },
     "phone_numbers_caller_ids": {
       "displayName": "List caller ids",
@@ -695,7 +729,8 @@
         "display_name": "display_name",
         "person": "person",
         "title": "title"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/phone-numbers-caller-ids-index"
     },
     "saved_list_views": {
       "displayName": "List saved list views",
@@ -706,7 +741,8 @@
         "shared": "shared",
         "view": "view",
         "view_params": "view_params"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/saved-list-views-index"
     },
     "steps": {
       "displayName": "List steps",
@@ -723,7 +759,8 @@
         "step_number": "step_number",
         "type": "type",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/steps-index"
     },
     "successes": {
       "displayName": "List successes",
@@ -741,14 +778,16 @@
         "success_window_started_at": "success_window_started_at",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/successes-index"
     },
     "tags": {
       "displayName": "List team tags",
       "fields": {
         "id": "id",
         "name": "name"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/tags-index"
     },
     "tasks": {
       "displayName": "List tasks",
@@ -769,7 +808,8 @@
         "task_type": "task_type",
         "updated_at": "updated_at",
         "user": "user"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/tasks-index"
     },
     "tasks_counts": {
       "displayName": "Fetch task counts",
@@ -780,7 +820,8 @@
         "integration": "integration",
         "other": "other",
         "total": "total"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/tasks-counts-index"
     },
     "team": {
       "displayName": "Fetch current team",
@@ -804,7 +845,8 @@
         "sentiments_required": "sentiments_required",
         "team_visibility_default": "team_visibility_default",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/team-index"
     },
     "team_template_attachments": {
       "displayName": "List team template attachments",
@@ -815,7 +857,8 @@
         "id": "id",
         "name": "name",
         "team_template": "team_template"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/team-template-attachments-index"
     },
     "team_templates": {
       "displayName": "List team templates",
@@ -836,47 +879,18 @@
         "tags": "tags",
         "title": "title",
         "updated_at": "updated_at"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/team-templates-index"
     },
     "users": {
       "displayName": "List users",
       "fields": {
-        "active": "active",
-        "bcc_email_address": "bcc_email_address",
-        "click_to_call_enabled": "click_to_call_enabled",
-        "created_at": "created_at",
-        "crm_connected": "crm_connected",
         "email": "email",
-        "email_client_configured": "email_client_configured",
-        "email_client_email_address": "email_client_email_address",
-        "email_signature": "email_signature",
-        "email_signature_click_tracking_disabled": "email_signature_click_tracking_disabled",
-        "email_signature_type": "email_signature_type",
-        "external_feature_flags": "external_feature_flags",
-        "first_name": "first_name",
-        "from_address": "from_address",
-        "full_email_address": "full_email_address",
-        "group": "group",
         "guid": "guid",
         "id": "id",
-        "job_role": "job_role",
-        "last_name": "last_name",
-        "local_dial_enabled": "local_dial_enabled",
-        "locale_utc_offset": "locale_utc_offset",
-        "manager_user_guid": "manager_user_guid",
-        "name": "name",
-        "phone_client": "phone_client",
-        "phone_number_assignment": "phone_number_assignment",
-        "role": "role",
-        "sending_email_address": "sending_email_address",
-        "slack_username": "slack_username",
-        "team": "team",
-        "team_admin": "team_admin",
-        "time_zone": "time_zone",
-        "twitter_handle": "twitter_handle",
-        "updated_at": "updated_at",
-        "work_country": "work_country"
-      }
+        "name": "name"
+      },
+      "url": "https://developers.salesloft.com/docs/api/users-index"
     },
     "webhook_subscriptions": {
       "displayName": "List webhook subscriptions",
@@ -888,7 +902,8 @@
         "id": "id",
         "tenant_id": "tenant_id",
         "user_guid": "user_guid"
-      }
+      },
+      "url": "https://developers.salesloft.com/docs/api/webhook-subscriptions-index"
     }
   }
 }

--- a/salesloft/metadata_test.go
+++ b/salesloft/metadata_test.go
@@ -60,6 +60,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							"id":         "id",
 							"name":       "name",
 							"order":      "order",
+							"active":     "active",
 							"updated_at": "updated_at",
 						},
 					},

--- a/scripts/scrapper/intercom/metadata/main.go
+++ b/scripts/scrapper/intercom/metadata/main.go
@@ -19,6 +19,7 @@ const (
 	ModelIndexURL = "https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Models/activity_log/"
 )
 
+// TODO this script got outdated with recent UI change.
 func main() {
 	// index will have URLs for every schema
 	createIndex()
@@ -74,12 +75,13 @@ func createSchemas() {
 	// Single GET methods to be discarded. Only match schemas that describe single item for LIST endpoint.
 	documents := getSchemasForListEndpoints(index)
 
-	for i, model := range documents {
+	for i := range documents {
+		model := documents[i]
 		doc := scrapper.QueryHTML(model.URL)
 
 		doc.Find(`.field-name`).Each(func(i int, s *goquery.Selection) {
 			name := s.Text()
-			schemas.Add(model.Name, model.DisplayName, name)
+			schemas.Add(model.Name, model.DisplayName, name, &model.URL)
 		})
 
 		log.Printf("Schemas completed %.2f%% [%v]\n", getPercentage(i, len(documents)), model.Name)

--- a/scripts/scrapper/pipeliner/metadata/main.go
+++ b/scripts/scrapper/pipeliner/metadata/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	for _, object := range objects {
 		for _, field := range object.Fields {
-			schemas.Add(aliases.Synonym(object.ObjectName), object.DisplayName, field)
+			schemas.Add(aliases.Synonym(object.ObjectName), object.DisplayName, field, nil)
 		}
 	}
 

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -68,7 +68,8 @@ func createSchemas() {
 	schemas := scrapper.NewObjectMetadataResult()
 
 	filteredListDocs := getFilteredListDocs(index)
-	for i, model := range filteredListDocs { // nolint:varnamelen
+	for i := range filteredListDocs { // nolint:varnamelen
+		model := filteredListDocs[i]
 		doc := scrapper.QueryHTML(model.URL)
 
 		// There are 2 unordered lists that describe response schema
@@ -81,7 +82,7 @@ func createSchemas() {
 					// Only the first most field represents top level fields of response payload
 					fieldName := property.Find(`strong`).First().Text()
 					if len(fieldName) != 0 {
-						schemas.Add(modelName, model.DisplayName, fieldName)
+						schemas.Add(modelName, model.DisplayName, fieldName, &model.URL)
 					}
 				})
 			})

--- a/scripts/scrapper/zendesksupport/metadata/main.go
+++ b/scripts/scrapper/zendesksupport/metadata/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	for _, object := range objects {
 		for _, field := range object.Fields {
-			schemas.Add(aliases.Synonym(object.ObjectName), object.DisplayName, field)
+			schemas.Add(aliases.Synonym(object.ObjectName), object.DisplayName, field, nil)
 		}
 	}
 

--- a/tools/scrapper/models.go
+++ b/tools/scrapper/models.go
@@ -71,6 +71,9 @@ type ObjectMetadata struct {
 
 	// FieldsMap is a map of field names to field display names
 	FieldsMap map[string]string `json:"fields"`
+
+	// URL points to docs endpoint. Optional.
+	URL *string `json:"url,omitempty"`
 }
 
 func NewObjectMetadataResult() *ObjectMetadataResult {
@@ -79,12 +82,13 @@ func NewObjectMetadataResult() *ObjectMetadataResult {
 	}
 }
 
-func (r *ObjectMetadataResult) Add(objectName string, objectDisplayName string, fieldName string) {
+func (r *ObjectMetadataResult) Add(objectName, objectDisplayName, fieldName string, url *string) {
 	data, ok := r.Result[objectName]
 	if !ok {
 		data = ObjectMetadata{
 			DisplayName: objectDisplayName,
 			FieldsMap:   make(map[string]string),
+			URL:         url,
 		}
 		r.Result[objectName] = data
 	}


### PR DESCRIPTION
# Background
As of now index has links but not schema file.
Index is more intermidiate file used to acquire schema. I think it is important to have docs reference there as people could review `schemas.json` to know what ListObjectMetadata offers.

# Changes
This PR passes docs URL links from index of object endpoints to static schema files that are used to serve ListObjectMetadata.

```go
// URL points to docs endpoint. Optional.
URL *string `json:"url,omitempty"`
```

Reran 4 scrapping scripts.
Intercom is the only that doesn't work due to UI changes.
The rest are not broken by the change either have Docs URL added or have some minor fields added/removed.
