### PR TITLE
feat(openapi): Select schemas based on Operation params

### DIFF
--- a/tools/fileconv/api3/README.md
+++ b/tools/fileconv/api3/README.md
@@ -40,3 +40,26 @@ if this is the correct response field that will hold your schema. Some common im
 
 Additionally, Explorer can be configured to apply display name processing after data is extracted. For example, you can capitalize every word of display for better look.
 Edge cases should still be directly specified via **displayNameOverride** map.
+
+
+### Configuration
+
+The OpenAPI schema explorer can be configured to tailor the handling of edge cases. 
+```go
+openapi.FileManager.GetExplorer(
+    api3.WithDisplayNamePostProcessors(
+        api3.CamelCaseToSpaceSeparated,
+        api3.CapitalizeFirstLetterEveryWord,
+    )
+    api3.WithParameterFilterGetMethod(
+        api3.OnlyOptionalQueryParameters        		
+    )
+)
+```
+**Display Name.**
+You can define a chained formatters of display name. For example: 
+first, convert camel case into space-separated words; then, capitalize the first letters.
+Of course, a single method will suffice, but chained processors allow for better composition of out-of-the-box utility methods.
+
+**Parameter Filter.**
+Some GET methods can be ignored based on the endpoint's input parameters. For example, retain endpoints that have exclusively optional query parameters.

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -51,10 +51,19 @@ func (s Schema) String() string {
 
 func (p PathItem) RetrieveSchemaOperationGet(
 	displayNameOverride map[string]string, check ObjectCheck, displayProcessor DisplayNameProcessor,
+	parameterFilter ParameterFilterGetMethod,
 ) (*Schema, bool, error) {
 	operation := p.delegate.Get
 	if operation == nil {
 		return nil, false, nil
+	}
+
+	if parameterFilter != nil {
+		ok := parameterFilter(p.objectName, operation)
+		if !ok {
+			// Omit this schema. We only work with GET method without required parameters
+			return nil, false, nil
+		}
 	}
 
 	schema := extractSchema(operation)

--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -28,7 +28,9 @@ func (e Explorer) GetBasicReadObjects(
 	schemas := make([]Schema, 0)
 
 	for _, path := range e.GetBasicPathItems(newIgnorePathStrategy(ignoreEndpoints), objectEndpoints) {
-		schema, found, err := path.RetrieveSchemaOperationGet(displayNameOverride, check, e.displayPostProcessing)
+		schema, found, err := path.RetrieveSchemaOperationGet(
+			displayNameOverride, check, e.displayPostProcessing, e.parameterFilter,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Background

Get operations may require non uniform parameters. Ex: managerId is required query parameter to list `coaches` for Gong.
As of now Read doesn't support parameterized listing, therefore such schemas should be dropped.

# Changes
Optional callback can be provided to filter schemas based on OpenAPI operation parameters.
Callback provides the most flexability. Sometimes OpenAPI and online documentation can be misleading and say that query parameter is a must have, while in practice no error is returned.