### PR TITLE
feat: Infer params for API Key auth from catalog

### DIFF
--- a/common/paramsbuilder/authclient.go
+++ b/common/paramsbuilder/authclient.go
@@ -1,0 +1,38 @@
+package paramsbuilder
+
+import (
+	"errors"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+var ErrMissingClient = errors.New("http client not set")
+
+// AuthClient params sets up authenticated proxy HTTP client.
+type AuthClient struct {
+	// Caller is an HTTP client that knows how to make authenticated requests.
+	// It also knows how to handle authentication and API response errors.
+	Caller *common.HTTPClient
+}
+
+func (p *AuthClient) ValidateParams() error {
+	// http client must be defined.
+	if p.Caller == nil {
+		return ErrMissingClient
+	}
+
+	// authentication client should be present.
+	if p.Caller.Client == nil {
+		return ErrMissingClient
+	}
+
+	return nil
+}
+
+// WithAuthenticatedClient sets up an HTTP client that uses your implementation of authentication.
+func (p *AuthClient) WithAuthenticatedClient(client common.AuthenticatedHTTPClient) {
+	p.Caller = &common.HTTPClient{
+		Client:       client,
+		ErrorHandler: common.InterpretError,
+	}
+}

--- a/providers/apollo/params.go
+++ b/providers/apollo/params.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 )
-
-var headerName = "X-Api-Key" //nolint:gochecknoglobals
 
 type Option = func(params *parameters)
 
@@ -28,19 +27,9 @@ func WithClient(
 	apiKey string,
 	opts ...common.HeaderAuthClientOption,
 ) Option {
-	options := []common.HeaderAuthClientOption{
-		common.WithHeaderClient(client),
+	return func(params *parameters) {
+		params.WithApiKeyHeaderClient(ctx, client, providers.Apollo, apiKey, opts...)
 	}
-
-	apiKeyClient, err := common.NewApiKeyHeaderAuthHTTPClient(ctx,
-		headerName, apiKey,
-		append(options, opts...)...,
-	)
-	if err != nil {
-		panic(err) // caught in NewConnector
-	}
-
-	return WithAuthenticatedClient(apiKeyClient)
 }
 
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {

--- a/providers/instantly/params.go
+++ b/providers/instantly/params.go
@@ -21,15 +21,9 @@ type Option = func(params *parameters)
 // parameters surface options by delegation.
 type parameters struct {
 	paramsbuilder.Client
-	// Error is set when any With<Method> fails, used for parameters validation.
-	setupError error
 }
 
 func (p parameters) ValidateParams() error {
-	if p.setupError != nil {
-		return p.setupError
-	}
-
 	return errors.Join(
 		p.Client.ValidateParams(),
 	)
@@ -40,21 +34,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	opts ...common.QueryParamAuthClientOption,
 ) Option {
 	return func(params *parameters) {
-		info, err := providers.ReadInfo(providers.Instantly)
-		if err != nil {
-			params.setupError = err
-
-			return
-		}
-
-		queryParam, err := info.GetApiKeyQueryParamName()
-		if err != nil {
-			params.setupError = err
-
-			return
-		}
-
-		params.WithApiKeyQueryParamClient(ctx, client, queryParam, apiKey, opts...)
+		params.WithApiKeyQueryParamClient(ctx, client, providers.Instantly, apiKey, opts...)
 	}
 }
 

--- a/providers/smartlead/params.go
+++ b/providers/smartlead/params.go
@@ -16,15 +16,9 @@ type Option = func(params *parameters)
 // parameters surface options by delegation.
 type parameters struct {
 	paramsbuilder.Client
-	// Error is set when any With<Method> fails, used for parameters validation.
-	setupError error
 }
 
 func (p parameters) ValidateParams() error {
-	if p.setupError != nil {
-		return p.setupError
-	}
-
 	return errors.Join(
 		p.Client.ValidateParams(),
 	)
@@ -35,21 +29,7 @@ func WithClient(ctx context.Context, client *http.Client,
 	opts ...common.QueryParamAuthClientOption,
 ) Option {
 	return func(params *parameters) {
-		info, err := providers.ReadInfo(providers.Smartlead)
-		if err != nil {
-			params.setupError = err
-
-			return
-		}
-
-		queryParam, err := info.GetApiKeyQueryParamName()
-		if err != nil {
-			params.setupError = err
-
-			return
-		}
-
-		params.WithApiKeyQueryParamClient(ctx, client, queryParam, apiKey, opts...)
+		params.WithApiKeyQueryParamClient(ctx, client, providers.Smartlead, apiKey, opts...)
 	}
 }
 


### PR DESCRIPTION
# Changes

1. paramsbuilder.Client is split, where AuthClient is embeded in Client. This shrinks client.go file focusing on picking `Auth Type`, while authclient.go has validation, basic definitions.
2. Most important: `WithApiKeyQueryParamClient` and `WithApiKeyHeaderClient` rely on provider.Provider to imply the name of header and the name of query parameters using **Catalog**.