### PR TITLE
feat: Deep connector Instantly (Metadata)

### DIFF
--- a/providers/instantly/metadata.go
+++ b/providers/instantly/metadata.go
@@ -1,0 +1,24 @@
+package instantly
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/instantly/metadata"
+)
+
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	// Ensure that objectNames is not empty
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	schemas, err := metadata.FileManager.LoadSchemas()
+	if err != nil {
+		return nil, common.ErrMetadataLoadFailure
+	}
+
+	return schemas.Select(objectNames)
+}

--- a/providers/instantly/metadata/schemas.json
+++ b/providers/instantly/metadata/schemas.json
@@ -1,0 +1,63 @@
+{
+  "data": {
+    "campaigns": {
+      "displayName": "Campaigns",
+      "url": "https://developer.instantly.ai/campaign-1/list-campaigns",
+      "fields": {
+        "id": "ID",
+        "name": "Name"
+      }
+    },
+    "accounts": {
+      "displayName": "Accounts",
+      "url": "https://developer.instantly.ai/account/list-accounts",
+      "fields": {
+        "email": "email1@domain.com",
+        "timestamp_created": "Timestamp Created",
+        "timestamp_updated": "Timestamp Updated",
+        "payload": "Payload"
+      }
+    },
+    "emails": {
+      "displayName": "Emails",
+      "url": "https://developer.instantly.ai/unibox/emails-or-list",
+      "fields": {
+        "id": "ID",
+        "message_id": "Message ID",
+        "is_unread": "Is Unread",
+        "lead": "Lead",
+        "campaign_id": "Campaign ID",
+        "from_address_email": "Sender's Email Address",
+        "from_address_json": "Sender's Email JSON",
+        "ai_interest_value": "AI Interest Value",
+        "reminder_ts": "Reminder Timestamp",
+        "i_status": "Interest Status Value",
+        "subject": "Subject",
+        "timestamp_created": "Timestamp Created",
+        "content_preview": "Content Preview",
+        "body": "Body",
+        "thread_id": "Thread ID",
+        "eaccount": "Email Account",
+        "to_address_email_list": "Receivers Email Address",
+        "to_address_json": "Receiver's Email JSON",
+        "ue_type": "Email Type",
+        "scheduled_at": "Scheduled At",
+        "cc_address_email_list": "CC Email Address List",
+        "cc_address_json": "CC Email Address JSON",
+        "bcc_address_email_list": "BCC Email Address List"
+      }
+    },
+    "tags": {
+      "displayName": "Tags",
+      "url": "https://developer.instantly.ai/tags/list-tags",
+      "fields": {
+        "id": "ID",
+        "timestamp_created": "Timestamp Created",
+        "timestamp_updated": "Timestamp Updated",
+        "organization_id": "Organization ID",
+        "label": "Label",
+        "description": "Description"
+      }
+    }
+  }
+}

--- a/providers/instantly/metadata/scraping.go
+++ b/providers/instantly/metadata/scraping.go
@@ -1,0 +1,17 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+)

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -1,0 +1,75 @@
+package instantly
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{scrapper.ErrObjectNotFound},
+		},
+		{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"campaigns", "emails"},
+			Server: mockserver.Dummy(),
+			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
+				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
+			},
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"emails": {
+						DisplayName: "Emails",
+						FieldsMap: map[string]string{
+							"is_unread":             "Is Unread",
+							"ue_type":               "Email Type",
+							"message_id":            "Message ID",
+							"campaign_id":           "Campaign ID",
+							"from_address_email":    "Sender's Email Address",
+							"to_address_email_list": "Receivers Email Address",
+						},
+					},
+					"campaigns": {
+						DisplayName: "Campaigns",
+						FieldsMap: map[string]string{
+							"id":   "ID",
+							"name": "Name",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/instantly/metadata/main.go
+++ b/test/instantly/metadata/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/instantly"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+)
+
+var objectName = "tags" // nolint: gochecknoglobals
+
+// We want to compare fields returned by read and schema properties provided by metadata methods.
+// Properties from read must all be present in schema definition.
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetInstantlyConnector(ctx)
+	defer utils.Close(conn)
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+	})
+	if err != nil {
+		utils.Fail("error reading from Smartlead", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for Smartlead", "error", err)
+	}
+
+	slog.Info("Comparing")
+
+	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
+	if mismatchErr != nil {
+		utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
+	} else {
+		slog.Info("Success: Object metadata schema and endpoint response have the same fields")
+	}
+}

--- a/test/instantly/read/main.go
+++ b/test/instantly/read/main.go
@@ -14,9 +14,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils"
 )
 
-var (
-	objectName = "campaigns" // nolint: gochecknoglobals
-)
+var objectName = "campaigns" // nolint: gochecknoglobals
 
 func main() {
 	// Handle Ctrl-C gracefully.

--- a/test/instantly/write-delete/main.go
+++ b/test/instantly/write-delete/main.go
@@ -18,9 +18,7 @@ type tagsPayload struct {
 	Description string `json:"description"`
 }
 
-var (
-	objectName = "tags" // nolint: gochecknoglobals
-)
+var objectName = "tags" // nolint: gochecknoglobals
 
 func main() {
 	// Handle Ctrl-C gracefully.


### PR DESCRIPTION
Closes #912 

# Description

Metadata is taken from documentation and saved as static files under `schema.json`.

# Testing
![image](https://github.com/user-attachments/assets/ddebf3b7-04be-40f3-9a76-515677e60e5a)

