### PR TITLE
feat: OpenAPI extract schema from Object or Array

### DIFF
--- a/scripts/openapi/gong/metadata/main.go
+++ b/scripts/openapi/gong/metadata/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewDenyPathStrategy(ignoreEndpoints),
-		nil, nil, api3.IdenticalObjectCheck,
+		nil, nil, api3.IdenticalObjectLocator,
 	)
 	must(err)
 

--- a/scripts/openapi/pipedrive/metadata/main.go
+++ b/scripts/openapi/pipedrive/metadata/main.go
@@ -70,7 +70,7 @@ func main() {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewDenyPathStrategy(ignoreEndpoints),
 		nil, displayName,
-		api3.DataObjectCheck)
+		api3.DataObjectLocator)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/scripts/openapi/pipeliner/metadata/main.go
+++ b/scripts/openapi/pipeliner/metadata/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewDenyPathStrategy(ignoreEndpoints),
-		nil, displayNameOverride, api3.DataObjectCheck,
+		nil, displayNameOverride, api3.DataObjectLocator,
 	)
 	must(err)
 

--- a/tools/fileconv/api3/README.md
+++ b/tools/fileconv/api3/README.md
@@ -30,7 +30,7 @@ schemas = yourconnector.FileManager.GetExplorer().GetBasicReadObjects(
     ignoreEndpoints,
     objectEndpoints,
     displayNameOverride,
-    objectCheck,
+    objectArrayLocator,
 )
 ```
 
@@ -46,10 +46,10 @@ Argument description:
   * By default, last URI part is used as Object Name.
 
 
-* **objectCheck** - function that accepts JSON response field and Object name. Using both you can determine 
+* **objectArrayLocator** - function that accepts JSON response field and Object name. Using both you can determine 
 if this is the correct response field that will hold your schema. Some common implementations are provided.
-  * api3.IdenticalObjectCheck - expects data to be stored under the same name as object name. Ex: {"contacts":[...]}
-  * api3.DataObjectCheck - expects schema to be returned under `data` field. Ex: {"data":[...]}
+  * api3.IdenticalObjectLocator - expects data to be stored under the same name as object name. Ex: {"contacts":[...]}
+  * api3.DataObjectLocator - expects schema to be returned under `data` field. Ex: {"data":[...]}
   * Your implementation can have exception or do combination of the two based on different objects.
 
 Additionally, Explorer can be configured to apply display name processing after data is extracted. For example, you can capitalize every word of display for better look.

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -7,23 +7,23 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// ObjectCheck is a procedure that decides if field name is related to the object name.
+// ObjectArrayLocator is a procedure that decides if field name is related to the object name.
 // Below you can find the common cases.
-type ObjectCheck func(objectName, fieldName string) bool
+type ObjectArrayLocator func(objectName, fieldName string) bool
 
-// IdenticalObjectCheck item schema within response is stored under matching object name.
+// IdenticalObjectLocator item schema within response is stored under matching object name.
 // Ex: requesting contacts will return payload with {"contacts":[...]}.
-func IdenticalObjectCheck(objectName, fieldName string) bool {
+func IdenticalObjectLocator(objectName, fieldName string) bool {
 	return fieldName == objectName
 }
 
-// DataObjectCheck item schema within response is always stored under the data field.
+// DataObjectLocator item schema within response is always stored under the data field.
 // Ex: requesting contacts or leads or users will return payload with {"data":[...]}.
-func DataObjectCheck(objectName, fieldName string) bool {
+func DataObjectLocator(objectName, fieldName string) bool {
 	return fieldName == "data"
 }
 
-// CustomMappingObjectCheck builds ObjectCheck using mapping,
+// CustomMappingObjectCheck builds ObjectArrayLocator using mapping,
 // which knows exceptions and patterns to determine response field name.
 //
 // Ex:
@@ -36,7 +36,7 @@ func DataObjectCheck(objectName, fieldName string) bool {
 //
 // This can be understood as follows: orders, carts, coupons REST resources will be found under JSON response field
 // matching "it's name", while the rest will be located under "data" field.
-func CustomMappingObjectCheck(dict handy.DefaultMap[string, string]) ObjectCheck {
+func CustomMappingObjectCheck(dict handy.DefaultMap[string, string]) ObjectArrayLocator {
 	return func(objectName, fieldName string) bool {
 		expected := dict.Get(objectName)
 

--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -35,9 +35,9 @@ func (e Explorer) ReadObjectsGet(
 	pathMatcher PathMatcher,
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
-	check ObjectCheck,
+	locator ObjectArrayLocator,
 ) (Schemas, error) {
-	return e.ReadObjects("GET", pathMatcher, objectEndpoints, displayNameOverride, check)
+	return e.ReadObjects("GET", pathMatcher, objectEndpoints, displayNameOverride, locator)
 }
 
 // ReadObjectsPost is the same as ReadObjectsGet but retrieves schemas for endpoints that perform reading via POST.
@@ -45,9 +45,9 @@ func (e Explorer) ReadObjectsPost(
 	pathMatcher PathMatcher,
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
-	check ObjectCheck,
+	locator ObjectArrayLocator,
 ) (Schemas, error) {
-	return e.ReadObjects("POST", pathMatcher, objectEndpoints, displayNameOverride, check)
+	return e.ReadObjects("POST", pathMatcher, objectEndpoints, displayNameOverride, locator)
 }
 
 // ReadObjects will explore OpenAPI file returning list of Schemas.
@@ -61,7 +61,7 @@ func (e Explorer) ReadObjectsPost(
 //	Note: deep connector would need to do the reverse mapping to reconstruct URL given orders objectName.
 //
 // displayNameOverride - objectName mapped to custom Display name.
-// check - callback that returns true if fieldName matched the target location of Object in response.
+// locator - callback that returns true if fieldName matched the target location of Object in response.
 // Ex: 	if (objectName == orders && fieldName == data) => true
 //
 //	Given response with fields {meta{}, data{}, pagination{}} for orders object,
@@ -71,13 +71,13 @@ func (e Explorer) ReadObjects(
 	pathMatcher PathMatcher,
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
-	check ObjectCheck,
+	locator ObjectArrayLocator,
 ) (Schemas, error) {
 	schemas := make(Schemas, 0)
 
 	for _, path := range e.GetPathItems(pathMatcher, objectEndpoints) {
 		schema, found, err := path.RetrieveSchemaOperation(operationName,
-			displayNameOverride, check, e.displayPostProcessing, e.parameterFilter,
+			displayNameOverride, locator, e.displayPostProcessing, e.parameterFilter,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Background

OpenAPI tool using response object schema, locates the field that holds an array and uses that schema to describe object that we return during Read/ListObjectMetadata.

# Changes

* Response schema might already be a an array, so there is no need for this extra "locate" step. We need to extract fields from current `array-item schema`.
* `ObjectCheck` was renamed to `ObjectArrayLocator`. Array holder would use this callback to find field name, ex (product schema is located under products response field): 
```json
{
  "field1":[{}, {}, {}],
  "field2":{...},
  "products":[],
  "field3":{},
}
```
A direct return of `[ {product1},  {product2},  {product3}, ]` doesn't need `ObjectArrayLocator`.

# TLDR
Array of objects is either returned directly or part of top level object under some field name resolved by `ObjectArrayLocator`.
Added support to arrays as top level JSON node.
![image](https://github.com/user-attachments/assets/71a21472-9cd3-47e1-8087-8ab908aba169)

