### PR TITLE
feat: Add Deep Connector Gong (Write)

### DIFF
--- a/providers/gong/errors.go
+++ b/providers/gong/errors.go
@@ -26,5 +26,5 @@ func (r ResponseError) CombineErr(base error) error {
 		return base
 	}
 
-	return fmt.Errorf("%w: %v", base, strings.Join(r.Errors, ","))
+	return fmt.Errorf("%w: %v", base, strings.Join(r.Errors, ", "))
 }

--- a/providers/gong/objectNames.go
+++ b/providers/gong/objectNames.go
@@ -5,7 +5,15 @@ import (
 	"github.com/amp-labs/connectors/providers/gong/metadata"
 )
 
+const (
+	objectNameCalls = "calls"
+)
+
 // Supported object names can be found under schemas.json.
 var supportedObjectsByRead = handy.NewSetFromList( //nolint:gochecknoglobals
 	metadata.Schemas.GetObjectNames(),
+)
+
+var supportedObjectsByWrite = handy.NewSet( //nolint:gochecknoglobals
+	objectNameCalls,
 )

--- a/providers/gong/test/write-call.json
+++ b/providers/gong/test/write-call.json
@@ -1,0 +1,4 @@
+{
+  "requestId": "3o43otp4g4ir55e44of",
+  "callId": "1102881687159885703"
+}

--- a/providers/gong/test/write-invalid-request.json
+++ b/providers/gong/test/write-invalid-request.json
@@ -1,0 +1,8 @@
+{
+  "requestId": "5ecgaap43atfmd8tt3d",
+  "errors": [
+    "parties: must not be null",
+    "direction: must not be null",
+    "actualStart: must not be null"
+  ]
+}

--- a/providers/gong/write.go
+++ b/providers/gong/write.go
@@ -1,0 +1,55 @@
+package gong
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// Write only supports creating Calls.
+func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+	if err := config.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	if !supportedObjectsByWrite.Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	url, err := c.getURL(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Client.Post(ctx, url.String(), config.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	body, ok := res.Body()
+	if !ok {
+		// it is unlikely to have no payload
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	// write response was with payload
+	return constructWriteResult(body)
+}
+
+func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
+	recordID, err := jsonquery.New(body).Str("callId", false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: *recordID,
+		Errors:   nil,
+		Data:     nil,
+	}, nil
+}

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -1,0 +1,94 @@
+package gong
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseInvalidRequest := testutils.DataFromFile(t, "write-invalid-request.json")
+	responseCreateCall := testutils.DataFromFile(t, "write-call.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs data payload",
+			Input:        common.WriteParams{ObjectName: "calls"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name:         "Unsupported object name",
+			Input:        common.WriteParams{ObjectName: "butterflies", RecordData: "dummy"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name:         "Mime response header expected",
+			Input:        common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{interpreter.ErrMissingContentType},
+		},
+		{
+			Name:  "Error on invalid json request",
+			Input: common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(responseInvalidRequest)
+			})),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New( // nolint:goerr113
+					"parties: must not be null, direction: must not be null, actualStart: must not be null",
+				),
+			},
+		},
+		{
+			Name:  "Valid creation of a call",
+			Input: common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
+			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mockutils.RespondToMethod(w, r, "POST", func() {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(responseCreateCall)
+				})
+			})),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "1102881687159885703",
+				Errors:   nil,
+				Data:     nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/gong/write/main.go
+++ b/test/gong/write/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"math/rand"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/gong"
+	connTest "github.com/amp-labs/connectors/test/gong"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+type CallsPayload struct {
+	ClientUniqueId string      `json:"clientUniqueId"`
+	ActualStart    string      `json:"actualStart"`
+	Title          string      `json:"title"`
+	Direction      string      `json:"direction"`
+	PrimaryUser    string      `json:"primaryUser"`
+	Parties        []CallParty `json:"parties"`
+}
+
+type CallParty struct {
+	EmailAddress string `json:"emailAddress,omitempty"`
+	UserId       string `json:"userId,omitempty"`
+}
+
+var objectName = "calls" // nolint: gochecknoglobals
+
+// This script creates the Call object.
+// Gong takes some time to process the call before it can be viewed on the dashboard
+// or retrieved via a GET API request. Deletion, in order to clean up, is only available on the dashboard.
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetGongConnector(ctx)
+	defer utils.Close(conn)
+
+	slog.Info("TEST Create Call")
+	slog.Info("Creating Call")
+
+	createCalls(ctx, conn, &CallsPayload{
+		ClientUniqueId: createUniqueID(),
+		ActualStart:    "2021-02-17T02:30:00-08:00",
+		Title:          "Created from Script",
+		Direction:      "Inbound",
+		PrimaryUser:    "2860266319383544353",
+		Parties: []CallParty{
+			{
+				EmailAddress: "test@test.com",
+			},
+			{
+				UserId: "2860266319383544353",
+			},
+		},
+	})
+
+	slog.Info("Successful test completion")
+}
+
+func createCalls(ctx context.Context, conn *gong.Connector, payload *CallsPayload) *common.WriteResult {
+	res, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: objectName,
+		RecordId:   "",
+		RecordData: payload,
+	})
+	if err != nil {
+		utils.Fail("error writing to Gong", "error", err)
+	}
+
+	if !res.Success {
+		utils.Fail("failed to create a Call")
+	}
+
+	return res
+}
+
+func createUniqueID() string {
+	minV := 1
+	maxV := 10000
+	uniqueID := strconv.Itoa(rand.Intn(maxV-minV+1) + minV)
+	return uniqueID
+}


### PR DESCRIPTION
# Description

Only one object **"calls"** is eligible for deep connector.

Allows to create calls.

Calls are not created immidietly, it takes arround a whole day for Gong to process them. Therefore manual tests doesn't do usual Read to check for side effects.