### PR TITLE
feat: Add Deep connector Instantly (Read)

### DIFF
--- a/providers/instantly/client.go
+++ b/providers/instantly/client.go
@@ -1,0 +1,16 @@
+package instantly
+
+import "github.com/amp-labs/connectors/common"
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/providers/instantly/connector.go
+++ b/providers/instantly/connector.go
@@ -1,0 +1,73 @@
+package instantly
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const apiVersion = "v1"
+
+type Connector struct {
+	BaseURL string
+	Client  *common.JSONHTTPClient
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := params.Client.Caller
+	conn = &Connector{
+		Client: &common.JSONHTTPClient{
+			HTTPClient: httpClient,
+		},
+	}
+
+	providerInfo, err := providers.ReadInfo(conn.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// connector and its client must mirror base url and provide its own error parser
+	conn.setBaseURL(providerInfo.BaseURL)
+	conn.Client.HTTPClient.ErrorHandler = interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
+	return conn, nil
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return providers.Instantly
+}
+
+func (c *Connector) String() string {
+	return fmt.Sprintf("%s.Connector", c.Provider())
+}
+
+func (c *Connector) getURL(parts ...string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.BaseURL, append([]string{
+		apiVersion,
+	}, parts...)...)
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}

--- a/providers/instantly/errors.go
+++ b/providers/instantly/errors.go
@@ -1,0 +1,29 @@
+package instantly
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	// Message usually has API Key query parameter. This shouldn't be returned.
+	Message string `json:"message"`
+	// Error is very general.
+	Error      string `json:"error"`
+	StatusCode int    `json:"statusCode"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	// Error field is the safest to return, though not very useful.
+	return fmt.Errorf("%w: %v", base, r.Error)
+}

--- a/providers/instantly/params.go
+++ b/providers/instantly/params.go
@@ -1,0 +1,65 @@
+package instantly
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const (
+	// DefaultPageSize is number of elements per page.
+	DefaultPageSize = 100
+)
+
+// Option is a function which mutates the connector configuration.
+type Option = func(params *parameters)
+
+// parameters surface options by delegation.
+type parameters struct {
+	paramsbuilder.Client
+	// Error is set when any With<Method> fails, used for parameters validation.
+	setupError error
+}
+
+func (p parameters) ValidateParams() error {
+	if p.setupError != nil {
+		return p.setupError
+	}
+
+	return errors.Join(
+		p.Client.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	apiKey string,
+	opts ...common.QueryParamAuthClientOption,
+) Option {
+	return func(params *parameters) {
+		info, err := providers.ReadInfo(providers.Instantly)
+		if err != nil {
+			params.setupError = err
+
+			return
+		}
+
+		queryParam, err := info.GetApiKeyQueryParamName()
+		if err != nil {
+			params.setupError = err
+
+			return
+		}
+
+		params.WithApiKeyQueryParamClient(ctx, client, queryParam, apiKey, opts...)
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
+	}
+}

--- a/providers/instantly/parse.go
+++ b/providers/instantly/parse.go
@@ -1,0 +1,31 @@
+package instantly
+
+import (
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/spyzhov/ajson"
+)
+
+func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		previousStart := 0
+
+		skipQP, ok := reqLink.GetFirstQueryParam("skip")
+		if ok {
+			// Try to use previous "skip" parameter to determine the next skip.
+			skipNum, err := strconv.Atoi(skipQP)
+			if err == nil {
+				previousStart = skipNum
+			}
+		}
+
+		nextStart := previousStart + DefaultPageSize
+
+		reqLink.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
+		reqLink.WithQueryParam("skip", strconv.Itoa(nextStart))
+
+		return reqLink.String(), nil
+	}
+}

--- a/providers/instantly/read.go
+++ b/providers/instantly/read.go
@@ -1,0 +1,96 @@
+package instantly
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	objectNameCampaigns = "campaigns"
+	objectNameAccounts  = "accounts"
+	objectNameEmails    = "emails"
+	objectNameTags      = "tags"
+)
+
+var supportedObjectsByRead = handy.NewSet([]string{ //nolint:gochecknoglobals
+	// Object Name	----------	API endpoint path
+	objectNameCampaigns, // campaign/list
+	objectNameAccounts,  // account/list
+	objectNameEmails,    // unibox/emails
+	objectNameTags,      // custom-tag
+})
+
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if len(config.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	urlPath, nodePath, err := matchObjectNameToEndpointPath(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := c.buildReadURL(config, urlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		rsp,
+		common.GetRecordsUnderJSONPath(nodePath),
+		makeNextRecordsURL(url),
+		common.GetMarshaledData,
+		config.Fields,
+	)
+}
+
+func matchObjectNameToEndpointPath(objectName string) (urlPath string, nodePath string, err error) {
+	switch objectName {
+	case objectNameCampaigns:
+		// https://developer.instantly.ai/campaign-1/list-campaigns
+		// Empty string of data location means the response is an array itself holding what we need.
+		return "campaign/list", "", nil
+	case objectNameAccounts:
+		// https://developer.instantly.ai/account/list-accounts
+		return "account/list", "accounts", nil
+	case objectNameEmails:
+		// https://developer.instantly.ai/unibox/emails-or-list
+		return "unibox/emails", "data", nil
+	case objectNameTags:
+		// https://developer.instantly.ai/tags/list-tags
+		return "custom-tag", "data", nil
+	default:
+		return "", "", common.ErrOperationNotSupportedForObject
+	}
+}
+
+func (c *Connector) buildReadURL(config common.ReadParams, urlPath string) (*urlbuilder.URL, error) {
+	if len(config.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(config.NextPage.String())
+	}
+
+	// First page
+	url, err := c.getURL(urlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("skip", "0")
+	url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
+
+	return url, nil
+}

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -1,0 +1,244 @@
+package instantly
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseInvalidPath := testutils.DataFromFile(t, "invalid-path.json")
+	responseCampaigns := testutils.DataFromFile(t, "read-campaigns.json")
+	responseTags := testutils.DataFromFile(t, "read-tags.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Mime response header expected",
+			Input:        common.ReadParams{ObjectName: "campaigns"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.ReadParams{ObjectName: "orders"},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+		{
+			Name:  "Correct error message is understood from JSON response",
+			Input: common.ReadParams{ObjectName: "campaigns"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write(responseInvalidPath)
+			})),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Not Found"), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Incorrect key in payload",
+			Input: common.ReadParams{ObjectName: "emails"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{
+					"yourEmails": []
+				}`)
+			})),
+			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
+		},
+		{
+			Name:  "Incorrect data type in payload",
+			Input: common.ReadParams{ObjectName: "emails"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{
+					"data": {}
+				}`)
+			})),
+			ExpectedErrs: []error{jsonquery.ErrNotArray},
+		},
+		{
+			Name: "Next page is correctly calculated",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				NextPage:   "test-placeholder?skip=700",
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				// Create fake response big enough to conclude that next page exists.
+				manyCampaigns := make([]string, DefaultPageSize)
+				for i := 0; i < DefaultPageSize; i++ {
+					manyCampaigns[i] = "{}"
+				}
+				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
+				mockutils.WriteBody(w, data)
+			})),
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return actual.NextPage.String() == expected.NextPage.String() &&
+					actual.Done == expected.Done
+			},
+			Expected: &common.ReadResult{
+				NextPage: "test-placeholder?limit=100&skip=800",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Current empty page signifies no next page",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, "[]")
+			})),
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
+
+				return actual.NextPage.String() == expectedNextPage &&
+					actual.Done == expected.Done
+			},
+			Expected: &common.ReadResult{
+				NextPage: "{{testServerURL}}/v1/campaign/list?limit=100&skip=100",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read campaigns with chosen fields",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     []string{"name"},
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(responseCampaigns)
+			})),
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+					actual.Done == expected.Done
+			},
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "Second Campaign",
+					},
+					Raw: map[string]any{
+						"id":   "27dd47ff-5a78-4377-a1eb-98f593f37219",
+						"name": "Second Campaign",
+					},
+				}, {
+					Fields: map[string]any{
+						"name": "My Campaign",
+					},
+					Raw: map[string]any{
+						"id":   "65d890fe-ae4d-43d0-b014-af0e89b6281f",
+						"name": "My Campaign",
+					},
+				}},
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read tags with chosen fields",
+			Input: common.ReadParams{
+				ObjectName: "tags",
+				Fields:     []string{"label", "description"},
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(responseTags)
+			})),
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+					actual.Done == expected.Done
+			},
+			Expected: &common.ReadResult{
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"label":       "High Delivery 3",
+						"description": "High Delivery Accounts 3",
+					},
+					Raw: map[string]any{
+						"organization_id": "803a064c-a636-49fe-bc45-5043da7a4ee7",
+						"label":           "High Delivery 3",
+						"description":     "High Delivery Accounts 3",
+					},
+				}, {
+					Fields: map[string]any{
+						"label":       "High Delivery 2",
+						"description": "High Delivery Accounts 2",
+					},
+					Raw: map[string]any{
+						"organization_id": "803a064c-a636-49fe-bc45-5043da7a4ee7",
+						"label":           "High Delivery 2",
+						"description":     "High Delivery Accounts 2",
+					},
+				}},
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/providers/instantly/test/invalid-path.json
+++ b/providers/instantly/test/invalid-path.json
@@ -1,0 +1,6 @@
+{
+    "message": "Route GET:/api/butterfly?api_key=<SENSITIVE_DATA> not found",
+    "error": "Not Found",
+    "statusCode": 404
+}
+

--- a/providers/instantly/test/read-campaigns.json
+++ b/providers/instantly/test/read-campaigns.json
@@ -1,0 +1,11 @@
+[
+    {
+        "id": "27dd47ff-5a78-4377-a1eb-98f593f37219",
+        "name": "Second Campaign"
+    },
+    {
+        "id": "65d890fe-ae4d-43d0-b014-af0e89b6281f",
+        "name": "My Campaign"
+    }
+]
+

--- a/providers/instantly/test/read-tags.json
+++ b/providers/instantly/test/read-tags.json
@@ -1,0 +1,24 @@
+{
+    "data": [
+        {
+            "id": "7e9196c1-2caf-44e2-b7a3-6c7c32a2f5b4",
+            "timestamp_created": "2024-08-14T17:45:40.571Z",
+            "timestamp_updated": "2024-08-14T17:45:40.571Z",
+            "organization_id": "803a064c-a636-49fe-bc45-5043da7a4ee7",
+            "label": "High Delivery 3",
+            "description": "High Delivery Accounts 3"
+        },
+        {
+            "id": "3b8c8265-fe9a-47c2-b9a3-c0406de65a66",
+            "timestamp_created": "2024-08-14T17:45:35.508Z",
+            "timestamp_updated": "2024-08-14T17:45:35.508Z",
+            "organization_id": "803a064c-a636-49fe-bc45-5043da7a4ee7",
+            "label": "High Delivery 2",
+            "description": "High Delivery Accounts 2"
+        }
+    ],
+    "total": 3,
+    "limit": 2,
+    "skip": 0
+}
+

--- a/test/instantly/connector.go
+++ b/test/instantly/connector.go
@@ -1,0 +1,27 @@
+package instantly
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/instantly"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetInstantlyConnector(ctx context.Context) *instantly.Connector {
+	filePath := credscanning.LoadPath(providers.Instantly)
+	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+
+	conn, err := instantly.NewConnector(
+		instantly.WithClient(ctx, http.DefaultClient,
+			reader.Get(credscanning.Fields.ApiKey),
+		),
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/instantly/read/main.go
+++ b/test/instantly/read/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/instantly"
+	connTest "github.com/amp-labs/connectors/test/instantly"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+var (
+	objectName = "campaigns" // nolint: gochecknoglobals
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetInstantlyConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields: []string{
+			"name",
+		},
+	})
+	if err != nil {
+		utils.Fail("error reading from Instantly", "error", err)
+	}
+
+	slog.Info("Reading campaigns..")
+	utils.DumpJSON(res, os.Stdout)
+
+	if res.Rows > instantly.DefaultPageSize {
+		utils.Fail(fmt.Sprintf("expected max %v rows", instantly.DefaultPageSize))
+	}
+}


### PR DESCRIPTION
Closes #912 

# Description

There are few endpoints that perform listing. Those that do have varying endpoint paths.
Therefore, there is a hard coded mapping between object name (in plural) to the appropriate URL path.
Pagination is manually calculated as response is not a reliable source as it differes among endpoints.

# Testing
![image](https://github.com/user-attachments/assets/8c90dd3a-9387-409a-a9eb-dd3358fc326d)
