### PR TITLE
feat: Add ZohoCRM Write Connector

### DIFF
--- a/providers/zohocrm/write.go
+++ b/providers/zohocrm/write.go
@@ -31,6 +31,7 @@ Sample Response Data:
             "message": "record added",
             "status": "success"
         },
+		{...}
     ]
 }
 */
@@ -94,7 +95,6 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 
 	return &common.WriteResult{
 		Success: true,
-		Data:    response.Data[0],
 		Errors:  errors,
 	}, nil
 }

--- a/providers/zohocrm/write.go
+++ b/providers/zohocrm/write.go
@@ -1,0 +1,85 @@
+package zohocrm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+)
+
+/*
+Sample Response Data:
+
+{
+    "data": [
+        {
+            "code": "SUCCESS",
+            "details": {
+                "Modified_Time": "2023-05-10T01:10:47-07:00",
+                "Modified_By": {
+                    "name": "Patricia Boyle",
+                    "id": "5725767000000411001"
+                },
+                "Created_Time": "2023-05-10T01:10:47-07:00",
+                "id": "5725767000000524157",
+                "Created_By": {
+                    "name": "Patricia Boyle",
+                    "id": "5725767000000424162"
+                },
+                "$approval_state": "approved"
+            },
+            "message": "record added",
+            "status": "success"
+        },
+    ]
+}
+*/
+
+type writeResponse struct {
+	Data []map[string]any `json:"data"`
+}
+
+// Write creates or updates records in a zohoCRM account.
+// A maximum of 100 records can be inserted per API call.
+// https://www.zoho.com/crm/developer/docs/api/v6/insert-records.html
+func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+	if err := config.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	var write common.WriteMethod
+
+	// Object names in ZohoCRM API are case sensitive.
+	// Capitalizing the first character of object names to form correct URL.
+	obj := naming.CapitalizeFirstLetterEveryWord(config.ObjectName)
+
+	url, err := c.getAPIURL(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(config.RecordId) != 0 {
+		url.AddPath(config.RecordId)
+
+		write = c.Client.Put
+	} else {
+		write = c.Client.Post
+	}
+
+	resp, err := write(ctx, url.String(), config.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := common.UnmarshalJSON[writeResponse](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: fmt.Sprint("id"),
+		Data:     response.Data[0],
+	}, nil
+}

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -42,7 +42,7 @@ func main() {
 func readContacts(ctx context.Context, conn connectors.ReadConnector) error {
 	config := connectors.ReadParams{
 		ObjectName: "contacts",
-		Since:      time.Now().Add(-1080 * time.Hour),
+		Since:      time.Now().Add(-30 * time.Hour),
 		Fields:     connectors.Fields("Assistant", "Created_By", "Full_Name", "id", "Created_Time"),
 		// NextPage:   "https://www.zohoapis.com/crm/v6/Contacts?fields=Assistant%2CCreated_By%2CFull_Name%2Cid%2CCreated_Time\u0026page_token=089df74ef7734aa9f877fa670550bcbafc9c43567bb2f2e2404aa4d2a466a0b2c9432951d4eb3ffe73094c25e18b4c6290eedc53160535ab40b8ed204dd80e7247a90a4d5cd8d69a348dcaeefbccd8087f658d4a72cfa6aaab8ae8e7065246bf6d1fffce6a3eb2a06bab02e3ae935bc3fb63067b3e0da43e421e36b71b7c1bb843d3af99c7679b53100a8f7b8343f012\u0026since=2024-10-22T16%3A15%3A55%2B03%3A00",
 	}
@@ -66,7 +66,7 @@ func readContacts(ctx context.Context, conn connectors.ReadConnector) error {
 func readDeals(ctx context.Context, conn connectors.ReadConnector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
-		Since:      time.Now().Add(-10800 * time.Hour),
+		Since:      time.Now().Add(-720 * time.Hour),
 		Fields:     connectors.Fields("Account_Name", "Closing_Date", "id"),
 	}
 

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -42,7 +42,7 @@ func main() {
 func readContacts(ctx context.Context, conn connectors.ReadConnector) error {
 	config := connectors.ReadParams{
 		ObjectName: "contacts",
-		Since:      time.Now().Add(-30 * time.Hour),
+		Since:      time.Now().Add(-1080 * time.Hour),
 		Fields:     connectors.Fields("Assistant", "Created_By", "Full_Name", "id", "Created_Time"),
 		// NextPage:   "https://www.zohoapis.com/crm/v6/Contacts?fields=Assistant%2CCreated_By%2CFull_Name%2Cid%2CCreated_Time\u0026page_token=089df74ef7734aa9f877fa670550bcbafc9c43567bb2f2e2404aa4d2a466a0b2c9432951d4eb3ffe73094c25e18b4c6290eedc53160535ab40b8ed204dd80e7247a90a4d5cd8d69a348dcaeefbccd8087f658d4a72cfa6aaab8ae8e7065246bf6d1fffce6a3eb2a06bab02e3ae935bc3fb63067b3e0da43e421e36b71b7c1bb843d3af99c7679b53100a8f7b8343f012\u0026since=2024-10-22T16%3A15%3A55%2B03%3A00",
 	}
@@ -66,7 +66,7 @@ func readContacts(ctx context.Context, conn connectors.ReadConnector) error {
 func readDeals(ctx context.Context, conn connectors.ReadConnector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
-		Since:      time.Now().Add(-720 * time.Hour),
+		Since:      time.Now().Add(-10800 * time.Hour),
 		Fields:     connectors.Fields("Account_Name", "Closing_Date", "id"),
 	}
 

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -26,31 +25,29 @@ func main() {
 	conn := zohocrm.GetZohoConnector(ctx)
 	defer utils.Close(conn)
 
-	if err := createActivity(ctx, conn); err != nil {
+	if err := createDeals(ctx, conn); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := updateActivity(ctx, conn); err != nil {
+	if err := createLeads(ctx, conn); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := createCallLog(ctx, conn); err != nil {
-		slog.Error(err.Error())
-	}
-
-	if err := createCallLog(ctx, conn); err != nil {
+	if err := updateContacts(ctx, conn); err != nil {
 		slog.Error(err.Error())
 	}
 }
 
-func createActivity(ctx context.Context, conn connectors.WriteConnector) error {
+func createDeals(ctx context.Context, conn connectors.WriteConnector) error {
 	config := common.WriteParams{
-		ObjectName: "activities",
-		RecordData: map[string]any{
-			"due_date":           "2024-10-30",
-			"location":           "Dar es salaam",
-			"public_description": "Demo activity",
-			"subject":            "I usually can't come up with words",
+		ObjectName: "Deals",
+		RecordData: []map[string]any{
+			{
+				"id":        "3652397000003852095",
+				"Deal_Name": "v6 Update",
+				"Stage":     "Closed Won",
+				"Pipeline":  "Standard (Standard)",
+			},
 		},
 	}
 
@@ -60,23 +57,28 @@ func createActivity(ctx context.Context, conn connectors.WriteConnector) error {
 		return err
 	}
 
-	// Print the results
 	jsonStr, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(jsonStr)
+	fmt.Println(string(jsonStr))
 
 	return nil
 }
 
-func updateActivity(ctx context.Context, conn connectors.WriteConnector) error {
+func createLeads(ctx context.Context, conn connectors.WriteConnector) error {
 	config := common.WriteParams{
-		ObjectName: "activities",
-		RecordId:   "1",
-		RecordData: map[string]any{
-			"done": "1",
+		ObjectName: "Leads",
+		RecordData: []map[string]any{
+			{
+				"Lead_Source": "Employee Referral",
+				"Company":     "ABC",
+				"Last_Name":   "Daly",
+				"First_Name":  "Paul",
+				"Email":       "p.daly@zylker.com",
+				"State":       "Texas",
+			},
 		},
 	}
 
@@ -92,21 +94,21 @@ func updateActivity(ctx context.Context, conn connectors.WriteConnector) error {
 		return err
 	}
 
-	fmt.Println(jsonStr)
+	fmt.Println(string(jsonStr))
 
 	return nil
 }
 
-func createCallLog(ctx context.Context, conn connectors.WriteConnector) error {
+func updateContacts(ctx context.Context, conn connectors.WriteConnector) error {
 	config := common.WriteParams{
-		ObjectName: "callLogs",
-		RecordData: map[string]any{
-			"outcome":         "connected",
-			"to_phone_number": "+1234567890",
-			"subject":         "string",
-			"start_time":      time.Now().Add(-4 * time.Hour).Format(time.RFC3339),
-			"end_time":        time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
-			"activity_id":     "1",
+		ObjectName: "contacts",
+		RecordId:   "64934900000005440112",
+		RecordData: []map[string]any{
+			{
+				"First_Name": "Ryan",
+				"Phone":      "+12343678",
+				"Last_Name":  "Dahl",
+			},
 		},
 	}
 
@@ -122,7 +124,7 @@ func createCallLog(ctx context.Context, conn connectors.WriteConnector) error {
 		return err
 	}
 
-	fmt.Println(jsonStr)
+	fmt.Println(string(jsonStr))
 
 	return nil
 }

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -102,12 +102,17 @@ func createLeads(ctx context.Context, conn connectors.WriteConnector) error {
 func updateContacts(ctx context.Context, conn connectors.WriteConnector) error {
 	config := common.WriteParams{
 		ObjectName: "contacts",
-		RecordId:   "64934900000005440112",
+		// RecordId:   "64934900000005440112",
 		RecordData: []map[string]any{
 			{
 				"First_Name": "Ryan",
 				"Phone":      "+12343678",
 				"Last_Name":  "Dahl",
+			},
+			{
+				"First_Name": "Ryan",
+				"Phone":      "+12343678",
+				// "Last_Name":  "Dahl",
 			},
 		},
 	}

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/zohocrm"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := zohocrm.GetZohoConnector(ctx)
+	defer utils.Close(conn)
+
+	if err := createActivity(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	if err := updateActivity(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	if err := createCallLog(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	if err := createCallLog(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func createActivity(ctx context.Context, conn connectors.WriteConnector) error {
+	config := common.WriteParams{
+		ObjectName: "activities",
+		RecordData: map[string]any{
+			"due_date":           "2024-10-30",
+			"location":           "Dar es salaam",
+			"public_description": "Demo activity",
+			"subject":            "I usually can't come up with words",
+		},
+	}
+
+	result, err := conn.Write(ctx, config)
+	if err != nil {
+		fmt.Println("Object: ", config.ObjectName)
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(jsonStr)
+
+	return nil
+}
+
+func updateActivity(ctx context.Context, conn connectors.WriteConnector) error {
+	config := common.WriteParams{
+		ObjectName: "activities",
+		RecordId:   "1",
+		RecordData: map[string]any{
+			"done": "1",
+		},
+	}
+
+	result, err := conn.Write(ctx, config)
+	if err != nil {
+		fmt.Println("Object: ", config.ObjectName)
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(jsonStr)
+
+	return nil
+}
+
+func createCallLog(ctx context.Context, conn connectors.WriteConnector) error {
+	config := common.WriteParams{
+		ObjectName: "callLogs",
+		RecordData: map[string]any{
+			"outcome":         "connected",
+			"to_phone_number": "+1234567890",
+			"subject":         "string",
+			"start_time":      time.Now().Add(-4 * time.Hour).Format(time.RFC3339),
+			"end_time":        time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
+			"activity_id":     "1",
+		},
+	}
+
+	result, err := conn.Write(ctx, config)
+	if err != nil {
+		fmt.Println("Object: ", config.ObjectName)
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(jsonStr)
+
+	return nil
+}


### PR DESCRIPTION
This Adds the ZohoCRM write conector. 

Writing to zoho supports upto 100 records per API Call. So the the RecordData should be a slice of maps.
Supports Updating 1 record per API Call. 

They have an API for updating several records as well.(We currently do not support this)

We do not return the recordId as one may create several records per call.

Tests:
<img width="1280" alt="Screenshot 2024-10-25 at 08 11 24" src="https://github.com/user-attachments/assets/73770b06-7de6-4824-8575-53bcfbb7bcec">

On the last call, The request was a success but there are some records that failed to insert. 