### PR TITLE
feat(utils): Map data structure with default return

### DIFF
--- a/common/handy/maps.go
+++ b/common/handy/maps.go
@@ -32,3 +32,29 @@ func (m Map[K, V]) Values() []V {
 
 	return values
 }
+
+// DefaultMap wrapper of the map that allows setting default return value on missing keys.
+type DefaultMap[K comparable, V any] struct {
+	// Map is a delegate.
+	// All methods are embedded which grants the same capabilities, plus default value.
+	Map[K, V]
+	// When key is not found this callback will be used to provide default value.
+	fallback func(key K) V
+}
+
+func NewDefaultMap[K comparable, V any](dict Map[K, V], fallback func(K) V) *DefaultMap[K, V] {
+	return &DefaultMap[K, V]{
+		Map:      dict,
+		fallback: fallback,
+	}
+}
+
+// Get method uses map with a fallback value.
+func (m DefaultMap[K, V]) Get(key K) V { // nolint:ireturn
+	value, ok := m.Map[key]
+	if ok {
+		return value
+	}
+
+	return m.fallback(key)
+}


### PR DESCRIPTION
# Description
Utility data structure that acts like a normal map but invokes a fallback method when there is "key" miss.

# Goal
This map is useful to define a relationship between 2 sets where one could apply "fallback" method to derive one from another. 

# Example
Let's say provider API usually returns Objects under `data` field. However, there are a handful of exceptions. This default map will be the bridge between Object Name and JSON field holding that object.

```
var ObjectNameToResponseField = handy.NewDefaultMap(map[string]string{
	"ticket_audits":               "audits",
	"search":                        "results",
	"satisfaction_reasons":  "reasons",
},
	func(key string) string {
		// Other response fields are named after Object.
		return key
	},
)
```
From above we can conclude the following: object Name `ticket_audits` will be located under `"audits": [{}, {}, {}...]` while object name `workspaces` under `workspaces` field.