### PR TITLE
fix: golinter compatability with golang version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version: "1.21.0"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version: "1.21.0"
           cache: false
       - name: Install gci
         run: "go install github.com/daixiang0/gci@latest"


### PR DESCRIPTION
Seems that the main issue with recent failures of `golangci-lint` have to do with this line:
```
Before:
go-version: ">=1.21.0"

After:
go-version: "1.21.0"
```
