### PR TITLE
fix: Time formatting to respect Zone diff

### DIFF
--- a/common/handy/timing.go
+++ b/common/handy/timing.go
@@ -1,0 +1,20 @@
+package handy
+
+import (
+	"time"
+)
+
+type timing struct{}
+
+var Time timing // nolint:gochecknoglobals
+
+// FormatRFC3339inUTC will convert time to UTC respecting the time zone difference
+// and only then apply time.RFC3339 format.
+func (timing) FormatRFC3339inUTC(input time.Time) string {
+	// Format cuts the zone, nanoseconds and other parts which are not used.
+	// Time zone should be preserved.
+	// Apply zone, keeping time difference.
+	utcTime := input.UTC()
+
+	return utcTime.Format("2006-01-02T15:04:05Z")
+}

--- a/common/handy/timing_test.go
+++ b/common/handy/timing_test.go
@@ -1,0 +1,60 @@
+package handy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestTimingFormatRFC3339inUTC(t *testing.T) {
+	t.Parallel()
+
+	const hour = 60 * 60
+
+	zoneUTC := time.FixedZone("UTC", 0)
+	zonePacific := time.FixedZone("UTC-8", -8*hour)
+	zoneEasternEu := time.FixedZone("UTC+2", 2*hour)
+
+	createTimeIn := func(zone *time.Location) time.Time {
+		return time.Date(2024, 9, 19, 4, 30, 45, 600, zone)
+	}
+
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected string
+	}{
+		{
+			name:     "Time origin",
+			input:    time.Time{},
+			expected: "0001-01-01T00:00:00Z",
+		},
+		{
+			name:     "UTC time",
+			input:    createTimeIn(zoneUTC),
+			expected: "2024-09-19T04:30:45Z",
+		},
+		{
+			name:     "Pacific time",
+			input:    createTimeIn(zonePacific),
+			expected: "2024-09-19T12:30:45Z",
+		},
+		{
+			name:     "Eastern EU time",
+			input:    createTimeIn(zoneEasternEu),
+			expected: "2024-09-19T02:30:45Z",
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			output := Time.FormatRFC3339inUTC(tt.input)
+			testutils.CheckOutputWithError(t, tt.name, tt.expected, nil, output, nil)
+		})
+	}
+}

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
 )
 
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
@@ -22,6 +23,13 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	if len(config.NextPage) != 0 { // not the first page, add a cursor
 		url.WithQueryParam("cursor", config.NextPage.String())
+	}
+
+	if !config.Since.IsZero() {
+		// This time format is RFC3339 but in UTC only.
+		// See calls or users object for query parameter requirements.
+		// https://gong.app.gong.io/settings/api/documentation#get-/v2/calls
+		url.WithQueryParam("fromDateTime", handy.Time.FormatRFC3339inUTC(config.Since))
 	}
 
 	res, err := c.Client.Get(ctx, url.String())

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 )
 
@@ -58,7 +59,7 @@ func makeSOQL(config common.ReadParams) *soqlBuilder {
 
 	// If Since is not set, then we're doing a backfill. We read all rows (in pages)
 	if !config.Since.IsZero() {
-		soql.Where("SystemModstamp > " + config.Since.Format("2006-01-02T15:04:05Z"))
+		soql.Where("SystemModstamp > " + handy.Time.FormatRFC3339inUTC(config.Since))
 	}
 
 	if config.Deleted {


### PR DESCRIPTION
# Background

While working on Gong found that calls and users objects support Since parameter but it must be in RFC3339 time format in UTC only.

# Changes

Gong - support incremental read.
Salesforce - SOQL relied on the same time format `2006-01-02T15:04:05Z`. It was modified next to Gong.

# Warning

This takes into account time zone differences and makes time universal. Salesforce Read is affected. If time was already passed in UTC then no changes will be noticed. Otherwise records could be omitted or duplicated depending on location of servers (likely duplicated).
