### PR TITLE
test: Salesforce Bulk Delete

### DIFF
--- a/providers/salesforce/bulk-delete.go
+++ b/providers/salesforce/bulk-delete.go
@@ -2,6 +2,8 @@ package salesforce
 
 import (
 	"context"
+
+	"github.com/amp-labs/connectors/common"
 )
 
 // BulkDelete launches async Bulk Job to delete records.
@@ -12,6 +14,14 @@ import (
 // * GetJobResults
 // * GetSuccessfulJobResults.
 func (c *Connector) BulkDelete(ctx context.Context, params BulkOperationParams) (*BulkOperationResult, error) {
+	if len(params.ObjectName) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	if params.CSVData == nil {
+		return nil, common.ErrMissingCSVData
+	}
+
 	body := map[string]any{
 		"object":    params.ObjectName,
 		"operation": DeleteMode,

--- a/providers/salesforce/bulk-delete_test.go
+++ b/providers/salesforce/bulk-delete_test.go
@@ -1,0 +1,88 @@
+package salesforce
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestBulkDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseCreateJob := testutils.DataFromFile(t, "bulk/delete/launch-job-opportunity.json")
+	responseUpdateJob := testutils.DataFromFile(t, "bulk/delete/update-job-opportunity.json")
+
+	bodyRequest := `{"object":"Opportunity","operation":"delete"}`
+
+	tests := []bulkDeleteTestCase{
+		{
+			Name: "Mime response header expected",
+			Input: BulkOperationParams{
+				ObjectName: "Opportunity",
+				CSVData:    strings.NewReader(""),
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			Name:  "Read object must be included",
+			Input: BulkOperationParams{},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNoContent)
+			})),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "CSV is required for upload",
+			Input: BulkOperationParams{
+				ObjectName: "Opportunity",
+				CSVData:    nil,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingCSVData},
+		},
+		{
+			Name: "Successful Job Create, CSV upload, Job Update",
+			Input: BulkOperationParams{
+				ObjectName: "Opportunity",
+				CSVData:    strings.NewReader(""),
+			},
+			Server: createBulkJobServer(bodyRequest, responseCreateJob, responseUpdateJob, "750ak000009BkrxAAC"),
+			Expected: &BulkOperationResult{
+				State: "UploadComplete",
+				JobId: "750ak000009BkrxAAC",
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (*Connector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+type bulkDeleteTestCase bulkWriteTestCase
+
+func (c bulkDeleteTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+	t.Helper()
+	conn := builder.Build(t, c.Name)
+	output, err := conn.BulkDelete(context.Background(), c.Input)
+	bulkWriteTestCaseType(c).Validate(t, err, output)
+}

--- a/providers/salesforce/bulk.go
+++ b/providers/salesforce/bulk.go
@@ -45,7 +45,7 @@ type BulkOperationParams struct {
 	ObjectName string // required
 
 	// The name of a field on the object which is an External ID. Provided in the case of upserts, not inserts
-	ExternalIdField string // required
+	ExternalIdField string
 
 	// The path to the CSV file we are writing
 	CSVData io.Reader // required

--- a/providers/salesforce/test/bulk/delete/launch-job-opportunity.json
+++ b/providers/salesforce/test/bulk/delete/launch-job-opportunity.json
@@ -1,0 +1,15 @@
+{
+  "id": "750ak000009BkrxAAC",
+  "operation": "delete",
+  "object": "Opportunity",
+  "createdById": "005ak000005hvjJAAQ",
+  "createdDate": "2024-09-09T20:41:31.000+0000",
+  "systemModstamp": "2024-09-09T20:41:31.000+0000",
+  "state": "Open",
+  "concurrencyMode": "Parallel",
+  "contentType": "CSV",
+  "apiVersion": 59.0,
+  "contentUrl": "services/data/v59.0/jobs/ingest/750ak000009BkrxAAC/batches",
+  "lineEnding": "LF",
+  "columnDelimiter": "COMMA"
+}

--- a/providers/salesforce/test/bulk/delete/update-job-opportunity.json
+++ b/providers/salesforce/test/bulk/delete/update-job-opportunity.json
@@ -1,0 +1,12 @@
+{
+  "id": "750ak000009BkrxAAC",
+  "operation": "delete",
+  "object": "Opportunity",
+  "createdById": "005ak000005hvjJAAQ",
+  "createdDate": "2024-09-09T20:41:31.000+0000",
+  "systemModstamp": "2024-09-09T20:41:31.000+0000",
+  "state": "UploadComplete",
+  "concurrencyMode": "Parallel",
+  "contentType": "CSV",
+  "apiVersion": 59.0
+}


### PR DESCRIPTION
# Description
Using real requests recorded Provider API output to create mock tests.

`BulkDelete` is very similiar to `BulkWrite` therefore created common `mock server` which is reused by both **TestSuites**.

Added validation to BulkDelete argument params. Also removed a comment that ExternalIdField is required (that is only true for **upserts**).