### PR TITLE
chore: Enable Ironclad proxy

### DIFF
--- a/providers/ironclad.go
+++ b/providers/ironclad.go
@@ -39,10 +39,13 @@ func init() { //nolint:funlen
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Labels: &Labels{
+			LabelExperimental: LabelValueTrue,
 		},
 	})
 
@@ -77,10 +80,13 @@ func init() { //nolint:funlen
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Labels: &Labels{
+			LabelExperimental: LabelValueTrue,
 		},
 	})
 
@@ -115,10 +121,13 @@ func init() { //nolint:funlen
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Labels: &Labels{
+			LabelExperimental: LabelValueTrue,
 		},
 	})
 }


### PR DESCRIPTION
We are unable to test Ironclad because it needs our app to be in production mode. We've submitted it for review, but they haven't responded yet. It's best to release this experimentally for the time being, because it's already been a month of waiting.