### PR TITLE
feat: Add write  Marketo connector

### DIFF
--- a/marketo/README.md
+++ b/marketo/README.md
@@ -1,0 +1,11 @@
+# Write connnector
+
+Currently the Write connector supports Leads API only. 
+
+- The objects that we can write to currently are:
+ - Companies
+ - Leads
+ - Named Account Lists
+ - Named Accounts
+ - Opportunites
+ - SalesPerson

--- a/marketo/connnector.go
+++ b/marketo/connnector.go
@@ -57,7 +57,7 @@ func (c *Connector) Provider() providers.Provider {
 	return providers.Marketo
 }
 
-func (c *Connector) getApiURL(objName string) (*urlbuilder.URL, error) {
+func (c *Connector) getAPIURL(objName string) (*urlbuilder.URL, error) {
 	bURL := strings.Join([]string{restAPIPrefix, c.Module, objName}, "/")
 
 	if !strings.HasSuffix(objName, ".json") {

--- a/marketo/types.go
+++ b/marketo/types.go
@@ -1,0 +1,5 @@
+package marketo
+
+import "errors"
+
+var ErrEmptyResultResponse = errors.New("writing reponded with an empty result")

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -45,8 +45,13 @@ func constructURL(base string, path ...string) (*urlbuilder.URL, error) {
 
 func updateURLWithID(url *urlbuilder.URL, id string) (*urlbuilder.URL, error) {
 	s := removeJSONSuffix(url.String())
-	s += id
-	s = addJSONSuffix(s)
+
+	url, err := constructURL(s, id)
+	if err != nil {
+		return nil, err
+	}
+
+	s = addJSONSuffix(url.String())
 
 	return constructURL(s)
 }

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -18,7 +18,7 @@ func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 		return constructURL(params.NextPage.String())
 	}
 
-	link, err := c.getApiURL(params.ObjectName)
+	link, err := c.getAPIURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -2,6 +2,7 @@ package marketo
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -40,4 +41,11 @@ func constructURL(base string, path ...string) (*urlbuilder.URL, error) {
 	}
 
 	return link, nil
+}
+
+func updateURLWithID(url *urlbuilder.URL, id string) (*urlbuilder.URL, error) {
+	s, _ := strings.CutSuffix(url.String(), ".json")
+	s = s + id + ".json"
+
+	return constructURL(s)
 }

--- a/marketo/url.go
+++ b/marketo/url.go
@@ -44,8 +44,17 @@ func constructURL(base string, path ...string) (*urlbuilder.URL, error) {
 }
 
 func updateURLWithID(url *urlbuilder.URL, id string) (*urlbuilder.URL, error) {
-	s, _ := strings.CutSuffix(url.String(), ".json")
-	s = s + id + ".json"
+	s := removeJSONSuffix(url.String())
+	s += id
+	s = addJSONSuffix(s)
 
 	return constructURL(s)
+}
+
+func removeJSONSuffix(s string) string {
+	return strings.TrimSuffix(s, ".json")
+}
+
+func addJSONSuffix(s string) string {
+	return s + ".json"
 }

--- a/marketo/write.go
+++ b/marketo/write.go
@@ -45,9 +45,21 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
+	if len(resp.Result) == 0 {
+		return nil, ErrEmptyResultResponse
+	}
+
+	id := resp.Result[0]["id"]
+
+	// By default the id is returned as a float64
+	id, ok := id.(float64)
+	if !ok || id == 0 {
+		return nil, common.ErrMissingRecordID
+	}
+
 	return &common.WriteResult{
 		Success:  resp.Success,
-		RecordId: fmt.Sprint(resp.Result[0]["id"]),
+		RecordId: fmt.Sprint(id),
 		Data:     resp.Result[0],
 	}, nil
 }

--- a/marketo/write.go
+++ b/marketo/write.go
@@ -15,7 +15,7 @@ type writeResponse struct {
 
 // Write creates/updates records in marketo. Write currently supports operations to the leads API only.
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
-	url, err := c.getApiURL(config.ObjectName)
+	url, err := c.getAPIURL(config.ObjectName)
 	if err != nil {
 		return nil, err
 	}

--- a/marketo/write.go
+++ b/marketo/write.go
@@ -15,8 +15,6 @@ type writeResponse struct {
 
 // Write creates/updates records in marketo. Write currently supports operations to the leads API only.
 func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
-	var write common.WriteMethod
-
 	url, err := c.getApiURL(config.ObjectName)
 	if err != nil {
 		return nil, err
@@ -28,14 +26,9 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		if err != nil {
 			return nil, err
 		}
-
-		write = c.Client.Patch
-	} else {
-		// prepares the creating data request.
-		write = c.Client.Post
 	}
 
-	json, err := write(ctx, url.String(), config.RecordData)
+	json, err := c.Client.Post(ctx, url.String(), config.RecordData)
 	if err != nil {
 		return nil, err
 	}

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -27,6 +27,21 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	return conn
 }
 
+func GetMarketoConnectorW(ctx context.Context) *marketo.Connector {
+	reader := getMarketoJSONReader()
+
+	conn, err := marketo.NewConnector(
+		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
+		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
+		marketo.WithModule(marketo.ModuleLeads),
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
 func getConfig(reader *credscanning.ProviderCredentials) *clientcredentials.Config {
 	workspace := reader.Get(credscanning.Fields.Workspace)
 

--- a/test/marketo/write/write.go
+++ b/test/marketo/write/write.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/marketo"
+	"github.com/brianvoe/gofakeit/v6"
 )
 
 func main() {
@@ -28,18 +29,15 @@ func testWrite(ctx context.Context) error {
 	conn := marketo.GetMarketoConnectorW(ctx)
 
 	params := common.WriteParams{
-		ObjectName: "opportunities",
+		ObjectName: "leads",
 		RecordData: map[string]any{
 			"input": []map[string]any{{
-				"marketoGUID": 0,
-				"seq":         0,
-				"reasons": []map[string]any{{
-					"code":    "mmmh",
-					"message": "I don't have one",
-				},
-				},
+				"email":     gofakeit.Email(),
+				"firstName": gofakeit.Name(),
 			},
 			},
+			"action":      "createOnly",
+			"lookupField": "email",
 		},
 	}
 

--- a/test/marketo/write/write.go
+++ b/test/marketo/write/write.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/marketo"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	err := testWrite(context.Background())
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testWrite(ctx context.Context) error {
+	conn := marketo.GetMarketoConnectorW(ctx)
+
+	params := common.WriteParams{
+		ObjectName: "opportunities",
+		RecordData: map[string]any{
+			"input": []map[string]any{{
+				"marketoGUID": 0,
+				"seq":         0,
+				"reasons": []map[string]any{{
+					"code":    "mmmh",
+					"message": "I don't have one",
+				},
+				},
+			},
+			},
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
Currently we write to the Leads API.

Note: We currently don't handle record level errors(These are individual record errors). 

Test Response:
<img width="1226" alt="Screenshot 2024-08-21 at 12 14 47" src="https://github.com/user-attachments/assets/429c3cf2-bedc-480d-af22-34a56c40b235">


Closes #908 