### PR TITLE
chore: Avoid escaping HTML characters in the JSON catalog 

### DIFF
--- a/scripts/catalog/json.go
+++ b/scripts/catalog/json.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -36,7 +37,7 @@ func main() {
 
 	catalog.Timestamp = timestamp
 
-	bytes, err := json.Marshal(catalog)
+	bytes, err := MarshalWithoutEscaping(catalog)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -67,4 +68,19 @@ func main() {
 	}
 
 	log.Printf("Catalog successfully written to: %s\n", tempFile)
+}
+
+// MarshalWithoutEscaping marshals an object into JSON without escaping HTML characters (e.g. <, >, &)
+func MarshalWithoutEscaping(v any) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	// The Encode method adds a newline at the end, so we need to trim it
+	// Source: https://go.dev/src/encoding/json/stream.go (Line 215)
+	return bytes.TrimSpace(buffer.Bytes()), nil
 }

--- a/scripts/catalog/json.go
+++ b/scripts/catalog/json.go
@@ -70,17 +70,19 @@ func main() {
 	log.Printf("Catalog successfully written to: %s\n", tempFile)
 }
 
-// MarshalWithoutEscaping marshals an object into JSON without escaping HTML characters (e.g. <, >, &)
+// MarshalWithoutEscaping marshals an object into JSON without escaping HTML characters.
+// This helps preserve label values as is (&, <, >, etc) in the JSON output.
 func MarshalWithoutEscaping(v any) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(false)
+
 	err := encoder.Encode(v)
 	if err != nil {
 		return nil, err
 	}
 
-	// The Encode method adds a newline at the end, so we need to trim it
-	// Source: https://go.dev/src/encoding/json/stream.go (Line 215)
+	// The Encode method adds a newline at the end, so we need to trim it.
+	// Source: https://go.dev/src/encoding/json/stream.go#L215
 	return bytes.TrimSpace(buffer.Bytes()), nil
 }


### PR DESCRIPTION
`json.Marshal` internally escapes certain HTML characters like <, > or & in the json which messes up strings like `Productivity & Collaboration` in the labels (from our current catalog) - 

<img width="670" alt="Screenshot 2024-08-16 at 12 42 24 PM" src="https://github.com/user-attachments/assets/69744193-69c5-4263-bd39-9bfc11e5576d">

This PR disables that behavior so that the character can be preserved as is in the generated json catalog - 
<img width="542" alt="Screenshot 2024-08-16 at 12 46 21 PM" src="https://github.com/user-attachments/assets/96ed9af6-2c6d-4a06-9051-d8b3447ca430">
