### PR TITLE
feat: Define ModuleID

### DIFF
--- a/common/module.go
+++ b/common/module.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/handy"
+)
+
+// ErrInvalidModuleDeclaration occurs when the identifier used for map indexing in Modules
+// does not match the module's ID.
+var ErrInvalidModuleDeclaration = errors.New("supported modules are not correctly defined")
+
+type ModuleID string
+
+type Modules = handy.Map[ModuleID, Module]
+
+// Module represents a set of endpoints and functionality available by provider.
+// Single provider may support multiple modules, requiring the user to choose a module before making requests.
+// Modules may differ by version or by theme, covering different systems or functionalities.
+type Module struct {
+	ID      ModuleID
+	Label   string // e.g. "crm"
+	Version string // e.g. "v3"
+}
+
+func (a Module) Path() string {
+	if len(a.Label) == 0 {
+		return a.Version
+	}
+
+	return fmt.Sprintf("%s/%s", a.Label, a.Version)
+}

--- a/common/paramsbuilder/module.go
+++ b/common/paramsbuilder/module.go
@@ -1,71 +1,44 @@
 package paramsbuilder
 
 import (
-	"errors"
-	"fmt"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
 )
-
-var ErrNoSupportedModule = errors.New("no supported module was chosen")
 
 // Module represents a sub-product of a provider.
 // This is relevant where there are several APIs for different sub-products, and the APIs
 // are versioned differently or have different ways of constructing URLs and requests for reading/writing.
 type Module struct {
-	// Name represents the name of the sub-product. e.g. crm, marketing, etc.
-	Name string
+	Selection common.Module
 	// Connector implementation must provide list of modules that are currently supported.
-	// This defines a list of module a user could switch to. Any out of scope module will be ignored.
-	supported []APIModule
-	// If user supplied unsupported module it will use this fallback.
-	fallback *APIModule
+	// This defines a list of modules a user could switch to.
+	// Validation will check module identifiers are consistent.
+	supported common.Modules
 }
 
 func (p *Module) ValidateParams() error {
-	// making sure the provided module is supported.
-	// If the provided module is not supported, use fallback.
-	if !p.isSupported() {
-		if p.fallback == nil {
-			// not supported and user didn't provide a fallback
-			return ErrNoSupportedModule
-		}
-
-		// replace with fallback module
-		p.Name = p.fallback.String()
-
-		// even fallback is not supported
-		if !p.isSupported() {
-			return ErrNoSupportedModule
+	// Module ID must match the ID which is used to index modules.
+	for id, module := range p.supported {
+		if module.ID != id {
+			return common.ErrInvalidModuleDeclaration
 		}
 	}
 
 	return nil
 }
 
-func (p *Module) WithModule(module APIModule, supported []APIModule, defaultModule *APIModule) {
-	p.Name = module.String()
+// WithModule allows API module selection.
+// Connector implementation must provide list of modules that are currently supported.
+// This defines a list of module a user could switch to. Any out of scope module will be ignored.
+// If user supplied unsupported module, then it will use this fallback.
+func (p *Module) WithModule(moduleID common.ModuleID, supported common.Modules, fallbackID common.ModuleID) {
+	modules := handy.NewDefaultMap(supported,
+		func(unknownID common.ModuleID) common.Module {
+			// Unknown module ids will receive a fallback module.
+			return supported[fallbackID]
+		},
+	)
+
+	p.Selection = modules.Get(moduleID)
 	p.supported = supported
-	p.fallback = defaultModule
-}
-
-func (p *Module) isSupported() bool {
-	for _, mod := range p.supported {
-		if p.Name == mod.String() {
-			return true
-		}
-	}
-
-	return false
-}
-
-type APIModule struct {
-	Label   string // e.g. "crm"
-	Version string // e.g. "v3"
-}
-
-func (a APIModule) String() string {
-	if len(a.Label) == 0 {
-		return a.Version
-	}
-
-	return fmt.Sprintf("%s/%s", a.Label, a.Version)
 }

--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -13,7 +13,18 @@ type ParamAssurance interface {
 // Apply will apply options to construct a ready to go set of parameters.
 // This is a generalized constructor of parameters used to initialize any connector.
 // To qualify as a parameter one must have data validation laid out.
-func Apply[P ParamAssurance](params P, opts []func(params *P)) (*P, error) {
+//
+// It is possible to give default options which will be applied first.
+// Any other options supplied by the user may override defaults,
+// as they are applied last and therefore take higher precedence.
+func Apply[P ParamAssurance](params P,
+	opts []func(params *P),
+	defaultOpts ...func(params *P),
+) (*P, error) {
+	for _, opt := range defaultOpts {
+		opt(&params)
+	}
+
 	for _, opt := range opts {
 		opt(&params)
 	}

--- a/providers/atlassian/modules.go
+++ b/providers/atlassian/modules.go
@@ -1,24 +1,27 @@
 package atlassian
 
 import (
-	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common"
 )
 
-// ModuleJira is the module used for listing Jira issues.
-var ModuleJira = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "rest/api",
-	Version: "3",
-}
-
-// ModuleEmpty is used for proxying requests through.
-var ModuleEmpty = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "",
-	Version: "",
-}
+const (
+	// ModuleEmpty is used for proxying requests through.
+	ModuleEmpty common.ModuleID = ""
+	// ModuleJira is the module used for listing Jira issues.
+	ModuleJira common.ModuleID = "jira"
+)
 
 // supportedModules represents currently working and supported modules within the Atlassian connector.
 // Any added module should be appended here.
-var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	ModuleEmpty,
-	ModuleJira,
+var supportedModules = common.Modules{ // nolint: gochecknoglobals
+	ModuleEmpty: {
+		ID:      ModuleEmpty,
+		Label:   "",
+		Version: "",
+	},
+	ModuleJira: {
+		ID:      ModuleJira,
+		Label:   "rest/api",
+		Version: "3",
+	},
 }

--- a/providers/atlassian/params.go
+++ b/providers/atlassian/params.go
@@ -51,9 +51,9 @@ func WithWorkspace(workspaceRef string) Option {
 }
 
 // WithModule sets the Atlassian API module to use for the connector. It's required.
-func WithModule(module paramsbuilder.APIModule) Option {
+func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, &ModuleEmpty)
+		params.WithModule(module, supportedModules, ModuleEmpty)
 	}
 }
 

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -8,9 +8,9 @@ import (
 
 // Connector is a Hubspot connector.
 type Connector struct {
-	Module  string
 	BaseURL string
 	Client  *common.JSONHTTPClient
+	Module  common.Module
 }
 
 // NewConnector returns a new Hubspot connector.
@@ -20,7 +20,9 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		conn = nil
 	})
 
-	params, err := paramsbuilder.Apply(parameters{}, opts)
+	params, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(ModuleEmpty), // The module is resolved on behalf of the user if the option is missing.
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +37,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		Client: &common.JSONHTTPClient{
 			HTTPClient: params.Client.Caller,
 		},
-		Module: params.Module.Name,
+		Module: params.Module.Selection,
 	}
 
 	conn.setBaseURL(providerInfo.BaseURL)

--- a/providers/hubspot/modules.go
+++ b/providers/hubspot/modules.go
@@ -1,24 +1,27 @@
 package hubspot
 
 import (
-	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common"
 )
 
-// ModuleCRM is the module used for accessing standard CRM objects.
-var ModuleCRM = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "crm",
-	Version: "v3",
-}
-
-// ModuleEmpty is used for proxying requests through.
-var ModuleEmpty = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "",
-	Version: "",
-}
+const (
+	// ModuleEmpty is used for proxying requests through.
+	ModuleEmpty common.ModuleID = ""
+	// ModuleCRM is the module used for accessing standard CRM objects.
+	ModuleCRM common.ModuleID = "CRM"
+)
 
 // supportedModules represents currently working and supported modules within the Hubspot connector.
 // Any added module should be appended added here.
-var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	ModuleEmpty,
-	ModuleCRM,
+var supportedModules = common.Modules{ // nolint: gochecknoglobals
+	ModuleEmpty: {
+		ID:      ModuleEmpty,
+		Label:   "",
+		Version: "",
+	},
+	ModuleCRM: {
+		ID:      ModuleCRM,
+		Label:   "crm",
+		Version: "v3",
+	},
 }

--- a/providers/hubspot/params.go
+++ b/providers/hubspot/params.go
@@ -48,9 +48,9 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 }
 
 // WithModule sets the hubspot API module to use for the connector. It's required.
-func WithModule(module paramsbuilder.APIModule) Option {
+func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, &ModuleEmpty)
+		params.WithModule(module, supportedModules, ModuleEmpty)
 	}
 }
 

--- a/providers/hubspot/string.go
+++ b/providers/hubspot/string.go
@@ -4,5 +4,5 @@ import "fmt"
 
 // String returns a string representation of the connector, which is useful for logging / debugging.
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.Module)
+	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.Module.Path())
 }

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -6,5 +6,5 @@ import (
 
 // getURL is a helper to return the full URL considering the base URL & module.
 func (c *Connector) getURL(arg string) string {
-	return strings.Join([]string{c.BaseURL, c.Module, arg}, "/")
+	return strings.Join([]string{c.BaseURL, c.Module.Path(), arg}, "/")
 }

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -12,7 +12,7 @@ import (
 type Connector struct {
 	BaseURL string
 	Client  *common.JSONHTTPClient
-	Module  string
+	Module  common.Module
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
@@ -21,7 +21,9 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		conn = nil
 	})
 
-	params, err := paramsbuilder.Apply(parameters{}, opts)
+	params, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(ModuleLeads), // The module is resolved on behalf of the user if the option is missing.
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +41,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 				ResponseHandler: responseHandler,
 			},
 		},
-		Module: params.Module.Name,
+		Module: params.Module.Selection,
 	}
 
 	conn.setBaseURL(providerInfo.BaseURL)
@@ -59,7 +61,7 @@ func (c *Connector) Provider() providers.Provider {
 
 func (c *Connector) getAPIURL(objName string) (*urlbuilder.URL, error) {
 	objName = common.AddSuffixIfNotExists(objName, ".json")
-	bURL := strings.Join([]string{restAPIPrefix, c.Module, objName}, "/")
+	bURL := strings.Join([]string{restAPIPrefix, c.Module.Path(), objName}, "/")
 
 	return urlbuilder.New(c.BaseURL, bURL)
 }

--- a/providers/marketo/module.go
+++ b/providers/marketo/module.go
@@ -1,22 +1,34 @@
 package marketo
 
-import "github.com/amp-labs/connectors/common/paramsbuilder"
+import (
+	"github.com/amp-labs/connectors/common"
+)
 
-// ModuleAssets is the module/API used for accessing assets objects.
-var ModuleAssets = paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	Label:   "asset",
-	Version: "v1",
-}
-
-// ModuleLeads is the module/API used for accessing leads objects.
-var ModuleLeads = paramsbuilder.APIModule{ //nolint: gochecknoglobals
-	Label:   "",
-	Version: "v1",
-}
+const (
+	// ModuleEmpty is used for proxying requests through.
+	ModuleEmpty common.ModuleID = ""
+	// ModuleAssets is the module/API used for accessing assets objects.
+	ModuleAssets common.ModuleID = "assets"
+	// ModuleLeads is the module/API used for accessing leads objects.
+	ModuleLeads common.ModuleID = "leads"
+)
 
 // supportedModules represents currently working and supported modules within the Marketo connector.
 // Any added module should be appended here.
-var supportedModules = []paramsbuilder.APIModule{ // nolint: gochecknoglobals
-	ModuleLeads,
-	ModuleAssets,
+var supportedModules = common.Modules{ // nolint: gochecknoglobals
+	ModuleEmpty: {
+		ID:      ModuleEmpty,
+		Label:   "",
+		Version: "",
+	},
+	ModuleAssets: {
+		ID:      ModuleAssets,
+		Label:   "asset",
+		Version: "v1",
+	},
+	ModuleLeads: {
+		ID:      ModuleLeads,
+		Label:   "",
+		Version: "v1",
+	},
 }

--- a/providers/marketo/params.go
+++ b/providers/marketo/params.go
@@ -37,9 +37,9 @@ func WithClient(ctx context.Context, client *http.Client,
 }
 
 // WithModule sets the marketo API module to use for the connector. It's required.
-func WithModule(module paramsbuilder.APIModule) Option {
+func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, &ModuleLeads)
+		params.WithModule(module, supportedModules, ModuleLeads)
 	}
 }
 

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -23,8 +23,8 @@ func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
 	if !params.Since.IsZero() {
-		switch c.Module {
-		case ModuleAssets.String():
+		switch c.Module.ID {
+		case ModuleAssets:
 			t := params.Since.Format(time.RFC3339)
 			fmtTime := fmt.Sprintf("%v", t)
 			url.WithQueryParam("earliestUpdatedAt", fmtTime)


### PR DESCRIPTION
# Background

Relying on the Module URL path as identifiter for that module seems limiting.


# Changes

* Module.Name is renamed to Module.Path
* Module has new field: ID which is of `APIModuleID` type.

# Usage

The developer of a deep connector defines the 'slugs' that the connector supports. These IDs can then be associated with a URL path. However, for some connectors, the endpoints of a module may not share identical URL prefixes, requiring custom mapping and code to resolve the URLs. This is why defining a Module ID adds more abstraction and flexibility for cases like this.