### PR TITLE
feat: Stop Read pagination on empty page

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -39,12 +39,16 @@ func ParseResult(
 		return nil, err
 	}
 
-	done := nextPage == ""
-
 	marshaledData, err := marshalFunc(records, fields)
 	if err != nil {
 		return nil, err
 	}
+
+	// Next page doesn't exist if:
+	// * either there is no next page token,
+	// * or current page was empty.
+	// This will guarantee that Read is finite.
+	done := nextPage == "" || len(marshaledData) == 0
 
 	return &ReadResult{
 		Rows:     int64(len(marshaledData)),


### PR DESCRIPTION
Since we removed page size calculation by every connector. Some connectors may not know when there is no next page since they construct URL themselfes. 

To resolve infinite Read we should signify that no more records exists after the page returns no records. 

That is the most broad catch it all precaution.