### PR TITLE
feat: Add Apollo Write connector

### DIFF
--- a/providers/apollo/README.md
+++ b/providers/apollo/README.md
@@ -24,3 +24,14 @@ This connector has two ways of reading data:
 
 The Search Endpoint has a display limit of 50,000 records. With the maximum page_size of 100 records, we can go up to 500 calls.
 
+
+No object supports filterinng and retrieving data from certain points in time. 
+
+
+# Apollo Write connector
+
+## Write Supported Objects
+    - accounts
+    - contacts
+    - opportunities
+    - 

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -1,0 +1,63 @@
+package apollo
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/spyzhov/ajson"
+)
+
+// Write creates/updates records in apolllo.
+func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+	var write common.WriteMethod
+
+	url, err := c.getAPIURL(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	// sets post as default
+	write = c.Client.Post
+
+	// prepares the updating data request.
+	if len(config.RecordId) > 0 {
+		url = url.AddPath(config.RecordId)
+
+		write = c.Client.Patch
+	}
+
+	json, err := write(ctx, url.String(), config.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	return constructWriteResult(json.Body, config.ObjectName)
+}
+
+func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult, error) {
+	obj := naming.NewSingularString(objName)
+
+	respObject, err := jsonquery.New(body).Object(obj.String(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	recordID, err := jsonquery.New(respObject).StrWithDefault("id", "")
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Errors:   nil,
+		Data:     data,
+	}, nil
+}

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -37,6 +37,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult, error) {
+	// API Response contains a json object having a singular objectName key with the
+	// created/updated details in it.
 	obj := naming.NewSingularString(objName)
 
 	respObject, err := jsonquery.New(body).Object(obj.String(), false)

--- a/test/apollo/write/write.go
+++ b/test/apollo/write/write.go
@@ -16,12 +16,19 @@ func main() {
 }
 
 func MainFn() int {
-	err := testCreatingOpportunities(context.Background())
+	ctx := context.Background()
+
+	err := testCreatingOpportunities(ctx)
 	if err != nil {
 		return 1
 	}
 
-	err = testUpdatingOpportunities(context.Background())
+	err = testUpdatingOpportunities(ctx)
+	if err != nil {
+		return 1
+	}
+
+	err = testCreatingAccounts(ctx)
 	if err != nil {
 		return 1
 	}
@@ -64,7 +71,7 @@ func testUpdatingOpportunities(ctx context.Context) error {
 
 	params := common.WriteParams{
 		ObjectName: "opportunities",
-		RecordId:   "66d19d6f0cb92801b3027306",
+		RecordId:   "66d573f1bb530101b230db6f",
 		RecordData: map[string]any{
 			"amount":               "250",
 			"opportunity_stage_id": "65b1974393794c0300d26dcf",

--- a/test/apollo/write/write.go
+++ b/test/apollo/write/write.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/apollo"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	err := testCreatingOpportunities(context.Background())
+	if err != nil {
+		return 1
+	}
+
+	err = testUpdatingOpportunities(context.Background())
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testCreatingOpportunities(ctx context.Context) error {
+	conn := apollo.GetApolloConnector(ctx, "apollo-creds.json")
+
+	params := common.WriteParams{
+		ObjectName: "opportunities",
+		RecordData: map[string]any{
+			"name":                 "opportunity - one",
+			"amount":               "200",
+			"opportunity_stage_id": "65b1974393794c0300d26dcf",
+			"closed_date":          "2024-12-18",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testUpdatingOpportunities(ctx context.Context) error {
+	conn := apollo.GetApolloConnector(ctx, "apollo-creds.json")
+
+	params := common.WriteParams{
+		ObjectName: "opportunities",
+		RecordId:   "66d19d6f0cb92801b3027306",
+		RecordData: map[string]any{
+			"amount":               "250",
+			"opportunity_stage_id": "65b1974393794c0300d26dcf",
+			"closed_date":          "2024-12-18",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testCreatingAccounts(ctx context.Context) error {
+	conn := apollo.GetApolloConnector(ctx, "apollo-creds.json")
+
+	params := common.WriteParams{
+		ObjectName: "accounts",
+		RecordData: map[string]any{
+			"name":         "Google",
+			"domain":       "google.com",
+			"phone_number": "1-866-246-6453",
+			"raw_address":  "1600 Amphitheatre Parkway",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
With the current implementation, the connector can only write to the following objects:
- Accounts
- Opportunities
- Contacts

Creating an Opportunity
<img width="1205" alt="Screenshot 2024-09-02 at 11 14 55" src="https://github.com/user-attachments/assets/7fa1a1c9-022b-4a23-b3d6-ecfb0886fe0d">


Updating the `amount` field of the created opportunity above.
<img width="1203" alt="Screenshot 2024-09-02 at 11 15 41" src="https://github.com/user-attachments/assets/a2262112-3548-4393-8250-2ba3a4b84a6b">




The rest are Bulk activities or search requests. 