### PR TITLE
Fix Salesforce subscription related methods

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -50,7 +50,6 @@ func (h *HTTPClient) Get(ctx context.Context, url string, headers ...Header) (*h
 	if err != nil {
 		return nil, nil, err
 	}
-
 	// Make the request, get the response body
 	res, body, err := h.httpGet(ctx, fullURL, headers) //nolint:bodyclose
 	if err != nil {
@@ -92,6 +91,7 @@ func (h *HTTPClient) Patch(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
+
 	// Make the request, get the response body
 	res, body, err := h.httpPatch(ctx, fullURL, headers, reqBody) //nolint:bodyclose
 	if err != nil {

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -93,7 +93,7 @@ func (c *Connector) getSoapURL() (*urlbuilder.URL, error) {
 // nolint: lll
 // https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_eventrelayconfig.htm?q=EventRelayConfig
 func (c *Connector) getURIPartEventRelayConfig(paths ...string) (*urlbuilder.URL, error) {
-	return urlbuilder.New(uriToolingEventRelayConfig, paths...)
+	return urlbuilder.New(restAPISuffix+"/"+uriToolingEventRelayConfig, paths...)
 }
 
 func (c *Connector) getURIPartSobjectsDescribe(objectName string) (*urlbuilder.URL, error) {

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -14,7 +14,7 @@ const (
 	version                    = versionPrefix + apiVersion
 	restAPISuffix              = "/services/data/" + version
 	uriSobjects                = restAPISuffix + "/sobjects"
-	uriToolingEventRelayConfig = "tooling/sobjects/EventRelayConfig"
+	uriToolingEventRelayConfig = restAPISuffix + "/tooling/sobjects/EventRelayConfig"
 )
 
 // Connector is a Salesforce connector.
@@ -93,7 +93,7 @@ func (c *Connector) getSoapURL() (*urlbuilder.URL, error) {
 // nolint: lll
 // https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_eventrelayconfig.htm?q=EventRelayConfig
 func (c *Connector) getURIPartEventRelayConfig(paths ...string) (*urlbuilder.URL, error) {
-	return urlbuilder.New(restAPISuffix+"/"+uriToolingEventRelayConfig, paths...)
+	return urlbuilder.New(uriToolingEventRelayConfig, paths...)
 }
 
 func (c *Connector) getURIPartSobjectsDescribe(objectName string) (*urlbuilder.URL, error) {

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -216,7 +216,7 @@ func (c *Connector) RunEventRelay(ctx context.Context, cfg *EventRelayConfig) er
 // nolint: lll
 // https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_responses_organization.htm?q=organization
 func (c *Connector) getOrganization(ctx context.Context) (map[string]*ajson.Node, error) {
-	resp, err := c.Client.Get(ctx, "connect/organization")
+	resp, err := c.Client.Get(ctx, restAPISuffix+"/connect/organization")
 	if err != nil {
 		return nil, err
 	}

--- a/test/salesforce/event-flow/main.go
+++ b/test/salesforce/event-flow/main.go
@@ -34,9 +34,6 @@ func main() {
 	}
 
 	testCDC(conn, ctx, namedCred, uniqueString)
-
-	peName := "Employee__e" // this should be created from UI
-	testPE(conn, ctx, namedCred, peName, uniqueString)
 }
 
 func testCDC(conn *salesforce.Connector, ctx context.Context, creds salesforce.Credential, uniqueString string) {
@@ -76,68 +73,7 @@ func testCDC(conn *salesforce.Connector, ctx context.Context, creds salesforce.C
 	printWithField("RemoteResource", "resource", remoteResource)
 }
 
-func testPE(conn *salesforce.Connector, ctx context.Context, creds salesforce.Credential, eventName string, uniqueString string) {
-	fmt.Println("-----------------Testing Platform Event-----------------")
-
-	peChannel, err := TestPlatformEventChannel(conn, ctx, "TestPEChannel"+uniqueString)
-	if err != nil {
-		return
-	}
-
-	evtCfg, err := TestEventRelayConfig(conn, ctx, creds, peChannel, "PE_"+uniqueString)
-	if err != nil {
-		return
-	}
-
-	objectName := "Account"
-
-	_, err = testPlatformEventChannelMembership(conn, ctx, eventName, peChannel.FullName, objectName, uniqueString)
-	if err != nil {
-		return
-	}
-
-	if conn.RunEventRelay(ctx, evtCfg) != nil {
-		return
-	}
-
-	slog.Info("Event relay config updated", "state", "RUN")
-
-	orgId, err := conn.GetOrganizationId(ctx)
-	if err != nil {
-		slog.Error("Failed to get orgId", "error", err)
-		return
-	}
-
-	remoteResource := salesforce.GetRemoteResource(orgId, peChannel.FullName)
-	printWithField("RemoteResource", "resource", remoteResource)
-}
-
-func testPlatformEventChannelMembership(conn *salesforce.Connector, ctx context.Context, peName string, channelName string, objectName string, uniqueString string) (*salesforce.EventChannelMember, error) {
-	rawPEName := getRawPEName(objectName)
-
-	rawChannelName := getRawChannelNameFromChannel(channelName) // TODO FIXME
-
-	member := &salesforce.EventChannelMember{
-		FullName: getPEChannelMembershipName(rawChannelName, rawPEName),
-		Metadata: &salesforce.EventChannelMemberMetadata{
-			EventChannel:   getChannelName(rawChannelName),
-			SelectedEntity: peName,
-		},
-	}
-
-	newChannelMember, err := conn.CreateEventChannelMember(ctx, member)
-	if err != nil {
-		slog.Error("Error event channel member", "error", err)
-
-		return nil, err
-	}
-
-	printWithField("Event channel membership created", "member", newChannelMember)
-
-	return newChannelMember, nil
-}
-
-func testChangeDataCaptureChannelMembership(conn *salesforce.Connector, ctx context.Context, channelName string, objecName string) (*salesforce.EventChannelMember, error) {
+func testChangeDataCaptureChannelMembership(sfc *salesforce.Connector, ctx context.Context, channelName string, objecName string) (*salesforce.EventChannelMember, error) {
 	eventName := getCDCEventName(objecName)
 	rawChannelName := getRawChannelNameFromChannel(channelName)
 
@@ -149,7 +85,7 @@ func testChangeDataCaptureChannelMembership(conn *salesforce.Connector, ctx cont
 		},
 	}
 
-	newChannelMember, err := conn.CreateEventChannelMember(ctx, member)
+	newChannelMember, err := sfc.CreateEventChannelMember(ctx, member)
 	if err != nil {
 		slog.Error("Error event channel member", "error", err)
 
@@ -248,7 +184,7 @@ func TestCredentialsLegacy(conn *salesforce.Connector, ctx context.Context, uniq
 			Label:                       "TestNamedCredentialLegacy" + uniqueString,
 
 			// below are legacy fields
-			Endpoint:      "arn:aws:us-east-2:381491976069",
+			Endpoint:      "arn:aws:US-EAST-2:381491976069",
 			PrincipalType: "NamedUser",
 			Protocol:      "NoAuthentication",
 		},

--- a/test/salesforce/event-flow/main.go
+++ b/test/salesforce/event-flow/main.go
@@ -73,7 +73,7 @@ func testCDC(conn *salesforce.Connector, ctx context.Context, creds salesforce.C
 	printWithField("RemoteResource", "resource", remoteResource)
 }
 
-func testChangeDataCaptureChannelMembership(sfc *salesforce.Connector, ctx context.Context, channelName string, objecName string) (*salesforce.EventChannelMember, error) {
+func testChangeDataCaptureChannelMembership(conn *salesforce.Connector, ctx context.Context, channelName string, objecName string) (*salesforce.EventChannelMember, error) {
 	eventName := getCDCEventName(objecName)
 	rawChannelName := getRawChannelNameFromChannel(channelName)
 
@@ -85,7 +85,7 @@ func testChangeDataCaptureChannelMembership(sfc *salesforce.Connector, ctx conte
 		},
 	}
 
-	newChannelMember, err := sfc.CreateEventChannelMember(ctx, member)
+	newChannelMember, err := conn.CreateEventChannelMember(ctx, member)
 	if err != nil {
 		slog.Error("Error event channel member", "error", err)
 

--- a/test/utils/creds.go
+++ b/test/utils/creds.go
@@ -4,6 +4,47 @@ import (
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 )
 
+<<<<<<< HEAD
+=======
+// preset values from JSON file from schema equal to response from reference: https://docs.withampersand.com/reference/getconnection
+func JSONFileReaders(filePath string) []scanning.Reader {
+	schema := []scanning.Reader{
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.AccessToken.token",
+			KeyName:  utils.AccessToken,
+		},
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.RefreshToken.token",
+			KeyName:  utils.RefreshToken,
+		},
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.providerApp.clientId",
+			KeyName:  utils.ClientId,
+		},
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.providerApp.clientSecret",
+			KeyName:  utils.ClientSecret,
+		},
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.providerWorkspaceRef",
+			KeyName:  utils.WorkspaceRef,
+		},
+		&scanning.JSONReader{
+			FilePath: filePath,
+			JSONPath: "$.providerApp.provider",
+			KeyName:  utils.Provider,
+		},
+	}
+
+	return schema
+}
+
+>>>>>>> 1076d84 (fix sf subscribe related methods)
 func MustCreateProvCredJSON(filePath string,
 	withRequiredAccessToken, withRequiredWorkspace bool,
 ) *credscanning.ProviderCredentials {

--- a/test/utils/creds.go
+++ b/test/utils/creds.go
@@ -4,47 +4,6 @@ import (
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 )
 
-<<<<<<< HEAD
-=======
-// preset values from JSON file from schema equal to response from reference: https://docs.withampersand.com/reference/getconnection
-func JSONFileReaders(filePath string) []scanning.Reader {
-	schema := []scanning.Reader{
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.AccessToken.token",
-			KeyName:  utils.AccessToken,
-		},
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.RefreshToken.token",
-			KeyName:  utils.RefreshToken,
-		},
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.providerApp.clientId",
-			KeyName:  utils.ClientId,
-		},
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.providerApp.clientSecret",
-			KeyName:  utils.ClientSecret,
-		},
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.providerWorkspaceRef",
-			KeyName:  utils.WorkspaceRef,
-		},
-		&scanning.JSONReader{
-			FilePath: filePath,
-			JSONPath: "$.providerApp.provider",
-			KeyName:  utils.Provider,
-		},
-	}
-
-	return schema
-}
-
->>>>>>> 1076d84 (fix sf subscribe related methods)
 func MustCreateProvCredJSON(filePath string,
 	withRequiredAccessToken, withRequiredWorkspace bool,
 ) *credscanning.ProviderCredentials {


### PR DESCRIPTION
The methods were not in use for a while, and during that time url building logics changed without testing these endpoints. This PR fixes those. Also, PlatformEvents will not be supported, so removed the testing code rather than debugging to fix it. 

## Test Results

```
jaehyunlim@Jaehyuns-MBP connectors % go run ./test/salesforce/event-flow
-----------------Testing Named Credential Legacy-----------------
time=2024-10-16T13:26:51.109-07:00 level=INFO msg="Named credential created" body="&{FullName:TestNamedCredentialLegacy1729110410507 Metadata:0x140002daea0 Id:0XAPa00000009GDOAY}"
-----------------Testing Change Data Capture-----------------
time=2024-10-16T13:26:51.307-07:00 level=INFO msg="Data Event channel created" body="&{Id:0YLPa00000000fxOAA FullName:TestCDCChannel1729110410507__chn Metadata:0x1400042a040}"
time=2024-10-16T13:26:51.757-07:00 level=INFO msg="Event relay config created" body="&{Id:7k2Pa00000007G1IAI FullName:TestEventRelayConfigCDC_1729110410507 Metadata:0x14000400e10 DeveloperName: DestinationResourceName: EventChannel:}"
time=2024-10-16T13:26:51.757-07:00 level=INFO msg="Event relay config metadata" metadata="&{DestinationResourceName:callout:TestNamedCredentialLegacy1729110410507 EventChannel:TestCDCChannel1729110410507__chn State:}"
time=2024-10-16T13:26:52.007-07:00 level=INFO msg="Event channel membership created" member="&{Id:0v8Pa00000002EjIAI FullName:TestCDCChannel1729110410507_chn_AccountChangeEvent Metadata:0x140002c3520}"
time=2024-10-16T13:26:52.263-07:00 level=INFO msg="Event relay config updated" state=RUN
time=2024-10-16T13:26:52.399-07:00 level=INFO msg=RemoteResource resource=aws.partner/salesforce.com/00DDo000001AONmMAO/TestCDCChannel1729110410507__chn
```

