### PR TITLE
feat: CustomerJourneysApp (Metadata)

### DIFF
--- a/providers/customerapp/metadata.go
+++ b/providers/customerapp/metadata.go
@@ -1,0 +1,18 @@
+package customerapp
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/customerapp/metadata"
+)
+
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	return metadata.Schemas.Select(c.Module.ID, objectNames)
+}

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -1,0 +1,77 @@
+package customerapp
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Unknown object requested",
+			Input:        []string{"butterflies"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+		},
+		{
+			Name:   "Successfully describe multiple objects with metadata",
+			Input:  []string{"reporting_webhooks", "workspaces"},
+			Server: mockserver.Dummy(),
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"reporting_webhooks": {
+						DisplayName: "Reporting Webhooks",
+						FieldsMap: map[string]string{
+							"disabled":        "disabled",
+							"endpoint":        "endpoint",
+							"events":          "events",
+							"full_resolution": "full_resolution",
+							"id":              "id",
+							"name":            "name",
+							"with_content":    "with_content",
+						},
+					},
+					"workspaces": {
+						DisplayName: "Workspaces",
+						FieldsMap: map[string]string{
+							"billable_messages_sent": "billable_messages_sent",
+							"id":                     "id",
+							"messages_sent":          "messages_sent",
+							"name":                   "name",
+							"object_types":           "object_types",
+							"objects":                "objects",
+							"people":                 "people",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/customerapp/openapi/file.go
+++ b/providers/customerapp/openapi/file.go
@@ -1,0 +1,16 @@
+package openapi
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+)
+
+var (
+	// Static file containing openapi spec.
+	//
+	//go:embed cio_journeys_app_api.json
+	apiFile []byte
+
+	FileManager = api3.NewOpenapiFileManager(apiFile) // nolint:gochecknoglobals
+)

--- a/scripts/openapi/customerio/journeysapp/metadata/main.go
+++ b/scripts/openapi/customerio/journeysapp/metadata/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"log"
+	"log/slog"
+
+	"github.com/amp-labs/connectors/common/handy"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/providers/customerapp"
+	"github.com/amp-labs/connectors/providers/customerapp/metadata"
+	"github.com/amp-labs/connectors/providers/customerapp/openapi"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	ignoreEndpoints = []string{ // nolint:gochecknoglobals
+		"/v1/customers",
+		"/v1/exports/customers",
+	}
+	displayNameOverride = map[string]string{ // nolint:gochecknoglobals
+
+	}
+)
+
+func main() {
+	explorer, err := openapi.FileManager.GetExplorer(
+		api3.WithDisplayNamePostProcessors(
+			api3.CamelCaseToSpaceSeparated,
+			api3.CapitalizeFirstLetterEveryWord,
+		))
+	must(err)
+
+	objects, err := explorer.ReadObjectsGet(
+		api3.NewDenyPathStrategy(ignoreEndpoints),
+		nil, displayNameOverride,
+		api3.CustomMappingObjectCheck(customerapp.ObjectNameToResponseField),
+	)
+	must(err)
+
+	schemas := staticschema.NewMetadata()
+	registry := handy.NamedLists[string]{}
+
+	for _, object := range objects {
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", object.ObjectName,
+				"error", object.Problem,
+			)
+		}
+
+		for _, field := range object.Fields {
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+		}
+
+		for _, queryParam := range object.QueryParams {
+			registry.Add(queryParam, object.ObjectName)
+		}
+	}
+
+	must(metadata.FileManager.SaveSchemas(schemas))
+	must(metadata.FileManager.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
+
+	log.Println("Completed.")
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/test/customerio/journeysapp/metadata/main.go
+++ b/test/customerio/journeysapp/metadata/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
+	connTest "github.com/amp-labs/connectors/test/customerio/journeysapp"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+var objectName = "segments"
+
+// we want to compare fields returned by read and schema properties provided by metadata methods
+// they must match for all such objects
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetCustomerJourneysAppConnector(ctx)
+	defer utils.Close(conn)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for Customers Journeys App", "error", err)
+	}
+
+	slog.Info("Read object using all fields from ListObjectMetadata")
+
+	requestFields := handy.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     requestFields,
+	})
+	if err != nil {
+		utils.Fail("error reading from Customer Journeys App", "error", err)
+	} else {
+		if response.Rows == 0 {
+			utils.Fail("expected to read at least one record", "error", err)
+		}
+
+		givenFields := handy.Map[string, any](response.Data[0].Fields).KeySet()
+
+		difference := givenFields.Diff(requestFields)
+		if len(difference) != 0 {
+			utils.Fail("connector read didn't match requested fields", "difference", difference)
+		}
+	}
+
+	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+}


### PR DESCRIPTION
# Description

Customer Journeys App implements `ListObjectMetadata` by serving static `schema.json`.
OpenAPI extraction script is created for this connector and OpenAPI file is attached (119,158 lines).

# Manual Test Output

![image](https://github.com/user-attachments/assets/ccac4dd6-418b-4511-8f89-44a13cd29bec)
