### PR TITLE
feat: Universal Oauth2 error handling

### DIFF
--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -46,15 +46,9 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	conn = &Connector{
 		Client: &common.JSONHTTPClient{
 			HTTPClient: httpClient,
-			ErrorPostProcessor: common.ErrorPostProcessor{
-				Process: handleError,
-			},
 		},
 		XMLClient: &common.XMLHTTPClient{
 			HTTPClient: httpClient,
-			ErrorPostProcessor: common.ErrorPostProcessor{
-				Process: handleError,
-			},
 		},
 	}
 

--- a/providers/salesforce/errors.go
+++ b/providers/salesforce/errors.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/xquery"
-	"golang.org/x/oauth2"
 )
 
 var ErrCannotReadMetadata = errors.New("cannot read object metadata, it is possible you don't have the correct permissions set") // nolint:lll
@@ -64,20 +62,6 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error { 
 
 	// No known errors, just do the normal error handling logic
 	return common.InterpretError(res, body)
-}
-
-func handleError(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		var oauthErr *oauth2.RetrieveError
-		if urlErr != nil && errors.As(urlErr.Err, &oauthErr) {
-			if oauthErr.ErrorCode == "invalid_grant" {
-				return errors.Join(common.ErrInvalidGrant, err)
-			}
-		}
-	}
-
-	return err
 }
 
 func (c *Connector) interpretXMLError(res *http.Response, body []byte) error {


### PR DESCRIPTION
# Background

There is `ErrorPostProcessor` that is used by JSON and XML HTTP Clients. Error handling method is called by those clients before return statement. Some connectors could choose to provide final callback to handle error in some way.

# Changes

Salesforce is the only connector that has custom handling of error coming from Oauth2 library when refresh token is not valid.
This logic is not specific to Salesforce and should be applied universally across all connectors. 
`ErrorPostProcessor` will now own this logic which will trickle down the effects to others.