### PR TITLE
feat: Add Read (Marketo deep connector)

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -10,7 +10,7 @@ import (
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
 func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
-	// A must check.
+	// A must check for customs, This  common error handler assumes 200 OK, can never be erroneous.
 	if res.StatusCode >= 200 || res.StatusCode <= 299 {
 		return nil
 	}

--- a/common/error.go
+++ b/common/error.go
@@ -9,7 +9,7 @@ import (
 
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
-func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
+func InterpretError(res *http.Response, body []byte) error {
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
 		// Access token invalid, refresh token and retry

--- a/common/error.go
+++ b/common/error.go
@@ -11,7 +11,7 @@ import (
 // way) and returns an error that can be handled by the caller.
 func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
 	// A must check.
-	if res.StatusCode < 200 || res.StatusCode > 299 {
+	if res.StatusCode >= 200 || res.StatusCode <= 299 {
 		return nil
 	}
 

--- a/common/error.go
+++ b/common/error.go
@@ -10,11 +10,6 @@ import (
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
 func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
-	// A must check for customs, This  common error handler assumes 200 OK, can never be erroneous.
-	if res.StatusCode >= 200 && res.StatusCode <= 299 {
-		return nil
-	}
-
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
 		// Access token invalid, refresh token and retry

--- a/common/error.go
+++ b/common/error.go
@@ -9,7 +9,12 @@ import (
 
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
-func InterpretError(res *http.Response, body []byte) error {
+func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
+	// A must check.
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return nil
+	}
+
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
 		// Access token invalid, refresh token and retry

--- a/common/error.go
+++ b/common/error.go
@@ -11,7 +11,7 @@ import (
 // way) and returns an error that can be handled by the caller.
 func InterpretError(res *http.Response, body []byte) error { //nolint:cyclop
 	// A must check for customs, This  common error handler assumes 200 OK, can never be erroneous.
-	if res.StatusCode >= 200 || res.StatusCode <= 299 {
+	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return nil
 	}
 

--- a/common/http.go
+++ b/common/http.go
@@ -262,7 +262,7 @@ func makeDeleteRequest(ctx context.Context, url string, headers []Header) (*http
 }
 
 // sendRequest sends the given request and returns the response & response body.
-func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, error) {
+func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, error) { //nolint:cyclop
 	// Send the request
 	res, err := h.Client.Do(req)
 	if err != nil {

--- a/common/http.go
+++ b/common/http.go
@@ -283,16 +283,11 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 		return nil, nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
-	// Check the response status code
-	if res.StatusCode < 200 || res.StatusCode > 299 {
-		if h.ErrorHandler != nil {
-			return nil, nil, h.ErrorHandler(res, body)
-		}
-
-		return nil, nil, InterpretError(res, body)
+	if h.ErrorHandler != nil {
+		return res, body, h.ErrorHandler(res, body)
 	}
 
-	return res, body, nil
+	return res, body, InterpretError(res, body)
 }
 
 // getURL returns the given URL if it is an absolute URL, or the given URL joined with the base URL.

--- a/common/http.go
+++ b/common/http.go
@@ -31,7 +31,7 @@ type HTTPClient struct {
 	Base         string                  // optional base URL. If not set, then all URLs must be absolute.
 	Client       AuthenticatedHTTPClient // underlying HTTP client. Required.
 	ErrorHandler ErrorHandler            // optional error handler. If not set, then the default error handler is used.
-	OKStatusErr  bool
+	OKStatusErr  bool                    // optional, If set true indicates 200OK http response may include errors.
 }
 
 // getURL returns the base prefixed URL.
@@ -290,10 +290,10 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		if h.ErrorHandler != nil {
-			return res, body, h.ErrorHandler(res, body)
+			return nil, nil, h.ErrorHandler(res, body)
 		}
 
-		return res, body, InterpretError(res, body)
+		return nil, nil, InterpretError(res, body)
 	}
 
 	return res, body, nil

--- a/marketo/client.go
+++ b/marketo/client.go
@@ -1,0 +1,16 @@
+package marketo
+
+import "github.com/amp-labs/connectors/common"
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/marketo/connnector.go
+++ b/marketo/connnector.go
@@ -34,6 +34,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 			HTTPClient: &common.HTTPClient{
 				Client:       params.Caller.Client,
 				ErrorHandler: interpretError,
+				OKStatusErr:  true,
 			},
 		},
 		Module: params.Module.Name,

--- a/marketo/connnector.go
+++ b/marketo/connnector.go
@@ -31,7 +31,10 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 
 	conn = &Connector{
 		Client: &common.JSONHTTPClient{
-			HTTPClient: params.Client.Caller,
+			HTTPClient: &common.HTTPClient{
+				Client:       params.Caller.Client,
+				ErrorHandler: interpretError,
+			},
 		},
 		Module: params.Module.Name,
 	}

--- a/marketo/connnector.go
+++ b/marketo/connnector.go
@@ -1,8 +1,11 @@
 package marketo
 
 import (
+	"strings"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -32,9 +35,8 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	conn = &Connector{
 		Client: &common.JSONHTTPClient{
 			HTTPClient: &common.HTTPClient{
-				Client:       params.Caller.Client,
-				ErrorHandler: interpretError,
-				OKStatusErr:  true,
+				Client:          params.Caller.Client,
+				ResponseHandler: responseHandler,
 			},
 		},
 		Module: params.Module.Name,
@@ -53,6 +55,16 @@ func (c *Connector) setBaseURL(newURL string) {
 // Provider returns the connector provider.
 func (c *Connector) Provider() providers.Provider {
 	return providers.Marketo
+}
+
+func (c *Connector) getApiURL(objName string) (*urlbuilder.URL, error) {
+	bURL := strings.Join([]string{restAPIPrefix, c.Module, objName}, "/")
+
+	if !strings.HasSuffix(objName, ".json") {
+		bURL += ".json"
+	}
+
+	return constructURL(c.BaseURL, bURL)
 }
 
 func (c *Connector) String() string {

--- a/marketo/connnector.go
+++ b/marketo/connnector.go
@@ -1,0 +1,56 @@
+package marketo
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	BaseURL string
+	Client  *common.JSONHTTPClient
+	Module  string
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read provider info
+	providerInfo, err := providers.ReadInfo(providers.Marketo, &params.Workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	conn = &Connector{
+		Client: &common.JSONHTTPClient{
+			HTTPClient: params.Client.Caller,
+		},
+		Module: params.Module.Name,
+	}
+
+	conn.setBaseURL(providerInfo.BaseURL)
+
+	return conn, nil
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}
+
+// Provider returns the connector provider.
+func (c *Connector) Provider() providers.Provider {
+	return providers.Marketo
+}
+
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -29,28 +29,33 @@ func checkResponseLeverErr(body []byte) (bool, int, error) {
 		return false, 0, err
 	}
 
+	if len(resp.Errors) == 0 {
+		return false, 0, nil
+	}
+
 	code, err := strconv.Atoi(resp.Errors[0].Code)
 	if err != nil {
 		return false, 0, err
 	}
 
-	return len(resp.Errors) > 0, code, nil
+	return (len(resp.Errors) > 0), code, nil
 }
 
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
 func interpretError(res *http.Response, body []byte) error { //nolint:cyclop
 	// A must check.
-	if res.StatusCode < 200 || res.StatusCode > 299 {
+	if res.StatusCode <= 200 || res.StatusCode <= 299 {
 		erroneous, code, err := checkResponseLeverErr(body)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Erroneous: ", erroneous)
 
-		// If response is 200 OK, but erroneous, we update the status code & continue with the switch cases.
+		// If response is 200 OK, but erroneous, we update the status code,
+		//  continue with the switch cases.
 		if erroneous {
 			statusCode := statusCodeMap(code)
+			fmt.Println("Mapped status code: ", statusCode)
 			res.StatusCode = statusCode
 		} else {
 			return nil

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -13,7 +13,7 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-type Respose struct {
+type Response struct {
 	Errors    []Error          `json:"errors"`
 	Result    []map[string]any `json:"result"`
 	RequestID string           `json:"requestId"`
@@ -23,7 +23,7 @@ type Respose struct {
 // checkResponseLeverErr reports wheather the response level error is available or not.
 // If available, returns the error code as well.
 func checkResponseLeverErr(body []byte) (bool, int, error) {
-	var resp Respose
+	var resp Response
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return false, 0, err
 	}

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -55,7 +55,6 @@ func interpretError(res *http.Response, body []byte) error { //nolint:cyclop
 		//  continue with the switch cases.
 		if erroneous {
 			statusCode := statusCodeMap(code)
-			fmt.Println("Mapped status code: ", statusCode)
 			res.StatusCode = statusCode
 		} else {
 			return nil

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -45,7 +45,7 @@ func checkResponseLeverErr(body []byte) (bool, int, error) {
 // way) and returns an error that can be handled by the caller.
 func interpretError(res *http.Response, body []byte) error { //nolint:cyclop
 	// A must check.
-	if res.StatusCode <= 200 || res.StatusCode <= 299 {
+	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		erroneous, code, err := checkResponseLeverErr(body)
 		if err != nil {
 			return err

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -2,11 +2,11 @@ package marketo
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
-	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/spyzhov/ajson"
+	"github.com/amp-labs/connectors/common"
 )
 
 type Error struct {
@@ -14,101 +14,135 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-// retrieveInternalCode returns the first error code in marketo http response.
-func retrieveInternalCode(root *ajson.Node) (int, error) {
-	var errD Error
-
-	Errors, err := jsonquery.New(root).Array("errors", true)
-	if err != nil {
-		return 0, err
-	}
-
-	if err := json.Unmarshal(Errors[0].Source(), &errD); err != nil {
-		return 0, err
-	}
-
-	code, err := strconv.Atoi(errD.Code)
-	if err != nil {
-		return 0, err
-	}
-
-	return code, nil
+type Respose struct {
+	Errors    []Error          `json:"errors"`
+	Result    []map[string]any `json:"result"`
+	RequestID string           `json:"requestId"`
+	Success   bool             `json:"success"`
 }
 
-// checkResponseLeverErr reports wheather the response level error is available.
-func checkResponseLeverErr(root *ajson.Node) (bool, error) {
-	size, err := jsonquery.New(root).ArraySize("errors")
-	if err != nil {
-		return false, err
+// checkResponseLeverErr reports wheather the response level error is available or not.
+// If available, returns the error code as well.
+func checkResponseLeverErr(body []byte) (bool, int, error) {
+	var resp Respose
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false, 0, err
 	}
 
-	return size > 0, nil
+	code, err := strconv.Atoi(resp.Errors[0].Code)
+	if err != nil {
+		return false, 0, err
+	}
+
+	return len(resp.Errors) > 0, code, nil
 }
 
-// func ErrorHandler(resp *http.Response)
+// InterpretError interprets the given HTTP response (in a fairly straightforward
+// way) and returns an error that can be handled by the caller.
+func interpretError(res *http.Response, body []byte) error { //nolint:cyclop
+	// A must check.
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		erroneous, code, err := checkResponseLeverErr(body)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Erroneous: ", erroneous)
+
+		// If response is 200 OK, but erroneous, we update the status code & continue with the switch cases.
+		if erroneous {
+			statusCode := statusCodeMap(code)
+			res.StatusCode = statusCode
+		} else {
+			return nil
+		}
+	}
+
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		// Access token invalid, refresh token and retry
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrAccessToken, string(body)))
+	case http.StatusForbidden:
+		// Forbidden, not retryable
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrForbidden, string(body)))
+	case http.StatusNotFound:
+		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrRetryable, string(body)))
+	case http.StatusTooManyRequests:
+		// Too many requests, retryable
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrRetryable, string(body)))
+	}
+
+	if res.StatusCode >= 400 && res.StatusCode < 500 {
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrCaller, string(body)))
+	} else if res.StatusCode >= 500 && res.StatusCode < 600 {
+		return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrServer, string(body)))
+	}
+
+	return common.NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", common.ErrUnknown, string(body)))
+}
 
 // statusCodeMap maps the erroneous response from marketo, with a valid http status code.
 // The response body can be sent as is.
 // https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/error-codes
-func statusCodeMap(code int) int { //nolint:funlen
+func statusCodeMap(code int) int { //nolint:funlen,cyclop
 	switch code {
-	case 502:
+	case 502: //nolint:gomnd
 		return http.StatusBadGateway
-	case 601:
+	case 601: //nolint:gomnd
 		return http.StatusUnauthorized
-	case 602:
+	case 602: //nolint:gomnd
 		return http.StatusUnauthorized // token Expired
-	case 603:
+	case 603: //nolint:gomnd
 		return http.StatusForbidden
-	case 604:
+	case 604: //nolint:gomnd
 		return http.StatusRequestTimeout
-	case 605:
+	case 605: //nolint:gomnd
 		return http.StatusMethodNotAllowed
-	case 606:
+	case 606: //nolint:gomnd
 		return http.StatusTooManyRequests
-	case 607:
+	case 607: //nolint:gomnd
 		return http.StatusTooManyRequests
-	case 608:
+	case 608: //nolint:gomnd
 		return http.StatusServiceUnavailable
-	case 609:
+	case 609: //nolint:gomnd
 		return http.StatusBadRequest
-	case 610:
+	case 610: //nolint:gomnd
 		return http.StatusNotFound
-	case 611:
+	case 611: //nolint:gomnd
 		return http.StatusInternalServerError
-	case 612:
+	case 612: //nolint:gomnd
 		return http.StatusUnsupportedMediaType
-	case 613:
+	case 613: //nolint:gomnd
 		return http.StatusBadRequest
-	case 614:
+	case 614: //nolint:gomnd
 		return http.StatusNotFound
-	case 615:
+	case 615: //nolint:gomnd
 		return http.StatusTooManyRequests
-	case 616:
+	case 616: //nolint:gomnd
 		return http.StatusForbidden
-	case 701:
+	case 701: //nolint:gomnd
 		return http.StatusBadRequest
-	case 702:
+	case 702: //nolint:gomnd
 		return http.StatusNotFound
-	case 703:
+	case 703: //nolint:gomnd
 		return http.StatusForbidden
-	case 704:
+	case 704: //nolint:gomnd
 		return http.StatusBadRequest
-	case 709:
+	case 709: //nolint:gomnd
 		return http.StatusConflict
-	case 710:
+	case 710: //nolint:gomnd
 		return http.StatusNotFound
-	case 711:
+	case 711: //nolint:gomnd
 		return http.StatusBadRequest
-	case 712:
+	case 712: //nolint:gomnd
 		return http.StatusBadRequest
-	case 713:
+	case 713: //nolint:gomnd
 		return http.StatusServiceUnavailable
-	case 714:
+	case 714: //nolint:gomnd
 		return http.StatusNotFound
-	case 718:
+	case 718: //nolint:gomnd
 		return http.StatusNotFound
-	case 719:
+	case 719: //nolint:gomnd
 		return http.StatusRequestTimeout
 	default:
 		return code

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -17,6 +17,7 @@ type Error struct {
 // retrieveInternalCode returns the first error code in marketo http response.
 func retrieveInternalCode(root *ajson.Node) (int, error) {
 	var errD Error
+
 	Errors, err := jsonquery.New(root).Array("errors", true)
 	if err != nil {
 		return 0, err
@@ -44,12 +45,12 @@ func checkResponseLeverErr(root *ajson.Node) (bool, error) {
 	return size > 0, nil
 }
 
-func ErrorHandler(resp *http.Response)
+// func ErrorHandler(resp *http.Response)
 
 // statusCodeMap maps the erroneous response from marketo, with a valid http status code.
 // The response body can be sent as is.
 // https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/error-codes
-func statusCodeMap(code int) int {
+func statusCodeMap(code int) int { //nolint:funlen
 	switch code {
 	case 502:
 		return http.StatusBadGateway

--- a/marketo/errors.go
+++ b/marketo/errors.go
@@ -1,0 +1,115 @@
+package marketo
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// retrieveInternalCode returns the first error code in marketo http response.
+func retrieveInternalCode(root *ajson.Node) (int, error) {
+	var errD Error
+	Errors, err := jsonquery.New(root).Array("errors", true)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := json.Unmarshal(Errors[0].Source(), &errD); err != nil {
+		return 0, err
+	}
+
+	code, err := strconv.Atoi(errD.Code)
+	if err != nil {
+		return 0, err
+	}
+
+	return code, nil
+}
+
+// checkResponseLeverErr reports wheather the response level error is available.
+func checkResponseLeverErr(root *ajson.Node) (bool, error) {
+	size, err := jsonquery.New(root).ArraySize("errors")
+	if err != nil {
+		return false, err
+	}
+
+	return size > 0, nil
+}
+
+func ErrorHandler(resp *http.Response)
+
+// statusCodeMap maps the erroneous response from marketo, with a valid http status code.
+// The response body can be sent as is.
+// https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/error-codes
+func statusCodeMap(code int) int {
+	switch code {
+	case 502:
+		return http.StatusBadGateway
+	case 601:
+		return http.StatusUnauthorized
+	case 602:
+		return http.StatusUnauthorized // token Expired
+	case 603:
+		return http.StatusForbidden
+	case 604:
+		return http.StatusRequestTimeout
+	case 605:
+		return http.StatusMethodNotAllowed
+	case 606:
+		return http.StatusTooManyRequests
+	case 607:
+		return http.StatusTooManyRequests
+	case 608:
+		return http.StatusServiceUnavailable
+	case 609:
+		return http.StatusBadRequest
+	case 610:
+		return http.StatusNotFound
+	case 611:
+		return http.StatusInternalServerError
+	case 612:
+		return http.StatusUnsupportedMediaType
+	case 613:
+		return http.StatusBadRequest
+	case 614:
+		return http.StatusNotFound
+	case 615:
+		return http.StatusTooManyRequests
+	case 616:
+		return http.StatusForbidden
+	case 701:
+		return http.StatusBadRequest
+	case 702:
+		return http.StatusNotFound
+	case 703:
+		return http.StatusForbidden
+	case 704:
+		return http.StatusBadRequest
+	case 709:
+		return http.StatusConflict
+	case 710:
+		return http.StatusNotFound
+	case 711:
+		return http.StatusBadRequest
+	case 712:
+		return http.StatusBadRequest
+	case 713:
+		return http.StatusServiceUnavailable
+	case 714:
+		return http.StatusNotFound
+	case 718:
+		return http.StatusNotFound
+	case 719:
+		return http.StatusRequestTimeout
+	default:
+		return code
+	}
+}

--- a/marketo/module.go
+++ b/marketo/module.go
@@ -14,16 +14,9 @@ var Leads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
 	Version: "v1",
 }
 
-// ModuleEmpty is used for proxying requests through.
-var ModuleEmpty = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "",
-	Version: "",
-}
-
 // supportedModules represents currently working and supported modules within the Hubspot connector.
 // Any added module should be appended here.
 var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	ModuleEmpty,
 	Leads,
 	Assets,
 }

--- a/marketo/module.go
+++ b/marketo/module.go
@@ -2,14 +2,14 @@ package marketo
 
 import "github.com/amp-labs/connectors/common/paramsbuilder"
 
-// Assets is the module/API used for accessing assets objects.
-var Assets = paramsbuilder.APIModule{ // nolint: gochecknoglobals
+// ModuleAssets is the module/API used for accessing assets objects.
+var ModuleAssets = paramsbuilder.APIModule{ // nolint: gochecknoglobals
 	Label:   "asset",
 	Version: "v1",
 }
 
-// Leads is the module/API used for accessing leads objects.
-var Leads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
+// ModuleLeads is the module/API used for accessing leads objects.
+var ModuleLeads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
 	Label:   "",
 	Version: "v1",
 }
@@ -17,6 +17,6 @@ var Leads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
 // supportedModules represents currently working and supported modules within the Marketo connector.
 // Any added module should be appended here.
 var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Leads,
-	Assets,
+	ModuleLeads,
+	ModuleAssets,
 }

--- a/marketo/module.go
+++ b/marketo/module.go
@@ -14,7 +14,7 @@ var Leads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
 	Version: "v1",
 }
 
-// supportedModules represents currently working and supported modules within the Hubspot connector.
+// supportedModules represents currently working and supported modules within the Marketo connector.
 // Any added module should be appended here.
 var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
 	Leads,

--- a/marketo/module.go
+++ b/marketo/module.go
@@ -1,0 +1,29 @@
+package marketo
+
+import "github.com/amp-labs/connectors/common/paramsbuilder"
+
+// Assets is the module/API used for accessing assets objects.
+var Assets = paramsbuilder.APIModule{ // nolint: gochecknoglobals
+	Label:   "asset",
+	Version: "v1",
+}
+
+// Leads is the module/API used for accessing leads objects.
+var Leads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
+	Label:   "",
+	Version: "v1",
+}
+
+// ModuleEmpty is used for proxying requests through.
+var ModuleEmpty = paramsbuilder.APIModule{ // nolint: gochecknoglobals
+	Label:   "",
+	Version: "",
+}
+
+// supportedModules represents currently working and supported modules within the Hubspot connector.
+// Any added module should be appended here.
+var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
+	ModuleEmpty,
+	Leads,
+	Assets,
+}

--- a/marketo/params.go
+++ b/marketo/params.go
@@ -30,7 +30,6 @@ func (p parameters) ValidateParams() error {
 func WithClient(ctx context.Context, client *http.Client,
 	config *clientcredentials.Config, token *oauth2.Token,
 ) Option {
-
 	authClient := config.Client(ctx)
 
 	return func(params *parameters) {
@@ -41,7 +40,7 @@ func WithClient(ctx context.Context, client *http.Client,
 // WithModule sets the marketo API module to use for the connector. It's required.
 func WithModule(module paramsbuilder.APIModule) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, &ModuleEmpty)
+		params.WithModule(module, supportedModules, &Assets)
 	}
 }
 

--- a/marketo/params.go
+++ b/marketo/params.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -28,7 +27,7 @@ func (p parameters) ValidateParams() error {
 }
 
 func WithClient(ctx context.Context, client *http.Client,
-	config *clientcredentials.Config, token *oauth2.Token,
+	config *clientcredentials.Config,
 ) Option {
 	authClient := config.Client(ctx)
 
@@ -44,6 +43,7 @@ func WithModule(module paramsbuilder.APIModule) Option {
 	}
 }
 
+// WithWorkspace sets the marketo API instance to use for the connector. It's required.
 func WithWorkspace(workspace string) Option {
 	return func(params *parameters) {
 		params.WithWorkspace(workspace)

--- a/marketo/params.go
+++ b/marketo/params.go
@@ -1,0 +1,58 @@
+package marketo
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type Option = func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
+	paramsbuilder.Workspace
+	paramsbuilder.Module
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+		p.Workspace.ValidateParams(),
+		p.Module.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	config *clientcredentials.Config, token *oauth2.Token,
+) Option {
+
+	authClient := config.Client(ctx)
+
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(authClient)
+	}
+}
+
+// WithModule sets the marketo API module to use for the connector. It's required.
+func WithModule(module paramsbuilder.APIModule) Option {
+	return func(params *parameters) {
+		params.WithModule(module, supportedModules, &ModuleEmpty)
+	}
+}
+
+func WithWorkspace(workspace string) Option {
+	return func(params *parameters) {
+		params.WithWorkspace(workspace)
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
+	}
+}

--- a/marketo/params.go
+++ b/marketo/params.go
@@ -39,7 +39,7 @@ func WithClient(ctx context.Context, client *http.Client,
 // WithModule sets the marketo API module to use for the connector. It's required.
 func WithModule(module paramsbuilder.APIModule) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, &Assets)
+		params.WithModule(module, supportedModules, &ModuleLeads)
 	}
 }
 

--- a/marketo/parse.go
+++ b/marketo/parse.go
@@ -1,0 +1,40 @@
+package marketo
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// getNextRecordsURL returns the URL for the next page of results.
+func getNextRecordsURL(node *ajson.Node) (string, error) {
+	return jsonquery.New(node).StrWithDefault("nextPageToken", "")
+}
+
+// getRecords returns the records from the response.
+func getRecords(node *ajson.Node) ([]map[string]any, error) {
+	result, err := jsonquery.New(node).Array("result", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonquery.Convertor.ArrayToMap(result)
+}
+
+func getTotalSize(node *ajson.Node) (int64, error) {
+	return jsonquery.New(node).ArraySize("result")
+}
+
+// getMarshalledData accepts a list of records and returns a list of structured data ([]ReadResultRow).
+func getMarshalledData(records []map[string]any, fields []string) ([]common.ReadResultRow, error) {
+	data := make([]common.ReadResultRow, len(records))
+
+	for i, record := range records {
+		data[i] = common.ReadResultRow{
+			Fields: common.ExtractLowercaseFieldsFromRaw(fields, record),
+			Raw:    record,
+		}
+	}
+
+	return data, nil
+}

--- a/marketo/read.go
+++ b/marketo/read.go
@@ -20,9 +20,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	// Handle Response Level Errors.
-	// Inject an error handling when response is 200 OK.
-
 	return common.ParseResult(res, getTotalSize,
 		getRecords,
 		getNextRecordsURL,

--- a/marketo/read.go
+++ b/marketo/read.go
@@ -1,0 +1,32 @@
+package marketo
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// Read retrieves data based on the provided configuration parameters.
+//
+// This function executes a read operation using the given context and
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	url, err := c.getURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle Response Level Errors.
+	// Inject an error handling when response is 200 OK.
+
+	return common.ParseResult(res, getTotalSize,
+		getRecords,
+		getNextRecordsURL,
+		getMarshalledData,
+		config.Fields,
+	)
+}

--- a/marketo/read.go
+++ b/marketo/read.go
@@ -8,7 +8,7 @@ import (
 
 // Read retrieves data based on the provided configuration parameters.
 //
-// This function executes a read operation using the given context and
+// This function executes a read operation using the given context and.
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
 	url, err := c.getURL(config)
 	if err != nil {

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -1,0 +1,35 @@
+package marketo
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+var restAPIPrefix string = "rest"
+
+func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	// make sure the object is in lowercase format.
+	objName := strings.ToLower(params.ObjectName)
+
+	bURL := strings.Join([]string{c.BaseURL, restAPIPrefix, c.Module, objName}, "/")
+	bURL += ".json"
+
+	link, err := urlbuilder.New(bURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// This affects  a very few number of objects.
+	// Leads, Deleted Leads, Lead Changes,
+	if !params.Since.IsZero() {
+		time := params.Since.Format(time.RFC3339)
+		fmtTime := fmt.Sprintf("%v", time)
+		link.WithQueryParam("sinceDatetime", fmtTime)
+	}
+
+	return link, nil
+}

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common/urlbuilder"
 )
 
-var restAPIPrefix string = "rest"
+var restAPIPrefix string = "rest" //nolint:gochecknoglobals
 
 func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	// make sure the object is in lowercase format.

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -16,7 +16,7 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	reader := getMarketoJSONReader()
 
 	conn, err := marketo.NewConnector(
-		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
+		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
 		marketo.WithModule(marketo.Assets),
 	)

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -1,0 +1,52 @@
+package marketo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/marketo"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+func GetMarketoConnector(ctx context.Context) *marketo.Connector {
+	reader := getMarketoJSONReader()
+
+	conn, err := marketo.NewConnector(
+		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
+		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
+		marketo.WithModule(marketo.Assets),
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *clientcredentials.Config {
+	workspace := reader.Get(credscanning.Fields.Workspace)
+
+	return &clientcredentials.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		TokenURL:     fmt.Sprintf("https://%s.mktorest.com/identity/oauth/token", workspace),
+		Scopes:       []string{},
+	}
+}
+
+func GetMarketoAccessToken() string {
+	reader := getMarketoJSONReader()
+
+	return reader.Get(credscanning.Fields.AccessToken)
+}
+
+func getMarketoJSONReader() *credscanning.ProviderCredentials {
+	filePath := credscanning.LoadPath(providers.Marketo)
+	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+
+	return reader
+}

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -18,7 +18,7 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	conn, err := marketo.NewConnector(
 		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		marketo.WithModule(marketo.Assets),
+		marketo.WithModule(marketo.ModuleAssets),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
 	mk "github.com/amp-labs/connectors/test/marketo"
@@ -29,9 +30,9 @@ func testReadActivities(ctx context.Context) error {
 	conn := mk.GetMarketoConnector(ctx)
 
 	params := common.ReadParams{
-		ObjectName: "channel",
+		ObjectName: "channels",
 		Fields:     []string{"applicableProgramType", "id", "name"},
-		// Since:      time.Now(),
+		Since:      time.Now().Add(-720 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -17,8 +17,7 @@ func main() {
 }
 
 func MainFn() int {
-
-	err := testReadActivities(context.Background())
+	err := testRead(context.Background())
 	if err != nil {
 		return 1
 	}
@@ -26,11 +25,11 @@ func MainFn() int {
 	return 0
 }
 
-func testReadActivities(ctx context.Context) error {
+func testRead(ctx context.Context) error {
 	conn := mk.GetMarketoConnector(ctx)
 
 	params := common.ReadParams{
-		ObjectName: "channel",
+		ObjectName: "channels",
 		Fields:     []string{"applicableProgramType", "id", "name"},
 		Since:      time.Now().Add(-720 * time.Hour),
 	}

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -30,7 +30,7 @@ func testReadActivities(ctx context.Context) error {
 	conn := mk.GetMarketoConnector(ctx)
 
 	params := common.ReadParams{
-		ObjectName: "channels",
+		ObjectName: "channel",
 		Fields:     []string{"applicableProgramType", "id", "name"},
 		Since:      time.Now().Add(-720 * time.Hour),
 	}

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -29,7 +29,7 @@ func testReadActivities(ctx context.Context) error {
 	conn := mk.GetMarketoConnector(ctx)
 
 	params := common.ReadParams{
-		ObjectName: "channels",
+		ObjectName: "channel",
 		Fields:     []string{"applicableProgramType", "id", "name"},
 		// Since:      time.Now(),
 	}

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	mk "github.com/amp-labs/connectors/test/marketo"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+
+	err := testReadActivities(context.Background())
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testReadActivities(ctx context.Context) error {
+	conn := mk.GetMarketoConnector(ctx)
+
+	params := common.ReadParams{
+		ObjectName: "channels",
+		Fields:     []string{"applicableProgramType", "id", "name"},
+		// Since:      time.Now(),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}

--- a/test/marketo/read/sample_response/channels.json
+++ b/test/marketo/read/sample_response/channels.json
@@ -1,0 +1,666 @@
+{
+  "rows": 15,
+  "data": [
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 3,
+        "name": "Online Advertising"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 3,
+        "name": "Online Advertising",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Filled-out Form",
+            "step": 10,
+            "success": false,
+            "type": "Filled-out Form"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "webinar",
+        "id": 1,
+        "name": "Webinar"
+      },
+      "raw": {
+        "applicableProgramType": "webinar",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 1,
+        "name": "Webinar",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Invited",
+            "step": 10,
+            "success": false,
+            "type": "Invited"
+          },
+          {
+            "hidden": false,
+            "name": "Registration Error",
+            "step": 20,
+            "success": false,
+            "type": "Registration Error"
+          },
+          {
+            "hidden": false,
+            "name": "Waitlisted",
+            "step": 20,
+            "success": false,
+            "type": "Waitlisted"
+          },
+          {
+            "hidden": false,
+            "name": "Registered",
+            "step": 20,
+            "success": false,
+            "type": "Registered"
+          },
+          {
+            "hidden": false,
+            "name": "No Show",
+            "step": 30,
+            "success": false,
+            "type": "No Show"
+          },
+          {
+            "hidden": false,
+            "name": "Attended",
+            "step": 40,
+            "success": true,
+            "type": "Attended"
+          },
+          {
+            "hidden": false,
+            "name": "Attended On-demand",
+            "step": 50,
+            "success": true,
+            "type": "Attended On-demand"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "webinar",
+        "id": 2,
+        "name": "Webinar (Asynchronous)"
+      },
+      "raw": {
+        "applicableProgramType": "webinar",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 2,
+        "name": "Webinar (Asynchronous)",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Invited",
+            "step": 10,
+            "success": false,
+            "type": "Invited"
+          },
+          {
+            "hidden": false,
+            "name": "Registration Error",
+            "step": 20,
+            "success": false,
+            "type": "Registration Error"
+          },
+          {
+            "hidden": false,
+            "name": "Registering",
+            "step": 20,
+            "success": false,
+            "type": "Registering"
+          },
+          {
+            "hidden": false,
+            "name": "Waitlisted",
+            "step": 20,
+            "success": false,
+            "type": "Waitlisted"
+          },
+          {
+            "hidden": false,
+            "name": "Registered",
+            "step": 20,
+            "success": false,
+            "type": "Registered"
+          },
+          {
+            "hidden": false,
+            "name": "No Show",
+            "step": 30,
+            "success": false,
+            "type": "No Show"
+          },
+          {
+            "hidden": false,
+            "name": "Attended",
+            "step": 40,
+            "success": true,
+            "type": "Attended"
+          },
+          {
+            "hidden": false,
+            "name": "Attended On-demand",
+            "step": 50,
+            "success": true,
+            "type": "Attended On-demand"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "event",
+        "id": 4,
+        "name": "Tradeshow"
+      },
+      "raw": {
+        "applicableProgramType": "event",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 4,
+        "name": "Tradeshow",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Invited",
+            "step": 10,
+            "success": false,
+            "type": "Invited"
+          },
+          {
+            "hidden": false,
+            "name": "Waitlisted",
+            "step": 20,
+            "success": false,
+            "type": "Waitlisted"
+          },
+          {
+            "hidden": false,
+            "name": "Registered",
+            "step": 20,
+            "success": false,
+            "type": "Registered"
+          },
+          {
+            "hidden": false,
+            "name": "Visited Booth",
+            "step": 30,
+            "success": false,
+            "type": "Visited"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 40,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "event",
+        "id": 5,
+        "name": "Live Event"
+      },
+      "raw": {
+        "applicableProgramType": "event",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 5,
+        "name": "Live Event",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Invited",
+            "step": 10,
+            "success": false,
+            "type": "Invited"
+          },
+          {
+            "hidden": false,
+            "name": "Waitlisted",
+            "step": 20,
+            "success": false,
+            "type": "Waitlisted"
+          },
+          {
+            "hidden": false,
+            "name": "Registered",
+            "step": 20,
+            "success": false,
+            "type": "Registered"
+          },
+          {
+            "hidden": false,
+            "name": "No Show",
+            "step": 30,
+            "success": false,
+            "type": "No Show"
+          },
+          {
+            "hidden": false,
+            "name": "Attended",
+            "step": 40,
+            "success": true,
+            "type": "Attended"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 6,
+        "name": "List Import"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 6,
+        "name": "List Import",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "On List",
+            "step": 10,
+            "success": false,
+            "type": "On List"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 7,
+        "name": "Web Content"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 7,
+        "name": "Web Content",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Filled-out Form",
+            "step": 10,
+            "success": false,
+            "type": "Filled-out Form"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "nurture",
+        "id": 8,
+        "name": "Nurture"
+      },
+      "raw": {
+        "applicableProgramType": "nurture",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 8,
+        "name": "Nurture",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Member",
+            "step": 10,
+            "success": false,
+            "type": "Member"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "email_batch",
+        "id": 9,
+        "name": "Email Send"
+      },
+      "raw": {
+        "applicableProgramType": "email_batch",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 9,
+        "name": "Email Send",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Member",
+            "step": 10,
+            "success": false,
+            "type": "Member"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "email_batch",
+        "id": 10,
+        "name": "Newsletter"
+      },
+      "raw": {
+        "applicableProgramType": "email_batch",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 10,
+        "name": "Newsletter",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Member",
+            "step": 10,
+            "success": false,
+            "type": "Member"
+          },
+          {
+            "hidden": false,
+            "name": "Influenced",
+            "step": 20,
+            "success": true,
+            "type": "Influenced"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 12,
+        "name": "Operational"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 12,
+        "name": "Operational",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Member",
+            "step": 10,
+            "success": false,
+            "type": "Member"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 11,
+        "name": "Web Request"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 11,
+        "name": "Web Request",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Filled-out Form",
+            "step": 10,
+            "success": true,
+            "type": "Filled-out Form"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "in_app",
+        "id": 13,
+        "name": "Mobile In-App"
+      },
+      "raw": {
+        "applicableProgramType": "in_app",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 13,
+        "name": "Mobile In-App",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Viewed",
+            "step": 10,
+            "success": false,
+            "type": "Viewed"
+          },
+          {
+            "hidden": false,
+            "name": "Engaged",
+            "step": 20,
+            "success": false,
+            "type": "Engaged"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "web",
+        "id": 14,
+        "name": "Web Personalization"
+      },
+      "raw": {
+        "applicableProgramType": "web",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 14,
+        "name": "Web Personalization",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Viewed",
+            "step": 10,
+            "success": false,
+            "type": "Viewed"
+          },
+          {
+            "hidden": false,
+            "name": "Engaged",
+            "step": 20,
+            "success": true,
+            "type": "Engaged"
+          },
+          {
+            "hidden": false,
+            "name": "Converted",
+            "step": 30,
+            "success": true,
+            "type": "Converted"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    },
+    {
+      "fields": {
+        "applicableprogramtype": "program",
+        "id": 15,
+        "name": "Chat"
+      },
+      "raw": {
+        "applicableProgramType": "program",
+        "createdAt": "2024-03-10T09:24:11Z+0000",
+        "id": 15,
+        "name": "Chat",
+        "progressionStatuses": [
+          {
+            "hidden": false,
+            "name": "Not in Program",
+            "step": 0,
+            "success": false,
+            "type": "Not in Program"
+          },
+          {
+            "hidden": false,
+            "name": "Member",
+            "step": 10,
+            "success": false,
+            "type": "Member"
+          },
+          {
+            "hidden": false,
+            "name": "Engaged",
+            "step": 20,
+            "success": true,
+            "type": "Engaged"
+          }
+        ],
+        "updatedAt": "2024-03-10T09:24:11Z+0000"
+      }
+    }
+  ],
+  "done": true
+}


### PR DESCRIPTION
This adds Read capability for the Marketo deep connector. 
Note:
- Marketo API responds with 200 Ok, for most cases, even when having errors.  Created a mapping function for mapping native marketo error codes to http status codes. So then the server can determine what to do with the response.

-doc link: https://experienceleague.adobe.com/en/docs/marketo-developer/marketo/rest/error-codes 

Sample test when the response from Marketo is 200, But the custom error handler returns a 404.
<img width="1182" alt="Screenshot 2024-08-15 at 18 53 40" src="https://github.com/user-attachments/assets/ac871fb8-e2ad-463c-91d9-8d7cde439938">

Closes #908 
