### PR TITLE
[ENG-1511] chore: Add filter for salesforce

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -108,6 +108,9 @@ type ReadParams struct {
 	Since time.Time // optional, omit this to fetch all records
 	// Deleted is true if we want to read deleted records instead of active records.
 	Deleted bool // optional, defaults to false
+	// Filter is only supported for salesforce. It is a SOQL string that comes after the WHERE clause
+	// which will be used to filter the records.
+	Filter string // optional
 }
 
 // WriteParams defines how we are writing data to a SaaS API.

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -67,5 +67,9 @@ func makeSOQL(config common.ReadParams) string {
 		soql.Where("IsDeleted = true")
 	}
 
+	if config.Filter != "" {
+		soql.Where(config.Filter)
+	}
+
 	return soql.String()
 }

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -67,6 +67,8 @@ func makeSOQL(config common.ReadParams) string {
 		soql.Where("IsDeleted = true")
 	}
 
+	// TODO: When we support builder facing filters, we should escape the
+	// filter string to avoid SOQL injection.
 	if config.Filter != "" {
 		soql.Where(config.Filter)
 	}


### PR DESCRIPTION
This adds a filter field to `ReadParams`, which is supported only for Salesforce. This should be removed in favour of a better filter concept later on.

## With filters
<img width="1171" alt="Screenshot 2024-08-28 at 7 19 39 PM" src="https://github.com/user-attachments/assets/6c7c416e-a3fd-437b-94c0-5b6e5b508181">
<img width="1060" alt="Screenshot 2024-08-28 at 7 17 34 PM" src="https://github.com/user-attachments/assets/c6fb2d4f-bae0-47a4-97ae-b0bb35b7b4bd">
<img width="1095" alt="Screenshot 2024-08-28 at 7 17 57 PM" src="https://github.com/user-attachments/assets/c0510a35-a6e6-43eb-b376-216d1f893678">

