### PR TITLE
tidy: Proxy, Token use consistent creds names

### DIFF
--- a/common/scanning/credscanning/fields.go
+++ b/common/scanning/credscanning/fields.go
@@ -29,6 +29,9 @@ var Fields = struct { // nolint:gochecknoglobals
 	ApiKey Field
 	// Catalog variables
 	Workspace Field
+	// Oauth2
+	State  Field
+	Scopes Field
 }{
 	Provider: Field{
 		Name:      "provider",
@@ -84,6 +87,16 @@ var Fields = struct { // nolint:gochecknoglobals
 		Name:      "workspace",
 		PathJSON:  "substitutions.workspace",
 		SuffixENV: "WORKSPACE",
+	},
+	State: Field{
+		Name:      "state",
+		PathJSON:  "state",
+		SuffixENV: "STATE",
+	},
+	Scopes: Field{
+		Name:      "scopes",
+		PathJSON:  "scopes",
+		SuffixENV: "SCOPES",
 	},
 }
 


### PR DESCRIPTION
# Description

Proxy, Token scripts to use the same credential readers as those under `test` repo.

This means that the same credential file can be used for either `Test`, `Proxy`, `Token` without altering any field names.
One such inconsitency was: **userName** vs **username**.

In future adding new fields will have all those destinations in sync.