### PR TITLE
feat: Add CloseCRM Read connector

### DIFF
--- a/providers/closecrm/connector.go
+++ b/providers/closecrm/connector.go
@@ -50,6 +50,11 @@ func (c *Connector) Provider() string {
 	return providers.Close
 }
 
+// String implements fmt.Stringer interface.
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}
+
 func (c *Connector) setBaseURL(newURL string) {
 	c.BaseURL = newURL
 	c.Client.HTTPClient.Base = newURL

--- a/providers/closecrm/metadata.go
+++ b/providers/closecrm/metadata.go
@@ -36,8 +36,6 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		mu sync.Mutex     //nolint: varnamelen
 	)
 
-	wg.Add(len(objectNames))
-
 	if len(objectNames) == 0 {
 		return nil, common.ErrMissingObjects
 	}
@@ -46,6 +44,8 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		Result: make(map[string]common.ObjectMetadata, len(objectNames)),
 		Errors: make(map[string]error, len(objectNames)),
 	}
+
+	wg.Add(len(objectNames))
 
 	for _, object := range objectNames {
 		go func(object string) {

--- a/providers/closecrm/parse.go
+++ b/providers/closecrm/parse.go
@@ -19,7 +19,7 @@ Read Response Schema:
 
 */
 
-var (
+const (
 	defaultPageSize = "100"      // nolint:gochecknoglobals
 	limitQuery      = "_limit"   // nolint:gochecknoglobals
 	skipQuery       = "_skip"    // nolint:gochecknoglobals
@@ -30,6 +30,7 @@ var (
 var ErrSkipFailure = errors.New("error: failed to create next page url")
 
 // nextRecordsURL builds the next-page url func.
+// https://developer.close.com/topics/pagination/
 func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
 		// check if there is more items in the collection.
@@ -54,17 +55,23 @@ func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 	}
 }
 
-func searchNextRecords() common.NextPageFunc {
-	return func(node *ajson.Node) (string, error) {
-		crs, err := jsonquery.New(node).Str("cursor", true)
-		if err != nil {
-			return "", err
-		}
+/*
+Search Response schema:
 
-		if crs == nil {
-			return "", nil
-		}
-
-		return *crs, nil
+	{
+		 "data": [{...},{...}],
+		 "cursor": "..."
 	}
+*/
+func getNextRecordCursor(node *ajson.Node) (string, error) {
+	crs, err := jsonquery.New(node).Str("cursor", true)
+	if err != nil {
+		return "", err
+	}
+
+	if crs == nil {
+		return "", nil
+	}
+
+	return *crs, nil
 }

--- a/providers/closecrm/parse.go
+++ b/providers/closecrm/parse.go
@@ -1,0 +1,42 @@
+package closecrm
+
+import (
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/spyzhov/ajson"
+)
+
+/*
+Response Schema:
+{
+    "has_more": false,
+    "total_results": 1,
+    "data": [
+        {...},
+		{...}
+    ]
+}
+
+*/
+
+// nextRecordsURL builds the next-page url func.
+func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		// check if there is more items in the collection.
+		hasMore, err := jsonquery.New(node).Bool("has_more", false)
+		if err != nil {
+			return "", err
+		}
+
+		if *hasMore {
+			url.WithQueryParam("start", strconv.FormatInt(*startValue, 10))
+
+			return url.String(), nil
+		}
+
+		return "", nil
+	}
+}

--- a/providers/closecrm/read.go
+++ b/providers/closecrm/read.go
@@ -22,7 +22,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	if !config.Since.IsZero() {
 		return c.Search(ctx, SearchParams{
 			ObjectName: config.ObjectName,
-			Fields:     config.Fields,
+			Fields:     config.Fields.List(),
 			Since:      config.Since,
 			NextPage:   config.NextPage,
 		})

--- a/providers/closecrm/read.go
+++ b/providers/closecrm/read.go
@@ -1,0 +1,44 @@
+package closecrm
+
+import (
+	"context"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// Read retrieves data based on the provided read parameters.
+// ref: https://developer.close.com/resources/leads/
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if err := config.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	url, err := c.buildReadURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add _fields query parameters for filtering the response fields.
+	url.WithQueryParamList("_fields", config.Fields.List())
+
+	if !config.Since.IsZero() {
+		// Filter response data according to the provided since data.
+		url.WithQueryParam("date_updated", config.Since.Format(time.RFC3339))
+	}
+
+	resp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+}
+
+func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
+	if len(config.NextPage) > 0 {
+		return urlbuilder.New(config.NextPage.String())
+	}
+
+	return c.getAPIURL(config.ObjectName)
+}

--- a/providers/closecrm/search.go
+++ b/providers/closecrm/search.go
@@ -1,0 +1,3 @@
+package closecrm
+
+func Search()

--- a/providers/closecrm/search.go
+++ b/providers/closecrm/search.go
@@ -1,3 +1,99 @@
 package closecrm
 
-func Search()
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+/*
+Response Schema:
+
+{
+  "data": [{...},{...}]
+  cursor: "..."
+
+}
+
+*/
+
+// searchEndpoint represents the search api endpoint.
+// ref: https://developer.close.com/resources/advanced-filtering/
+const searchEndpoint = "data/search"
+
+// Search reads data through searching API. Supports advanced filtering using the filters field.
+// The NextPage Token generated takes 30 seconds to expire.
+//
+// doc: https://developer.close.com/resources/advanced-filtering
+func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.ReadResult, error) {
+	input, err := buildUpdatedDateFilter(config)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := c.getAPIURL(searchEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Client.Post(ctx, url.String(), input)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		resp,
+		common.GetRecordsUnderJSONPath("data"),
+		searchNextRecords(),
+		common.GetMarshaledData,
+		config.Fields,
+	)
+}
+
+func buildUpdatedDateFilter(config SearchParams) (Filters, error) {
+	limit, err := strconv.Atoi(defaultPageSize)
+	if err != nil {
+		return Filters{}, err
+	}
+
+	flt := Filters{
+		FilterQueries: FilterQueries{
+			Type: "and",
+			Queries: []map[string]any{
+				{
+					ObjectTypeQueryKey: config.ObjectName,
+					TypeQueryKey:       "object_type",
+				},
+				{
+					TypeQueryKey: "field_condition",
+					FieldQueryKey: map[string]any{
+						TypeQueryKey:          "regular_field",
+						ObjectTypeQueryKey:    config.ObjectName,
+						FieldNameTypeQueryKey: "date_updated",
+					},
+					ConditionQueryKey: map[string]any{
+						OnOrAfterQueryKey: map[string]any{
+							TypeQueryKey:  "fixed_local_date",
+							ValueQueryKey: config.Since.Format(time.DateOnly),
+							WhichQueryKey: "start",
+						},
+						TypeQueryKey: "moment_range",
+					},
+				},
+			},
+		},
+		Fields: map[string][]string{
+			config.ObjectName: config.Fields.List(),
+		},
+		Cursor: nil,
+		Limit:  limit,
+	}
+
+	if len(config.NextPage) > 0 {
+		flt.Cursor = config.NextPage.String()
+	}
+
+	return flt, nil
+}

--- a/providers/closecrm/types.go
+++ b/providers/closecrm/types.go
@@ -4,31 +4,30 @@ import (
 	"time"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/common/handy"
 )
 
 type SearchParams struct {
 	ObjectName string
-	Fields     handy.StringSet
+	Fields     []string
 	Since      time.Time
 	NextPage   common.NextPageToken
-	Filters    Filters
+	Filters    Filter
 }
 
-type Filters struct {
-	FilterQueries FilterQueries       `json:"query"`
-	Cursor        any                 `json:"cursor"`
-	Limit         int                 `json:"_limit"`  //nolint:tagliatelle
-	Fields        map[string][]string `json:"_fields"` //nolint:tagliatelle
+type Filter struct {
+	Query  Query               `json:"query"`
+	Cursor any                 `json:"cursor"`
+	Limit  int                 `json:"_limit"`  //nolint:tagliatelle
+	Fields map[string][]string `json:"_fields"` //nolint:tagliatelle
 }
 
-type FilterQueries struct {
+type Query struct {
 	Type    string           `json:"type"`
 	Queries []map[string]any `json:"queries"`
 }
 
 // nolint:gochecknoglobals
-var (
+const (
 	TypeQueryKey          = "type"
 	ObjectTypeQueryKey    = "object_type"
 	FieldQueryKey         = "field"

--- a/providers/closecrm/types.go
+++ b/providers/closecrm/types.go
@@ -1,0 +1,40 @@
+package closecrm
+
+import (
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/handy"
+)
+
+type SearchParams struct {
+	ObjectName string
+	Fields     handy.StringSet
+	Since      time.Time
+	NextPage   common.NextPageToken
+	Filters    Filters
+}
+
+type Filters struct {
+	FilterQueries FilterQueries       `json:"query"`
+	Cursor        any                 `json:"cursor"`
+	Limit         int                 `json:"_limit"`  //nolint:tagliatelle
+	Fields        map[string][]string `json:"_fields"` //nolint:tagliatelle
+}
+
+type FilterQueries struct {
+	Type    string           `json:"type"`
+	Queries []map[string]any `json:"queries"`
+}
+
+// nolint:gochecknoglobals
+var (
+	TypeQueryKey          = "type"
+	ObjectTypeQueryKey    = "object_type"
+	FieldQueryKey         = "field"
+	FieldNameTypeQueryKey = "field_name"
+	ConditionQueryKey     = "condition"
+	ValueQueryKey         = "value"
+	WhichQueryKey         = "which"
+	OnOrAfterQueryKey     = "on_or_after"
+)

--- a/test/closecrm/connector.go
+++ b/test/closecrm/connector.go
@@ -1,4 +1,4 @@
-package close
+package closecrm
 
 import (
 	"context"

--- a/test/closecrm/metadata/metadata.go
+++ b/test/closecrm/metadata/metadata.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/test/close"
+	"github.com/amp-labs/connectors/test/closecrm"
 	"github.com/amp-labs/connectors/test/utils"
 )
 
@@ -18,7 +18,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := close.GetCloseConnector(ctx)
+	conn := closecrm.GetCloseConnector(ctx)
 
 	defer utils.Close(conn)
 

--- a/test/closecrm/read/read.go
+++ b/test/closecrm/read/read.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/closecrm"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := closecrm.GetCloseConnector(ctx)
+	defer utils.Close(conn)
+
+	// if err := readActivities(ctx, conn); err != nil {
+	// 	slog.Error(err.Error())
+	// }
+
+	// if err := readContacts(ctx, conn); err != nil {
+	// 	slog.Error(err.Error())
+	// }
+
+	if err := readLeads(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func readActivities(ctx context.Context, conn connectors.ReadConnector) error {
+	config := connectors.ReadParams{
+		ObjectName: "activity",
+		Fields:     connectors.Fields("user_id", "user_name", "source", "id"),
+	}
+
+	result, err := conn.Read(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonStr))
+
+	return nil
+}
+
+func readContacts(ctx context.Context, conn connectors.ReadConnector) error {
+	config := connectors.ReadParams{
+		ObjectName: "contact",
+		Fields:     connectors.Fields("name", "title", "emails", "phones", "id"),
+	}
+
+	result, err := conn.Read(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonStr))
+
+	return nil
+}
+
+func readLeads(ctx context.Context, conn connectors.ReadConnector) error {
+	config := connectors.ReadParams{
+		ObjectName: "lead",
+		Since:      time.Now().Add(-72 * time.Hour),
+		// NextPage:   "eyJza2lwIjo0fQ.ZyJitQ.4Mg19Fds1IrDqBmI8UZ0U-mbsT8",
+		Fields: connectors.Fields("display_name", "description", "name", "id"),
+	}
+
+	result, err := conn.Read(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonStr))
+
+	return nil
+}

--- a/test/closecrm/read/read.go
+++ b/test/closecrm/read/read.go
@@ -25,13 +25,13 @@ func main() {
 	conn := closecrm.GetCloseConnector(ctx)
 	defer utils.Close(conn)
 
-	// if err := readActivities(ctx, conn); err != nil {
-	// 	slog.Error(err.Error())
-	// }
+	if err := readActivities(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
 
-	// if err := readContacts(ctx, conn); err != nil {
-	// 	slog.Error(err.Error())
-	// }
+	if err := readContacts(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
 
 	if err := readLeads(ctx, conn); err != nil {
 		slog.Error(err.Error())


### PR DESCRIPTION
Adds the CloseCRM Read Connector. The Close API offers the Listing and Searching APIs.
The searching API supports incremental Read by Adding Filtering Queries in the request body. I have added the switching route to search if the Since Field is provided. 

The search API has a limitation of reading up to 10K with pagination.
The Cursor for pagination expires in 30 seconds.

Test Outputs:
<img width="1213" alt="Screenshot 2024-10-30 at 20 21 31" src="https://github.com/user-attachments/assets/883a57ad-7e7d-482c-85ce-57649629c6b3">
 