### PR TITLE
[ENG-1536] chore: Add list job results endpoint

### DIFF
--- a/common/handy/set.go
+++ b/common/handy/set.go
@@ -60,3 +60,12 @@ func (s Set[T]) Has(key T) bool {
 
 	return ok
 }
+
+// Remove will delete a key from the set.
+func (s Set[T]) Remove(key T) {
+	delete(s, key)
+}
+
+func (s Set[T]) IsEmpty() bool {
+	return len(s) == 0
+}

--- a/providers/salesforce/bulk-info.go
+++ b/providers/salesforce/bulk-info.go
@@ -40,6 +40,7 @@ func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIds ...string) ([
 
 	// To keep track of pages
 	location := url.String()
+
 	domain, err := c.getDomainURL()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Context
We can get all job results in a single call instead of calling this endpoint for each job - https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/get_all_jobs.htm

## Testing
When I asked for ~4 jobs that were spread out over ~38 pages, i.e. from page 200 to page 7800
<img width="134" alt="Screenshot 2024-09-11 at 3 20 47 PM" src="https://github.com/user-attachments/assets/eb957889-9f0a-47a5-bb69-9f9d4d8ffe52">
<img width="155" alt="Screenshot 2024-09-11 at 3 20 42 PM" src="https://github.com/user-attachments/assets/fbd0f765-88ff-4801-a72f-db4c5ea95954">

the quota used up was 3 units. I am fairly certain that it's only 1 unit, and the other 2 units were from previous calls. This is because when I tested this function to get ALL jobs, only 1 unit was used up.
<img width="918" alt="Screenshot 2024-09-11 at 3 20 29 PM" src="https://github.com/user-attachments/assets/fec50ea1-1e23-4476-8a9c-0bfad6647613">

## Benchmark
To pick out 7 jobs out of the dataset, it took the function ~15 seconds, going over 40 pages / 8000 records
<img width="278" alt="Screenshot 2024-09-11 at 3 38 08 PM" src="https://github.com/user-attachments/assets/dcee0625-df12-4f3c-8db1-ac6e9f5b688b">
