### PR TITLE
[ENG-1423] fix: Enable rate limiting for oauth token refresher

### DIFF
--- a/common/oauth.go
+++ b/common/oauth.go
@@ -211,6 +211,12 @@ func getTokenSource(ctx context.Context, params *oauthClientParams) oauth2.Token
 		return params.tokenSource
 	}
 
+	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
+		if params.client != nil {
+			ctx = context.WithValue(ctx, oauth2.HTTPClient, params.client)
+		}
+	}
+
 	return params.config.TokenSource(ctx, params.token)
 }
 

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -341,6 +341,12 @@ func createOAuth2ClientCredentialsHTTPClient( //nolint:ireturn
 	dbg bool,
 	cfg *OAuth2ClientCredentialsParams,
 ) (common.AuthenticatedHTTPClient, error) {
+	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
+		if client != nil {
+			ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+		}
+	}
+
 	options := []common.OAuthOption{
 		common.WithOAuthClient(getClient(client)),
 		common.WithTokenSource(cfg.Config.TokenSource(ctx)),


### PR DESCRIPTION
Passing in a custom HTTP client to the OAuth token refresher actually requires a context value to pull off. Without this, the default client gets used, which right now is resulting in HTTP throttle errors (since our rate-limited client is being ignored for these calls).