### PR TITLE
feat: Sync Read capability with OpenAPI

### DIFF
--- a/providers/intercom/objectNames.go
+++ b/providers/intercom/objectNames.go
@@ -1,0 +1,26 @@
+package intercom
+
+import (
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/providers/intercom/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = handy.NewSet( //nolint:gochecknoglobals
+	metadata.Schemas.GetObjectNames(),
+)
+
+// ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
+var ObjectNameToResponseField = handy.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
+	"admins":        "admins",
+	"teams":         "teams",
+	"ticket_types":  "ticket_types",
+	"events":        "events",
+	"segments":      "segments",
+	"activity_logs": "activity_logs",
+},
+	func(key string) string {
+		// Other objects are mapped to `data`.
+		return "data"
+	},
+)

--- a/providers/intercom/parse.go
+++ b/providers/intercom/parse.go
@@ -80,8 +80,17 @@ func getNextPageStringURL(node *ajson.Node) (string, error) {
 	return jsonquery.New(node, "pages").StrWithDefault("next", "")
 }
 
-// The key that stores array in response payload will be dynamically figured out.
-// Ex: {"data": []} vs {"teams":[]} vs {"segments":[]}.
+// Intercom returns a type field which tells us where the response array is located,
+// which is why we do not need to hardcode the mapping. If we need to override this at any point,
+// we can add the mapping here.
+//
+// Other connectors don't have the ability to infer field names programmatically, so they rely on hardcoded mappings.
+// In this case, the response field name will be dynamically determined using the value of the "type" field.
+// Ex:
+//
+//	{"type":"data", "data": []}
+//	{"type":"teams", "teams":[]}
+//	{"type":"segments", "segments":[]}
 func extractListFieldName(node *ajson.Node) (string, error) {
 	// default field at which list is stored
 	defaultFieldName := "data"

--- a/providers/intercom/read.go
+++ b/providers/intercom/read.go
@@ -13,6 +13,10 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
 	url, err := c.buildReadURL(config)
 	if err != nil {
 		return nil, err

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -47,6 +47,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: []error{common.ErrMissingFields},
 		},
 		{
+			Name:         "Unsupported object name",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: []string{"id"}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
 			Name:         "Mime response header expected",
 			Input:        common.ReadParams{ObjectName: "contacts", Fields: []string{"id"}},
 			Server:       mockserver.Dummy(),
@@ -108,7 +114,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		},
 		{
 			Name:  "API version header is passed as server request",
-			Input: common.ReadParams{ObjectName: "notes", Fields: []string{"id"}},
+			Input: common.ReadParams{ObjectName: "articles", Fields: []string{"id"}},
+			// notes is not supported for now, but its payload is good for testing
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
@@ -125,7 +132,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		},
 		{
 			Name:  "Next page URL is resolved, when provided with a string",
-			Input: common.ReadParams{ObjectName: "notes", Fields: []string{"id"}},
+			Input: common.ReadParams{ObjectName: "articles", Fields: []string{"id"}},
+			// notes is not supported for now, but its payload is good for testing
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -159,7 +167,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		},
 		{
 			Name:  "Next page URL is empty, when provided with null object",
-			Input: common.ReadParams{ObjectName: "notes", Fields: []string{"id"}},
+			Input: common.ReadParams{ObjectName: "articles", Fields: []string{"id"}},
+			// notes is not supported for now, but its payload is good for testing
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)

--- a/providers/pipeliner/objectNames.go
+++ b/providers/pipeliner/objectNames.go
@@ -1,0 +1,11 @@
+package pipeliner
+
+import (
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/providers/pipeliner/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = handy.NewSet( //nolint:gochecknoglobals
+	metadata.Schemas.GetObjectNames(),
+)

--- a/providers/pipeliner/read.go
+++ b/providers/pipeliner/read.go
@@ -13,6 +13,10 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
 	url, err := c.buildReadURL(config)
 	if err != nil {
 		return nil, err

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -38,6 +38,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: []error{common.ErrMissingFields},
 		},
 		{
+			Name:         "Unsupported object name",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: []string{"id"}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
 			Name:         "Mime response header expected",
 			Input:        common.ReadParams{ObjectName: "Profiles", Fields: []string{"id"}},
 			Server:       mockserver.Dummy(),

--- a/providers/salesloft/objectNames.go
+++ b/providers/salesloft/objectNames.go
@@ -1,0 +1,11 @@
+package salesloft
+
+import (
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/providers/salesloft/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = handy.NewSet( //nolint:gochecknoglobals
+	metadata.Schemas.GetObjectNames(),
+)

--- a/providers/salesloft/read.go
+++ b/providers/salesloft/read.go
@@ -14,6 +14,10 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
 	url, err := c.buildReadURL(config)
 	if err != nil {
 		return nil, err

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -43,6 +43,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: []error{common.ErrMissingFields},
 		},
 		{
+			Name:         "Unsupported object name",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: []string{"id"}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
 			Name:         "Mime response header expected",
 			Input:        common.ReadParams{ObjectName: "users", Fields: []string{"id"}},
 			Server:       mockserver.Dummy(),

--- a/providers/smartlead/objectNames.go
+++ b/providers/smartlead/objectNames.go
@@ -1,11 +1,19 @@
 package smartlead
 
-import "github.com/amp-labs/connectors/common/handy"
+import (
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/providers/smartlead/metadata"
+)
 
 const (
 	objectNameCampaign     = "campaigns"
 	objectNameEmailAccount = "email-accounts"
 	objectNameClient       = "client"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = handy.NewSet( //nolint:gochecknoglobals
+	metadata.Schemas.GetObjectNames(),
 )
 
 var supportedObjectsByWrite = handy.NewSet([]string{ //nolint:gochecknoglobals

--- a/providers/smartlead/read.go
+++ b/providers/smartlead/read.go
@@ -11,6 +11,10 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
 	url, err := c.getURL(config.ObjectName)
 	if err != nil {
 		return nil, err

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -32,19 +32,25 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 		{
 			Name:         "At least one field is requested",
-			Input:        common.ReadParams{ObjectName: "contact"},
+			Input:        common.ReadParams{ObjectName: "email-accounts"},
 			Server:       mockserver.Dummy(),
 			ExpectedErrs: []error{common.ErrMissingFields},
 		},
 		{
+			Name:         "Unsupported object name",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: []string{"id"}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
 			Name:         "Mime response header expected",
-			Input:        common.ReadParams{ObjectName: "contact", Fields: []string{"id"}},
+			Input:        common.ReadParams{ObjectName: "email-accounts", Fields: []string{"id"}},
 			Server:       mockserver.Dummy(),
 			ExpectedErrs: []error{interpreter.ErrMissingContentType},
 		},
 		{
 			Name:  "Correct error message is understood from HTML response",
-			Input: common.ReadParams{ObjectName: "contact", Fields: []string{"id"}},
+			Input: common.ReadParams{ObjectName: "email-accounts", Fields: []string{"id"}},
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/html")
 				w.WriteHeader(http.StatusBadRequest)
@@ -57,7 +63,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 		{
 			Name:  "Incorrect data type in payload",
-			Input: common.ReadParams{ObjectName: "contact", Fields: []string{"id"}},
+			Input: common.ReadParams{ObjectName: "email-accounts", Fields: []string{"id"}},
 			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)

--- a/providers/zendesksupport/objectNames.go
+++ b/providers/zendesksupport/objectNames.go
@@ -1,0 +1,23 @@
+package zendesksupport
+
+import (
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = handy.NewSet( //nolint:gochecknoglobals
+	metadata.Schemas.GetObjectNames(),
+)
+
+// ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
+var ObjectNameToResponseField = handy.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
+	"ticket_audits":        "audits",
+	"search":               "results", // This is "/api/v2/search"
+	"satisfaction_reasons": "reasons",
+},
+	func(key string) string {
+		// Other response fields are named after Object.
+		return key
+	},
+)

--- a/providers/zendesksupport/read.go
+++ b/providers/zendesksupport/read.go
@@ -12,6 +12,10 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if !supportedObjectsByRead.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
 	url, err := c.buildReadURL(config)
 	if err != nil {
 		return nil, err
@@ -22,9 +26,11 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	responseFieldName := ObjectNameToResponseField.Get(config.ObjectName)
+
 	return common.ParseResult(
 		rsp,
-		common.GetRecordsUnderJSONPath(config.ObjectName),
+		common.GetRecordsUnderJSONPath(responseFieldName),
 		getNextRecordsURL,
 		common.GetMarshaledData,
 		config.Fields,

--- a/scripts/openapi/README.md
+++ b/scripts/openapi/README.md
@@ -1,0 +1,29 @@
+# Description
+
+This folder contains **scripts that process OpenAPI spec to produce Object Schemas**.
+These schemas are later will be served via ListObjectMetadata.
+
+# Structure
+
+Scripts will be located under `scripts/openapi/<PROVIDER_NAME>/metadata/main.go`.
+
+OpenAPI files that it loads can be found under `providers/<PROVIDER_NAME>/openapi/<FILE_NAME>.yaml|json`.
+The output will be saved under `providers/<PROVIDER_NAME>/metadata/schemas.json`.
+
+# Running instructions
+
+Update OpenAPI file to the latest version, then execute the following command in the project root directory:
+
+```
+go run ./scripts/openapi/intercom/metadata
+```
+Check `providers/intercom/metadata/schemas.json` for any side effects. Please monitor the log output,
+and if there are any errors, manually review the OpenAPI spec. Based on your review,
+decide whether the endpoint should be integrated or ignored.
+
+# Capability
+
+These scripts offer:
+* Control over which parts of the OpenAPI spec are relevant for processing.
+* Formatting options for display names.
+* Establishing relationship between Resource/Object Name and JSON field name, containing said object.

--- a/scripts/openapi/intercom/metadata/main.go
+++ b/scripts/openapi/intercom/metadata/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"log/slog"
 
+	"github.com/amp-labs/connectors/providers/intercom"
 	"github.com/amp-labs/connectors/providers/intercom/metadata"
 	"github.com/amp-labs/connectors/providers/intercom/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -32,15 +33,6 @@ var (
 		"news_items":      "News Items",
 		"newsfeeds":       "Newsfeeds",
 	}
-	objectNameToResponseField = map[string]string{ // nolint:gochecknoglobals
-		"admins":        "admins",
-		"teams":         "teams",
-		"ticket_types":  "ticket_types",
-		"events":        "events",
-		"segments":      "segments",
-		"activity_logs": "activity_logs",
-		// the rest uses `data`
-	}
 )
 
 func main() {
@@ -48,7 +40,8 @@ func main() {
 	must(err)
 
 	objects, err := explorer.GetBasicReadObjects(
-		ignoreEndpoints, nil, displayNameOverride, IsResponseFieldAppropriate,
+		ignoreEndpoints, nil, displayNameOverride,
+		api3.CustomMappingObjectCheck(intercom.ObjectNameToResponseField),
 	)
 	must(err)
 
@@ -70,15 +63,6 @@ func main() {
 	must(metadata.FileManager.SaveSchemas(schemas))
 
 	slog.Info("Completed.")
-}
-
-func IsResponseFieldAppropriate(objectName, fieldName string) bool {
-	if responseFieldName, ok := objectNameToResponseField[objectName]; ok {
-		return fieldName == responseFieldName
-	}
-
-	// Other objects have items located under `data` response field.
-	return api3.DataObjectCheck(objectName, fieldName)
 }
 
 func must(err error) {

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 
+	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -67,11 +68,6 @@ var (
 		"satisfaction_reasons": "Satisfaction Rating Reasons",
 		"ticket_audits":        "Ticket Audits",
 	}
-	objectNameToResponseField = map[string]string{ // nolint:gochecknoglobals
-		"ticket_audits":        "audits",
-		"search":               "results", // This is "/api/v2/search"
-		"satisfaction_reasons": "reasons",
-	}
 )
 
 func main() {
@@ -84,7 +80,8 @@ func main() {
 	must(err)
 
 	objects, err := explorer.GetBasicReadObjects(
-		ignoreEndpoints, nil, displayNameOverride, IsResponseFieldAppropriate,
+		ignoreEndpoints, nil, displayNameOverride,
+		api3.CustomMappingObjectCheck(zendesksupport.ObjectNameToResponseField),
 	)
 	must(err)
 
@@ -106,14 +103,6 @@ func main() {
 	must(metadata.FileManager.SaveSchemas(schemas))
 
 	slog.Info("Completed.")
-}
-
-func IsResponseFieldAppropriate(objectName, fieldName string) bool {
-	if responseFieldName, ok := objectNameToResponseField[objectName]; ok {
-		return fieldName == responseFieldName
-	}
-
-	return api3.IdenticalObjectCheck(objectName, fieldName)
 }
 
 func must(err error) {

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -1,6 +1,7 @@
 package api3
 
 import (
+	"github.com/amp-labs/connectors/common/handy"
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/iancoleman/strcase"
 )
@@ -19,6 +20,27 @@ func IdenticalObjectCheck(objectName, fieldName string) bool {
 // Ex: requesting contacts or leads or users will return payload with {"data":[...]}.
 func DataObjectCheck(objectName, fieldName string) bool {
 	return fieldName == "data"
+}
+
+// CustomMappingObjectCheck builds ObjectCheck using mapping,
+// which knows exceptions and patterns to determine response field name.
+//
+// Ex:
+//
+//	CustomMappingObjectCheck(handy.NewDefaultMap(map[string]string{
+//			"orders":	"orders",
+//			"carts":	"carts",
+//			"coupons":	"coupons",
+//		}, func(key string) string { return "data" }))
+//
+// This can be understood as follows: orders, carts, coupons REST resources will be found under JSON response field
+// matching "it's name", while the rest will be located under "data" field.
+func CustomMappingObjectCheck(dict *handy.DefaultMap[string, string]) ObjectCheck {
+	return func(objectName, fieldName string) bool {
+		expected := dict.Get(objectName)
+
+		return fieldName == expected
+	}
 }
 
 // DisplayNameProcessor allows to format Display Names.


### PR DESCRIPTION
# Changes

* Every connector that serves Metadata from `schema.json` has additional check during **Read** that prunes unsupported objects (not part of metadata)
* OpenAPI did some special mapping between `ObjectName` and `JsonPath` holding that object. This logically belongs to the connector and is moved as `DefaultMap` called `ObjectNameToResponseField`. 

# Benefits
`ObjectNameToResponseField` is used by `ZendeskSupport` and `Intercom`.

Because of the move it is not only beneficial for OpenAPI scripts to extract schemas but now it offers correct JSON resolution!
**Zendesk Support Read:**
![image](https://github.com/user-attachments/assets/5653e7e0-407a-4469-b984-3bd73c44c958)

# Summary
This removes the gap between ListObjectMetadata and Read methods. It syncs both, making Read cover **no more** and **no less** than what ListObjetMetadata returns.