### PR TITLE
feat(utils): Conditional mock server

### DIFF
--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -272,7 +272,7 @@ func setup() *OAuthApp {
 
 	substitutions, err := registry.GetMap(SubstitutionsFieldName)
 	if err != nil {
-		slog.Warn("no substitutions, ensure that the provider info doesn't have any {{variables}}", err)
+		slog.Warn("no substitutions, ensure that the provider info doesn't have any {{variables}}", "error", err)
 	}
 
 	provider := registry.MustString(credscanning.Fields.Provider.Name)

--- a/test/utils/mockutils/mockcond/body.go
+++ b/test/utils/mockutils/mockcond/body.go
@@ -1,0 +1,46 @@
+package mockcond
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Body returns a check expecting body to match template text.
+func Body(expectedBody string) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		reader := r.Body
+
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+
+		r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+		a := stringCleaner(string(body), []string{"\n", "\t"})
+		b := stringCleaner(expectedBody, []string{"\n", "\t"})
+		match := a == b
+
+		return match
+	}
+}
+
+func stringCleaner(text string, toRemove []string) string {
+	rules := make(map[string]string)
+	for _, remove := range toRemove {
+		rules[remove] = ""
+	}
+
+	return stringReplacer(text, rules)
+}
+
+func stringReplacer(text string, rules map[string]string) string {
+	for from, to := range rules {
+		text = strings.ReplaceAll(text, from, to)
+	}
+
+	return text
+}

--- a/test/utils/mockutils/mockcond/conditions.go
+++ b/test/utils/mockutils/mockcond/conditions.go
@@ -1,0 +1,61 @@
+package mockcond
+
+import "net/http"
+
+// Condition computes whether http.Request meets some rule.
+type Condition interface {
+	EvaluateCondition(w http.ResponseWriter, r *http.Request) bool
+}
+
+// Check is the most basic Condition. It is a function definition that allows custom implementation.
+// There are some out of the box functions in this package that have this signature.
+type Check func(w http.ResponseWriter, r *http.Request) bool
+
+// Or is a composite Condition which evaluates to true if at least one condition is met.
+// Empty list returns false.
+type Or []Condition
+
+// And is a composite Condition which evaluates to true if all conditions are met.
+// Empty list returns false.
+type And []Condition
+
+func (c Check) EvaluateCondition(w http.ResponseWriter, r *http.Request) bool {
+	return c(w, r)
+}
+
+func (o Or) EvaluateCondition(w http.ResponseWriter, r *http.Request) bool {
+	if len(o) == 0 {
+		return false
+	}
+
+	for _, condition := range o {
+		if condition == nil {
+			// Nil conditions are not allowed.
+			return false
+		}
+
+		if condition.EvaluateCondition(w, r) {
+			return true
+		}
+	}
+
+	return false
+}
+func (a And) EvaluateCondition(w http.ResponseWriter, r *http.Request) bool {
+	if len(a) == 0 {
+		return false
+	}
+
+	for _, condition := range a {
+		if condition == nil {
+			// Nil conditions are not allowed.
+			return false
+		}
+
+		if !condition.EvaluateCondition(w, r) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/test/utils/mockutils/mockserver/conditional.go
+++ b/test/utils/mockutils/mockserver/conditional.go
@@ -1,0 +1,61 @@
+package mockserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+)
+
+// Conditional is a server recipe that describes how mock server should react when conditions are met.
+type Conditional struct {
+	// Setup is optional handler, where common http.ResponseWrite configuration takes place.
+	Setup http.HandlerFunc
+	// If, may consist of nested Or, And clauses allowing sophisticated logic.
+	If mockcond.Condition
+	// Then will be called when If evaluates to true.
+	Then http.HandlerFunc
+	// Else will be called when If evaluates to false.
+	Else http.HandlerFunc
+}
+
+// Server creates mock server that will produce different response based on conditionals.
+func (c Conditional) Server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Common setup is optional.
+		if c.Setup != nil {
+			c.Setup(w, r)
+		}
+
+		c.apply(w, r)
+	}))
+}
+
+// Apply will try to resolve conditions and find respective scenario to execute.
+// If check condition is satisfied Then is executed, otherwise Else.
+// There is a default behaviour for each leaf case.
+func (c Conditional) apply(w http.ResponseWriter, r *http.Request) {
+	if c.If.EvaluateCondition(w, r) {
+		if c.Then != nil {
+			c.Then(w, r)
+
+			return
+		}
+
+		// Default success behaviour.
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
+
+	if c.Else != nil {
+		c.Else(w, r)
+
+		return
+	}
+
+	// Default fail behaviour.
+	w.WriteHeader(http.StatusInternalServerError)
+	mockutils.WriteBody(w, `{"error": {"message": "condition failed"}}`)
+}

--- a/test/utils/mockutils/mockserver/conditional.go
+++ b/test/utils/mockutils/mockserver/conditional.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Conditional is a server recipe that describes how mock server should react when conditions are met.
+// It is equivalent to If() Then{} Else{}.
 type Conditional struct {
 	// Setup is optional handler, where common http.ResponseWrite configuration takes place.
 	Setup http.HandlerFunc

--- a/test/utils/mockutils/mockserver/handlers.go
+++ b/test/utils/mockutils/mockserver/handlers.go
@@ -1,0 +1,30 @@
+package mockserver
+
+import "net/http"
+
+// ContentJSON is a setup handler, which configures server to use JSON.
+func ContentJSON() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+	}
+}
+
+// Response is used to configure server response with HTTP status and body data.
+// Data is optional.
+func Response(status int, data ...[]byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+
+		if len(data) == 1 {
+			_, _ = w.Write(data[0])
+		}
+		if len(data) > 1 {
+			// The test author made a mistake.
+			panic("at most one response body can be returned by mockserver")
+		}
+	}
+}
+
+func ResponseString(status int, data string) http.HandlerFunc {
+	return Response(status, []byte(data))
+}


### PR DESCRIPTION
# Background

This is part of PR series dedicated to simplifying expressing the goal of mock server used by test case.
Often times when designing a test scenario you want to express if part of request matches certain criteria (condition) and when it does it should act one way otherwise fallback, following `if...else` paradigm.


# Features
* `mockserver.Reactive{...}.Server()` describes what mock server should do when condition evaluates to true
* `mockond.Condition` is an interface which allows to express nested rules very easily:
  * `Check func(w http.ResponseWriter, r *http.Request) bool` -- basic building block of conditions. Future PRs introduce such things as: if URL matches then, if REST operation is POST then, if has query paremeter then, etc.
  * `Or []Condition` and `And []Condition` allow nesting and expressing more sophisticated rules.

# Example
Let's take bulk write test for Salesforce as an example. The new version can be read as follows: "Create mock server that will react/respond with `200, responseCreateJob` only when URL path matches `**and**` body matches".
![image](https://github.com/user-attachments/assets/c9e7fbb0-3bd6-463c-8ed0-1598104e7485)
This is much more readable and understandable than older version:
![image](https://github.com/user-attachments/assets/d9c21271-b67d-404b-bd6f-da48cb453d25)



