### PR TITLE
feat: Update Read Marketo connector

### DIFF
--- a/providers/marketo/README.md
+++ b/providers/marketo/README.md
@@ -2,7 +2,7 @@
 
 Currently the Write connector supports Leads API only. 
 
-- The objects that we can write to currently are:
+The objects that we can write to currently are:
  - Companies
  - Leads
  - Named Account Lists

--- a/providers/marketo/parse.go
+++ b/providers/marketo/parse.go
@@ -21,5 +21,8 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 }
 
 func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("result")
+	// When there is no result value, it indicates [], we should ot error it.
+	size, _ := jsonquery.New(node).ArraySize("result")
+
+	return size, nil
 }

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -23,11 +23,16 @@ func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	}
 
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
-	if !params.Since.IsZero() && c.Module == ModuleAssets.String() {
-		t := params.Since.Format(time.RFC3339)
-		fmtTime := fmt.Sprintf("%v", t)
-		link.WithQueryParam("earliestUpdatedAt", fmtTime)
-		link.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
+	if !params.Since.IsZero() {
+		switch c.Module {
+		case ModuleAssets.String():
+			t := params.Since.Format(time.RFC3339)
+			fmtTime := fmt.Sprintf("%v", t)
+			link.WithQueryParam("earliestUpdatedAt", fmtTime)
+			link.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
+
+		default: // we currently don't support filtering in leads.
+		}
 	}
 
 	return link, nil

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -12,32 +12,31 @@ import (
 var restAPIPrefix string = "rest" //nolint:gochecknoglobals
 
 func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
-	// If NextPage is set, then we're reading the next page of results.
-	// The NextPage URL has all the necessary parameters.
-	if len(params.NextPage) > 0 {
-		return urlbuilder.New(params.NextPage.String())
-	}
-
 	link, err := c.getAPIURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	// This affects  a very few number of objects.
-	// Leads, Deleted Leads, Lead Changes,
-	if !params.Since.IsZero() {
-		time := params.Since.Format(time.RFC3339)
-		fmtTime := fmt.Sprintf("%v", time)
-		link.WithQueryParam("sinceDatetime", fmtTime)
+	// If NextPage is set, then we're reading the next page of results.
+	if len(params.NextPage) > 0 {
+		link.WithQueryParam("nextPageToken", params.NextPage.String())
+	}
+
+	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
+	if !params.Since.IsZero() && c.Module == ModuleAssets.String() {
+		t := params.Since.Format(time.RFC3339)
+		fmtTime := fmt.Sprintf("%v", t)
+		link.WithQueryParam("earliestUpdatedAt", fmtTime)
+		link.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
 	}
 
 	return link, nil
 }
 
-func updateURLWithID(url *urlbuilder.URL, id string) (*urlbuilder.URL, error) {
+func updateURLPath(url *urlbuilder.URL, path string) (*urlbuilder.URL, error) {
 	s := removeJSONSuffix(url.String())
 
-	url, err := urlbuilder.New(s, id)
+	url, err := urlbuilder.New(s, path)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/marketo/write.go
+++ b/providers/marketo/write.go
@@ -22,7 +22,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 
 	// prepares the updating data request.
 	if len(config.RecordId) > 0 {
-		url, err = updateURLWithID(url, config.RecordId)
+		url, err = updateURLPath(url, config.RecordId)
 		if err != nil {
 			return nil, err
 		}

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -17,7 +17,12 @@ func main() {
 }
 
 func MainFn() int {
-	err := testRead(context.Background())
+	err := testReadChannels(context.Background())
+	if err != nil {
+		return 1
+	}
+
+	err = testReadSmartCampaigns(context.Background())
 	if err != nil {
 		return 1
 	}
@@ -25,13 +30,39 @@ func MainFn() int {
 	return 0
 }
 
-func testRead(ctx context.Context) error {
+func testReadChannels(ctx context.Context) error {
 	conn := mk.GetMarketoConnector(ctx)
 
 	params := common.ReadParams{
 		ObjectName: "channels",
 		Fields:     []string{"applicableProgramType", "id", "name"},
 		Since:      time.Now().Add(-720 * time.Hour),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testReadSmartCampaigns(ctx context.Context) error {
+	conn := mk.GetMarketoConnector(ctx)
+
+	params := common.ReadParams{
+		ObjectName: "smartCampaigns",
+		Fields:     []string{"description", "id", "name"},
+		Since:      time.Now().Add(-1020 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -27,6 +27,11 @@ func MainFn() int {
 		return 1
 	}
 
+	err = testReadCampaigns(context.Background())
+	if err != nil {
+		return 1
+	}
+
 	return 0
 }
 
@@ -36,7 +41,6 @@ func testReadChannels(ctx context.Context) error {
 	params := common.ReadParams{
 		ObjectName: "channels",
 		Fields:     []string{"applicableProgramType", "id", "name"},
-		Since:      time.Now().Add(-720 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)
@@ -62,7 +66,33 @@ func testReadSmartCampaigns(ctx context.Context) error {
 	params := common.ReadParams{
 		ObjectName: "smartCampaigns",
 		Fields:     []string{"description", "id", "name"},
-		Since:      time.Now().Add(-1020 * time.Hour),
+		Since:      time.Now().Add(-1800 * time.Hour),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testReadCampaigns(ctx context.Context) error {
+	conn := mk.GetMarketoConnectorW(ctx)
+
+	params := common.ReadParams{
+		ObjectName: "campaigns",
+		Fields:     []string{"createdAt", "id", "name"},
+		Since:      time.Now().Add(-1800 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
This updates the Marketo Read connector to support Since filtering with the following Objects:

- Emails
- Programs
- SmartCampaigns
- SmartLists

Removed the `SinceDateTime` since all the objects it supports are currently not supported using the Write Ampersand API.
The `sinceDateTime` supports  `lead activities` object which requires a client to send the `activityTypeIds`  as a query parameter during the request.

<img width="1215" alt="Screenshot 2024-08-23 at 17 13 50" src="https://github.com/user-attachments/assets/0badb666-f772-41bc-aee8-bba987feb526">

Example responses:
Reading `campaign` does not use Since, even if provided
<img width="617" alt="Screenshot 2024-08-26 at 14 56 08" src="https://github.com/user-attachments/assets/80aa98dd-cbe6-461f-8953-a286d8a09cf3">

Reading `channels` does not use Since, even if provided.
<img width="1192" alt="Screenshot 2024-08-26 at 14 57 02" src="https://github.com/user-attachments/assets/d4da74eb-b073-4a82-b0da-2a5feca4bc23">

Reading `smartCampaigns` uses provided Since value.
<img width="1191" alt="Screenshot 2024-08-26 at 14 56 44" src="https://github.com/user-attachments/assets/f6b055a3-00b8-42c4-9850-a891fecfd6fd">


