### PR TITLE
chore: Linter includes formatting check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,3 +15,14 @@ jobs:
         continue-on-error: false
         with:
           version: v1.54
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.21.0"
+          cache: false
+      - name: Install gci
+        run: "go install github.com/daixiang0/gci@latest"
+      - name: List files with wrong format
+        run: "gci list . | sed 's/^/BadFormat: /'"
+      - name: Formatting check gci
+        run: "[ $(gci list . | wc -c) -eq 0 ] && exit 0 || exit 1"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 # ====================
 # Formatting & linting
 # ====================
+# Lint checking consists of two parts: "golangci-lint" and "gci". Both should be used together.
+# "gci" may still flag issues even if the golangci-lint check passes.
+# Therefore, if any files need formatting, they will be printed, and the final exit code will be
+# successful only if no such files exist.
 .PHONY: lint
 lint:
-	golangci-lint run -c .golangci.yml
+	golangci-lint run -c .golangci.yml && (gci list . | sed 's/^/BadFormat: /'; [ $$(gci list . | wc -c) -eq 0 ])
 
 # Run a few autoformatters and print out unfixable errors
 # PRE-REQUISITES: install linters, see https://ampersand.slab.com/posts/engineering-onboarding-guide-environment-set-up-9v73t3l8#huik9-install-linters

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"log"
 	"log/slog"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/scanning"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"

--- a/test/gong/connector.go
+++ b/test/gong/connector.go
@@ -2,12 +2,13 @@ package gong
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/gong"
 	"github.com/amp-labs/connectors/test/utils"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 func GetGongConnector(ctx context.Context) *gong.Connector {

--- a/test/hubspot/connector.go
+++ b/test/hubspot/connector.go
@@ -2,13 +2,13 @@ package hubspot
 
 import (
 	"context"
-	"golang.org/x/oauth2"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/hubspot"
 	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
 )
 
 // GetHubspotConnector returns a Hubspot connector.

--- a/test/intercom/connector.go
+++ b/test/intercom/connector.go
@@ -2,13 +2,13 @@ package intercom
 
 import (
 	"context"
-	"github.com/amp-labs/connectors/common/scanning/credscanning"
-	"github.com/amp-labs/connectors/providers"
-	"golang.org/x/oauth2"
 	"net/http"
 
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/intercom"
 	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
 )
 
 func GetIntercomConnector(ctx context.Context) *intercom.Connector {

--- a/test/outreach/connector.go
+++ b/test/outreach/connector.go
@@ -2,13 +2,13 @@ package outreach
 
 import (
 	"context"
-	"github.com/amp-labs/connectors/common/scanning/credscanning"
-	"github.com/amp-labs/connectors/providers"
-	"golang.org/x/oauth2"
 	"net/http"
 
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/outreach"
 	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
 )
 
 func GetOutreachConnector(ctx context.Context) *outreach.Connector {

--- a/test/outreach/read/read.go
+++ b/test/outreach/read/read.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/amp-labs/connectors/test/utils"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	connTest "github.com/amp-labs/connectors/test/outreach"
+	"github.com/amp-labs/connectors/test/utils"
 )
 
 func main() {

--- a/test/salesloft/connector.go
+++ b/test/salesloft/connector.go
@@ -2,13 +2,13 @@ package salesloft
 
 import (
 	"context"
-	"golang.org/x/oauth2"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/salesloft"
 	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
 )
 
 func GetSalesloftConnector(ctx context.Context) *salesloft.Connector {


### PR DESCRIPTION
# Background

I always run `make lint` but noticed that `make fix` may modify files that were not flagged by `make lint`. I tried clearing the cache using `golangci-lint cache clean`, but the issue persisted.

# Changes

After researching more about `gci`, which is used for formatting, I found the command `gci list .` which performs a "dry run" by returning a list of files that need to be modified.

Now, `make lint` will also print the files that should be changed by running `make fix`. If no files require changes, the exit code will be 0. This preserves the existing behavior while adding an extra check to notify when `make fix` needs running.

# Review

There are 2 commits. One is the result of running `make fix`, the other adds additional check under Makefile and Github action. I used this PR to test github action, such that removing first commit would result into `linter` job failure.