### PR TITLE
feat: Zendesk modules use URLs from schema.json

### DIFF
--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -10,7 +10,7 @@ func init() { // nolint:funlen
 	SetInfo(ZendeskSupport, ProviderInfo{
 		DisplayName: "Zendesk Support",
 		AuthType:    Oauth2,
-		BaseURL:     "https://{{.workspace}}.zendesk.com/api",
+		BaseURL:     "https://{{.workspace}}.zendesk.com",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://{{.workspace}}.zendesk.com/oauth/authorizations/new",

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -59,7 +59,7 @@ func (c *Connector) String() string {
 }
 
 func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
-	path, err := metadata.Schemas.LookupURLPath(c.ModuleID, objectName)
+	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -6,9 +6,8 @@ import (
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
-
-const apiVersion = "v2"
 
 type Connector struct {
 	BaseURL string
@@ -59,8 +58,13 @@ func (c *Connector) String() string {
 	return c.Provider() + ".Connector"
 }
 
-func (c *Connector) getURL(arg string) (*urlbuilder.URL, error) {
-	return urlbuilder.New(c.BaseURL, apiVersion, arg)
+func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.LookupURLPath(c.ModuleID, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.BaseURL, path)
 }
 
 func (c *Connector) setBaseURL(newURL string) {

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -47,8 +47,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.MethodDELETE(),
-				Then:  mockserver.Response(http.StatusNoContent),
+				If: mockcond.And{
+					mockcond.PathSuffix("/v2/brands/31207417638931"),
+					mockcond.MethodDELETE(),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
 
-func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
 	tests := []testroutines.Metadata{
@@ -23,8 +23,8 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
+			Name:         "Object coming from different module is unknown",
+			Input:        []string{"articles"},
 			Server:       mockserver.Dummy(),
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
@@ -102,6 +102,72 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
 				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+			})
+		})
+	}
+}
+
+func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "Object coming from different module is unknown",
+			Input:        []string{"brands"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+		},
+		{
+			Name:   "Successfully describe one object with metadata",
+			Input:  []string{"articles"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"articles": {
+						DisplayName: "Articles",
+						FieldsMap: map[string]string{
+							"author_id":           "author_id",
+							"body":                "body",
+							"comments_disabled":   "comments_disabled",
+							"content_tag_ids":     "content_tag_ids",
+							"created_at":          "created_at",
+							"draft":               "draft",
+							"edited_at":           "edited_at",
+							"html_url":            "html_url",
+							"id":                  "id",
+							"label_names":         "label_names",
+							"locale":              "locale",
+							"outdated":            "outdated",
+							"outdated_locales":    "outdated_locales",
+							"permission_group_id": "permission_group_id",
+							"position":            "position",
+							"promoted":            "promoted",
+							"section_id":          "section_id",
+							"source_locale":       "source_locale",
+							"title":               "title",
+							"updated_at":          "updated_at",
+							"url":                 "url",
+							"user_segment_id":     "user_segment_id",
+							"user_segment_ids":    "user_segment_ids",
+							"vote_count":          "vote_count",
+							"vote_sum":            "vote_sum",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL, ModuleHelpCenter)
 			})
 		})
 	}

--- a/providers/zendesksupport/parse.go
+++ b/providers/zendesksupport/parse.go
@@ -6,5 +6,16 @@ import (
 )
 
 func getNextRecordsURL(node *ajson.Node) (string, error) {
-	return jsonquery.New(node, "links").StrWithDefault("next", "")
+	nextPage, err := jsonquery.New(node, "links").StrWithDefault("next", "")
+	if err != nil {
+		return "", err
+	}
+
+	if len(nextPage) != 0 {
+		return nextPage, nil
+	}
+
+	// Next page can be found under different location.
+	// This format was noticed via Zendesk HelpCenter module.
+	return jsonquery.New(node).StrWithDefault("next_page", "")
 }

--- a/providers/zendesksupport/test/read-posts.json
+++ b/providers/zendesksupport/test/read-posts.json
@@ -1,0 +1,33 @@
+{
+  "posts": [
+    {
+      "id": 27980065413139,
+      "title": "How do I get around the community?",
+      "details": "<p>You can use search to find answers. You can also browse topics and posts using views and filters. See <a href=\"https://support.zendesk.com/hc/en-us/articles/203664386#topic_dqx_znw_3k\" target=\"_blank\" rel=\"nofollow noreferrer\">Getting around the community</a>.</p>",
+      "author_id": 26363624373267,
+      "vote_sum": 0,
+      "vote_count": 0,
+      "comment_count": 0,
+      "follower_count": 0,
+      "topic_id": 27980065395091,
+      "html_url": "https://d3v-ampersand.zendesk.com/hc/en-us/community/posts/27980065413139-How-do-I-get-around-the-community",
+      "created_at": "2024-04-01T13:01:11Z",
+      "updated_at": "2024-04-01T13:01:11Z",
+      "url": "https://d3v-ampersand.zendesk.com/api/v2/help_center/community/posts/27980065413139-How-do-I-get-around-the-community.json",
+      "featured": false,
+      "pinned": false,
+      "closed": false,
+      "frozen": false,
+      "status": "none",
+      "non_author_editor_id": null,
+      "non_author_updated_at": null,
+      "content_tag_ids": []
+    }
+  ],
+  "page": 1,
+  "previous_page": null,
+  "next_page": "https://d3v-ampersand.zendesk.com/api/v2/help_center/community/posts.json?page=2&per_page=30",
+  "per_page": 30,
+  "page_count": 2,
+  "count": 32
+}

--- a/providers/zendesksupport/test/write-post.json
+++ b/providers/zendesksupport/test/write-post.json
@@ -1,0 +1,25 @@
+{
+  "post": {
+    "id": 33507191590803,
+    "title": "Help!",
+    "details": "My printer is on fire!",
+    "author_id": 26363624373267,
+    "vote_sum": 0,
+    "vote_count": 0,
+    "comment_count": 0,
+    "follower_count": 0,
+    "topic_id": 27980065395091,
+    "html_url": "https://d3v-ampersand.zendesk.com/hc/en-us/community/posts/33507191590803-Help",
+    "created_at": "2024-09-17T20:15:16Z",
+    "updated_at": "2024-09-17T20:15:16Z",
+    "url": "https://d3v-ampersand.zendesk.com/api/v2/help_center/community/posts/33507191590803-Help.json",
+    "featured": false,
+    "pinned": false,
+    "closed": false,
+    "frozen": false,
+    "status": "none",
+    "non_author_editor_id": null,
+    "non_author_updated_at": null,
+    "content_tag_ids": []
+  }
+}

--- a/test/zendesksupport/metadata/main.go
+++ b/test/zendesksupport/metadata/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -29,6 +30,7 @@ func main() {
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,
+		Fields:     connectors.Fields("name", "time_zone", "role"),
 	})
 	if err != nil {
 		utils.Fail("error reading from ZendeskSupport", "error", err)


### PR DESCRIPTION
# Background

As of now the only supported resources have short URLs. There is no systematic approach for other cases.

# Changes

* The static schema file holds URL paths for every object, allowing nested REST API resources to be requested via Read/Write/Delete methods.
Some connectors have few endpoints with hardcoded mapping between ObjectName and URL. However, in this case `schema.json` was generated from the OpenAPI file, so it naturally holds the mapping. As a result, creating URLs is straightforward.
```go
path, err := metadata.Schemas.LookupURLPath(c.ModuleID, objectName)
url, err := urlbuilder.New(c.BaseURL, path)
```
* I noticed that pagination response format differs between ticketing and help center modules. I updated the parsing so that both pagination formats are handled in a fallback sequence, starting with the more likely format.
* ZendeskSupport BaseURL is modified :exclamation: :exclamation: :exclamation: 

# Test Results
Running Zendesk test scripts for backwards compatability.
![image](https://github.com/user-attachments/assets/9c8b1b02-16fe-4c39-9c95-293cb895b345)
![image](https://github.com/user-attachments/assets/2c31e41b-10d2-482e-ad4c-eb9729dc3285)
![image](https://github.com/user-attachments/assets/99a78981-2c49-4dd5-af4c-4c4995c8ce72)


# Review
[First commit](https://github.com/amp-labs/connectors/pull/1041/commits/c44521ce0216efbeb7a2e8f4b6dca45609da146c) has main code changes. [Second](https://github.com/amp-labs/connectors/pull/1041/commits/9bc54f7fff8075934648693e3283ec080d11d69c) is mock tests.