### PR TITLE
fix: when cloning http.Requests, also clone the context

### DIFF
--- a/common/oauth.go
+++ b/common/oauth.go
@@ -189,7 +189,7 @@ func cloneRequest(r *http.Request) *http.Request {
 		r2.Header[k] = append([]string(nil), s...)
 	}
 
-	return r2
+	return r2.WithContext(r.Context())
 }
 
 func cloneResponse(r *http.Response) *http.Response {

--- a/common/oauth.go
+++ b/common/oauth.go
@@ -178,18 +178,18 @@ func (t *oauth2Transport) base() http.RoundTripper {
 	return http.DefaultTransport
 }
 
-func cloneRequest(r *http.Request) *http.Request {
+func cloneRequest(req *http.Request) *http.Request {
 	// shallow copy of the struct
 	r2 := new(http.Request)
-	*r2 = *r
+	*r2 = *req
 
 	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
+	r2.Header = make(http.Header, len(req.Header))
+	for k, s := range req.Header {
 		r2.Header[k] = append([]string(nil), s...)
 	}
 
-	return r2.WithContext(r.Context())
+	return r2.WithContext(req.Context())
 }
 
 func cloneResponse(r *http.Response) *http.Response {


### PR DESCRIPTION
To satisfy the `http.RoundTripper` contract, the http request is cloned before being modified. Unfortunately this is discarding the context, which means that certain context values won't carry over to the actual http transport.

This is important for us because our rate limiter relies on these context values, and can't receive them. This will copy over the context, thus making these values available.