### PR TITLE
chore: Bump golangci version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         continue-on-error: false
         with:
-          version: v1.54
+          version: v1.56.2
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -1,7 +1,7 @@
 package apollo
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
@@ -29,7 +29,7 @@ func getNextRecords(node *ajson.Node) (string, error) {
 		}
 
 		if page < *totalPages {
-			nextPage = fmt.Sprint(page + 1)
+			nextPage = strconv.FormatInt(page+1, 10)
 		}
 	}
 

--- a/providers/dynamicscrm/connector.go
+++ b/providers/dynamicscrm/connector.go
@@ -55,7 +55,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(arg string) (*urlbuilder.URL, error) {

--- a/providers/instantly/connector.go
+++ b/providers/instantly/connector.go
@@ -1,8 +1,6 @@
 package instantly
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -58,7 +56,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(parts ...string) (*urlbuilder.URL, error) {

--- a/providers/intercom/connector.go
+++ b/providers/intercom/connector.go
@@ -1,8 +1,6 @@
 package intercom
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -58,7 +56,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 // nolint:unused

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -1,7 +1,6 @@
 package marketo
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -25,8 +24,7 @@ func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	if !params.Since.IsZero() {
 		switch c.Module.ID {
 		case ModuleAssets:
-			t := params.Since.Format(time.RFC3339)
-			fmtTime := fmt.Sprintf("%v", t)
+			fmtTime := params.Since.Format(time.RFC3339)
 			url.WithQueryParam("earliestUpdatedAt", fmtTime)
 			url.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
 

--- a/providers/outreach/read.go
+++ b/providers/outreach/read.go
@@ -2,7 +2,6 @@ package outreach
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -52,8 +51,8 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 	// If Since is not set, then we're doing a backfill. We read all rows (in pages)
 	// If Since is present, we turn it into the format the Outreach API expects
 	if !config.Since.IsZero() {
-		time := config.Since.Format(time.DateOnly)
-		fmtTime := fmt.Sprintf("%s..inf", time)
+		t := config.Since.Format(time.DateOnly)
+		fmtTime := t + "..inf"
 		url.WithQueryParam("filter[updatedAt]", fmtTime)
 	}
 

--- a/providers/pipeliner/connector.go
+++ b/providers/pipeliner/connector.go
@@ -1,8 +1,6 @@
 package pipeliner
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -54,7 +52,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(parts ...string) (*urlbuilder.URL, error) {

--- a/providers/salesforce/bulk-info.go
+++ b/providers/salesforce/bulk-info.go
@@ -21,7 +21,7 @@ type ListIngestJobsResult struct {
 // It is possible to get information about all current ingest jobs by not providing any jobIds. Note that Salesforce
 // returns terminal state jobs from a maximum of 7 days ago.
 // nolint:funlen,cyclop
-func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIds ...string) ([]GetJobInfoResult, error) {
+func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIDs ...string) ([]GetJobInfoResult, error) {
 	url, err := c.getRestApiURL("jobs/ingest")
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIds ...string) ([
 	// If we have jobIds, we create a set to keep track of the matches we need to find. Each time we get
 	// a match, we remove it from the set. If the set is empty, we can break the loop to save time and unnecessary
 	// pagination.
-	pending := handy.NewSetFromList(jobIds)
+	pending := handy.NewSetFromList(jobIDs)
 
 	// To keep track of pages
 	location := url.String()
@@ -65,7 +65,7 @@ func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIds ...string) ([
 
 		// Add the jobs we need to the list (or all of them if we don't have a filter)
 		for _, result := range response.Records {
-			if len(jobIds) == 0 || slices.Contains(jobIds, result.Id) {
+			if len(jobIDs) == 0 || slices.Contains(jobIDs, result.Id) {
 				jobsInfo = append(jobsInfo, result)
 
 				// This is a no-op if we don't have jobIds, or if the job is not in the set.
@@ -78,7 +78,7 @@ func (c *Connector) ListIngestJobsInfo(ctx context.Context, jobIds ...string) ([
 		}
 
 		// If we aren't done yet, check if we have all the jobs we need
-		if len(jobIds) > 0 && pending.IsEmpty() {
+		if len(jobIDs) > 0 && pending.IsEmpty() {
 			break
 		}
 

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -1,8 +1,6 @@
 package salesforce
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -73,7 +71,7 @@ func (c *Connector) Provider() providers.Provider {
 
 // String returns a string representation of the connector, which is useful for logging / debugging.
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getRestApiURL(paths ...string) (*urlbuilder.URL, error) {

--- a/providers/salesloft/connector.go
+++ b/providers/salesloft/connector.go
@@ -1,8 +1,6 @@
 package salesloft
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -53,7 +51,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(arg string) (*urlbuilder.URL, error) {

--- a/providers/smartlead/connector.go
+++ b/providers/smartlead/connector.go
@@ -1,8 +1,6 @@
 package smartlead
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -55,7 +53,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(arg string) (*urlbuilder.URL, error) {

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -1,8 +1,6 @@
 package zendesksupport
 
 import (
-	"fmt"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
@@ -54,7 +52,7 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector", c.Provider())
+	return c.Provider() + ".Connector"
 }
 
 func (c *Connector) getURL(arg string) (*urlbuilder.URL, error) {

--- a/tools/scrapper/utils.go
+++ b/tools/scrapper/utils.go
@@ -77,7 +77,7 @@ func FlushToFile(filename string, object any) error {
 		return err
 	}
 
-	return os.WriteFile(filename, data, os.ModePerm)
+	return os.WriteFile(filename, data, os.ModePerm) //nolint:gosec
 }
 
 func LoadFile(filename string, object any) error {


### PR DESCRIPTION
`golangci-lint-action` upgraded from `v1.54` to `v1.56.2`.
That also means that some lines of code need to abide by new rules, hence the changes.