### PR TITLE
feat: Embeded parameter holders

### DIFF
--- a/common/paramsbuilder/authclient.go
+++ b/common/paramsbuilder/authclient.go
@@ -8,6 +8,12 @@ import (
 
 var ErrMissingClient = errors.New("http client not set")
 
+// ClientHolder gives authenticated client.
+// This is useful to check if object is of interface type to get access to HTTP client.
+type ClientHolder interface {
+	GiveClient() *AuthClient
+}
+
 // AuthClient params sets up authenticated proxy HTTP client.
 type AuthClient struct {
 	// Caller is an HTTP client that knows how to make authenticated requests.
@@ -35,4 +41,8 @@ func (p *AuthClient) WithAuthenticatedClient(client common.AuthenticatedHTTPClie
 		Client:       client,
 		ErrorHandler: common.InterpretError,
 	}
+}
+
+func (p *AuthClient) GiveClient() *AuthClient {
+	return p
 }

--- a/common/paramsbuilder/catalogVariable.go
+++ b/common/paramsbuilder/catalogVariable.go
@@ -27,3 +27,29 @@ func NewCatalogVariables[V substitutions.RegistryValue](
 
 	return result
 }
+
+// ExtractCatalogVariables accepts any struct that embeds one or multiple CatalogVariables.
+// It will try to explore all known implementors of CatalogVariable and return them.
+func ExtractCatalogVariables(parameters any) []catalogreplacer.CatalogVariable {
+	var catalogsVars []catalogreplacer.CatalogVariable
+
+	// Workspace is the only known CatalogVariable
+	if workspaceHolder, ok := parameters.(WorkspaceHolder); ok {
+		workspace := workspaceHolder.GiveWorkspace()
+		catalogsVars = append(catalogsVars, workspace)
+	}
+
+	return catalogsVars
+}
+
+// CustomCatalogVariable is a variable that can be created on the fly. Just specify the plan of what
+// should be replaced with what data, it implements CatalogVariable.
+type CustomCatalogVariable struct {
+	Plan catalogreplacer.SubstitutionPlan
+}
+
+var _ catalogreplacer.CatalogVariable = CustomCatalogVariable{}
+
+func (c CustomCatalogVariable) GetSubstitutionPlan() catalogreplacer.SubstitutionPlan {
+	return c.Plan
+}

--- a/common/paramsbuilder/metadata.go
+++ b/common/paramsbuilder/metadata.go
@@ -10,6 +10,10 @@ var (
 	ErrIncorrectMetadataParamUsage = errors.New("metadata parameter must have required fields")
 )
 
+type MetadataHolder interface {
+	GiveMetadata() *Metadata
+}
+
 // Metadata params sets metadata describing authentication information.
 type Metadata struct {
 	// Map is a registry of metadata values that are needed for connector to function.
@@ -17,6 +21,10 @@ type Metadata struct {
 	// Connector implementation makes a decision on what fields must be supplied in metadata map by the user.
 	// Any missing or empty fields will result into error constructing a connector.
 	requiredKeys []string
+}
+
+func (p *Metadata) GiveMetadata() *Metadata {
+	return p
 }
 
 func (p *Metadata) ValidateParams() error {

--- a/common/paramsbuilder/module.go
+++ b/common/paramsbuilder/module.go
@@ -5,6 +5,10 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
+type ModuleHolder interface {
+	GiveModule() *Module
+}
+
 // Module represents a sub-product of a provider.
 // This is relevant where there are several APIs for different sub-products, and the APIs
 // are versioned differently or have different ways of constructing URLs and requests for reading/writing.
@@ -14,6 +18,10 @@ type Module struct {
 	// This defines a list of modules a user could switch to.
 	// Validation will check module identifiers are consistent.
 	supported common.Modules
+}
+
+func (p *Module) GiveModule() *Module {
+	return p
 }
 
 func (p *Module) ValidateParams() error {

--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -4,6 +4,8 @@
 // and exposed to end user via delegation. Most would do delegation only.
 package paramsbuilder
 
+import "github.com/amp-labs/connectors/common"
+
 // ParamAssurance checks that param data is valid
 // Every param instance must implement it.
 type ParamAssurance interface {
@@ -20,7 +22,14 @@ type ParamAssurance interface {
 func Apply[P ParamAssurance](params P,
 	opts []func(params *P),
 	defaultOpts ...func(params *P),
-) (*P, error) {
+) (paramsOut *P, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		// Options may have calls to panic().
+		// We allow this and recover by converting it to normal error.
+		outErr = cause
+		paramsOut = nil
+	})
+
 	for _, opt := range defaultOpts {
 		opt(&params)
 	}

--- a/common/paramsbuilder/workspace.go
+++ b/common/paramsbuilder/workspace.go
@@ -8,9 +8,17 @@ import (
 
 var ErrMissingWorkspace = errors.New("missing workspace name")
 
+type WorkspaceHolder interface {
+	GiveWorkspace() *Workspace
+}
+
 // Workspace params sets up varying workspace name.
 type Workspace struct {
 	Name string
+}
+
+func (p *Workspace) GiveWorkspace() *Workspace {
+	return p
 }
 
 func (p *Workspace) ValidateParams() error {


### PR DESCRIPTION
# Change

Modified package `paramsbuilder`.
Every parameter has a matching interface that it implements. 
By doing so, the parameters struct which emebds multiple "simple" parameters will also implement each interface.

# Purpose
In code you can do conditional check if connector parameters has Workspace, has Metadata, has Client.
Ex:
![image](https://github.com/user-attachments/assets/1abd4cc3-bdab-4e64-94e7-5db1e3e3383f)

Just by embeding `paramsbuilder.Client` you can dynamically ask if `parameters` is a `ClientHolder` and get instance of `common.HTTPClient`. This way when developing deep connectors the `parameters` struct is consise and speaks for itself (no need to add any delegate methods). Any reference to `parameters` doesn't need to do reflection to know what properties it has, it will do interface checking.