### PR TITLE
feat: Add clientcredentials OAuth2 option

### DIFF
--- a/common/clientcredentials.go
+++ b/common/clientcredentials.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+var ClientCredentials Oauth2OptsGrantType = "clientcredentials" //nolint:gochecknoglobals
+
+// get2leggedTokenSource generates tokenSource using the clientcreds config.
+func get2leggedTokenSource(ctx context.Context, params *oauthClientParams) oauth2.TokenSource { //nolint:ireturn
+	if params.tokenSource != nil {
+		return params.tokenSource
+	}
+
+	return params.clientCredsConfig.TokenSource(ctx)
+}
+
+// WithClientCredentialsConfig sets the client-credentials config to use for the connector.
+// It's required in two-legged OAuth2, unless TokenSource is provided.
+func WithClientCredentialsConfig(config *clientcredentials.Config) OAuthOption {
+	return func(params *oauthClientParams) {
+		params.clientCredsConfig = config
+	}
+}

--- a/common/paramsbuilder/client.go
+++ b/common/paramsbuilder/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 var ErrMissingClient = errors.New("http client not set")
@@ -37,6 +38,27 @@ func (p *Client) WithOauthClient(
 		common.WithOAuthClient(client),
 		common.WithOAuthConfig(config),
 		common.WithOAuthToken(token),
+	}
+
+	oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)
+	if err != nil {
+		panic(err) // caught in NewConnector
+	}
+
+	p.WithAuthenticatedClient(oauthClient)
+}
+
+// WithClientCredsClient option that sets up client that utilises Oauth2 2-legged configuration.
+func (p *Client) With2LeggedClient(
+	ctx context.Context, client *http.Client,
+	config *clientcredentials.Config, token *oauth2.Token,
+	opts ...common.OAuthOption,
+) {
+	options := []common.OAuthOption{
+		common.WithOAuthClient(client),
+		common.WithClientCredentialsConfig(config),
+		common.WithOAuthToken(token),
+		common.WithOAuth2GrantType(common.ClientCredentials),
 	}
 
 	oauthClient, err := common.NewOAuthHTTPClient(ctx, append(options, opts...)...)

--- a/common/types.go
+++ b/common/types.go
@@ -93,6 +93,8 @@ var (
 	ErrRecordDataNotJSON = errors.New("record data is not JSON")
 )
 
+type Oauth2OptsGrantType string
+
 // ReadParams defines how we are reading data from a SaaS API.
 type ReadParams struct {
 	// The name of the object we are reading, e.g. "Account"

--- a/test/salesforce/connector.go
+++ b/test/salesforce/connector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/salesforce"
-	"github.com/amp-labs/connectors/test/utils"
 	testUtils "github.com/amp-labs/connectors/test/utils"
 	"golang.org/x/oauth2"
 )
@@ -49,7 +48,7 @@ func GetSalesforceAccessToken() string {
 
 func getSalesforceJSONReader() *credscanning.ProviderCredentials {
 	filePath := credscanning.LoadPath(providers.Salesforce)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := testUtils.MustCreateProvCredJSON(filePath, true, true)
 
 	return reader
 }


### PR DESCRIPTION
This PR adds 2 legged as an option in creating the Authenticated client using OAuth2. This will allow adding deep connectors implementing Client Credentials Grant Type.  