### PR TITLE
feat: Add Deep connector Smartlead (Metadata)

### DIFF
--- a/smartlead/metadata.go
+++ b/smartlead/metadata.go
@@ -1,0 +1,24 @@
+package smartlead
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/smartlead/metadata"
+)
+
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	schemas, err := metadata.FileManager.LoadSchemas()
+	if err != nil {
+		return nil, common.ErrMetadataLoadFailure
+	}
+
+	return schemas.Select(objectNames)
+}

--- a/smartlead/metadata/schemas.json
+++ b/smartlead/metadata/schemas.json
@@ -1,0 +1,95 @@
+{
+  "data": {
+    "campaigns": {
+      "displayName": "Campaigns",
+      "fields": {
+        "id": "ID",
+        "user_id": "User ID",
+        "created_at": "Created at",
+        "updated_at": "Updated at",
+        "status": "Status",
+        "name": "Name",
+        "track_settings": "Track settings",
+        "scheduler_cron_value": "Scheduler CRON value",
+        "min_time_btwn_emails": "Min time between emails",
+        "max_leads_per_day": "Max leads per day",
+        "parent_campaign_id": "Parent campaign ID",
+        "stop_lead_settings": "Stop lead settings",
+        "unsubscribe_text": "Unsubscribe text",
+        "client_id": "Client ID",
+        "follow_up_percentage": "Follow up percentage",
+        "enable_ai_esp_matching": "Enable AI ESP matching",
+        "send_as_plain_text": "Send as plain text"
+      }
+    },
+    "email-accounts": {
+      "displayName": "Email Accounts",
+      "fields": {
+        "id": "ID",
+        "created_at": "Created at",
+        "updated_at": "Updated at",
+        "user_id": "User ID",
+        "from_name": "From name",
+        "from_email": "From email",
+        "username": "Username",
+        "password": "Password",
+        "imap_password": "IMAP Password",
+        "smtp_host": "SMTP Host",
+        "smtp_port": "SMTP Port",
+        "smtp_port_type": "SMTP Port type",
+        "message_per_day": "Message per day",
+        "different_reply_to_address": "Different reply to address",
+        "is_different_imap_account": "Is different IMAP account",
+        "imap_username": "IMAP Username",
+        "imap_host": "IMAP Host",
+        "imap_port": "IMAP Port",
+        "imap_port_type": "IMAP Port type",
+        "signature": "Signature",
+        "custom_tracking_domain": "Custom tracking domain",
+        "bcc_email": "BCC Email",
+        "is_smtp_success": "Is SMTP success",
+        "is_imap_success": "Is IMAP success",
+        "smtp_failure_error": "SMTP Failure error",
+        "imap_failure_error": "IMAP Failure error",
+        "type": "Type",
+        "daily_sent_count": "Daily sent count",
+        "client_id": "Client ID",
+        "warmup_details": "Warmup Details"
+      }
+    },
+    "leads": {
+      "displayName": "Leads",
+      "fields": {
+        "id": "ID",
+        "first_name": "First name",
+        "last_name": "Last name",
+        "email": "Email",
+        "created_at": "Created at",
+        "phone_number": "Phone number",
+        "company_name": "Company name",
+        "website": "Website",
+        "location": "Location",
+        "custom_fields": "Custom fields",
+        "linkedin_profile": "Linkedin profile",
+        "company_url": "Company URL",
+        "is_unsubscribed": "Is unsubscribed",
+        "unsubscribed_client_id_map": "Unsubscribed client ID map",
+        "lead_campaign_data": "Lead campaign data"
+      }
+    },
+    "client": {
+      "displayName": "Clients",
+      "fields": {
+        "id": "ID",
+        "name": "Name",
+        "email": "Email",
+        "uuid": "UUID",
+        "created_at": "Created at",
+        "user_id": "User ID",
+        "logo": "Logo",
+        "logo_url": "Logo URL",
+        "client_permision": "Client permission"
+      }
+    }
+  }
+}

--- a/smartlead/metadata/scraping.go
+++ b/smartlead/metadata/scraping.go
@@ -1,0 +1,27 @@
+package metadata
+
+import (
+	_ "embed"
+	"path/filepath"
+	"runtime"
+
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+)
+
+type locator struct{}
+
+func (locator) AbsPathTo(filename string) string {
+	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
+	localDir := filepath.Dir(thisMethodsLocation)
+
+	return localDir + "/" + filename
+}

--- a/smartlead/metadata_test.go
+++ b/smartlead/metadata_test.go
@@ -1,0 +1,79 @@
+package smartlead
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
+		},
+		{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"campaigns", "leads"},
+			Server: mockserver.Dummy(),
+			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
+				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
+			},
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"campaigns": {
+						DisplayName: "Campaigns",
+						FieldsMap: map[string]string{
+							"id":         "ID",
+							"user_id":    "User ID",
+							"created_at": "Created at",
+							"updated_at": "Updated at",
+							"status":     "Status",
+							"name":       "Name",
+						},
+					},
+					"leads": {
+						DisplayName: "Leads",
+						FieldsMap: map[string]string{
+							"first_name":   "First name",
+							"last_name":    "Last name",
+							"email":        "Email",
+							"created_at":   "Created at",
+							"phone_number": "Phone number",
+							"company_name": "Company name",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/smartlead/metadata/main.go
+++ b/test/smartlead/metadata/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/smartlead"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+)
+
+var (
+	objectName = "campaigns" // nolint: gochecknoglobals
+)
+
+// We want to compare fields returned by read and schema properties provided by metadata methods.
+// Properties from read must all be present in schema definition.
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSmartleadConnector(ctx)
+	defer utils.Close(conn)
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+	})
+	if err != nil {
+		utils.Fail("error reading from Smartlead", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for Smartlead", "error", err)
+	}
+
+	slog.Info("Comparing")
+
+	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
+	if mismatchErr != nil {
+		utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
+	} else {
+		slog.Info("Success: Object metadata schema and endpoint response have the same fields")
+	}
+}


### PR DESCRIPTION
Closes #911

# Description

Static schema file is served as Object Metadata.
The file is created using documentation. For campaigns the docs had less fields than what endpoint returns, so it was manually added.

# Testing
Verified campaings, client endpoints.
![image](https://github.com/user-attachments/assets/6eb75e5d-ae76-4686-94b0-d26b51ecde08)
