### PR TITLE
feat: Add UrlConnector interface, and implement it for Salesforce

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -27,6 +27,22 @@ type Connector interface {
 	Provider() providers.Provider
 }
 
+// UrlConnector is an interface that extends the Connector interface with the ability to
+// retrieve URLs for resources.
+type UrlConnector interface {
+	Connector
+
+	// GetURL returns the URL of some resource. The resource is provider-specific.
+	// The URL is returned as a string, or an error is returned if the URL cannot be
+	// retrieved. The precise meaning of the resource is provider-specific, and the
+	// caller should consult the provider's documentation for more information.
+	// The args parameter is a map of key-value pairs that can be used to customize
+	// the URL. The keys and values are provider-specific, and the caller should
+	// consult the provider's documentation for more information. Certain providers
+	// may ignore the args parameter entirely if it's unnecessary.
+	GetURL(resource string, args map[string]any) (string, error)
+}
+
 // ReadConnector is an interface that extends the Connector interface with read capabilities.
 type ReadConnector interface {
 	Connector

--- a/connectors.go
+++ b/connectors.go
@@ -27,9 +27,9 @@ type Connector interface {
 	Provider() providers.Provider
 }
 
-// UrlConnector is an interface that extends the Connector interface with the ability to
+// URLConnector is an interface that extends the Connector interface with the ability to
 // retrieve URLs for resources.
-type UrlConnector interface {
+type URLConnector interface {
 	Connector
 
 	// GetURL returns the URL of some resource. The resource is provider-specific.

--- a/providers/salesforce/url.go
+++ b/providers/salesforce/url.go
@@ -9,7 +9,7 @@ import (
 
 const OAuthIntrospectResource = "oauth-introspect"
 
-var ErrUnknownUrlResource = errors.New("unknown url resource")
+var ErrUnknownURLResource = errors.New("unknown URL resource")
 
 func (c *Connector) GetURL(resource string, _ map[string]any) (string, error) {
 	if resource == OAuthIntrospectResource {
@@ -21,5 +21,5 @@ func (c *Connector) GetURL(resource string, _ map[string]any) (string, error) {
 		return u.String(), nil
 	}
 
-	return "", fmt.Errorf("%w: %s", ErrUnknownUrlResource, resource)
+	return "", fmt.Errorf("%w: %s", ErrUnknownURLResource, resource)
 }

--- a/providers/salesforce/url.go
+++ b/providers/salesforce/url.go
@@ -1,0 +1,25 @@
+package salesforce
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const OAuthIntrospectResource = "oauth-introspect"
+
+var ErrUnknownUrlResource = errors.New("unknown url resource")
+
+func (c *Connector) GetURL(resource string, _ map[string]any) (string, error) {
+	if resource == OAuthIntrospectResource {
+		u, err := urlbuilder.New(c.BaseURL, "/services/oauth2/introspect")
+		if err != nil {
+			return "", err
+		}
+
+		return u.String(), nil
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrUnknownUrlResource, resource)
+}


### PR DESCRIPTION
This introduces a new interface for looking up URLs. I need this in order to use the token introspection endpoint for Salesforce.