### PR TITLE
feat(tests): Modernize mock servers

### DIFF
--- a/providers/atlassian/authmetadata_test.go
+++ b/providers/atlassian/authmetadata_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/go-test/deep"
@@ -38,22 +37,20 @@ func TestGetPostAuthInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 		},
 		{
 			name: "Response should be an array",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{}`)
-			})),
+			server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
 			expectedErrs: []error{
 				ErrDiscoveryFailure,
 			},
 		},
 		{
 			name: "Empty container list, missing cloud id",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `[]`)
-			})),
+			server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `[]`),
+			}.Server(),
 			expectedErrs: []error{
 				ErrContainerNotFound,
 				ErrDiscoveryFailure,
@@ -61,12 +58,11 @@ func TestGetPostAuthInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 		},
 		{
 			name: "Workspace is matched against container, success locating cloud id",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
+			server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
 				// response file has workspace that we set up in the constructor
-				_, _ = w.Write(responseCloudID)
-			})),
+				Always: mockserver.Response(http.StatusOK, responseCloudID),
+			}.Server(),
 			expected: &common.PostAuthInfo{
 				CatalogVars: &map[string]string{
 					"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12",

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -53,10 +53,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "issues", RecordId: "10010"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -59,10 +59,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "issues", RecordId: "10010"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "DELETE")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -47,11 +46,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseErrorFormat)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseErrorFormat),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Date value '-53s' for field 'updated' is invalid"), // nolint:goerr113
@@ -60,11 +58,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Invalid path understood as not found error",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responsePathNotFoundError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responsePathNotFoundError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Not Found - No message available"), // nolint:goerr113
@@ -73,39 +70,36 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Incorrect key in payload",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"garbage": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Incorrect data type in payload",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"issues": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
 			Name:  "Empty array produces no next page",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `
 				{
 				  "startAt": 6,
 				  "issues": []
-				}`)
-			})),
+				}`),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return nextPageComparator(actual, expected)
 			},
@@ -119,42 +113,39 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Issue must have fields property",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `
 				{
 				  "issues": [{}]
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Issue must have id property",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `
 				{
 				  "issues": [{"fields":{}}]
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Missing starting index produces no next page",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `
 				{
 				  "issues": [
 					{"fields":{}, "id": "0"},
 					{"fields":{}, "id": "1"}
-				]}`)
-			})),
+				]}`),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return nextPageComparator(actual, expected)
 			},
@@ -168,17 +159,16 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Next page is implied from start index and issues size",
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `
 				{
 				  "startAt": 6,
 				  "issues": [
 					{"fields":{}, "id": "0"},
 					{"fields":{}, "id": "1"}
-				]}`)
-			})),
+				]}`),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return nextPageComparator(actual, expected)
 			},
@@ -247,11 +237,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "issues",
 				Fields:     connectors.Fields("id", "summary"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseIssuesFirstPage)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseIssuesFirstPage),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -186,11 +186,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Fields:     connectors.Fields("id"),
 				Since:      time.Now().Add(-5 * time.Minute),
 			},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				// server was asked to get issues that occurred in the last 5 min
-				Condition: mockcond.QueryParam("jql", `updated > "-5m"`),
-				OnSuccess: mockserver.ResponseString(http.StatusOK, `
+				If: mockcond.QueryParam("jql", `updated > "-5m"`),
+				Then: mockserver.ResponseString(http.StatusOK, `
 					{
 					  "startAt": 0,
 					  "issues": [{"fields":{}, "id": "0"}]
@@ -211,10 +211,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Fields:     connectors.Fields("id"),
 				NextPage:   "17",
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.QueryParam("startAt", "17"),
-				OnSuccess: mockserver.ResponseString(http.StatusOK, `
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.QueryParam("startAt", "17"),
+				Then: mockserver.ResponseString(http.StatusOK, `
 					{
 					  "startAt": 17,
 					  "issues": [

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -68,10 +68,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "issues", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -79,10 +79,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "issues", RecordId: "10003", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPUT(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPUT(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -90,10 +90,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of an Issue",
 			Input: common.WriteParams{ObjectName: "issues", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, createIssueResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, createIssueResponse),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -45,11 +44,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Error missing project during write",
 			Input: common.WriteParams{ObjectName: "issues", RecordId: "10003", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseInvalidProjectError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseInvalidProjectError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("project:Specify a valid project ID or key"), // nolint:goerr113
@@ -58,11 +56,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Error missing issue type during write",
 			Input: common.WriteParams{ObjectName: "issues", RecordId: "10003", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseInvalidTypeError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseInvalidTypeError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("issuetype:Specify an issue type"), // nolint:goerr113

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -3,12 +3,12 @@ package attio
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -33,28 +33,28 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successfully describe multiple object with metadata",
 			Input: []string{"objects", "lists", "workspace_members", "notes", "webhooks", "tasks"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Simulating different behavior based on URL path
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				switch r.URL.Path {
-				case "/v2/objects":
-					_, _ = w.Write(objectresponse)
-				case "/v2/lists":
-					_, _ = w.Write(listresponse)
-				case "/v2/workspace_members":
-					_, _ = w.Write(workspacemembersresponse)
-				case "/v2/notes":
-					_, _ = w.Write(notesresponse)
-				case "/v2/tasks":
-					_, _ = w.Write(tasksresponse)
-				case "/v2/webhooks":
-					_, _ = w.Write(webhooksresponse)
-				default:
-					// Return 400 for any unexpected paths
-					http.Error(w, "Invalid URL", http.StatusBadRequest)
-				}
-			})),
+			Server: mockserver.Crossroad{
+				Setup: mockserver.ContentJSON(),
+				Paths: []mockserver.Path{{
+					Condition: mockcond.PathSuffix("/v2/objects"),
+					OnSuccess: mockserver.Response(http.StatusOK, objectresponse),
+				}, {
+					Condition: mockcond.PathSuffix("/v2/lists"),
+					OnSuccess: mockserver.Response(http.StatusOK, listresponse),
+				}, {
+					Condition: mockcond.PathSuffix("/v2/workspace_members"),
+					OnSuccess: mockserver.Response(http.StatusOK, workspacemembersresponse),
+				}, {
+					Condition: mockcond.PathSuffix("/v2/notes"),
+					OnSuccess: mockserver.Response(http.StatusOK, notesresponse),
+				}, {
+					Condition: mockcond.PathSuffix("/v2/tasks"),
+					OnSuccess: mockserver.Response(http.StatusOK, tasksresponse),
+				}, {
+					Condition: mockcond.PathSuffix("/v2/webhooks"),
+					OnSuccess: mockserver.Response(http.StatusOK, webhooksresponse),
+				}},
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
 				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
 			},

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -33,26 +33,26 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successfully describe multiple object with metadata",
 			Input: []string{"objects", "lists", "workspace_members", "notes", "webhooks", "tasks"},
-			Server: mockserver.Crossroad{
+			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
-				Paths: []mockserver.Path{{
-					Condition: mockcond.PathSuffix("/v2/objects"),
-					OnSuccess: mockserver.Response(http.StatusOK, objectresponse),
+				Cases: []mockserver.Case{{
+					If:   mockcond.PathSuffix("/v2/objects"),
+					Then: mockserver.Response(http.StatusOK, objectresponse),
 				}, {
-					Condition: mockcond.PathSuffix("/v2/lists"),
-					OnSuccess: mockserver.Response(http.StatusOK, listresponse),
+					If:   mockcond.PathSuffix("/v2/lists"),
+					Then: mockserver.Response(http.StatusOK, listresponse),
 				}, {
-					Condition: mockcond.PathSuffix("/v2/workspace_members"),
-					OnSuccess: mockserver.Response(http.StatusOK, workspacemembersresponse),
+					If:   mockcond.PathSuffix("/v2/workspace_members"),
+					Then: mockserver.Response(http.StatusOK, workspacemembersresponse),
 				}, {
-					Condition: mockcond.PathSuffix("/v2/notes"),
-					OnSuccess: mockserver.Response(http.StatusOK, notesresponse),
+					If:   mockcond.PathSuffix("/v2/notes"),
+					Then: mockserver.Response(http.StatusOK, notesresponse),
 				}, {
-					Condition: mockcond.PathSuffix("/v2/tasks"),
-					OnSuccess: mockserver.Response(http.StatusOK, tasksresponse),
+					If:   mockcond.PathSuffix("/v2/tasks"),
+					Then: mockserver.Response(http.StatusOK, tasksresponse),
 				}, {
-					Condition: mockcond.PathSuffix("/v2/webhooks"),
-					OnSuccess: mockserver.Response(http.StatusOK, webhooksresponse),
+					If:   mockcond.PathSuffix("/v2/webhooks"),
+					Then: mockserver.Response(http.StatusOK, webhooksresponse),
 				}},
 			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -3,12 +3,10 @@ package attio
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -45,11 +43,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "An Empty response",
 			Input: common.ReadParams{ObjectName: "webhooks", Fields: connectors.Fields("")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{"data":[]}`)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{"data":[]}`),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 0,
 				Data: []common.ReadResultRow{},
@@ -60,11 +57,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all objects",
 			Input: common.ReadParams{ObjectName: "objects", Fields: connectors.Fields("")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseObjects)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseObjects),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -100,11 +96,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all lists",
 			Input: common.ReadParams{ObjectName: "lists", Fields: connectors.Fields("")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseLists)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseLists),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -142,11 +137,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all workspace members",
 			Input: common.ReadParams{ObjectName: "workspace_members", Fields: connectors.Fields("")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseWorkspace)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseWorkspace),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -186,11 +180,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all notes",
 			Input: common.ReadParams{ObjectName: "notes", Fields: connectors.Fields(""), NextPage: "test?limit=10"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseNotes)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseNotes),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -220,11 +213,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all tasks",
 			Input: common.ReadParams{ObjectName: "tasks", Fields: connectors.Fields(""), NextPage: "test?limit=10"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseTasks)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseTasks),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -260,11 +252,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Read list of all webhooks",
 			Input: common.ReadParams{ObjectName: "webhooks", Fields: connectors.Fields(""), NextPage: "test?limit=10"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseWebhooks)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseWebhooks),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{

--- a/providers/attio/write_test.go
+++ b/providers/attio/write_test.go
@@ -45,10 +45,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create objects as POST",
 			Input: common.WriteParams{ObjectName: "objects", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseObj),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseObj),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -70,10 +70,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update objects as PATCH",
 			Input: common.WriteParams{ObjectName: "objects", RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseObj),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, responseObj),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -95,10 +95,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create lists as POST",
 			Input: common.WriteParams{ObjectName: "lists", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, listResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, listResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -133,10 +133,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update lists as PATCH",
 			Input: common.WriteParams{ObjectName: "lists", RecordId: "e09a041c-0555-4bb2-8f6e-997bfc9b54e8", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, listResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, listResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -171,10 +171,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create notes as POST",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, notesresponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, notesresponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -201,10 +201,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create tasks as POST",
 			Input: common.WriteParams{ObjectName: "tasks", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, tasksResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, tasksResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -242,10 +242,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update tasks as PATCH",
 			Input: common.WriteParams{ObjectName: "tasks", RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, tasksResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, tasksResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -283,10 +283,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create webhooks as POST",
 			Input: common.WriteParams{ObjectName: "webhooks", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, webhookResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, webhookResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -314,10 +314,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update webhooks as PATCH",
 			Input: common.WriteParams{ObjectName: "webhooks", RecordId: "7e5209b8-bd4e-41d9-bbcd-2f9bab7d4030", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, webhookResponse),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, webhookResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,

--- a/providers/attio/write_test.go
+++ b/providers/attio/write_test.go
@@ -3,12 +3,11 @@ package attio
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -17,7 +16,7 @@ import (
 func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	responseObject := testutils.DataFromFile(t, "write_objects.json")
+	responseObj := testutils.DataFromFile(t, "write_objects.json")
 	listResponse := testutils.DataFromFile(t, "write_lists.json")
 	notesresponse := testutils.DataFromFile(t, "write_notes.json")
 	tasksResponse := testutils.DataFromFile(t, "write_tasks.json")
@@ -46,13 +45,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create objects as POST",
 			Input: common.WriteParams{ObjectName: "objects", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseObject)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseObj),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502",
@@ -73,13 +70,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update objects as PATCH",
 			Input: common.WriteParams{ObjectName: "objects", RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseObject)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseObj),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502",
@@ -100,13 +95,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create lists as POST",
 			Input: common.WriteParams{ObjectName: "lists", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(listResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, listResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "e09a041c-0555-4bb2-8f6e-997bfc9b54e8",
@@ -140,13 +133,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update lists as PATCH",
 			Input: common.WriteParams{ObjectName: "lists", RecordId: "e09a041c-0555-4bb2-8f6e-997bfc9b54e8", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(listResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, listResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "e09a041c-0555-4bb2-8f6e-997bfc9b54e8",
@@ -180,13 +171,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create notes as POST",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(notesresponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, notesresponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "126e58a5-5e3f-4644-89ff-6474e97fcecd",
@@ -212,13 +201,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create tasks as POST",
 			Input: common.WriteParams{ObjectName: "tasks", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(tasksResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, tasksResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "b38142c7-00f6-4d92-813e-7b0f689a5873",
@@ -255,13 +242,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update tasks as PATCH",
 			Input: common.WriteParams{ObjectName: "tasks", RecordId: "bf012982-06a9-47f7-9e87-07dc4945d502", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(tasksResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, tasksResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "b38142c7-00f6-4d92-813e-7b0f689a5873",
@@ -298,13 +283,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Create webhooks as POST",
 			Input: common.WriteParams{ObjectName: "webhooks", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(webhookResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, webhookResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "7e5209b8-bd4e-41d9-bbcd-2f9bab7d4030",
@@ -331,13 +314,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Update webhooks as PATCH",
 			Input: common.WriteParams{ObjectName: "webhooks", RecordId: "7e5209b8-bd4e-41d9-bbcd-2f9bab7d4030", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(webhookResponse)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, webhookResponse),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "7e5209b8-bd4e-41d9-bbcd-2f9bab7d4030",

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -54,10 +54,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -56,10 +57,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "DELETE")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -3,13 +3,11 @@ package dynamicscrm
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -39,16 +37,15 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.DeleteParams{ObjectName: "fax", RecordId: "dd2f7870-3fe8-ee11-a204-0022481f9e3c"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusBadRequest, `{
 					"error": {
 						"code": "0x80060888",
 						"message":"Resource not found for the segment 'conacs'."
 					}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Resource not found for the segment 'conacs'"), // nolint:goerr113

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -38,11 +38,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Schema endpoint is not available for object",
 			Input: []string{"butterflies"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseContactsSchema)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseContactsSchema),
+			}.Server(),
 			ExpectedErrs: []error{ErrObjectNotFound},
 		},
 		{

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -54,10 +54,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "fax", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -69,10 +69,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "dd2f7870-3fe8-ee11-a204-0022481f9e3c",
 				RecordData: "dummy",
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -3,13 +3,11 @@ package dynamicscrm
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -39,16 +37,15 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.WriteParams{ObjectName: "fax", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusBadRequest, `{
 					"error": {
 						"code": "0x80060888",
 						"message":"Resource not found for the segment 'conacs'."
 					}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Resource not found for the segment 'conacs'"), // nolint:goerr113

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -56,10 +57,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "fax", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "POST")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
@@ -70,10 +72,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "dd2f7870-3fe8-ee11-a204-0022481f9e3c",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "PATCH")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -111,11 +111,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
 					time.FixedZone("UTC-8", -8*60*60)),
 			},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				// Pacific time to UTC is achieved by adding 8 hours
-				Condition: mockcond.QueryParam("fromDateTime", "2024-09-19T12:30:45Z"),
-				OnSuccess: mockserver.Response(http.StatusOK, fakeServerResp),
+				If:   mockcond.QueryParam("fromDateTime", "2024-09-19T12:30:45Z"),
+				Then: mockserver.Response(http.StatusOK, fakeServerResp),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.ReadResult) bool {
 				return actual.Rows == expected.Rows

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -3,7 +3,6 @@ package gong
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -51,28 +49,26 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Incorrect key in payload",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"garbage": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Bad request handling test",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusBadRequest, `{
 					"requestId": "3h2gqar52fo4dkqpsly",
 					"errors": [
 						"Failed to verify cursor"
 					]
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("Failed to verify cursor"), // nolint:goerr113
 			},
@@ -80,32 +76,27 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Records section is missing in the payload",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"value": []
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "currentPageSize may be missing in payload",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"requestId": "7eey0z6mf3elkp1n5b6",
 					"records": {
 						"totalRecords": 11,
 						"currentPageNumber": 0
 					},
-					"calls": [     
-			]
-			}		
-					`)
-			})),
+					"calls": []}`),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{},
 				Done: true,
@@ -135,11 +126,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successful read with 2 entries without cursor/next page",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(fakeServerResp)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, fakeServerResp),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -173,11 +163,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successful read with 2 entries and cursor for next page",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(fakeServerResp2)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, fakeServerResp2),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -211,13 +200,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Incorrect data type in payload",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"calls": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 	}

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -63,13 +63,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a call",
 			Input: common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseCreateCall)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseCreateCall),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1102881687159885703",

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -3,7 +3,6 @@ package gong
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -48,11 +47,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Error on invalid json request",
 			Input: common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseInvalidRequest)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseInvalidRequest),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New( // nolint:goerr113

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -61,10 +61,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a call",
 			Input: common.WriteParams{ObjectName: "calls", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseCreateCall),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseCreateCall),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,

--- a/providers/instantly/delete_test.go
+++ b/providers/instantly/delete_test.go
@@ -3,7 +3,6 @@ package instantly
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -50,11 +49,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Cannot remove missing tag",
 			Input: common.DeleteParams{ObjectName: "tags", RecordId: "5043"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseNotFoundErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseNotFoundErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New(`Not Found`), // nolint:goerr113

--- a/providers/instantly/delete_test.go
+++ b/providers/instantly/delete_test.go
@@ -61,13 +61,13 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "tags", RecordId: "5043"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodDELETE(),
 					mockcond.PathSuffix("custom-tag/5043"),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK, responseTag),
+				Then: mockserver.Response(http.StatusOK, responseTag),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -94,7 +93,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage:   "test-placeholder?skip=700",
 				Fields:     connectors.Fields("id"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Server: mockserver.NewServer(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				// Create fake response big enough to conclude that next page exists.
@@ -104,7 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				}
 				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
 				mockutils.WriteBody(w, data)
-			})),
+			}),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.NextPage.String() == expected.NextPage.String() &&
 					actual.Done == expected.Done

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -102,7 +102,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					manyCampaigns[i] = "{}"
 				}
 				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
-				mockutils.WriteBody(w, data)
+				_, _ = w.Write([]byte(data))
 			}),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.NextPage.String() == expected.NextPage.String() &&

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -56,11 +56,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.ReadParams{ObjectName: "campaigns", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseInvalidPath)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseInvalidPath),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Not Found"), // nolint:goerr113
@@ -69,25 +68,23 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Incorrect key in payload",
 			Input: common.ReadParams{ObjectName: "emails", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"yourEmails": []
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Incorrect data type in payload",
 			Input: common.ReadParams{ObjectName: "emails", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"data": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
@@ -124,11 +121,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "campaigns",
 				Fields:     connectors.Fields("id"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, "[]")
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, "[]"),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
 
@@ -147,11 +143,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "campaigns",
 				Fields:     connectors.Fields("name"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseCampaigns)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseCampaigns),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
@@ -186,11 +181,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "tags",
 				Fields:     connectors.Fields("label", "description"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseTags)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseTags),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -57,10 +57,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Blocklist Entry",
 			Input: common.WriteParams{ObjectName: "blocklist-entries", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseBlocklistEntry),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseBlocklistEntry),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -73,10 +73,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Unibox Reply",
 			Input: common.WriteParams{ObjectName: "unibox-replies", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseReply),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseReply),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -102,10 +102,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Lead",
 			Input: common.WriteParams{ObjectName: "leads", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseLead),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseLead),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -130,10 +130,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Tag acts as POST",
 			Input: common.WriteParams{ObjectName: "tags", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseTag),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseTag),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -146,10 +146,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Update tag acts as PATCH",
 			Input: common.WriteParams{ObjectName: "tags", RecordId: "885633", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseTag),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, responseTag),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -58,13 +58,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Blocklist Entry",
 			Input: common.WriteParams{ObjectName: "blocklist-entries", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseBlocklistEntry)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseBlocklistEntry),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cf8fd143-08c3-438e-a396-491aa1ced9d4",
@@ -76,13 +74,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Unibox Reply",
 			Input: common.WriteParams{ObjectName: "unibox-replies", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseReply)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseReply),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "19e9d7f9-bd4f-45aa-8d77-9eecc9bd3f9a",
@@ -108,13 +104,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Lead",
 			Input: common.WriteParams{ObjectName: "leads", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseLead)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseLead),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "", // lead doesn't have ID
@@ -139,13 +133,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create Tag acts as POST",
 			Input: common.WriteParams{ObjectName: "tags", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseTag)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseTag),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "f6825fcf-c51b-4724-937b-0814ed02af83",
@@ -157,13 +149,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Update tag acts as PATCH",
 			Input: common.WriteParams{ObjectName: "tags", RecordId: "885633", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseTag)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseTag),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "f6825fcf-c51b-4724-937b-0814ed02af83",

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -3,7 +3,6 @@ package instantly
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -91,11 +90,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Invalid Lead creation",
 			Input: common.WriteParams{ObjectName: "leads", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseLeadErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseLeadErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Leads array is empty"), // nolint:goerr113
@@ -120,11 +118,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Invalid Tag creation",
 			Input: common.WriteParams{ObjectName: "tags", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseTagErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseTagErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Bad Request"), // nolint:goerr113

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -3,7 +3,6 @@ package intercom
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -41,11 +40,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write(responseNotFound)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, responseNotFound),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("not_found[Resource Not Found]"), // nolint:goerr113

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -52,13 +52,13 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodDELETE(),
 					mockcond.Header(testApiVersionHeader),
 				},
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+				Then: mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -54,12 +54,14 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "articles", RecordId: "9333415"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
-					mockutils.RespondNoContentForMethod(w, r, "DELETE")
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup: mockserver.ContentJSON(),
+				Condition: mockcond.And{
+					mockcond.MethodDELETE(),
+					mockcond.Header(testApiVersionHeader),
+				},
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -112,10 +112,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name:  "API version header is passed as server request",
 			Input: common.ReadParams{ObjectName: "articles", Fields: connectors.Fields("id")},
 			// notes is not supported for now, but its payload is good for testing
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.Header(testApiVersionHeader),
-				OnSuccess: mockserver.Response(http.StatusOK, responseNotesSecondPage),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Header(testApiVersionHeader),
+				Then:  mockserver.Response(http.StatusOK, responseNotesSecondPage),
 			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				// response doesn't matter much, as soon as we don't have errors we are good

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -3,7 +3,6 @@ package intercom
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -45,11 +44,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write(responseInvalidSyntax)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, responseInvalidSyntax),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New(messageForInvalidSyntax), // nolint:goerr113

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -57,24 +58,24 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "signals", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PUT", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup: mockserver.ContentJSON(),
+				Condition: mockcond.And{
+					mockcond.MethodPUT(),
+				},
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
@@ -97,13 +98,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of an article",
 			Input: common.WriteParams{ObjectName: "articles", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(createArticle)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, createArticle),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -56,10 +56,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "signals", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -67,12 +67,12 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodPUT(),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK),
+				Then: mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -80,13 +80,13 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of an article when API version header is passed",
 			Input: common.WriteParams{ObjectName: "articles", RecordData: "dummy"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodPOST(),
 					mockcond.Header(testApiVersionHeader),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK, createArticle),
+				Then: mockserver.Response(http.StatusOK, createArticle),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -80,27 +80,14 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			ExpectedErrs: nil,
 		},
 		{
-			Name:  "API version header is passed as server request on POST",
-			Input: common.WriteParams{ObjectName: "articles", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToHeader(w, r, testApiVersionHeader, func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(createArticle)
-				})
-			})),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return actual.Success == expected.Success
-			},
-			Expected:     &common.WriteResult{Success: true},
-			ExpectedErrs: nil,
-		},
-		{
-			Name:  "Valid creation of an article",
+			Name:  "Valid creation of an article when API version header is passed",
 			Input: common.WriteParams{ObjectName: "articles", RecordData: "dummy"},
 			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
+				Setup: mockserver.ContentJSON(),
+				Condition: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Header(testApiVersionHeader),
+				},
 				OnSuccess: mockserver.Response(http.StatusOK, createArticle),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {

--- a/providers/pipedrive/metadata_test.go
+++ b/providers/pipedrive/metadata_test.go
@@ -2,7 +2,6 @@ package pipedrive
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -28,11 +27,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "A success API Response",
 			Input: []string{"currencies"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(success))
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, success),
+			}.Server(),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"currencies": {
@@ -55,11 +53,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Zero records returned from server",
 			Input: []string{"activities"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(zeroRecords))
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, zeroRecords),
+			}.Server(),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"activities": {

--- a/providers/pipeliner/delete_test.go
+++ b/providers/pipeliner/delete_test.go
@@ -2,13 +2,12 @@ package pipeliner
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -40,15 +39,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "DELETE", func() {
-					w.WriteHeader(http.StatusOK)
-					// response body is ignored by connector implementation
-					// but this serves as documentation as response
-					_, _ = w.Write(responseRemoveNote)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseRemoveNote),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/pipeliner/delete_test.go
+++ b/providers/pipeliner/delete_test.go
@@ -39,10 +39,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "quotes", RecordId: "019097b8-a5f4-ca93-62c5-5a25c58afa63"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseRemoveNote),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusOK, responseRemoveNote),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -3,7 +3,6 @@ package pipeliner
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -49,11 +48,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write(responseCreateFailedValidation)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, responseCreateFailedValidation),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New( // nolint:goerr113
@@ -68,11 +66,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseCreateInvalidBody)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseCreateInvalidBody),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Missing or invalid JSON data."), // nolint:goerr113

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -80,12 +81,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
@@ -96,25 +96,22 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
 		{
 			Name:  "Valid creation of a note",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseCreateNote)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseCreateNote),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
@@ -137,13 +134,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PATCH", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseUpdateNote)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPATCH(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseUpdateNote),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -78,10 +78,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -93,10 +93,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -104,10 +104,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a note",
 			Input: common.WriteParams{ObjectName: "notes", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseCreateNote),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseCreateNote),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
@@ -131,10 +131,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "019097b8-a5f4-ca93-62c5-5a25c58afa63",
 				RecordData: "dummy",
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPATCH(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseUpdateNote),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, responseUpdateNote),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)

--- a/providers/salesforce/bulk-delete_test.go
+++ b/providers/salesforce/bulk-delete_test.go
@@ -3,7 +3,6 @@ package salesforce
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -35,10 +34,10 @@ func TestBulkDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Read object must be included",
 			Input: BulkOperationParams{},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNoContent)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{

--- a/providers/salesforce/bulk-info_test.go
+++ b/providers/salesforce/bulk-info_test.go
@@ -30,10 +30,10 @@ func TestJobInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Request fails due to internal server error",
 			Input: "",
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusInternalServerError),
+			}.Server(),
 			ExpectedErrs: []error{common.ErrRequestFailed},
 		},
 		{
@@ -169,11 +169,10 @@ func TestJobResults(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Complete failure with descriptive message",
 			Input: "750ak000009E1YXAA0",
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // nolint:varnamelen
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseJobCompleteFailure)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseJobCompleteFailure),
+			}.Server(),
 			Comparator: testJobResultsComparator,
 			Expected: &JobResults{
 				JobId:          "750ak000009E1YXAA0",
@@ -188,11 +187,10 @@ func TestJobResults(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Successful info parsed from JobCompleted response",
 			Input: "750ak000009BWKLAA4",
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { // nolint:varnamelen
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseJobSuccess)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseJobSuccess),
+			}.Server(),
 			Comparator: testJobResultsComparator,
 			Expected: &JobResults{
 				JobId:          "750ak000009BWKLAA4",

--- a/providers/salesforce/bulk-info_test.go
+++ b/providers/salesforce/bulk-info_test.go
@@ -38,10 +38,10 @@ func TestJobInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Correct endpoint is invoked",
 			Input: "750ak000009Bq9OAAS",
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Bq9OAAS"),
-				OnSuccess: mockserver.Response(http.StatusOK, responseJobInProgress),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Bq9OAAS"),
+				Then:  mockserver.Response(http.StatusOK, responseJobInProgress),
 			}.Server(),
 			Comparator: testConciseJobInfoComparator,
 			Expected: &GetJobInfoResult{
@@ -76,10 +76,10 @@ func TestGetBulkQueryInfo(t *testing.T) { // nolint:dupl
 		{
 			Name:  "Requesting BulkQuery information invokes correct endpoint",
 			Input: "750ak000009AVi5AAG",
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/query/750ak000009AVi5AAG"),
-				OnSuccess: mockserver.Response(http.StatusOK, responseAccount),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/services/data/v59.0/jobs/query/750ak000009AVi5AAG"),
+				Then:  mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
 			Comparator: testConciseJobInfoComparator,
 			Expected: &GetJobInfoResult{
@@ -117,14 +117,14 @@ func TestJobResults(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Partial failure is parsed",
 			Input: "750ak000009Dl5bAAC",
-			Server: mockserver.Crossroad{
+			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
-				Paths: []mockserver.Path{{
-					Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC"),
-					OnSuccess: mockserver.Response(http.StatusOK, responseJobPartialFailure),
+				Cases: []mockserver.Case{{
+					If:   mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC"),
+					Then: mockserver.Response(http.StatusOK, responseJobPartialFailure),
 				}, {
-					Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC/failedResults"),
-					OnSuccess: mockserver.Response(http.StatusOK, responseJobPartialFailureDescribed),
+					If:   mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC/failedResults"),
+					Then: mockserver.Response(http.StatusOK, responseJobPartialFailureDescribed),
 				}},
 			}.Server(),
 			Comparator: testJobResultsComparator,
@@ -205,10 +205,10 @@ func TestGetSuccessfulJobResults(t *testing.T) { // nolint:dupl
 			// this guards against unexpected URL changes
 			Name:  "GetSuccessfulJobResults - endpoint is invoked",
 			Input: "750ak000009Dl5bAAC",
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC/successfulResults"),
-				OnSuccess: mockserver.Response(http.StatusOK, []byte{}),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/services/data/v59.0/jobs/ingest/750ak000009Dl5bAAC/successfulResults"),
+				Then:  mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
 			Comparator:   statusCodeComparator,
 			Expected:     &http.Response{StatusCode: http.StatusOK},
@@ -237,10 +237,10 @@ func TestGetBulkQueryResults(t *testing.T) { // nolint:dupl
 			// this guards against unexpected URL changes
 			Name:  "GetBulkQueryResults - endpoint is invoked",
 			Input: "750ak000009Dl5bAAC",
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.PathSuffix("/services/data/v59.0/jobs/query/750ak000009Dl5bAAC/results"),
-				OnSuccess: mockserver.Response(http.StatusOK, []byte{}),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/services/data/v59.0/jobs/query/750ak000009Dl5bAAC/results"),
+				Then:  mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
 			Comparator:   statusCodeComparator,
 			Expected:     &http.Response{StatusCode: http.StatusOK},

--- a/providers/salesforce/bulk-query_test.go
+++ b/providers/salesforce/bulk-query_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
@@ -52,11 +51,10 @@ func TestBulkQuery(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				query:          "",
 				includeDeleted: false,
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseUnknownObject)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseUnknownObject),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("sObject type 'Accout' is not supported"), // nolint:goerr113
 			},

--- a/providers/salesforce/bulk-query_test.go
+++ b/providers/salesforce/bulk-query_test.go
@@ -81,15 +81,15 @@ func TestBulkQuery(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				query:          "SELECT Id,Name,BillingCity FROM Account",
 				includeDeleted: true,
 			},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.PathSuffix("/services/data/v59.0/jobs/query"),
 					mockcond.Body(`{
 						"operation":"queryAll",
 						"query":"SELECT Id,Name,BillingCity FROM Account"}`),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK, responseAccount),
+				Then: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
 			Expected:     account,
 			ExpectedErrs: nil,

--- a/providers/salesforce/bulk-read_test.go
+++ b/providers/salesforce/bulk-read_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -44,11 +43,10 @@ func TestBulkRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.ReadParams{ObjectName: "Accout", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseUnknownObject)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseUnknownObject),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("sObject type 'Accout' is not supported"), // nolint:goerr113
 			},

--- a/providers/salesforce/bulk-write_test.go
+++ b/providers/salesforce/bulk-write_test.go
@@ -132,13 +132,13 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				CSVData:         strings.NewReader(""),
 				Mode:            UpsertMode,
 			},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.PathSuffix("/services/data/v59.0/jobs/ingest"),
 					mockcond.Body(bodyRequest),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK, responseCreateJob),
+				Then: mockserver.Response(http.StatusOK, responseCreateJob),
 			}.Server(),
 			ExpectedErrs: []error{ErrCSVUploadFailure},
 		},

--- a/providers/salesforce/bulk-write_test.go
+++ b/providers/salesforce/bulk-write_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -48,10 +47,10 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: BulkOperationParams{
 				Mode: UpsertMode,
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNoContent)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
@@ -91,11 +90,10 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				CSVData:         strings.NewReader(""),
 				Mode:            UpsertMode,
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte{})
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusInternalServerError, []byte{}),
+			}.Server(),
 			ExpectedErrs: []error{ErrCreateJob},
 		},
 		{
@@ -106,11 +104,10 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				CSVData:         strings.NewReader(""),
 				Mode:            UpsertMode,
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{"id":true, "state":"Open"}`)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{"id":true, "state":"Open"}`),
+			}.Server(),
 			ExpectedErrs: []error{common.ErrParseError},
 		},
 		{
@@ -121,11 +118,10 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				CSVData:         strings.NewReader(""),
 				Mode:            UpsertMode,
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{"id":"132", "state":"UploadComplete"}`)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{"id":"132", "state":"UploadComplete"}`),
+			}.Server(),
 			ExpectedErrs: []error{ErrInvalidJobState},
 		},
 		{

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -44,17 +45,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successfully describe one object with metadata",
 			Input: []string{"Organization"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToBody(w, r, `{"allOrNone":false,"compositeRequest":[{
+			Server: mockserver.Reactive{
+				Setup: mockserver.ContentJSON(),
+				Condition: mockcond.Body(`{"allOrNone":false,"compositeRequest":[{
 					"referenceId":"Organization",
 					"method":"GET",
 					"url":"/services/data/v59.0/sobjects/Organization/describe"
-				}]}`, func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseOrgMeta)
-				})
-			})),
+				}]}`),
+				OnSuccess: mockserver.Response(http.StatusOK, responseOrgMeta),
+			}.Server(),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"organization": {

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -42,14 +42,14 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Successfully describe one object with metadata",
 			Input: []string{"Organization"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.Body(`{"allOrNone":false,"compositeRequest":[{
+				If: mockcond.Body(`{"allOrNone":false,"compositeRequest":[{
 					"referenceId":"Organization",
 					"method":"GET",
 					"url":"/services/data/v59.0/sobjects/Organization/describe"
 				}]}`),
-				OnSuccess: mockserver.Response(http.StatusOK, responseOrgMeta),
+				Then: mockserver.Response(http.StatusOK, responseOrgMeta),
 			}.Server(),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -2,13 +2,11 @@ package salesforce
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -36,10 +34,9 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		{
 			Name:  "Mime response header expected for successful response",
 			Input: []string{"butterflies"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{}`)
-			})),
+			Server: mockserver.Fixed{
+				Always: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
 			ExpectedErrs: []error{common.ErrNotJSON},
 		},
 		{

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -93,13 +94,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of account",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseCreateOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseCreateOK),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "001ak00000OQTieAAH",
@@ -111,13 +110,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "OK Response, but with errors field",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseOKWithErrors)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseOKWithErrors),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  false,
 				RecordId: "001RM000003oLruYAE",

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -67,13 +67,13 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "account", RecordId: "003ak000004dQCUAA2", RecordData: "dummy"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodPOST(),
 					mockcond.QueryParam("_HttpMethod", "PATCH"),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK, responseCreateOK),
+				Then: mockserver.Response(http.StatusOK, responseCreateOK),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -86,10 +86,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of account",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseCreateOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseCreateOK),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -102,10 +102,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "OK Response, but with errors field",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseOKWithErrors),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseOKWithErrors),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  false,

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -3,7 +3,6 @@ package salesloft
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -41,11 +40,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write(listSchema)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, listSchema),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("no Signal Registration found for integration id 5167 and given type"), // nolint:goerr113

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -54,10 +54,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "DELETE")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -52,10 +52,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "signals", RecordId: "22165"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -3,7 +3,6 @@ package salesloft
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -57,13 +56,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.ReadParams{ObjectName: "users", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusNotFound, `{
 					"error": "Not Found"
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest, errors.New("Not Found"), // nolint:goerr113
 			},
@@ -71,35 +69,32 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Incorrect key in payload",
 			Input: common.ReadParams{ObjectName: "users", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"garbage": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name:  "Incorrect data type in payload",
 			Input: common.ReadParams{ObjectName: "users", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				mockutils.WriteBody(w, `{
+			Server: mockserver.Fixed{
+				Setup: mockserver.ContentJSON(),
+				Always: mockserver.ResponseString(http.StatusOK, `{
 					"data": {}
-				}`)
-			})),
+				}`),
+			}.Server(),
 			ExpectedErrs: []error{jsonquery.ErrNotArray},
 		},
 		{
 			Name:  "Next page cursor may be missing in payload",
 			Input: common.ReadParams{ObjectName: "users", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseEmptyRead)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseEmptyRead),
+			}.Server(),
 			Expected: &common.ReadResult{
 				Data: []common.ReadResultRow{},
 				Done: true,
@@ -109,11 +104,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Next page URL is correctly inferred",
 			Input: common.ReadParams{ObjectName: "people", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseListPeople)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseListPeople),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
 				return actual.NextPage.String() == expectedNextPage // nolint:nlreturn
@@ -126,11 +120,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Successful read with 25 entries, checking one row",
 			Input: common.ReadParams{ObjectName: "people", Fields: connectors.Fields("id")},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseListPeople)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseListPeople),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
 					actual.Done == expected.Done &&
@@ -158,11 +151,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "people",
 				Fields:     connectors.Fields("email_address", "person_company_website"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseListPeople)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseListPeople),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected)
@@ -189,11 +181,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				ObjectName: "users",
 				Fields:     connectors.Fields("email", "guid"),
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(responseListUsers)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseListUsers),
+			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
 					mockutils.ReadResultComparator.SubsetRaw(actual, expected)

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -210,10 +210,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name:  "Successful read accounts without since query",
 			Input: common.ReadParams{ObjectName: "accounts", Fields: connectors.Fields("id")},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.QueryParamsMissing("updated_at[gte]"),
-				OnSuccess: mockserver.Response(http.StatusOK, responseListAccounts),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.QueryParamsMissing("updated_at[gte]"),
+				Then:  mockserver.Response(http.StatusOK, responseListAccounts),
 			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.Rows == expected.Rows
@@ -230,10 +230,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Since:      accountsSince,
 				Fields:     connectors.Fields("id"),
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.QueryParam("updated_at[gte]", "2024-06-07T10:51:20.851224-04:00"),
-				OnSuccess: mockserver.Response(http.StatusOK, responseListAccountsSince),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.QueryParam("updated_at[gte]", "2024-06-07T10:51:20.851224-04:00"),
+				Then:  mockserver.Response(http.StatusOK, responseListAccountsSince),
 			}.Server(),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.Rows == expected.Rows

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -55,10 +55,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "signals", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -66,12 +66,12 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: mockserver.Reactive{
+			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				Condition: mockcond.And{
+				If: mockcond.And{
 					mockcond.MethodPUT(),
 				},
-				OnSuccess: mockserver.Response(http.StatusOK),
+				Then: mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -79,10 +79,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of account",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, createAccountRes),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, createAccountRes),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
@@ -104,10 +104,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a task",
 			Input: common.WriteParams{ObjectName: "tasks", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, createTaskRes),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, createTaskRes),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
@@ -127,10 +127,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid update of Saved List View",
 			Input: common.WriteParams{ObjectName: "saved_list_views", RecordId: "22463", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPUT(),
-				OnSuccess: mockserver.ResponseString(http.StatusOK, `{"data":{"id":22463,"view":"companies",
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPUT(),
+				Then: mockserver.ResponseString(http.StatusOK, `{"data":{"id":22463,"view":"companies",
 					"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -3,7 +3,6 @@ package salesloft
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -44,11 +43,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Correct error message is understood from JSON response",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write(listSchema)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, listSchema),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("no Signal Registration found for integration id 5167 and given type"), // nolint:goerr113

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -56,37 +57,35 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "signals", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
 		{
 			Name:  "Write must act as an Update",
 			Input: common.WriteParams{ObjectName: "signals", RecordId: "22165", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PUT", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup: mockserver.ContentJSON(),
+				Condition: mockcond.And{
+					mockcond.MethodPUT(),
+				},
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
 		{
 			Name:  "Valid creation of account",
 			Input: common.WriteParams{ObjectName: "accounts", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(createAccountRes)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, createAccountRes),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
@@ -107,13 +106,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a task",
 			Input: common.WriteParams{ObjectName: "tasks", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(createTaskRes)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, createTaskRes),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},
@@ -132,14 +129,12 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid update of Saved List View",
 			Input: common.WriteParams{ObjectName: "saved_list_views", RecordId: "22463", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PUT", func() {
-					w.WriteHeader(http.StatusOK)
-					mockutils.WriteBody(w, `{"data":{"id":22463,"view":"companies",
-							"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPUT(),
+				OnSuccess: mockserver.ResponseString(http.StatusOK, `{"data":{"id":22463,"view":"companies",
+					"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -63,13 +63,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "campaigns", RecordId: "782647"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "DELETE", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseCampaign)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseCampaign),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -3,7 +3,6 @@ package smartlead
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -50,11 +49,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Cannot remove missing campaign",
 			Input: common.DeleteParams{ObjectName: "campaigns", RecordId: "782647"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseNotFoundErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseNotFoundErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New(`Campaign not found - Invalid campaign_id.`), // nolint:goerr113

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -61,10 +61,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "campaigns", RecordId: "782647"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseCampaign),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusOK, responseCampaign),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -80,13 +80,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new email campaign",
 			Input: common.WriteParams{ObjectName: "campaigns", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseCampaign)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseCampaign),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "552906",
@@ -98,13 +96,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new client",
 			Input: common.WriteParams{ObjectName: "client", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusCreated)
-					_, _ = w.Write(responseClient)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseClient),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "18402",
@@ -116,13 +112,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new email account",
 			Input: common.WriteParams{ObjectName: "email-accounts", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(responseAccount)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, responseAccount),
+			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2849",

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -3,7 +3,6 @@ package smartlead
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -54,11 +53,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Update non-existent Email Account",
 			Input: common.WriteParams{ObjectName: "email-accounts", RecordId: "08037", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write(responseAccountMissingErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseAccountMissingErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Email account not found!"), // nolint:goerr113
@@ -67,11 +65,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Invalid field when creating campaign",
 			Input: common.WriteParams{ObjectName: "campaigns", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseCampaignInvalidFieldErr)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseCampaignInvalidFieldErr),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New(`"clinet_id" is not allowed`), // nolint:goerr113

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -77,10 +77,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new email campaign",
 			Input: common.WriteParams{ObjectName: "campaigns", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseCampaign),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseCampaign),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -93,10 +93,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new client",
 			Input: common.WriteParams{ObjectName: "client", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseClient),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseClient),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
@@ -109,10 +109,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Create new email account",
 			Input: common.WriteParams{ObjectName: "email-accounts", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, responseAccount),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -52,10 +52,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodDELETE(),
-				OnSuccess: mockserver.Response(http.StatusNoContent),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
 			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -54,10 +54,11 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondNoContentForMethod(w, r, "DELETE")
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodDELETE(),
+				OnSuccess: mockserver.Response(http.StatusNoContent),
+			}.Server(),
 			Expected:     &common.DeleteResult{Success: true},
 			ExpectedErrs: nil,
 		},

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -3,7 +3,6 @@ package zendesksupport
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -41,11 +40,10 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Internal server error in response",
 			Input: common.DeleteParams{ObjectName: "brands", RecordId: "31207417638931"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write(responseServerError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusInternalServerError, responseServerError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrServer,
 				errors.New("Internal Server Error"), // nolint:goerr113

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -87,10 +87,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -102,10 +102,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "31207417638931",
 				RecordData: "dummy",
 			},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPUT(),
-				OnSuccess: mockserver.Response(http.StatusOK),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPUT(),
+				Then:  mockserver.Response(http.StatusOK),
 			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
@@ -113,10 +113,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Valid creation of a brand",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: mockserver.Reactive{
-				Setup:     mockserver.ContentJSON(),
-				Condition: mockcond.MethodPOST(),
-				OnSuccess: mockserver.Response(http.StatusOK, createBrand),
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, createBrand),
 			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -3,7 +3,6 @@ package zendesksupport
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -48,11 +47,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Missing write parameter",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseMissingParameterError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseMissingParameterError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("Parameter brands is required"), // nolint:goerr113
@@ -61,11 +59,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Record validation with single detail",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseDuplicateError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseDuplicateError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("[RecordInvalid]Record validation errors"),               // nolint:goerr113
@@ -75,11 +72,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Record validation with multiple details is split into dedicated errors",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write(responseRecordValidationError)
-			})),
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseRecordValidationError),
+			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				errors.New("[RecordInvalid]Record validation errors"),        // nolint:goerr113

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -90,12 +91,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name:  "Write must act as a Create",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
@@ -106,25 +106,22 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				RecordId:   "31207417638931",
 				RecordData: "dummy",
 			},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "PUT", func() {
-					w.WriteHeader(http.StatusOK)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPUT(),
+				OnSuccess: mockserver.Response(http.StatusOK),
+			}.Server(),
 			Expected:     &common.WriteResult{Success: true},
 			ExpectedErrs: nil,
 		},
 		{
 			Name:  "Valid creation of a brand",
 			Input: common.WriteParams{ObjectName: "brands", RecordData: "dummy"},
-			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				mockutils.RespondToMethod(w, r, "POST", func() {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write(createBrand)
-				})
-			})),
+			Server: mockserver.Reactive{
+				Setup:     mockserver.ContentJSON(),
+				Condition: mockcond.MethodPOST(),
+				OnSuccess: mockserver.Response(http.StatusOK, createBrand),
+			}.Server(),
 			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
 				return mockutils.WriteResultComparator.SubsetData(actual, expected)
 			},

--- a/test/intercom/search/main.go
+++ b/test/intercom/search/main.go
@@ -66,5 +66,4 @@ func main() {
 
 	fmt.Println("Reading conversations (SecondPage)..")
 	utils.DumpJSON(res, os.Stdout)
-
 }

--- a/test/utils/mockutils/mockcond/header.go
+++ b/test/utils/mockutils/mockcond/header.go
@@ -1,0 +1,28 @@
+package mockcond
+
+import (
+	"net/http"
+)
+
+func Header(header http.Header) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		return headerIsSubset(r.Header, header)
+	}
+}
+
+func headerIsSubset(superset, subset http.Header) bool {
+	for name, values := range subset {
+		superValues := make(map[string]bool)
+		for _, v := range superset.Values(name) {
+			superValues[v] = true
+		}
+		// every value of this header must be part of superset
+		for _, value := range values {
+			if _, found := superValues[value]; !found {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/test/utils/mockutils/mockcond/queries.go
+++ b/test/utils/mockutils/mockcond/queries.go
@@ -1,0 +1,54 @@
+package mockcond
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func QueryParam(key string, value ...string) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		return queryParamsAreSubset(r.URL.Query(), url.Values{
+			key: value,
+		})
+	}
+}
+
+func QueryParamsMissing(keys ...string) Check {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		return queryParamsMissing(r.URL.Query(), keys)
+	}
+}
+
+func queryParamsAreSubset(superset, subset url.Values) bool {
+	for param, values := range subset {
+		superValues := make(map[string]bool)
+
+		strList, ok := superset[param]
+		if !ok {
+			return false
+		}
+
+		for _, v := range strList {
+			superValues[v] = true
+		}
+
+		for _, value := range values {
+			if _, found := superValues[value]; !found {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func queryParamsMissing(superset url.Values, missing []string) bool {
+	for _, param := range missing {
+		if superset.Has(param) {
+			// query was found, while should be missing
+			return false
+		}
+	}
+
+	return true
+}

--- a/test/utils/mockutils/mockcond/request.go
+++ b/test/utils/mockutils/mockcond/request.go
@@ -21,6 +21,18 @@ func Method(methodName string) Check {
 	}
 }
 
+func MethodPOST() Check {
+	return Method("POST")
+}
+
+func MethodPUT() Check {
+	return Method("PUT")
+}
+
 func MethodPATCH() Check {
 	return Method("PATCH")
+}
+
+func MethodDELETE() Check {
+	return Method("DELETE")
 }

--- a/test/utils/mockutils/mockserver/crossroads.go
+++ b/test/utils/mockutils/mockserver/crossroads.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 )
 
@@ -46,7 +45,7 @@ func (c Switch) Server() *httptest.Server {
 
 		// Default fail behaviour.
 		w.WriteHeader(http.StatusInternalServerError)
-		mockutils.WriteBody(w, `{"error": {"message": "condition failed"}}`)
+		_, _ = w.Write([]byte(`{"error": {"message": "condition failed"}}`))
 	})
 }
 

--- a/test/utils/mockutils/mockserver/crossroads.go
+++ b/test/utils/mockutils/mockserver/crossroads.go
@@ -22,7 +22,7 @@ type Switch struct {
 
 // Server creates mock server that will produce different response based on conditionals.
 func (c Switch) Server() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return NewServer(func(w http.ResponseWriter, r *http.Request) {
 		// Common setup is optional.
 		if c.Setup != nil {
 			c.Setup(w, r)
@@ -47,7 +47,7 @@ func (c Switch) Server() *httptest.Server {
 		// Default fail behaviour.
 		w.WriteHeader(http.StatusInternalServerError)
 		mockutils.WriteBody(w, `{"error": {"message": "condition failed"}}`)
-	}))
+	})
 }
 
 // Case is one possible route a mock server can take if condition is satisfied.

--- a/test/utils/mockutils/mockserver/dummy.go
+++ b/test/utils/mockutils/mockserver/dummy.go
@@ -9,7 +9,12 @@ import (
 // Acknowledges requests and does nothing else.
 func Dummy() *httptest.Server {
 	// This is a factory method. Every server instance will be deleted after the test suite finishes.
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return NewServer(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
-	}))
+	})
+}
+
+// NewServer is syntactic sugar for creating test server.
+func NewServer(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
 }

--- a/test/utils/mockutils/mockserver/fixed.go
+++ b/test/utils/mockutils/mockserver/fixed.go
@@ -17,11 +17,11 @@ type Fixed struct {
 
 // Server creates mock server.
 func (f Fixed) Server() *httptest.Server {
-	return Reactive{
+	return Conditional{
 		Setup: f.Setup,
-		Condition: mockcond.Check(func(w http.ResponseWriter, r *http.Request) bool {
+		If: mockcond.Check(func(w http.ResponseWriter, r *http.Request) bool {
 			return true
 		}),
-		OnSuccess: f.Always,
+		Then: f.Always,
 	}.Server()
 }

--- a/test/utils/mockutils/mockserver/fixed.go
+++ b/test/utils/mockutils/mockserver/fixed.go
@@ -1,0 +1,27 @@
+package mockserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+)
+
+// Fixed is a server recipe that responds the same way regardless of the input.
+type Fixed struct {
+	// Setup is optional handler, where common http.ResponseWrite configuration takes place.
+	Setup http.HandlerFunc
+	// Always represents server handler that should implement how server should respond.
+	Always http.HandlerFunc
+}
+
+// Server creates mock server.
+func (f Fixed) Server() *httptest.Server {
+	return Reactive{
+		Setup: f.Setup,
+		Condition: mockcond.Check(func(w http.ResponseWriter, r *http.Request) bool {
+			return true
+		}),
+		OnSuccess: f.Always,
+	}.Server()
+}

--- a/test/utils/mockutils/mockserver/handlers.go
+++ b/test/utils/mockutils/mockserver/handlers.go
@@ -18,6 +18,7 @@ func Response(status int, data ...[]byte) http.HandlerFunc {
 		if len(data) == 1 {
 			_, _ = w.Write(data[0])
 		}
+
 		if len(data) > 1 {
 			// The test author made a mistake.
 			panic("at most one response body can be returned by mockserver")

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -1,33 +1,10 @@
 package mockutils
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
 )
-
-func RespondNoContentForMethod(w http.ResponseWriter, r *http.Request, methodName string) {
-	RespondToMethod(w, r, methodName, func() {
-		w.WriteHeader(http.StatusNoContent)
-	})
-}
-
-func RespondToMethod(w http.ResponseWriter, r *http.Request, methodName string, onSuccess func()) {
-	// if method is not as expected we return error code so the test will fail
-	// and with response payload which will be a helpful message for debugging
-	if r.Method == methodName {
-		// if method is matching execute callback
-		onSuccess()
-	} else {
-		w.WriteHeader(http.StatusBadRequest)
-		WriteBody(w, fmt.Sprintf(`{
-			"error": {
-				"code": "from test",
-				"message": "test server expected %v request"
-			}}`, methodName))
-	}
-}
 
 func RespondToBody(w http.ResponseWriter, r *http.Request, body string, onSuccess func()) {
 	if ok := bodiesMatch(r.Body, body); ok {

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -1,51 +1,9 @@
 package mockutils
 
 import (
-	"io"
 	"net/http"
-	"strings"
 )
-
-func RespondToBody(w http.ResponseWriter, r *http.Request, body string, onSuccess func()) {
-	if ok := bodiesMatch(r.Body, body); ok {
-		// if method is matching bodies
-		onSuccess()
-	} else {
-		w.WriteHeader(http.StatusBadRequest)
-		WriteBody(w, `{
-			"error": {
-				"code": "from test",
-				"message": "test server mismatching bodies"
-			}}`)
-	}
-}
 
 func WriteBody(w http.ResponseWriter, body string) {
 	_, _ = w.Write([]byte(body))
-}
-
-func bodiesMatch(reader io.ReadCloser, expected string) bool {
-	body, err := io.ReadAll(reader)
-	if err != nil {
-		return false
-	}
-
-	return string(body) == stringCleaner(expected, []string{"\n", "\t"})
-}
-
-func stringCleaner(text string, toRemove []string) string {
-	rules := make(map[string]string)
-	for _, remove := range toRemove {
-		rules[remove] = ""
-	}
-
-	return stringReplacer(text, rules)
-}
-
-func stringReplacer(text string, rules map[string]string) string {
-	for from, to := range rules {
-		text = strings.ReplaceAll(text, from, to)
-	}
-
-	return text
 }

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -1,9 +1,0 @@
-package mockutils
-
-import (
-	"net/http"
-)
-
-func WriteBody(w http.ResponseWriter, body string) {
-	_, _ = w.Write([]byte(body))
-}

--- a/test/utils/mockutils/server.go
+++ b/test/utils/mockutils/server.go
@@ -30,21 +30,6 @@ func RespondToMethod(w http.ResponseWriter, r *http.Request, methodName string, 
 	}
 }
 
-func RespondToHeader(w http.ResponseWriter, r *http.Request, header http.Header, onSuccess func()) {
-	// if some headers are missing we return error code so the test will fail
-	if missingHeader, ok := headerIsSubset(r.Header, header); ok {
-		// if method is matching headers
-		onSuccess()
-	} else {
-		w.WriteHeader(http.StatusBadRequest)
-		WriteBody(w, fmt.Sprintf(`{
-			"error": {
-				"code": "from test",
-				"message": "test server mismatching [%v] header"
-			}}`, missingHeader))
-	}
-}
-
 func RespondToBody(w http.ResponseWriter, r *http.Request, body string, onSuccess func()) {
 	if ok := bodiesMatch(r.Body, body); ok {
 		// if method is matching bodies
@@ -91,23 +76,6 @@ func RespondToMissingQueryParameters(w http.ResponseWriter, r *http.Request, mis
 
 func WriteBody(w http.ResponseWriter, body string) {
 	_, _ = w.Write([]byte(body))
-}
-
-func headerIsSubset(superset, subset http.Header) (string, bool) {
-	for name, values := range subset {
-		superValues := make(map[string]bool)
-		for _, v := range superset.Values(name) {
-			superValues[v] = true
-		}
-		// every value of this header must be part of superset
-		for _, value := range values {
-			if _, found := superValues[value]; !found {
-				return name, false
-			}
-		}
-	}
-
-	return "", true
 }
 
 func queryParamsAreSubset(superset, subset url.Values) (string, bool) {


### PR DESCRIPTION
# Features

Introduced `mockserver.Fixed` which is a syntactic sugar of expressing the constant, persistent response of a server. It responds always in a fixed way.

Reactive and Crossroad tests can have the following conditionals Out of the Box:
* `mockcond.Header()`
* `mockcond.QueryParam()` or `mockcond.QueryParamsMissing()`
* `MethodPATCH()`, etc.

From previous PRs:
* `mockcond.Body()`
* `mockcond.PathSuffix()`

# Review

I went over every test cases that had `httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request)`. All are replaced with new simpler utils. All tests are intact and act as before. Functionality wise, there is no change.

Every commit tries to gradually remove/replace methods in [this file](https://github.com/amp-labs/connectors/blob/main/test/utils/mockutils/server.go). That is the main essence of this PR! Before the codebase grows even more refactoring at this time is important.