### PR TITLE
update record size response in ListMetadata

### DIFF
--- a/providers/marketo/metadata.go
+++ b/providers/marketo/metadata.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers/marketo/metadata"
 )
 
@@ -36,6 +37,8 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, //
 		if err != nil {
 			return nil, err
 		}
+
+		url = c.retrieveSingleRecordParameter(url)
 
 		resp, err := c.Client.Get(ctx, url.String())
 		if err != nil || resp == nil || resp.Body == nil {
@@ -120,4 +123,15 @@ func runFallback(obj string, res *common.ListObjectMetadataResult) *common.ListO
 	res.Result[obj] = *metadata
 
 	return res
+}
+
+func (c *Connector) retrieveSingleRecordParameter(url *urlbuilder.URL) *urlbuilder.URL {
+	switch c.Module {
+	case ModuleAssets.String():
+		url.WithQueryParam(assetsQueryParameter, metadataPageSize)
+	case ModuleLeads.String():
+		url.WithQueryParam(leadsQueryParameter, metadataPageSize)
+	}
+
+	return url
 }

--- a/providers/marketo/types.go
+++ b/providers/marketo/types.go
@@ -3,3 +3,9 @@ package marketo
 import "errors"
 
 var ErrEmptyResultResponse = errors.New("writing reponded with an empty result")
+
+var (
+	metadataPageSize     string = "1"         //nolint:gochecknoglobals
+	assetsQueryParameter string = "maxReturn" //nolint:gochecknoglobals
+	leadsQueryParameter  string = "batchSize" //nolint:gochecknoglobals
+)

--- a/providers/outreach/metadata.go
+++ b/providers/outreach/metadata.go
@@ -7,6 +7,11 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
+var (
+	metadataPageSize      string = "1"          //nolint:gochecknoglobals
+	metadataPageSizeQuery string = "page[size]" //nolint: gochecknoglobals
+)
+
 type Data struct {
 	Data []DataItem `json:"data"`
 }
@@ -37,6 +42,10 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+
+		// Requesting a single record only
+		// As this if for generating metadata only.
+		url.WithQueryParam(metadataPageSizeQuery, metadataPageSize)
 
 		res, err := c.Client.Get(ctx, url.String())
 		if err != nil {

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -341,7 +341,8 @@ func setup() *OAuthApp {
 		}
 
 		// Determine the OAuth redirect URL.
-		redirect := fmt.Sprintf("%s://localhost:%d%s", *proto, *port, *callback)
+		// redirect := fmt.Sprintf("%s://localhost:%d%s", *proto, *port, *callback)
+		redirect := "https://staging-api.withampersand.com/callbacks/v1/oauth"
 
 		state, err := registry.GetString("State")
 		if err != nil {

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -341,8 +341,7 @@ func setup() *OAuthApp {
 		}
 
 		// Determine the OAuth redirect URL.
-		// redirect := fmt.Sprintf("%s://localhost:%d%s", *proto, *port, *callback)
-		redirect := "https://staging-api.withampersand.com/callbacks/v1/oauth"
+		redirect := fmt.Sprintf("%s://localhost:%d%s", *proto, *port, *callback)
 
 		state, err := registry.GetString("State")
 		if err != nil {

--- a/test/outreach/metadata/metadata.go
+++ b/test/outreach/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	objects := []string{"sequences"}
+	objects := []string{"sequences", "mailings", "users"}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This limits the record response returned during metadata generation to only 1 record. 

- Outreach
- Marketo (forgot to implement this in the previous PR, as you recommended)

Running tests:
Outreach
<img width="1193" alt="Screenshot 2024-09-04 at 15 06 00" src="https://github.com/user-attachments/assets/8e4b8051-1b52-40b8-912a-d63cae7b6ef9">

Marketo
<img width="1200" alt="Screenshot 2024-09-04 at 15 42 14" src="https://github.com/user-attachments/assets/6d74cc1a-c853-497e-b255-dcde0cb35d74">

