### PR TITLE
test: Salesforce Bulk Write

### DIFF
--- a/common/csv.go
+++ b/common/csv.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -12,6 +13,9 @@ import (
 // Currently done on JSONHTTPClient, but we might need a separate CSVHTTPClient instead
   // Research and see if there is a better way to do this
 */
+
+// ErrMissingCSVData is returned when no CSV data was given for the upload.
+var ErrMissingCSVData = errors.New("no CSV data provided")
 
 func (j *JSONHTTPClient) PutCSV(ctx context.Context, url string, reqBody []byte, headers ...Header) ([]byte, error) {
 	fullURL, err := j.HTTPClient.getURL(url)

--- a/providers/salesforce/bulk-delete.go
+++ b/providers/salesforce/bulk-delete.go
@@ -14,7 +14,7 @@ import (
 func (c *Connector) BulkDelete(ctx context.Context, params BulkOperationParams) (*BulkOperationResult, error) {
 	body := map[string]any{
 		"object":    params.ObjectName,
-		"operation": Delete,
+		"operation": DeleteMode,
 	}
 
 	return c.bulkOperation(ctx, params, body)

--- a/providers/salesforce/bulk-write.go
+++ b/providers/salesforce/bulk-write.go
@@ -2,8 +2,13 @@ package salesforce
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/amp-labs/connectors/common"
 )
+
+var ErrExternalIdEmpty = errors.New("external id is required")
 
 // BulkWrite launches async Bulk Job to upsert records.
 // https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/create_job.htm
@@ -16,14 +21,28 @@ func (c *Connector) BulkWrite( //nolint:funlen,cyclop
 	ctx context.Context,
 	params BulkOperationParams,
 ) (*BulkOperationResult, error) {
+	if len(params.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
 	// Only support upsert for now
-	if params.Mode != Upsert {
+	if params.Mode != UpsertMode {
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedMode, params.Mode)
+	}
+
+	if len(params.ExternalIdField) == 0 {
+		// Upsert operation requires at least one field that is considered to be an External ID.
+		// https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/bulk_api_2_0_upsert.htm
+		return nil, ErrExternalIdEmpty
+	}
+
+	if params.CSVData == nil {
+		return nil, common.ErrMissingCSVData
 	}
 
 	body := map[string]any{
 		"object":              params.ObjectName,
-		"operation":           Upsert,
+		"operation":           UpsertMode,
 		"externalIdFieldName": params.ExternalIdField,
 		"contentType":         "CSV",
 		"lineEnding":          "LF",

--- a/providers/salesforce/bulk-write_test.go
+++ b/providers/salesforce/bulk-write_test.go
@@ -1,0 +1,254 @@
+package salesforce
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseCreateJob := testutils.DataFromFile(t, "bulk/write/launch-job-opportunity.json")
+	responseUpdateJob := testutils.DataFromFile(t, "bulk/write/update-job-opportunity.json")
+
+	bodyRequest := `{
+		"contentType":"CSV",
+		"externalIdFieldName":"external_id__c",
+		"lineEnding":"LF",
+		"object":"Opportunity",
+		"operation":"upsert"
+	}`
+
+	tests := []bulkWriteTestCase{
+		{
+			Name: "Mime response header expected",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "fieldName8",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			Name: "Read object must be included",
+			Input: BulkOperationParams{
+				Mode: UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNoContent)
+			})),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Delete mode cannot be used in BulkWrite",
+			Input: BulkOperationParams{
+				ObjectName: "Opportunity",
+				Mode:       DeleteMode,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrUnsupportedMode},
+		},
+		{
+			Name: "Upsert requires External ID",
+			Input: BulkOperationParams{
+				ObjectName: "Opportunity",
+				Mode:       UpsertMode,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrExternalIdEmpty},
+		},
+		{
+			Name: "CSV is required for upload",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         nil,
+				Mode:            UpsertMode,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingCSVData},
+		},
+		{
+			Name: "Creating Job fails on bad response",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte{})
+			})),
+			ExpectedErrs: []error{ErrCreateJob},
+		},
+		{
+			Name: "Create job id must be string",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{"id":true, "state":"Open"}`)
+			})),
+			ExpectedErrs: []error{common.ErrParseError},
+		},
+		{
+			Name: "Created job must have 'Open' state",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				mockutils.WriteBody(w, `{"id":"132", "state":"UploadComplete"}`)
+			})),
+			ExpectedErrs: []error{ErrInvalidJobState},
+		},
+		{
+			Name: "Server rejects CSV upload with internal server error",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // nolint:varnamelen
+				w.Header().Set("Content-Type", "application/json")
+				switch path := r.URL.Path; {
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest"):
+					// Create job if body matches.
+					mockutils.RespondToBody(w, r, bodyRequest, func() {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(responseCreateJob)
+					})
+				default:
+					w.WriteHeader(http.StatusInternalServerError) // will be returned for CSV upload
+					_, _ = w.Write([]byte{})
+				}
+			})),
+			ExpectedErrs: []error{ErrCSVUploadFailure},
+		},
+		{
+			Name: "Updating Job status fails",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // nolint:varnamelen
+				w.Header().Set("Content-Type", "application/json")
+				switch path := r.URL.Path; {
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest"):
+					// Create job if body matches.
+					mockutils.RespondToBody(w, r, bodyRequest, func() {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(responseCreateJob)
+					})
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest/750ak000009BWKLAA4/batches"):
+					// We expect CSV to be uploaded via this endpoint.
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte{})
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest/750ak000009BWKLAA4"):
+					// Mark job Completed.
+					mockutils.RespondToMethod(w, r, "PATCH", func() {
+						mockutils.RespondToBody(w, r, `{"state":"UploadComplete"}`, func() {
+							w.WriteHeader(http.StatusOK)
+							mockutils.WriteBody(w, `{...]`) // deliberate failure
+						})
+					})
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte{})
+				}
+			})),
+			ExpectedErrs: []error{ErrUpdateJob},
+		},
+		{
+			Name: "Successful Job Create, CSV upload, Job Update",
+			Input: BulkOperationParams{
+				ObjectName:      "Opportunity",
+				ExternalIdField: "external_id__c",
+				CSVData:         strings.NewReader(""),
+				Mode:            UpsertMode,
+			},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // nolint:varnamelen
+				w.Header().Set("Content-Type", "application/json")
+				switch path := r.URL.Path; {
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest"):
+					// Create job if body matches.
+					mockutils.RespondToBody(w, r, bodyRequest, func() {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(responseCreateJob)
+					})
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest/750ak000009BWKLAA4/batches"):
+					// We expect CSV to be uploaded via this endpoint.
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte{})
+				case strings.HasSuffix(path, "/services/data/v59.0/jobs/ingest/750ak000009BWKLAA4"):
+					// Mark job Completed.
+					mockutils.RespondToMethod(w, r, "PATCH", func() {
+						mockutils.RespondToBody(w, r, `{"state":"UploadComplete"}`, func() {
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write(responseUpdateJob)
+						})
+					})
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte{})
+				}
+			})),
+			Expected: &BulkOperationResult{
+				State: "UploadComplete",
+				JobId: "750ak000009BWKLAA4",
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (*Connector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+type (
+	bulkWriteTestCaseType = testroutines.TestCase[BulkOperationParams, *BulkOperationResult]
+	bulkWriteTestCase     bulkWriteTestCaseType
+)
+
+func (c bulkWriteTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+	t.Helper()
+	conn := builder.Build(t, c.Name)
+	output, err := conn.BulkWrite(context.Background(), c.Input)
+	bulkWriteTestCaseType(c).Validate(t, err, output)
+}

--- a/providers/salesforce/bulk.go
+++ b/providers/salesforce/bulk.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	Upsert BulkOperationMode = "upsert"
-	Delete BulkOperationMode = "delete"
+	UpsertMode BulkOperationMode = "upsert"
+	DeleteMode BulkOperationMode = "delete"
 
 	JobStateAborted        = "Aborted"
 	JobStateFailed         = "Failed"
@@ -30,11 +30,13 @@ const (
 
 var (
 	ErrKeyNotFound          = errors.New("key not found")
-	ErrInvalidType          = errors.New("invalid type")
 	ErrInvalidJobState      = errors.New("invalid job state")
+	ErrCreateJob            = errors.New("failed to create job")
+	ErrUpdateJob            = errors.New("failed to update job")
 	ErrUnsupportedMode      = errors.New("unsupported mode")
 	ErrReadToByteFailed     = errors.New("failed to read data to bytes")
 	ErrUnsupportedOperation = errors.New("unsupported operation")
+	ErrCSVUploadFailure     = errors.New("CSV upload failure")
 )
 
 // BulkOperationParams defines how we are writing data to a SaaS API.
@@ -244,10 +246,10 @@ func (c *Connector) getPartialFailureDetails(ctx context.Context, jobInfo *GetJo
 		var referenceId string
 
 		switch jobInfo.Operation {
-		case Upsert:
+		case UpsertMode:
 			// for bulkwrite, we will have ExternalIdFieldName
 			referenceId = record[externalIdColIdx]
-		case Delete:
+		case DeleteMode:
 			// for bulkdelete, we will have sf__Id as reference
 			referenceId = sfId
 		default:
@@ -303,7 +305,24 @@ func getIncompleteJobMessage(jobInfo *GetJobInfoResult) string {
 	}
 }
 
-//nolint:funlen,cyclop
+type ingestJobResponse struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
+
+func (r ingestJobResponse) validateIsOpened() error {
+	if strings.ToLower(r.State) != "open" {
+		message := r.State
+		if r.State == "" {
+			message = "nothing"
+		}
+
+		return fmt.Errorf("%w: expected job state to be open, got %s", ErrInvalidJobState, message)
+	}
+
+	return nil
+}
+
 func (c *Connector) bulkOperation(
 	ctx context.Context,
 	params BulkOperationParams,
@@ -311,92 +330,35 @@ func (c *Connector) bulkOperation(
 ) (*BulkOperationResult, error) {
 	res, err := c.createJob(ctx, jobBody)
 	if err != nil {
-		return nil, fmt.Errorf("createJob failed: %w", err)
+		return nil, errors.Join(ErrCreateJob, err)
 	}
 
-	body, ok := res.Body() // nolint:varnamelen
-	if !ok {
-		return nil, fmt.Errorf("createJob failed: %w", common.ErrEmptyJSONHTTPResponse)
-	}
-
-	resObject, err := body.GetObject()
+	job, err := common.UnmarshalJSON[ingestJobResponse](res)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"parsing result of createJob failed: %w",
-			errors.Join(err, common.ErrParseError),
-		)
+		return nil, errors.Join(common.ErrParseError, err)
 	}
 
-	state, err := resObject["state"].GetString()
-	if err != nil {
-		unpacked, _ := resObject["state"].Unpack()
-
-		return nil, fmt.Errorf(
-			"%w: expected salesforce job state to be string in response, got %T",
-			ErrInvalidType,
-			unpacked,
-		)
-	}
-
-	if strings.ToLower(state) != "open" {
-		return nil, fmt.Errorf("%w: expected job state to be open, got %s", ErrInvalidJobState, state)
-	}
-
-	jobId, err := resObject["id"].GetString()
-	if err != nil {
-		unpacked, _ := resObject["id"].Unpack()
-
-		return nil, fmt.Errorf(
-			"%w: expected salesforce job id to be string in response, got %T",
-			ErrInvalidType,
-			unpacked)
+	if err = job.validateIsOpened(); err != nil {
+		return nil, err
 	}
 
 	// upload csv and there is no response body other than status code
-	_, err = c.uploadCSV(ctx, jobId, params.CSVData)
-	if err != nil {
-		return nil, fmt.Errorf("uploadCSV failed: %w", err)
+	if _, err = c.uploadCSV(ctx, job.ID, params.CSVData); err != nil {
+		return nil, errors.Join(ErrCSVUploadFailure, err)
 	}
 
-	data, err := c.completeUpload(ctx, jobId)
+	res, err = c.completeUpload(ctx, job.ID)
 	if err != nil {
-		return nil, fmt.Errorf("completeUpload failed: %w", err)
+		return nil, errors.Join(ErrUpdateJob, err)
 	}
 
-	body, ok = data.Body()
-	if !ok {
-		return nil, fmt.Errorf("completeUpload failed: %w", common.ErrEmptyJSONHTTPResponse)
-	}
-
-	dataObject, err := body.GetObject()
+	job, err = common.UnmarshalJSON[ingestJobResponse](res)
 	if err != nil {
-		return nil, fmt.Errorf("parsing result of completeUpload failed: %w", errors.Join(err, common.ErrParseError))
-	}
-
-	updatedJobId, err := dataObject["id"].GetString()
-	if err != nil {
-		unpacked, _ := dataObject["id"].Unpack()
-
-		return nil, fmt.Errorf(
-			"%w: expected salesforce job id to be string in response, got %T",
-			ErrInvalidType,
-			unpacked,
-		)
-	}
-
-	completeState, err := dataObject["state"].GetString() //nolint:varnamelen
-	if err != nil {
-		unpacked, _ := resObject["state"].Unpack()
-
-		return nil, fmt.Errorf(
-			"%w: expected salesforce job state to be string in response, got %T",
-			ErrInvalidType,
-			unpacked,
-		)
+		return nil, errors.Join(common.ErrParseError, err)
 	}
 
 	return &BulkOperationResult{
-		JobId: updatedJobId,
-		State: completeState,
+		JobId: job.ID,
+		State: job.State,
 	}, nil
 }

--- a/providers/salesforce/test/bulk/write/launch-job-opportunity.json
+++ b/providers/salesforce/test/bulk/write/launch-job-opportunity.json
@@ -1,0 +1,16 @@
+{
+  "id" : "750ak000009BWKLAA4",
+  "operation" : "upsert",
+  "object" : "Opportunity",
+  "createdById" : "005ak000005hvjJAAQ",
+  "createdDate" : "2024-09-09T19:25:27.000+0000",
+  "systemModstamp" : "2024-09-09T19:25:27.000+0000",
+  "state" : "Open",
+  "externalIdFieldName" : "external_id__c",
+  "concurrencyMode" : "Parallel",
+  "contentType" : "CSV",
+  "apiVersion" : 59.0,
+  "contentUrl" : "services/data/v59.0/jobs/ingest/750ak000009BWKLAA4/batches",
+  "lineEnding" : "LF",
+  "columnDelimiter" : "COMMA"
+}

--- a/providers/salesforce/test/bulk/write/update-job-opportunity.json
+++ b/providers/salesforce/test/bulk/write/update-job-opportunity.json
@@ -1,0 +1,13 @@
+{
+  "id" : "750ak000009BWKLAA4",
+  "operation" : "upsert",
+  "object" : "Opportunity",
+  "createdById" : "005ak000005hvjJAAQ",
+  "createdDate" : "2024-09-09T19:25:27.000+0000",
+  "systemModstamp" : "2024-09-09T19:25:27.000+0000",
+  "state" : "UploadComplete",
+  "externalIdFieldName" : "external_id__c",
+  "concurrencyMode" : "Parallel",
+  "contentType" : "CSV",
+  "apiVersion" : 59.0
+}

--- a/test/salesforce/bulk/delete/main.go
+++ b/test/salesforce/bulk/delete/main.go
@@ -75,7 +75,7 @@ func createObjects(ctx context.Context, conn *salesforce.Connector, filePath str
 		ObjectName:      "Opportunity",
 		ExternalIdField: "external_id__c",
 		CSVData:         file,
-		Mode:            salesforce.Upsert,
+		Mode:            salesforce.UpsertMode,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error bulk writing to prepare bulk delete: %w", err)

--- a/test/salesforce/bulk/write/check-result.go
+++ b/test/salesforce/bulk/write/check-result.go
@@ -21,7 +21,7 @@ func testGetJobResultsForFile(ctx context.Context, conn *salesforce.Connector, f
 		ObjectName:      "Opportunity",
 		ExternalIdField: "external_id__c",
 		CSVData:         file,
-		Mode:            salesforce.Upsert,
+		Mode:            salesforce.UpsertMode,
 	})
 	if err != nil {
 		return "", fmt.Errorf("error bulk writing: %w", err)

--- a/test/salesforce/bulk/write/launch-job.go
+++ b/test/salesforce/bulk/write/launch-job.go
@@ -22,7 +22,7 @@ func testBulkWriteOpportunity(ctx context.Context, conn *salesforce.Connector, f
 		ObjectName:      "Opportunity",
 		ExternalIdField: "external_id__c",
 		CSVData:         file,
-		Mode:            salesforce.Upsert,
+		Mode:            salesforce.UpsertMode,
 	})
 	if err != nil {
 		return "", fmt.Errorf("error bulk writing: %w", err)


### PR DESCRIPTION
# Description
Using real requests recorded Provider API output to create mock tests.

Added validation to **BulkWrite** to require **ObjectName**, **ExternalIdField** (enforced by Salesforce, so we do that too), and **CSV reader**.

The test immitiates 3 API calls. 3 different endpoints are called to initiate Bulk Job, upload CSV and finally update bulk job to mark the completion of upload.