### PR TITLE
Feat: Remove TokenMetadatafields Mural

### DIFF
--- a/providers/mural.go
+++ b/providers/mural.go
@@ -14,9 +14,6 @@ func init() {
 			TokenURL:                  "https://app.mural.co/api/public/v1/authorization/oauth2/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
-			TokenMetadataFields: TokenMetadataFields{
-				ScopesField: "scope",
-			},
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
Remove TokenMetadatafields from the connector as it does not return scopes 