### PR TITLE
tidy: testroutines improvement with generics

### DIFF
--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Name: "Since parameter is reflected in query parameter",
 			Input: common.ReadParams{
 				ObjectName: "calls",
-				Fields:     []string{"id"},
+				Fields:     connectors.Fields("id"),
 				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
 					time.FixedZone("UTC-8", -8*60*60)),
 			},

--- a/test/apollo/read/read.go
+++ b/test/apollo/read/read.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/amp-labs/connectors"
 	"log"
 	"os"
 	"time"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	ap "github.com/amp-labs/connectors/providers/apollo"
 	"github.com/amp-labs/connectors/test/apollo"

--- a/test/apollo/search/search.go
+++ b/test/apollo/search/search.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/amp-labs/connectors"
 	"log"
 	"os"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	ap "github.com/amp-labs/connectors/providers/apollo"
 	"github.com/amp-labs/connectors/test/apollo"

--- a/test/gong/metadata/main.go
+++ b/test/gong/metadata/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/amp-labs/connectors"
 	"log/slog"
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/gong"
 	"github.com/amp-labs/connectors/test/utils"

--- a/test/instantly/read/main.go
+++ b/test/instantly/read/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/amp-labs/connectors"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/instantly"
 	connTest "github.com/amp-labs/connectors/test/instantly"

--- a/test/instantly/write-delete/main.go
+++ b/test/instantly/write-delete/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/amp-labs/connectors"
 	"log/slog"
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/instantly"
 	connTest "github.com/amp-labs/connectors/test/instantly"

--- a/test/salesforce/bulk/read/main.go
+++ b/test/salesforce/bulk/read/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"github.com/amp-labs/connectors"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/salesforce"
 	"github.com/amp-labs/connectors/test/salesforce/bulk"

--- a/test/utils/testroutines/README.md
+++ b/test/utils/testroutines/README.md
@@ -1,0 +1,81 @@
+# Package testroutines
+
+## Purpose
+
+This package provides base test case for creating `Test Suites`.
+
+## Description
+
+Most common connector methods can be tested using:
+
+* testroutines.Read - Read
+* testroutines.Write - Write
+* testroutines.Metadata - ListObjectMetadata
+* testroutines.Delete - Delete
+
+They can be used as a template to declare your unique test case type.
+The main difference among them is
+
+* input type
+* output type
+* tested method
+
+Below is the example of the run method:
+
+```go
+// Declaration
+func (r Read) Run(t *testing.T, builder ConnectorBuilder[connectors.ReadConnector]) {
+t.Helper()
+conn := builder.Build(t, r.Name) // builder will return Connector of certain type
+output, err := conn.Read(context.Background(), r.Input) // select a method that you want to test and pass input
+ReadType(r).Validate(t, err, output) // invoke TestCase[InputType,OutputType].Validate(...)
+}
+
+// Example calling method
+tt.Run(t, func () (connectors.ReadConnector, error) {
+return constructTestConnector(tt.Server.URL)
+})
+```
+
+### TestCase
+
+A **Test case** consists of:
+
+* `InputType`: captures all inputs to the tested method. Inside the `Run` method,
+  it is wired and passed as arguments required by the method.
+* `OutputType`: represents the result of a successful method execution, which is then compared
+  against `TestCase.Expected` using `TestCase.Comparator`for equality check (or deep equal if none specified).
+
+A test case can also include `TestCase.ExpectedErrs`,
+which ensures that all expected errors are present in the returned error (checked as a subset, not strict equality).
+
+```go
+type Read TestCase[common.ReadParams, *common.ReadResult]
+
+func TestRead(t *testing.T) {
+  t.Parallel()
+  
+  // Common test setup
+  // ...
+
+  // Suite definition
+  tests := []testroutines.Read{
+    {
+      Name:         "Title of the test",
+      Input:        &common.ReadParams{} // This object represents `InputType`
+      Server:       mockserver.Dummy(),  // Configure mock server to respond on requests.
+      Comparator:   func (baseURL string, actual, expected *common.ReadResult) bool {
+        return true // Custom function to compare expected vs given `OutputType`.
+      },
+      ExpectedErrs: []error{common.ErrMissingObjects}, // List of expected errors to be inside error object 
+      Expected:     &common.ReadResult{} // This object represents `OutputType`
+    },
+    
+    // ... other test cases ...
+
+  }
+  
+  // Running tests in the loop
+  // ...
+}
+```

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -3,9 +3,18 @@
 package testroutines
 
 import (
-	"github.com/amp-labs/connectors"
+	"testing"
 )
 
 // ConnectorBuilder is a callback method to construct and configure connector for testing.
 // This is a factory method called for every test suite.
-type ConnectorBuilder[C connectors.Connector] func() (C, error)
+type ConnectorBuilder[Conn any] func() (Conn, error)
+
+func (builder ConnectorBuilder[C]) Build(t *testing.T, testCaseName string) C {
+	conn, err := builder()
+	if err != nil {
+		t.Fatalf("%s: error in test while constructing connector %v", testCaseName, err)
+	}
+
+	return conn
+}

--- a/test/utils/testroutines/delete.go
+++ b/test/utils/testroutines/delete.go
@@ -2,45 +2,22 @@ package testroutines
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
-// Delete is a test suite useful for testing connectors.DeleteConnector interface.
-type Delete struct {
-	Name  string
-	Input common.DeleteParams
-	// dependencies
-	Server *httptest.Server
-	// custom comparison
-	Comparator func(serverURL string, actual, expected *common.DeleteResult) bool
-	// output
-	Expected     *common.DeleteResult
-	ExpectedErrs []error
-}
-
-func (d Delete) getOutline() suiteOutline[common.DeleteResult] {
-	return suiteOutline[common.DeleteResult]{
-		Name:         d.Name,
-		Server:       d.Server,
-		Comparator:   d.Comparator,
-		Expected:     d.Expected,
-		ExpectedErrs: d.ExpectedErrs,
-	}
-}
+type (
+	DeleteType = TestCase[common.DeleteParams, *common.DeleteResult]
+	// Delete is a test suite useful for testing connectors.DeleteConnector interface.
+	Delete DeleteType
+)
 
 // Run provides a procedure to test connectors.DeleteConnector
 func (d Delete) Run(t *testing.T, builder ConnectorBuilder[connectors.DeleteConnector]) {
-	defer d.Server.Close()
-
-	conn, err := builder()
-	if err != nil {
-		t.Fatalf("%s: error in test while constructing connector %v", d.Name, err)
-	}
-
+	t.Helper()
+	conn := builder.Build(t, d.Name)
 	output, err := conn.Delete(context.Background(), d.Input)
-	d.getOutline().Validate(t, err, output)
+	DeleteType(d).Validate(t, err, output)
 }

--- a/test/utils/testroutines/metadata.go
+++ b/test/utils/testroutines/metadata.go
@@ -2,47 +2,22 @@ package testroutines
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
-// Metadata is a test suite useful for testing connectors.ObjectMetadataConnector interface.
-type Metadata struct {
-	Name  string
-	Input []string
-	// dependencies
-	Server *httptest.Server
-	// custom comparison
-	Comparator func(serverURL string, actual, expected *common.ListObjectMetadataResult) bool
-	// output
-	Expected     *common.ListObjectMetadataResult
-	ExpectedErrs []error
-}
-
-func (m Metadata) getOutline() suiteOutline[common.ListObjectMetadataResult] {
-	return suiteOutline[common.ListObjectMetadataResult]{
-		Name:         m.Name,
-		Server:       m.Server,
-		Comparator:   m.Comparator,
-		Expected:     m.Expected,
-		ExpectedErrs: m.ExpectedErrs,
-	}
-}
+type (
+	MetadataType = TestCase[[]string, *common.ListObjectMetadataResult]
+	// Metadata is a test suite useful for testing connectors.ObjectMetadataConnector interface.
+	Metadata MetadataType
+)
 
 // Run provides a procedure to test connectors.ObjectMetadataConnector
-func (m Metadata) Run(t *testing.T,
-	builder ConnectorBuilder[connectors.ObjectMetadataConnector],
-) {
-	defer m.Server.Close()
-
-	conn, err := builder()
-	if err != nil {
-		t.Fatalf("%s: error in test while constructing connector %v", m.Name, err)
-	}
-
+func (m Metadata) Run(t *testing.T, builder ConnectorBuilder[connectors.ObjectMetadataConnector]) {
+	t.Helper()
+	conn := builder.Build(t, m.Name)
 	output, err := conn.ListObjectMetadata(context.Background(), m.Input)
-	m.getOutline().Validate(t, err, output)
+	MetadataType(m).Validate(t, err, output)
 }

--- a/test/utils/testroutines/outline.go
+++ b/test/utils/testroutines/outline.go
@@ -10,23 +10,26 @@ import (
 	"github.com/go-test/deep"
 )
 
-// suiteOutline describes major components that are used to test any Connector methods.
-// It is universal and generic `V` value represents the data type of the expected output.
-type suiteOutline[V any] struct {
+// TestCase describes major components that are used to test any Connector methods.
+// It is universal and generic `Input` data type is what the tested method accepts,
+// while `Output` value represents the data type of the expected output.
+type TestCase[Input any, Output any] struct {
 	// Name of the test suite.
 	Name string
+	// Input passed to the tested method.
+	Input Input
 	// Mock Server which connector will call.
 	Server *httptest.Server
 	// Custom Comparator of how expected output agrees with actual output.
-	Comparator func(serverURL string, actual, expected *V) bool
+	Comparator func(serverURL string, actual, expected Output) bool
 	// Expected return value.
-	Expected *V
+	Expected Output
 	// ExpectedErrs is a list of errors that must be present in error output.
 	ExpectedErrs []error
 }
 
 // Validate checks if supplied input conforms to the test intention.
-func (o suiteOutline[V]) Validate(t *testing.T, err error, output *V) {
+func (o TestCase[Input, Output]) Validate(t *testing.T, err error, output Output) {
 	defer o.Server.Close()
 
 	// performs validation of error output using described test suite outline.
@@ -35,7 +38,7 @@ func (o suiteOutline[V]) Validate(t *testing.T, err error, output *V) {
 	o.checkValue(t, output)
 }
 
-func (o suiteOutline[V]) checkError(t *testing.T, err error) {
+func (o TestCase[Input, Output]) checkError(t *testing.T, err error) {
 	if err != nil {
 		if len(o.ExpectedErrs) == 0 {
 			t.Fatalf("%s: expected no errors, got: (%v)", o.Name, err)
@@ -55,7 +58,7 @@ func (o suiteOutline[V]) checkError(t *testing.T, err error) {
 	}
 }
 
-func (o suiteOutline[V]) checkValue(t *testing.T, output *V) {
+func (o TestCase[Input, Output]) checkValue(t *testing.T, output Output) {
 	// compare desired output
 	var ok bool
 	if o.Comparator == nil {

--- a/test/utils/testroutines/read.go
+++ b/test/utils/testroutines/read.go
@@ -2,47 +2,22 @@ package testroutines
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
-// Read is a test suite useful for testing connectors.ReadConnector interface.
-type Read struct {
-	Name  string
-	Input common.ReadParams
-	// dependencies
-	Server *httptest.Server
-	// custom comparison
-	Comparator func(serverURL string, actual, expected *common.ReadResult) bool
-	// output
-	Expected     *common.ReadResult
-	ExpectedErrs []error
-}
-
-func (r Read) getOutline() suiteOutline[common.ReadResult] {
-	// It is better to create suiteOutline on a fly then store it directly on Read struct.
-	// Nested objects make the test ugly. Better this function then all test files.
-	return suiteOutline[common.ReadResult]{
-		Name:         r.Name,
-		Server:       r.Server,
-		Comparator:   r.Comparator,
-		Expected:     r.Expected,
-		ExpectedErrs: r.ExpectedErrs,
-	}
-}
+type (
+	ReadType = TestCase[common.ReadParams, *common.ReadResult]
+	// Read is a test suite useful for testing connectors.ReadConnector interface.
+	Read ReadType
+)
 
 // Run provides a procedure to test connectors.ReadConnector
 func (r Read) Run(t *testing.T, builder ConnectorBuilder[connectors.ReadConnector]) {
-	defer r.Server.Close()
-
-	conn, err := builder()
-	if err != nil {
-		t.Fatalf("%s: error in test while constructing connector %v", r.Name, err)
-	}
-
+	t.Helper()
+	conn := builder.Build(t, r.Name)
 	output, err := conn.Read(context.Background(), r.Input)
-	r.getOutline().Validate(t, err, output)
+	ReadType(r).Validate(t, err, output)
 }

--- a/test/utils/testroutines/write.go
+++ b/test/utils/testroutines/write.go
@@ -2,45 +2,22 @@ package testroutines
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
-// Write is a test suite useful for testing connectors.WriteConnector interface.
-type Write struct {
-	Name  string
-	Input common.WriteParams
-	// dependencies
-	Server *httptest.Server
-	// custom comparison
-	Comparator func(serverURL string, actual, expected *common.WriteResult) bool
-	// output
-	Expected     *common.WriteResult
-	ExpectedErrs []error
-}
-
-func (w Write) getOutline() suiteOutline[connectors.WriteResult] {
-	return suiteOutline[connectors.WriteResult]{
-		Name:         w.Name,
-		Server:       w.Server,
-		Comparator:   w.Comparator,
-		Expected:     w.Expected,
-		ExpectedErrs: w.ExpectedErrs,
-	}
-}
+type (
+	WriteType = TestCase[common.WriteParams, *common.WriteResult]
+	// Write is a test suite useful for testing connectors.WriteConnector interface.
+	Write WriteType
+)
 
 // Run provides a procedure to test connectors.WriteConnector
 func (w Write) Run(t *testing.T, builder ConnectorBuilder[connectors.WriteConnector]) {
-	defer w.Server.Close()
-
-	conn, err := builder()
-	if err != nil {
-		t.Fatalf("%s: error in test while constructing connector %v", w.Name, err)
-	}
-
+	t.Helper()
+	conn := builder.Build(t, w.Name)
 	output, err := conn.Write(context.Background(), w.Input)
-	w.getOutline().Validate(t, err, output)
+	WriteType(w).Validate(t, err, output)
 }


### PR DESCRIPTION
# Description

Discovered that test cases for Read/Write/Delete/ListObjectMetadata can be further improved with generics making the code shorter.

Another advantage is custom `TestCase` can be declared by any connector. This allows to reuse the same testing checks (expected errors, output matching) and turns the problem into type declaration instead of rewriting boiler plate.

Included `README` file for those who are planning on using this package with examples.