### PR TITLE
feat: Enable proxy: Kit

### DIFF
--- a/providers/kit.go
+++ b/providers/kit.go
@@ -22,7 +22,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Created PR from non-main branch

## Notes
No fishy behaviour was observed. All the requests/responses were parsed correctly.

## Catelog variables
Kit Provider = "kit"

## Notes
It supports pagination and batching

## Testing
### GET
URL: https://proxy.withampersand.com/v4/custom_fields
![image](https://github.com/user-attachments/assets/817ad43a-94fe-41a1-b8d5-11cd96f00df4)

### POST
URL: https://proxy.withampersand.com/v4/custom_fields
![image](https://github.com/user-attachments/assets/5043d229-c060-4a40-b7f6-7b79479bcda8)

### PUT
URL: https://proxy.withampersand.com/v4/custom_fields/728151
![image](https://github.com/user-attachments/assets/7579cde5-99f7-41ad-82f0-5f8023bc1e8d)

### DELETE
URL: https://proxy.withampersand.com/v4/custom_fields/728151
![image](https://github.com/user-attachments/assets/0288137b-2b3a-4dca-a3cd-608f2b6dbb6e)

### Pagination
Requesting a paginated list of custom fields using the **per_page** parameter to set the record limit and the **include_total_count** parameter to return the total record count
URL: https://proxy.withampersand.com/v4/custom_fields?include_total_count=true&per_page=5
![image](https://github.com/user-attachments/assets/9f32448d-b706-417d-bc0d-0595ac2a3795)

Request the next paginated list of custom fields by using the token from the **end_cursor** field in the response and passing it in the **after** parameter
URL: https://proxy.withampersand.com/v4/custom_fields?after=WzcyODE0OV0=
![image](https://github.com/user-attachments/assets/5480578c-4215-4683-9e0b-f14bbdb01df4)

Request the previous paginated list of custom fields by using the token from the **start_cursor** field in the response and passing it in the **before** parameter
URL: https://proxy.withampersand.com/v4/custom_fields?before=WzcyMTI5N10=
![image](https://github.com/user-attachments/assets/d9c58f03-068a-4981-bb02-0be8a0ec8de7)

Empty response when the **has_previous_page** fields have **false** value and using token from the **start_cursor** field in the response and passing it in the **before** parameter
URL: https://proxy.withampersand.com/v4/custom_fields?before=WzcyODE1NV0=
![image](https://github.com/user-attachments/assets/d0456632-eb4a-4b56-a67c-47c5b3f12812)

Empty response when the **has_next_page** fields have **false** value and using token from the **end_cursor** field in the response and passing it in the **after** parameter
URL: https://proxy.withampersand.com/v4/custom_fields?after=WzcxOTkyNl0=
![image](https://github.com/user-attachments/assets/d0370f32-649e-4124-ad33-f2008880d44e)

### Batching
To create a bulk of custom_fields
URL: https://proxy.withampersand.com/v4/bulk/custom_fields
![image](https://github.com/user-attachments/assets/0c105a31-d4b2-461f-b5d5-7522cfac1f57)

### Invalid request
Invalid endpoint
![image](https://github.com/user-attachments/assets/a81e9bdb-0c5d-47e2-8ee3-895f4c3a2b2c)

Invalid method
![image](https://github.com/user-attachments/assets/9663ec8d-6cf8-4c9a-9afd-9efdeb8cea36)

### Success Console Operation
![image](https://github.com/user-attachments/assets/d11894b9-4cf8-4f0b-a94b-6275648f1ff4)

### Failure Console Operation
![image](https://github.com/user-attachments/assets/af7c86ee-7d1d-4cd1-9173-b94e75ad1440)
