### PR TITLE
feat: Intercom Read conversations via Search

### DIFF
--- a/providers/intercom/params.go
+++ b/providers/intercom/params.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	// DefaultPageSize is number of elements per page.
-	DefaultPageSize = 60
+	DefaultPageSize              = 60
+	DefaultConversationsPageSize = 150
 )
 
 // Option is a function which mutates the connector configuration.

--- a/providers/intercom/read.go
+++ b/providers/intercom/read.go
@@ -3,6 +3,7 @@ package intercom
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -17,12 +18,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 
-	url, err := c.buildReadURL(config)
-	if err != nil {
-		return nil, err
-	}
-
-	rsp, err := c.Client.Get(ctx, url.String(), apiVersionHeader)
+	rsp, url, err := c.performReadQuery(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -34,6 +30,47 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		common.GetMarshaledData,
 		config.Fields,
 	)
+}
+
+// There are 2 choices. Default usage of GET.
+// Or we can do POST for conversations scoping by `Since` time.
+func (c *Connector) performReadQuery(
+	ctx context.Context, config common.ReadParams,
+) (*common.JSONHTTPResponse, *urlbuilder.URL, error) {
+	if config.ObjectName == "conversations" && !config.Since.IsZero() {
+		// Conversations with non-empty Since fallback to POST, searching for conversation by time.
+		// https://developers.intercom.com/docs/references/rest-api/api.intercom.io/conversations/searchconversations
+		url, err := constructURL(c.BaseURL, config.ObjectName, "search")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		conversation, err := c.createSearchPayload(config.NextPage, config.Since)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		rsp, err := c.Client.Post(ctx, url.String(), &conversation, apiVersionHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return rsp, url, nil
+	}
+
+	// Default.
+	// READ is done the usual way via GET, listing object.
+	url, err := c.buildReadURL(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rsp, err := c.Client.Get(ctx, url.String(), apiVersionHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rsp, url, nil
 }
 
 func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
@@ -51,4 +88,56 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 	url.WithQueryParam("per_page", strconv.Itoa(DefaultPageSize))
 
 	return url, nil
+}
+
+func (c *Connector) createSearchPayload(
+	nextPageURL common.NextPageToken, since time.Time,
+) (*searchReqPayload, error) {
+	url, err := urlbuilder.New(nextPageURL.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Unix time format is used.
+	updatedAfter := strconv.FormatInt(since.Unix(), 10)
+	// We no longer request by GET, so query parameter must be moved to the POST payload.
+	startingAfter, _ := url.GetFirstQueryParam("starting_after")
+
+	conversation := searchReqPayload{
+		Query: searchQuery{
+			Operator: "AND",
+			Value: []searchQueryValue{{
+				Field:    "updated_at",
+				Operator: ">=",
+				Value:    updatedAfter,
+			}},
+		},
+		Pagination: searchPagination{
+			PerPage:       DefaultConversationsPageSize,
+			StartingAfter: startingAfter,
+		},
+	}
+
+	return &conversation, nil
+}
+
+type searchReqPayload struct {
+	Query      searchQuery      `json:"query"`
+	Pagination searchPagination `json:"pagination"`
+}
+
+type searchQuery struct {
+	Operator string             `json:"operator"`
+	Value    []searchQueryValue `json:"value"`
+}
+
+type searchQueryValue struct {
+	Field    string `json:"field"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
+type searchPagination struct {
+	PerPage       int    `json:"per_page"`                 //nolint:tagliatelle
+	StartingAfter string `json:"starting_after,omitempty"` //nolint:tagliatelle
 }

--- a/test/attio/write/main.go
+++ b/test/attio/write/main.go
@@ -81,6 +81,7 @@ func testObjects(ctx context.Context) error {
 	}
 
 	slog.Info("Updating the object")
+
 	updateparams := common.WriteParams{
 		ObjectName: "objects",
 		RecordData: map[string]interface{}{
@@ -141,6 +142,7 @@ func testLists(ctx context.Context) error {
 	}
 
 	slog.Info("Updating the list")
+
 	updateParams := common.WriteParams{
 		ObjectName: "lists",
 		RecordData: map[string]any{
@@ -243,6 +245,7 @@ func testTasks(ctx context.Context) error {
 	}
 
 	slog.Info("Updating the tasks")
+
 	updateParams := common.WriteParams{
 		ObjectName: "tasks",
 		RecordData: map[string]any{
@@ -300,6 +303,7 @@ func testWebhooks(ctx context.Context) error {
 	}
 
 	slog.Info("Updating the webhooks")
+
 	updateParams := common.WriteParams{
 		ObjectName: "webhooks",
 		RecordData: map[string]any{

--- a/test/gong/write/main.go
+++ b/test/gong/write/main.go
@@ -87,5 +87,6 @@ func createUniqueID() string {
 	minV := 1
 	maxV := 10000
 	uniqueID := strconv.Itoa(rand.Intn(maxV-minV+1) + minV)
+
 	return uniqueID
 }

--- a/test/intercom/search/main.go
+++ b/test/intercom/search/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/intercom"
+	msTest "github.com/amp-labs/connectors/test/intercom"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := msTest.GetIntercomConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "conversations",
+		Fields: connectors.Fields(
+			"id",
+			"state",
+			"type",
+		),
+		Since: time.Unix(1726674883, 0),
+	})
+	if err != nil {
+		utils.Fail("error reading from Intercom", "error", err)
+	}
+
+	fmt.Println("Reading conversations..")
+	utils.DumpJSON(res, os.Stdout)
+
+	if res.Rows > intercom.DefaultConversationsPageSize {
+		utils.Fail(fmt.Sprintf("expected max %v rows", intercom.DefaultConversationsPageSize))
+	}
+
+	if len(res.NextPage) == 0 {
+		return
+	}
+
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "conversations",
+		Fields: connectors.Fields(
+			"id",
+			"state",
+			"type",
+		),
+		NextPage: res.NextPage,
+		Since:    time.Unix(1726674883, 0),
+	})
+	if err != nil {
+		utils.Fail("error reading from Intercom", "error", err)
+	}
+
+	fmt.Println("Reading conversations (SecondPage)..")
+	utils.DumpJSON(res, os.Stdout)
+
+}


### PR DESCRIPTION
# Description

Read for Intercom is changed such that:

* When object is `conversations` and we use incremental read then use POST, where search query relying on `updated_at` with page token will be used. Page size is increased to 150 as per documentation. This [link](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/conversations/searchconversations) is also added as a comment.
* All other objects (and non-incremental conversations) will work as before using List via GET.

# Postman
Query example:
![image](https://github.com/user-attachments/assets/6ef127c3-ad2f-46b4-bbad-2b052c051416)
Via Ampersand proxy:
```
curl --location --request POST 'https://proxy.withampersand.com/conversations/search' \
--header 'x-amp-project-id: 8b257c62-6b89-4b9b-9271-6fe3f6b700f1' \
--header 'x-amp-installation-id: 16d68884-e6ed-4d61-b0a1-d8be82c0f679' \
--header 'x-amp-proxy-version: 1' \
--header 'x-api-key: <API_KEY>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": {
        "operator": "AND",
        "value": [
            {
                "field": "updated_at",
                "operator": ">=",
                "value": "1726674883"
            }
        ]
    },
    "pagination": {
        "per_page": 1,
        "starting_after": "WzE3MjY3NTIxNDUwMDAsNSwyXQ=="
    }
}
'
```

# Testing
Added alike script to read under `search` repo. Just for the demonstration changed `DefaultConversationsPageSize` to 1. As a result, first page has one conversation updated after specific Unix time and querying again using page token we get last second page. 

This proves that implementation relies on `updated_at` and `starting_after` properties.

![image](https://github.com/user-attachments/assets/e1c64550-0555-49ee-b2d8-b52850ab7763)
![image](https://github.com/user-attachments/assets/33e4b971-e78b-411f-9775-f6648c8ce5d3)
![image](https://github.com/user-attachments/assets/0bd728a5-3567-40ef-8046-2db0951c06f5)


PS: you can see that next page token is using URL with query param appropriate format for GET, but if we are doing search it extracts query param and moves it into the payload. The builders shouldn't care about it anyway and treat `NextPageToken` as opaque string.
