### PR TITLE
feat(utils): Switch mock server

### DIFF
--- a/test/utils/mockutils/mockcond/request.go
+++ b/test/utils/mockutils/mockcond/request.go
@@ -1,0 +1,26 @@
+package mockcond
+
+import (
+	"net/http"
+	"strings"
+)
+
+// PathSuffix returns a check expecting request URL path to match the template.
+func PathSuffix(expectedSuffix string) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		path := r.URL.Path
+
+		return strings.HasSuffix(path, expectedSuffix)
+	}
+}
+
+// Method returns a check expecting HTTP method name to match the template.
+func Method(methodName string) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		return r.Method == methodName
+	}
+}
+
+func MethodPATCH() Check {
+	return Method("PATCH")
+}

--- a/test/utils/mockutils/mockserver/crossroads.go
+++ b/test/utils/mockutils/mockserver/crossroads.go
@@ -1,0 +1,80 @@
+package mockserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+)
+
+// Switch is a server recipe that describes multiple path a server may take.
+// It is equivalent to Switch() {Case->Then...Case->Then} Default{}.
+type Switch struct {
+	// Setup is optional handler, where common http.ResponseWrite configuration takes place.
+	Setup http.HandlerFunc
+	// Cases is an ordered list of possible pathways a mock server could take.
+	// The first case that satisfies a condition will be picked.
+	Cases []Case
+	// Default will be called only if all case had failed.
+	Default http.HandlerFunc
+}
+
+// Server creates mock server that will produce different response based on conditionals.
+func (c Switch) Server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Common setup is optional.
+		if c.Setup != nil {
+			c.Setup(w, r)
+		}
+
+		// Explore all paths stopping at the first satisfying server request requirement.
+		for _, path := range c.Cases {
+			if path.isOpen(w, r) {
+				path.takeWalk(w, r)
+
+				return
+			}
+		}
+
+		// Server request has no matching resolution.
+		if c.Default != nil {
+			c.Default(w, r)
+
+			return
+		}
+
+		// Default fail behaviour.
+		w.WriteHeader(http.StatusInternalServerError)
+		mockutils.WriteBody(w, `{"error": {"message": "condition failed"}}`)
+	}))
+}
+
+// Case is one possible route a mock server can take if condition is satisfied.
+type Case struct {
+	// If, may consist of nested Or, And clauses allowing sophisticated logic.
+	If mockcond.Condition
+	// Then will be called when If evaluates to true.
+	Then http.HandlerFunc
+}
+
+func (p *Case) isOpen(w http.ResponseWriter, r *http.Request) bool {
+	if p.If == nil {
+		return false
+	}
+
+	return p.If.EvaluateCondition(w, r)
+}
+
+func (p *Case) takeWalk(w http.ResponseWriter, r *http.Request) {
+	if p.Then != nil {
+		p.Then(w, r)
+
+		return
+	}
+
+	// Default success behaviour.
+	w.WriteHeader(http.StatusNoContent)
+
+	return
+}


### PR DESCRIPTION
# Background

There are tests that require mock server to return values multiple times based on different conditions and producing respective responses. This is a more complicated case of `mockserver.Conditional`, where more than one outcome is possible.

# Features
Inroduced `mockserver.Switch` which includes a list of case, which are condition to response pairs. 
Conditional mock server is an `if` server while Switch is just like go switch.

# Example
Bulk write has mock server which is called 3 times. Each case has its own "reason" and response:
![image](https://github.com/user-attachments/assets/0b8766cc-c0db-4489-b0bf-657465eaa7a8)

I think the former version is much more confusing where `RespondToBody` is nested under `RespondToMethod` which itself is nested under the `switch case`. The structure is very cumbersome. And adding one more check would increase nesting even more.
![image](https://github.com/user-attachments/assets/7f1dcc59-a87a-4c96-a10d-62f1eea4299e)

