### PR TITLE
tidy: Remove RecordsSize method

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -7,13 +7,11 @@ import (
 )
 
 type (
-	ListSizeFunc func(*ajson.Node) (int64, error)
 	NextPageFunc func(*ajson.Node) (string, error)
 	RecordsFunc  func(*ajson.Node) ([]map[string]any, error)
 )
 
 // ParseResult parses the response from a provider into a ReadResult. A 2xx return type is assumed.
-// The sizeFunc, recordsFunc, nextPageFunc, and marshalFunc are used to extract the relevant data from the response.
 // The sizeFunc returns the total number of records in the response.
 // The recordsFunc returns the records in the response.
 // The nextPageFunc returns the URL for the next page of results.
@@ -21,7 +19,6 @@ type (
 // The fields are used to populate ReadResultRow.Fields.
 func ParseResult(
 	resp *JSONHTTPResponse,
-	sizeFunc func(*ajson.Node) (int64, error),
 	recordsFunc func(*ajson.Node) ([]map[string]any, error),
 	nextPageFunc func(*ajson.Node) (string, error),
 	marshalFunc func([]map[string]any, []string) ([]ReadResultRow, error),
@@ -29,11 +26,6 @@ func ParseResult(
 ) (*ReadResult, error) {
 	if resp == nil {
 		return nil, ErrEmptyJSONHTTPResponse
-	}
-
-	totalSize, err := sizeFunc(resp.Body)
-	if err != nil {
-		return nil, err
 	}
 
 	records, err := recordsFunc(resp.Body)
@@ -54,7 +46,7 @@ func ParseResult(
 	}
 
 	return &ReadResult{
-		Rows:     totalSize,
+		Rows:     int64(len(marshaledData)),
 		Data:     marshaledData,
 		NextPage: NextPageToken(nextPage),
 		Done:     done,

--- a/providers/atlassian/parse.go
+++ b/providers/atlassian/parse.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("issues")
-}
-
 /*
 Records cannot be returned as is from the API. Extra processing is described below.
  1. First of all, main properties are located under "fields" key.
@@ -68,10 +64,12 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 
 // Next starting page index is calculated base on current index and array size.
 func getNextRecords(node *ajson.Node) (string, error) {
-	size, err := getTotalSize(node)
+	records, err := getRecords(node)
 	if err != nil {
 		return "", err
 	}
+
+	size := int64(len(records))
 
 	if size == 0 {
 		// No elements returned for the current page.

--- a/providers/atlassian/read.go
+++ b/providers/atlassian/read.go
@@ -27,7 +27,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecords,
 		common.GetMarshaledData,

--- a/providers/dynamicscrm/parse.go
+++ b/providers/dynamicscrm/parse.go
@@ -5,10 +5,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("value")
-}
-
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	arr, err := jsonquery.New(node).Array("value", false)
 	if err != nil {

--- a/providers/dynamicscrm/read.go
+++ b/providers/dynamicscrm/read.go
@@ -35,7 +35,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/gong/parse.go
+++ b/providers/gong/parse.go
@@ -6,12 +6,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func makeGetTotalSize(objectName string) common.ListSizeFunc {
-	return func(node *ajson.Node) (int64, error) {
-		return jsonquery.New(node).ArraySize(objectName)
-	}
-}
-
 func makeGetRecords(objectName string) common.RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
 		// items are stored in array named after the API object

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -26,7 +26,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	return common.ParseResult(res,
-		makeGetTotalSize(config.ObjectName),
 		makeGetRecords(config.ObjectName),
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -114,20 +114,6 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 	return out, nil
 }
 
-// getTotalSize returns the total number of records that match the query.
-func getTotalSize(node *ajson.Node) (int64, error) {
-	node, err := node.GetKey("results")
-	if err != nil {
-		return 0, err
-	}
-
-	if !node.IsArray() {
-		return 0, ErrNotArray
-	}
-
-	return int64(node.Size()), nil
-}
-
 // getMarshalledData accepts a list of records and returns a list of structured data ([]ReadResultRow).
 func getMarshalledData(records []map[string]interface{}, fields []string) ([]common.ReadResultRow, error) {
 	data := make([]common.ReadResultRow, len(records))

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -63,7 +63,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsURL,
 		getMarshalledData,

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -29,7 +29,6 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsAfter,
 		getMarshalledData,

--- a/providers/intercom/parse.go
+++ b/providers/intercom/parse.go
@@ -32,15 +32,6 @@ Note:
 	=> `pages.next` can be null.
 	=> Sometimes array of objects is not stored at `data` but named after `type`.
 */
-func getTotalSize(node *ajson.Node) (int64, error) {
-	arrKey, err := extractListFieldName(node)
-	if err != nil {
-		return 0, err
-	}
-
-	return jsonquery.New(node).ArraySize(arrKey)
-}
-
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	arrKey, err := extractListFieldName(node)
 	if err != nil {

--- a/providers/intercom/read.go
+++ b/providers/intercom/read.go
@@ -21,7 +21,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		makeNextRecordsURL(link),
 		common.GetMarshaledData,

--- a/providers/marketo/parse.go
+++ b/providers/marketo/parse.go
@@ -19,10 +19,3 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 
 	return jsonquery.Convertor.ArrayToMap(result)
 }
-
-func getTotalSize(node *ajson.Node) (int64, error) {
-	// When there is no result value, it indicates [], we should ot error it.
-	size, _ := jsonquery.New(node).ArraySize("result")
-
-	return size, nil
-}

--- a/providers/marketo/read.go
+++ b/providers/marketo/read.go
@@ -20,7 +20,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	return common.ParseResult(res, getTotalSize,
+	return common.ParseResult(res,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/outreach/parse.go
+++ b/providers/outreach/parse.go
@@ -36,10 +36,6 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	return records, nil
 }
 
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("data")
-}
-
 func constructRecords(d Data) []map[string]any {
 	records := make([]map[string]any, len(d.Data))
 

--- a/providers/outreach/read.go
+++ b/providers/outreach/read.go
@@ -25,7 +25,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	return common.ParseResult(res, getTotalSize,
+	return common.ParseResult(res,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/pipeliner/parse.go
+++ b/providers/pipeliner/parse.go
@@ -5,10 +5,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("data")
-}
-
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	arr, err := jsonquery.New(node).Array("data", false)
 	if err != nil {

--- a/providers/pipeliner/read.go
+++ b/providers/pipeliner/read.go
@@ -21,7 +21,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/salesforce/parse.go
+++ b/providers/salesforce/parse.go
@@ -1,26 +1,9 @@
 package salesforce
 
 import (
-	"errors"
-
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/spyzhov/ajson"
 )
-
-// getTotalSize returns the total number of records that match the query.
-func getTotalSize(node *ajson.Node) (int64, error) {
-	size, err := jsonquery.New(node).Integer("totalSize", false)
-	if err != nil {
-		if !errors.Is(err, jsonquery.ErrKeyNotFound) {
-			return 0, err
-		}
-
-		// The totalSize key was missing. Try to manually count the number of records
-		return jsonquery.New(node).ArraySize("records")
-	}
-
-	return *size, nil
-}
 
 // getRecords returns the records from the response.
 func getRecords(node *ajson.Node) ([]map[string]any, error) {

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -27,7 +27,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/salesloft/parse.go
+++ b/providers/salesloft/parse.go
@@ -30,10 +30,6 @@ Response example:
 	  "data": [...]
 	}
 */
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("data")
-}
-
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	arr, err := jsonquery.New(node).Array("data", false)
 	if err != nil {

--- a/providers/salesloft/read.go
+++ b/providers/salesloft/read.go
@@ -22,7 +22,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		makeNextRecordsURL(link),
 		common.GetMarshaledData,

--- a/providers/smartlead/parse.go
+++ b/providers/smartlead/parse.go
@@ -5,10 +5,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func getTotalSize(node *ajson.Node) (int64, error) {
-	return jsonquery.New(node).ArraySize("")
-}
-
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	arr, err := jsonquery.New(node).Array("", false)
 	if err != nil {

--- a/providers/smartlead/read.go
+++ b/providers/smartlead/read.go
@@ -23,7 +23,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getTotalSize,
 		getRecords,
 		getNextRecordsURL,
 		common.GetMarshaledData,

--- a/providers/zendesksupport/parse.go
+++ b/providers/zendesksupport/parse.go
@@ -6,12 +6,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-func makeGetTotalSize(objectName string) common.ListSizeFunc {
-	return func(node *ajson.Node) (int64, error) {
-		return jsonquery.New(node).ArraySize(objectName)
-	}
-}
-
 func makeGetRecords(objectName string) common.RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
 		// items are stored in array named after the API object

--- a/providers/zendesksupport/read.go
+++ b/providers/zendesksupport/read.go
@@ -24,7 +24,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		makeGetTotalSize(config.ObjectName),
 		makeGetRecords(config.ObjectName),
 		getNextRecordsURL,
 		common.GetMarshaledData,


### PR DESCRIPTION
In general the implemenation of `getTotalSize` is directly connected to `getRecords`. Since we already have this array, why not get the length from it.
Sometimes, some connector do have `size` field in their response but thats not going to give any performence boost but only complicate the code. 