### PR TITLE
add: Map and Lists utilities

### DIFF
--- a/common/handy/lists.go
+++ b/common/handy/lists.go
@@ -12,3 +12,23 @@ func (l Lists[T]) Add(kind string, objects ...T) {
 
 	l[kind] = append(l[kind], objects...)
 }
+
+// GetBucketNames returns names of lists, buckets they are in.
+// Example:
+//
+//	veggies: cucumber, tomato;
+//	fruits: pineapple;
+//
+// Will return veggies and fruits.
+func (l Lists[T]) GetBucketNames() []string {
+	result := make([]string, len(l))
+
+	index := 0
+
+	for name := range l {
+		result[index] = name
+		index++
+	}
+
+	return result
+}

--- a/common/handy/maps.go
+++ b/common/handy/maps.go
@@ -16,3 +16,19 @@ func (m Map[K, V]) Keys() []K {
 func (m Map[K, V]) KeySet() Set[K] {
 	return NewSet(m.Keys())
 }
+
+func (m Map[K, V]) Has(key K) bool {
+	_, ok := m[key]
+
+	return ok
+}
+
+func (m Map[K, V]) Values() []V {
+	values := make([]V, 0, len(m))
+
+	for key := range m {
+		values = append(values, m[key])
+	}
+
+	return values
+}

--- a/test/marketo/metadata/metadata.go
+++ b/test/marketo/metadata/metadata.go
@@ -21,5 +21,4 @@ func main() {
 	// Print the results
 	fmt.Println("Results: ", m.Result)
 	fmt.Println("Errors: ", m.Errors)
-
 }


### PR DESCRIPTION
Extends methods of Map data structure.

Lists data structure can return names of buckets they sit in.