### PR TITLE
tidy: Move CatalogVars out of paramsbuilder

### DIFF
--- a/common/paramsbuilder/catalogVariable.go
+++ b/common/paramsbuilder/catalogVariable.go
@@ -4,44 +4,21 @@ import (
 	"log/slog"
 
 	"github.com/amp-labs/connectors/common/substitutions"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 )
-
-const (
-	variableWorkspace = "workspace"
-)
-
-// CatalogVariable allows dynamically to replace variables represented with `{{VAR_NAME}}` string.
-type CatalogVariable interface {
-	GetSubstitutionPlan() SubstitutionPlan
-}
-
-// SubstitutionPlan defines an intent to replace `from` with `to`.
-type SubstitutionPlan struct {
-	From string
-	To   string
-}
-
-func NewCatalogSubstitutionRegistry(vars []CatalogVariable) substitutions.Registry[string] {
-	subs := make(substitutions.Registry[string])
-
-	for _, variable := range vars {
-		s := variable.GetSubstitutionPlan()
-		subs[s.From] = s.To
-	}
-
-	return subs
-}
 
 // NewCatalogVariables converts JSON into supported list of Catalog Variables.
 // This enforces type checking.
-func NewCatalogVariables[V substitutions.RegistryValue](registry substitutions.Registry[V]) []CatalogVariable {
-	result := make([]CatalogVariable, 0)
+func NewCatalogVariables[V substitutions.RegistryValue](
+	registry substitutions.Registry[V],
+) []catalogreplacer.CatalogVariable {
+	result := make([]catalogreplacer.CatalogVariable, 0)
 
 	for key, value := range registry {
 		name := substitutions.RegistryValueToString(value)
 
 		switch key {
-		case variableWorkspace:
+		case catalogreplacer.VariableWorkspace:
 			result = append(result, &Workspace{Name: name})
 		default:
 			slog.Info("unknown substitution SubstitutionPlan for catalog", key, value)

--- a/common/paramsbuilder/catalogVariable_test.go
+++ b/common/paramsbuilder/catalogVariable_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common/substitutions"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 )
 
 func TestNewCatalogVariables(t *testing.T) {
@@ -13,7 +14,7 @@ func TestNewCatalogVariables(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    substitutions.Registry[string]
-		expected []CatalogVariable
+		expected []catalogreplacer.CatalogVariable
 	}{
 		{
 			name: "Unknown substitutions are not translated to Variables",
@@ -23,7 +24,7 @@ func TestNewCatalogVariables(t *testing.T) {
 				"nothing": "",
 				"":        "something",
 			},
-			expected: []CatalogVariable{},
+			expected: []catalogreplacer.CatalogVariable{},
 		},
 		{
 			name: "Only workspace Variable is captured",
@@ -31,7 +32,7 @@ func TestNewCatalogVariables(t *testing.T) {
 				"insect":    "butterfly",
 				"workspace": "office",
 			},
-			expected: []CatalogVariable{
+			expected: []catalogreplacer.CatalogVariable{
 				&Workspace{Name: "office"},
 			},
 		},
@@ -55,21 +56,21 @@ func TestNewCatalogSubstitutionRegistry(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		input    []CatalogVariable
+		input    []catalogreplacer.CatalogVariable
 		expected substitutions.Registry[string]
 	}{
 		{
 			name:     "No variables - no substitutions",
-			input:    []CatalogVariable{},
+			input:    []catalogreplacer.CatalogVariable{},
 			expected: substitutions.Registry[string]{},
 		},
 		{
 			name: "Workspace is translated into substitution",
-			input: []CatalogVariable{
+			input: []catalogreplacer.CatalogVariable{
 				&Workspace{Name: "cool organization"},
 			},
 			expected: substitutions.Registry[string]{
-				variableWorkspace: "cool organization",
+				catalogreplacer.VariableWorkspace: "cool organization",
 			},
 		},
 	}
@@ -79,7 +80,7 @@ func TestNewCatalogSubstitutionRegistry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output := NewCatalogSubstitutionRegistry(tt.input)
+			output := catalogreplacer.NewCatalogSubstitutionRegistry(tt.input)
 			if !reflect.DeepEqual(output, tt.expected) {
 				t.Fatalf("%s: expected: (%v), got: (%v)", tt.name, tt.expected, output)
 			}

--- a/common/paramsbuilder/workspace.go
+++ b/common/paramsbuilder/workspace.go
@@ -1,6 +1,10 @@
 package paramsbuilder
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
+)
 
 var ErrMissingWorkspace = errors.New("missing workspace name")
 
@@ -23,9 +27,9 @@ func (p *Workspace) WithWorkspace(workspaceRef string) {
 
 // GetSubstitutionPlan of the workspace describes how to insert its value into string templates.
 // This makes Workspace parameter a catalog variable.
-func (p *Workspace) GetSubstitutionPlan() SubstitutionPlan {
-	return SubstitutionPlan{
-		From: variableWorkspace,
+func (p *Workspace) GetSubstitutionPlan() catalogreplacer.SubstitutionPlan {
+	return catalogreplacer.SubstitutionPlan{
+		From: catalogreplacer.VariableWorkspace,
 		To:   p.Name,
 	}
 }

--- a/common/substitutions/catalogreplacer/catalogVariable.go
+++ b/common/substitutions/catalogreplacer/catalogVariable.go
@@ -1,0 +1,43 @@
+package catalogreplacer
+
+import (
+	"github.com/amp-labs/connectors/common/substitutions"
+)
+
+const (
+	VariableWorkspace = "workspace"
+)
+
+// CatalogVariable allows dynamically to replace variables represented with `{{VAR_NAME}}` string.
+type CatalogVariable interface {
+	GetSubstitutionPlan() SubstitutionPlan
+}
+
+// SubstitutionPlan defines an intent to replace `from` with `to`.
+type SubstitutionPlan struct {
+	From string
+	To   string
+}
+
+func NewCatalogSubstitutionRegistry(vars []CatalogVariable) substitutions.Registry[string] {
+	subs := make(substitutions.Registry[string])
+
+	for _, variable := range vars {
+		s := variable.GetSubstitutionPlan()
+		subs[s.From] = s.To
+	}
+
+	return subs
+}
+
+// CustomCatalogVariable is a variable that can be created on the fly. Just specify the plan of what
+// should be replaced with what data, it implements CatalogVariable.
+type CustomCatalogVariable struct {
+	Plan SubstitutionPlan
+}
+
+var _ CatalogVariable = CustomCatalogVariable{}
+
+func (c CustomCatalogVariable) GetSubstitutionPlan() SubstitutionPlan {
+	return c.Plan
+}

--- a/providers/docusign/authmetamodel.go
+++ b/providers/docusign/authmetamodel.go
@@ -1,7 +1,7 @@
 package docusign
 
 import (
-	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 )
 
 const serverKey = "server"
@@ -33,8 +33,8 @@ func (v AuthMetadataVars) AsMap() *map[string]string {
 
 // GetSubstitutionPlan allows variable substitution when resolving provider information.
 // Only server URL is supported.
-func (v AuthMetadataVars) GetSubstitutionPlan() paramsbuilder.SubstitutionPlan {
-	return paramsbuilder.SubstitutionPlan{
+func (v AuthMetadataVars) GetSubstitutionPlan() catalogreplacer.SubstitutionPlan {
+	return catalogreplacer.SubstitutionPlan{
 		From: serverKey,
 		To:   v.Server,
 	}

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/handy"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 	"github.com/go-playground/validator"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -111,11 +111,11 @@ func SetInfo(provider Provider, info ProviderInfo) {
 // ReadInfo reads the information from the catalog for specific provider. It also performs string substitution
 // on the values in the config that are surrounded by {{}}, if vars are provided.
 // The catalog variable will be applied such that `{{.VAR_NAME}}` string will be replaced with `VAR_VALUE`.
-func ReadInfo(provider Provider, vars ...paramsbuilder.CatalogVariable) (*ProviderInfo, error) {
+func ReadInfo(provider Provider, vars ...catalogreplacer.CatalogVariable) (*ProviderInfo, error) {
 	return NewCustomCatalog().ReadInfo(provider, vars...)
 }
 
-func (c CustomCatalog) ReadInfo(provider Provider, vars ...paramsbuilder.CatalogVariable) (*ProviderInfo, error) {
+func (c CustomCatalog) ReadInfo(provider Provider, vars ...catalogreplacer.CatalogVariable) (*ProviderInfo, error) {
 	catalogInstance, err := c.catalog()
 	if err != nil {
 		return nil, err
@@ -153,8 +153,8 @@ func (c CustomCatalog) ReadInfo(provider Provider, vars ...paramsbuilder.Catalog
 	return &providerInfo, nil
 }
 
-func (i *ProviderInfo) SubstituteWith(vars []paramsbuilder.CatalogVariable) error {
-	return paramsbuilder.NewCatalogSubstitutionRegistry(vars).Apply(i)
+func (i *ProviderInfo) SubstituteWith(vars []catalogreplacer.CatalogVariable) error {
+	return catalogreplacer.NewCatalogSubstitutionRegistry(vars).Apply(i)
 }
 
 func (i *ProviderInfo) GetOption(key string) (string, bool) {

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 )
 
 var (
@@ -102,7 +102,7 @@ func TestReadInfo(t *testing.T) { // nolint:funlen
 	type inType struct {
 		options  []CatalogOption
 		provider Provider
-		vars     []paramsbuilder.CatalogVariable
+		vars     []catalogreplacer.CatalogVariable
 	}
 
 	tests := []struct {
@@ -141,8 +141,13 @@ func TestReadInfo(t *testing.T) { // nolint:funlen
 			input: inType{
 				options:  customTestCatalogOption,
 				provider: "test",
-				vars: []paramsbuilder.CatalogVariable{
-					&paramsbuilder.Workspace{Name: "europe"},
+				vars: []catalogreplacer.CatalogVariable{
+					catalogreplacer.CustomCatalogVariable{
+						Plan: catalogreplacer.SubstitutionPlan{
+							From: "workspace",
+							To:   "europe",
+						},
+					},
 				},
 			},
 			expected: &ProviderInfo{


### PR DESCRIPTION
# Reason
`paramsbuilder` cannot import provider package to do better Authenticated Client setup.

# Result
To break circular dependency a new small package is created.

`provider` uses `catalogreplacer` to resolve catalog variables.
`paramsbuilder` produces `catalogreplacer` catalog variables from parameters.