### PR TITLE
chore(semgrep): Ignore connector OpenAPI files

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# OpenAPI are third party files that we do not control.
+/providers/*/openapi/*.json
+/providers/*/openapi/*.yaml


### PR DESCRIPTION

Adding new OpenAPI files breaks `semgrep`.
These files can be treated as opaque content as they are downloaded from connector documentation or its dashboard.

Common complaint is about basic authentication being weak:
![image](https://github.com/user-attachments/assets/1e8c0a4e-f8b1-4f87-89a1-151775f1af71)
