### PR TITLE
add: Get URL query param

### DIFF
--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -48,6 +48,15 @@ func (u *URL) WithQueryParam(name, value string) {
 	u.queryParams[name] = []string{value}
 }
 
+func (u *URL) GetSingleQueryParam(name string) (string, bool) {
+	value, ok := u.queryParams[name]
+	if !ok || len(value) == 0 {
+		return "", false
+	}
+
+	return value[0], true
+}
+
 func (u *URL) RemoveQueryParam(name string) {
 	delete(u.queryParams, name)
 }

--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -48,7 +48,7 @@ func (u *URL) WithQueryParam(name, value string) {
 	u.queryParams[name] = []string{value}
 }
 
-func (u *URL) GetSingleQueryParam(name string) (string, bool) {
+func (u *URL) GetFirstQueryParam(name string) (string, bool) {
 	value, ok := u.queryParams[name]
 	if !ok || len(value) == 0 {
 		return "", false


### PR DESCRIPTION
Add capability to return query parameter from our custom URL. 

Note: URL primarily manages path and query params.