### PR TITLE
tidy: Improve OpenAPI scripts, 3 connectors

### DIFF
--- a/providers/pipeliner/metadata/schemas.json
+++ b/providers/pipeliner/metadata/schemas.json
@@ -284,7 +284,7 @@
       }
     },
     "ActivityKPIs": {
-      "displayName": "Activity Kp Is",
+      "displayName": "Activity KPIs",
       "fields": {
         "activity_id": "activity_id",
         "application_id": "application_id",
@@ -442,7 +442,7 @@
       }
     },
     "ApiAccesses": {
-      "displayName": "Api Accesses",
+      "displayName": "API Accesses",
       "fields": {
         "created": "created",
         "email": "email",
@@ -1082,7 +1082,7 @@
       }
     },
     "ContactKPIs": {
-      "displayName": "Contact Kp Is",
+      "displayName": "Contact KPIs",
       "fields": {
         "application_id": "application_id",
         "client": "client",
@@ -2151,7 +2151,7 @@
       }
     },
     "LeadOpptyKPIs": {
-      "displayName": "Lead Oppty Kp Is",
+      "displayName": "Lead Oppty KPIs",
       "fields": {
         "application_id": "application_id",
         "client": "client",
@@ -3316,7 +3316,7 @@
       }
     },
     "ProjectKPIs": {
-      "displayName": "Project Kp Is",
+      "displayName": "Project KPIs",
       "fields": {
         "application_id": "application_id",
         "client": "client",
@@ -3490,7 +3490,7 @@
       }
     },
     "QuoteKPIs": {
-      "displayName": "Quote Kp Is",
+      "displayName": "Quote KPIs",
       "fields": {
         "application_id": "application_id",
         "client": "client",
@@ -4253,7 +4253,7 @@
       }
     },
     "Webresources": {
-      "displayName": "Webresources",
+      "displayName": "Web Resources",
       "fields": {
         "created": "created",
         "display_param": "display_param",

--- a/scripts/openapi/intercom/metadata/main.go
+++ b/scripts/openapi/intercom/metadata/main.go
@@ -22,9 +22,6 @@ var (
 		"/conversations/search",
 		"/articles/search", // this one is similar to /articles
 	}
-	objectEndpoints = map[string]string{ // nolint:gochecknoglobals
-		// none
-	}
 	displayNameOverride = map[string]string{ // nolint:gochecknoglobals
 		"activity_logs":   "Activity Logs",
 		"data_attributes": "Data Attributes",
@@ -51,7 +48,7 @@ func main() {
 	must(err)
 
 	objects, err := explorer.GetBasicReadObjects(
-		ignoreEndpoints, objectEndpoints, displayNameOverride, IsResponseFieldAppropriate,
+		ignoreEndpoints, nil, displayNameOverride, IsResponseFieldAppropriate,
 	)
 	must(err)
 
@@ -75,13 +72,13 @@ func main() {
 	slog.Info("Completed.")
 }
 
-func IsResponseFieldAppropriate(fieldName, objectName string) bool {
+func IsResponseFieldAppropriate(objectName, fieldName string) bool {
 	if responseFieldName, ok := objectNameToResponseField[objectName]; ok {
 		return fieldName == responseFieldName
 	}
 
 	// Other objects have items located under `data` response field.
-	return api3.DataObjectCheck(fieldName, objectName)
+	return api3.DataObjectCheck(objectName, fieldName)
 }
 
 func must(err error) {

--- a/scripts/openapi/pipeliner/metadata/main.go
+++ b/scripts/openapi/pipeliner/metadata/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"log"
+	"log/slog"
 
 	"github.com/amp-labs/connectors/providers/pipeliner/metadata"
 	"github.com/amp-labs/connectors/providers/pipeliner/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 	"github.com/amp-labs/connectors/tools/scrapper"
-	"github.com/iancoleman/strcase"
 )
 
 var (
@@ -15,9 +15,6 @@ var (
 		"*/batch-modify",
 		"*/batch-delete",
 		"/entities/Accounts/merge",
-	}
-	objectEndpoints = map[string]string{ // nolint:gochecknoglobals
-		// none
 	}
 	displayNameOverride = map[string]string{ // nolint:gochecknoglobals
 		"AccountKPIs":   "Account KPIs",
@@ -34,22 +31,26 @@ var (
 func main() {
 	explorer, err := openapi.FileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
-			func(displayName string) string {
-				// Camel case changed to space delimited.
-				return strcase.ToDelimited(displayName, ' ')
-			},
+			api3.CamelCaseToSpaceSeparated,
 			api3.CapitalizeFirstLetterEveryWord,
 		))
 	must(err)
 
 	objects, err := explorer.GetBasicReadObjects(
-		ignoreEndpoints, objectEndpoints, displayNameOverride, api3.DataObjectCheck,
+		ignoreEndpoints, nil, displayNameOverride, api3.DataObjectCheck,
 	)
 	must(err)
 
 	schemas := scrapper.NewObjectMetadataResult()
 
 	for _, object := range objects {
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", object.ObjectName,
+				"error", object.Problem,
+			)
+		}
+
 		for _, field := range object.Fields {
 			schemas.Add(object.ObjectName, object.DisplayName, field, nil)
 		}

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log/slog"
-	"strings"
 
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
@@ -13,6 +12,7 @@ import (
 var (
 	ignoreEndpoints = []string{ // nolint:gochecknoglobals
 		// Wild rules.
+		"/api/lotus/*",
 		"*/create_many",
 		"*/update_many",
 		"*/destroy_many",
@@ -26,13 +26,20 @@ var (
 		"*/active",
 		"*/export",
 		"*/definitions",
-		// Complex Path.
+		"*/assignable",
+		// Complex Path with multiple slashes.
 		"/api/v2/channels/twitter/tickets",
 		"/api/v2/suspended_tickets/attachments",
-		"/api/v2/group_memberships/assignable",
 		"/api/v2/dynamic_content/items",
 		"/api/v2/slas/policies",
 		"/api/v2/macros/*",
+		"/api/v2/object_layouts/essentials_cards",
+		"/api/v2/locales/public",
+		"/api/v2/views/compact",
+		"/api/v2/locales/agent",
+		"/api/v2/group_slas/policies",
+		"/api/v2/slas/policies",
+		"/api/v2/routing/requirements/fulfilled",
 		// Resources with search.
 		"/api/v2/users/search",
 		"/api/v2/requests/search",
@@ -43,9 +50,16 @@ var (
 		// Not applicable.
 		"/api/v2/channels/voice/tickets", // only POST method for create.
 		"/api/v2/imports/tickets",        // only POST method for create.
-	}
-	objectEndpoints = map[string]string{ // nolint:gochecknoglobals
-		// Path: /api/v2/problems -> additionalProperties (this is a dictionary/map/free-form data structure)
+		"/api/v2/custom_objects/limits/object_limit",
+		"/api/v2/users/me/session/renew",
+		"/api/v2/locales/current",
+		"/api/v2/locales/detect_best_locale",
+		"/api/v2/brands/check_host_mapping",
+		"/api/v2/views/count_many",
+		"/api/v2/accounts/available",
+		"/api/v2/users/me",
+		"/api/v2/custom_objects/limits/record_limit",
+		"/api/v2/account/settings",
 	}
 	displayNameOverride = map[string]string{ // nolint:gochecknoglobals
 		"search":               "Search Results",
@@ -63,22 +77,27 @@ var (
 func main() {
 	explorer, err := openapi.FileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
-			func(displayName string) string {
-				return strings.ReplaceAll(displayName, "_", " ")
-			},
+			api3.CamelCaseToSpaceSeparated,
 			api3.CapitalizeFirstLetterEveryWord,
 		),
 	)
 	must(err)
 
 	objects, err := explorer.GetBasicReadObjects(
-		ignoreEndpoints, objectEndpoints, displayNameOverride, IsResponseFieldAppropriate,
+		ignoreEndpoints, nil, displayNameOverride, IsResponseFieldAppropriate,
 	)
 	must(err)
 
 	schemas := scrapper.NewObjectMetadataResult()
 
 	for _, object := range objects {
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", object.ObjectName,
+				"error", object.Problem,
+			)
+		}
+
 		for _, field := range object.Fields {
 			schemas.Add(object.ObjectName, object.DisplayName, field, nil)
 		}
@@ -89,12 +108,12 @@ func main() {
 	slog.Info("Completed.")
 }
 
-func IsResponseFieldAppropriate(fieldName, objectName string) bool {
+func IsResponseFieldAppropriate(objectName, fieldName string) bool {
 	if responseFieldName, ok := objectNameToResponseField[objectName]; ok {
 		return fieldName == responseFieldName
 	}
 
-	return api3.IdenticalObjectCheck(fieldName, objectName)
+	return api3.IdenticalObjectCheck(objectName, fieldName)
 }
 
 func must(err error) {

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -102,7 +102,7 @@ func extractFieldsFromArrayItem(objectName string, schema *openapi3.Schema, chec
 				// Those fields of an item are what we are after.
 				// Now ask the discriminator if this is the target List.
 				// It is possible that response has multiple arrays, that's why we are asking to resolve ambiguity.
-				if check(name, objectName) {
+				if check(objectName, name) {
 					return extractFields(items.Value)
 				}
 			}

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -2,21 +2,22 @@ package api3
 
 import (
 	"github.com/amp-labs/connectors/common/naming"
+	"github.com/iancoleman/strcase"
 )
 
 // ObjectCheck is a procedure that decides if field name is related to the object name.
 // Below you can find the common cases.
-type ObjectCheck func(fieldName, objectName string) bool
+type ObjectCheck func(objectName, fieldName string) bool
 
 // IdenticalObjectCheck item schema within response is stored under matching object name.
 // Ex: requesting contacts will return payload with {"contacts":[...]}.
-func IdenticalObjectCheck(fieldName, objectName string) bool {
+func IdenticalObjectCheck(objectName, fieldName string) bool {
 	return fieldName == objectName
 }
 
 // DataObjectCheck item schema within response is always stored under the data field.
 // Ex: requesting contacts or leads or users will return payload with {"data":[...]}.
-func DataObjectCheck(fieldName, objectName string) bool {
+func DataObjectCheck(objectName, fieldName string) bool {
 	return fieldName == "data"
 }
 
@@ -26,6 +27,11 @@ type DisplayNameProcessor func(displayName string) string
 // CapitalizeFirstLetterEveryWord makes all words start with capital except some prepositions.
 func CapitalizeFirstLetterEveryWord(displayName string) string {
 	return naming.CapitalizeFirstLetterEveryWord(displayName)
+}
+
+// CamelCaseToSpaceSeparated converts camel case into lower case space separated string.
+func CamelCaseToSpaceSeparated(displayName string) string {
+	return strcase.ToDelimited(displayName, ' ')
 }
 
 type parameters struct {


### PR DESCRIPTION
# Changes
Every OpenAPI script must log errors for every schema it failed to extract.

I ensured no errors are present. I went through every error and looked OpenAPI spec. All of them were safe to be added to ignored. Some objects, resources are duplicate of each other or not suitable for reading.

Added utility function `CamelCaseToSpaceSeparated`, also Zendesk has better formating of display names that is commited.
Utility function had object name and field name in weird order that confuses me so I flipped it. Object name comes first in the codebase.

# Sciprts output
## Intercom
![image](https://github.com/user-attachments/assets/70fee5b0-da0b-4f01-95e4-18dca6377792)
## Pipeliner
![image](https://github.com/user-attachments/assets/7ddc42ba-4141-4427-ba2b-2f7c2b66e8c5)
## Zendesk Support
![image](https://github.com/user-attachments/assets/c58f17b4-8c81-4bb8-bce7-e55c34a881f8)

