### PR TITLE
tidy: Simplify locating schemas.json for scrapping

### DIFF
--- a/gong/metadata/scrapping.go
+++ b/gong/metadata/scrapping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}

--- a/intercom/metadata/scrapping.go
+++ b/intercom/metadata/scrapping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}

--- a/pipeliner/metadata/scrapping.go
+++ b/pipeliner/metadata/scrapping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}

--- a/salesloft/metadata/scrapping.go
+++ b/salesloft/metadata/scrapping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}

--- a/smartlead/metadata/scraping.go
+++ b/smartlead/metadata/scraping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}

--- a/test/marketo/metadata/metadata.go
+++ b/test/marketo/metadata/metadata.go
@@ -21,5 +21,4 @@ func main() {
 	// Print the results
 	fmt.Println("Results: ", m.Result)
 	fmt.Println("Errors: ", m.Errors)
-
 }

--- a/tools/fileconv/files.go
+++ b/tools/fileconv/files.go
@@ -1,8 +1,32 @@
 package fileconv
 
+import (
+	"path/filepath"
+	"runtime"
+)
+
 // FileLocator provides an absolute path to the file.
 // This is useful for writing data to that file.
 // Loading data from file should be done via go embed.
 type FileLocator interface {
 	AbsPathTo(filename string) string
+}
+
+type SiblingFileLocator struct {
+	directory string
+}
+
+// NewSiblingFileLocator creates locator, which is capable of resolving full path to files
+// located under the same directory where this constructor was called.
+func NewSiblingFileLocator() *SiblingFileLocator {
+	_, thisMethodsLocation, _, _ := runtime.Caller(1) // nolint:dogsled
+	directory := filepath.Dir(thisMethodsLocation)
+
+	return &SiblingFileLocator{
+		directory: directory,
+	}
+}
+
+func (l SiblingFileLocator) AbsPathTo(filename string) string {
+	return filepath.Join(l.directory, filename)
 }

--- a/zendesksupport/metadata/scrapping.go
+++ b/zendesksupport/metadata/scrapping.go
@@ -2,9 +2,8 @@ package metadata
 
 import (
 	_ "embed"
-	"path/filepath"
-	"runtime"
 
+	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,14 +13,5 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, locator{}) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
 )
-
-type locator struct{}
-
-func (locator) AbsPathTo(filename string) string {
-	_, thisMethodsLocation, _, _ := runtime.Caller(0) // nolint:dogsled
-	localDir := filepath.Dir(thisMethodsLocation)
-
-	return localDir + "/" + filename
-}


### PR DESCRIPTION
Scrapping writes, reads index.json and schema.json files.
These file are located neighbouring, sibling to the `FileManager` declaration.
This is refactoring.
