### PR TITLE
feat: Support OpenAPI V2

### DIFF
--- a/tools/fileconv/api2/README.md
+++ b/tools/fileconv/api2/README.md
@@ -1,0 +1,24 @@
+# Package api2
+
+## Purpose
+This package extracts schemas metadata from OpenAPI files version 2.
+If your OpenAPI file is using newer version 3 check out `api3` package.
+
+## Description
+
+Before extracting metadata from OpenAPI, the schema is initially converted from V2 to V3 format.
+For further details, refer to the `api3` package README, as the remaining process follows the same approach as `api3`.
+This pacakge acts as a gateway and a wrapper of `api3`.
+
+## Loading File
+
+```go
+var (
+    // Static file containing openapi spec.
+    //
+    //go:embed specs.json
+    apiFile []byte
+
+	FileManager = api2.NewOpenapiFileManager(apiFile) // nolint:gochecknoglobals
+)
+```

--- a/tools/fileconv/api2/manager.go
+++ b/tools/fileconv/api2/manager.go
@@ -1,0 +1,51 @@
+package api2
+
+import (
+	"encoding/json"
+
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi2conv"
+	"github.com/invopop/yaml"
+)
+
+// OpenapiFileManager locates openapi file.
+// Allows to read data of interest.
+// Use it when dealing with OpenAPI v2.
+type OpenapiFileManager struct {
+	file []byte
+}
+
+func NewOpenapiFileManager(file []byte) *OpenapiFileManager {
+	return &OpenapiFileManager{
+		file: file,
+	}
+}
+
+func (m OpenapiFileManager) GetExplorer(opts ...api3.Option) (*api3.Explorer, error) {
+	dataV2, err := parseV2(m.file)
+	if err != nil {
+		return nil, err
+	}
+
+	dataV3, err := openapi2conv.ToV3(dataV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return api3.NewExplorer(dataV3, opts...), nil
+}
+
+func parseV2(file []byte) (*openapi2.T, error) {
+	var data openapi2.T
+
+	if err := yaml.Unmarshal(file, &data); err != nil {
+		// YAML parsing failed. Fallback to JSON.
+		if err = json.Unmarshal(file, &data); err != nil {
+			// Cannot be parsed neither as YAML nor JSON.
+			return nil, err
+		}
+	}
+
+	return &data, nil
+}

--- a/tools/fileconv/api3/README.md
+++ b/tools/fileconv/api3/README.md
@@ -1,18 +1,32 @@
 # Package api3
 
 ## Purpose
-This package extracts schemas metadata from OpenAPI files.
+This package extracts schemas metadata from OpenAPI files version 3.
+If your OpenAPI file is using older version 2 check out `api2` package.
 
 ## Description
 Some connectors cannot serve metadata via APIs and do this via static files.
 Those files are a processed version of OpenAPI spec. 
+
+## Loading File
+
+```go
+var (
+    // Static file containing openapi spec.
+    //
+    //go:embed specs.json
+    apiFile []byte
+
+	FileManager = api3.NewOpenapiFileManager(apiFile) // nolint:gochecknoglobals
+)
+```
 
 ## Usage
 Scripts that use this package are located under `scripts/openapi/<connector_name>/main.go`.
 
 ```go
 // Pseudo code, omitting err.
-schemas = api3.NewOpenapiFileManager(openapiBytesDataFile).GetExplorer().GetBasicReadObjects(
+schemas = yourconnector.FileManager.GetExplorer().GetBasicReadObjects(
     ignoreEndpoints,
     objectEndpoints,
     displayNameOverride,

--- a/tools/fileconv/api3/manager.go
+++ b/tools/fileconv/api3/manager.go
@@ -6,6 +6,7 @@ import (
 
 // OpenapiFileManager locates openapi file.
 // Allows to read data of interest.
+// Use it when dealing with OpenAPI v3.
 type OpenapiFileManager struct {
 	file []byte
 }
@@ -24,10 +25,5 @@ func (m OpenapiFileManager) GetExplorer(opts ...Option) (*Explorer, error) {
 		return nil, err
 	}
 
-	return &Explorer{
-		schema: &Document{
-			delegate: data,
-		},
-		parameters: createParams(opts),
-	}, nil
+	return NewExplorer(data, opts...), nil
 }

--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common/handy"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // Explorer allows to traverse schema in most common ways
@@ -13,6 +14,17 @@ import (
 type Explorer struct {
 	schema *Document
 	*parameters
+}
+
+// NewExplorer creates explorer on openAPI v3 file.
+// See Option to discover how explorer can be customized.
+func NewExplorer(data *openapi3.T, opts ...Option) *Explorer {
+	return &Explorer{
+		schema: &Document{
+			delegate: data,
+		},
+		parameters: createParams(opts),
+	}
 }
 
 // ReadObjectsGet is the same as ReadObjectsGet but retrieves schemas for endpoints that perform reading via GET.


### PR DESCRIPTION
# Background

We have `api3` package as a tool to extract object schema for ListObjectMetadata and Read methods using OpenAPI V3 files.

# Description

This PR adds a simple way of supporting OpenAPI V2 by introducing package `api2` which first parses the file and converts from V2 to V3 producing `api3.Explorer`. Therefore, it acts as a wrapper utilizing the same processing logic as `api3.Explorer`.

The convertor is part of the library that I already use for dealing with OpenAPI.
Reference: https://github.com/getkin/kin-openapi

# Usage
Under provider package we create `openapi` repository holding json or yaml file with golang "wiring".
![image](https://github.com/user-attachments/assets/0c1f5d66-757a-41dd-bcc9-3028db781a01)
![image](https://github.com/user-attachments/assets/416904fc-db0c-4963-af00-193c4c5d1697)
If we want to treat it as version 2, simply change the pacakge:
![image](https://github.com/user-attachments/assets/5a5da8d9-51d5-4b26-a039-ca046d6f0484)
Everything else remains unchanged.

