### PR TITLE
feat: Explicit loading of Metadata Schema

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -68,8 +68,8 @@ var (
 	// ErrBadRequest is returned when we get a 400 response from the provider.
 	ErrBadRequest = errors.New("bad request")
 
-	// ErrMetadataLoadFailure is returned when files that contain metadata for a connector cannot be loaded.
-	ErrMetadataLoadFailure = errors.New("cannot load metadata")
+	// ErrMissingExpectedValues is returned when response data doesn't have values expected for processing.
+	ErrMissingExpectedValues = errors.New("response data is missing expected values")
 
 	// ErrEmptyJSONHTTPResponse is returned when the JSONHTTPResponse is nil.
 	ErrEmptyJSONHTTPResponse = errors.New("empty json http response")

--- a/providers/apollo/metadata.go
+++ b/providers/apollo/metadata.go
@@ -2,7 +2,6 @@ package apollo
 
 import (
 	"context"
-	"errors"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
@@ -55,13 +54,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 
 		metadata, err := parseMetadataFromResponse(body, objectName)
 		if err != nil {
-			if errors.Is(err, common.ErrMetadataLoadFailure) {
-				metadataResult.Errors[objectName] = common.ErrMetadataLoadFailure
-
-				continue
-			} else {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		metadata.DisplayName = objectName

--- a/providers/gong/metadata.go
+++ b/providers/gong/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/gong/metadata/scrapping.go
+++ b/providers/gong/metadata/scrapping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/instantly/metadata.go
+++ b/providers/instantly/metadata.go
@@ -15,10 +15,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/instantly/metadata/scraping.go
+++ b/providers/instantly/metadata/scraping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/intercom/metadata.go
+++ b/providers/intercom/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/intercom/metadata/scraping.go
+++ b/providers/intercom/metadata/scraping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/marketo/metadata/file.go
+++ b/providers/marketo/metadata/file.go
@@ -12,4 +12,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/pipeliner/metadata.go
+++ b/providers/pipeliner/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/pipeliner/metadata/scraping.go
+++ b/providers/pipeliner/metadata/scraping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/salesloft/metadata.go
+++ b/providers/salesloft/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/salesloft/metadata/scrapping.go
+++ b/providers/salesloft/metadata/scrapping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/smartlead/metadata.go
+++ b/providers/smartlead/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/smartlead/metadata/scraping.go
+++ b/providers/smartlead/metadata/scraping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/zendesksupport/metadata.go
+++ b/providers/zendesksupport/metadata.go
@@ -14,10 +14,5 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	schemas, err := metadata.FileManager.LoadSchemas()
-	if err != nil {
-		return nil, common.ErrMetadataLoadFailure
-	}
-
-	return schemas.Select(objectNames)
+	return metadata.Schemas.Select(objectNames)
 }

--- a/providers/zendesksupport/metadata/scrapping.go
+++ b/providers/zendesksupport/metadata/scrapping.go
@@ -14,4 +14,7 @@ var (
 	schemas []byte
 
 	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/tools/scrapper/files.go
+++ b/tools/scrapper/files.go
@@ -45,15 +45,17 @@ func (m MetadataFileManager) SaveSchemas(schemas *ObjectMetadataResult) error {
 	return FlushToFile(m.locator.AbsPathTo(SchemasFile), schemas)
 }
 
-func (m MetadataFileManager) LoadSchemas() (*ObjectMetadataResult, error) {
+func (m MetadataFileManager) MustLoadSchemas() *ObjectMetadataResult {
 	var result *ObjectMetadataResult
 
 	err := json.Unmarshal(m.schemas, &result)
 	if err != nil {
-		return nil, err
+		// This error should never occur if schemas file is of correct format.
+		// If at least one test exists for the connector this will be caught at development time.
+		return &ObjectMetadataResult{}
 	}
 
-	return result, nil
+	return result
 }
 
 func (m MetadataFileManager) SaveQueryParamStats(stats *QueryParamStats) error {

--- a/tools/scrapper/models.go
+++ b/tools/scrapper/models.go
@@ -96,6 +96,18 @@ func (r *ObjectMetadataResult) Add(objectName, objectDisplayName, fieldName stri
 	data.FieldsMap[fieldName] = fieldName
 }
 
+func (r *ObjectMetadataResult) GetObjectNames() []string {
+	names := make([]string, len(r.Result))
+	index := 0
+
+	for key := range r.Result {
+		names[index] = key
+		index += 1
+	}
+
+	return names
+}
+
 type QueryParamStats struct {
 	Meta queryParamStatsMeta     `json:"meta"`
 	Data []queryParamObjectStats `json:"queryParams"`


### PR DESCRIPTION
Every call to ListObjectMetadata involves parsing file data into schemas before serving. To give substantial performence boost as it was discovered after using benchmarking, see discussion: https://github.com/amp-labs/connectors/pull/722#discussion_r1697443793

It is pretty safe to ignore marshal error as every connector must have mock tests for ListObjectMetadata using `schema.json` content.