### PR TITLE
proxy: enable LinkedIn

### DIFF
--- a/providers/linkedIn.go
+++ b/providers/linkedIn.go
@@ -25,7 +25,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
This was the very first proxy connector I added ([originally in the server](https://github.com/amp-labs/server/pull/511)) and have tested it many times already. I guess after we moved it out of the server into this repo, we never enabled it. 