### PR TITLE
feat: ConstantContact (Read)

### DIFF
--- a/providers/constantcontact/client.go
+++ b/providers/constantcontact/client.go
@@ -1,0 +1,18 @@
+package constantcontact
+
+import (
+	"github.com/amp-labs/connectors/common"
+)
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/providers/constantcontact/connector.go
+++ b/providers/constantcontact/connector.go
@@ -1,0 +1,73 @@
+package constantcontact
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/constantcontact/metadata"
+)
+
+const ApiVersion = "v3"
+
+type Connector struct {
+	BaseURL string
+	Client  *common.JSONHTTPClient
+	Module  common.Module
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := params.Client.Caller
+	conn = &Connector{
+		Client: &common.JSONHTTPClient{
+			HTTPClient: httpClient,
+		},
+	}
+
+	// Read provider info
+	providerInfo, err := providers.ReadInfo(conn.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	// connector and its client must mirror base url and provide its own error parser
+	conn.setBaseURL(providerInfo.BaseURL)
+	conn.Client.HTTPClient.ErrorHandler = interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
+	return conn, nil
+}
+
+func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.BaseURL, ApiVersion, path)
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return providers.ConstantContact
+}
+
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}

--- a/providers/constantcontact/errors.go
+++ b/providers/constantcontact/errors.go
@@ -1,0 +1,26 @@
+package constantcontact
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ErrorDetails{} },
+		},
+	}...,
+)
+
+// nolint:tagliatelle
+type ErrorDetails struct {
+	Key     string `json:"error_key"`
+	Message string `json:"error_message"`
+}
+
+func (r ErrorDetails) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, r.Message)
+}

--- a/providers/constantcontact/metadata/schemas.json
+++ b/providers/constantcontact/metadata/schemas.json
@@ -1,0 +1,208 @@
+{
+  "modules": {
+    "root": {
+      "id": "root",
+      "path": "",
+      "objects": {
+        "account_emails": {
+          "displayName": "Account Emails",
+          "path": "/account/emails",
+          "responseKey": "",
+          "fields": {
+            "confirm_source_type": "confirm_source_type",
+            "confirm_status": "confirm_status",
+            "confirm_time": "confirm_time",
+            "email_address": "email_address",
+            "email_id": "email_id",
+            "pending_roles": "pending_roles",
+            "roles": "roles"
+          }
+        },
+        "accounts": {
+          "displayName": "Accounts",
+          "path": "/partner/accounts",
+          "responseKey": "site_owner_list",
+          "fields": {
+            "billing_status": "billing_status",
+            "encoded_account_id": "encoded_account_id",
+            "last_login_date": "last_login_date",
+            "organization_name": "organization_name",
+            "site_owner_name": "site_owner_name",
+            "subscriber_count": "subscriber_count"
+          }
+        },
+        "activities": {
+          "displayName": "Activities",
+          "path": "/activities",
+          "responseKey": "activities",
+          "fields": {
+            "_links": "_links",
+            "activity_errors": "activity_errors",
+            "activity_id": "activity_id",
+            "completed_at": "completed_at",
+            "created_at": "created_at",
+            "percent_done": "percent_done",
+            "source_file_name": "source_file_name",
+            "started_at": "started_at",
+            "state": "state",
+            "status": "status",
+            "updated_at": "updated_at"
+          }
+        },
+        "campaign_id_xrefs": {
+          "displayName": "Email Campaign Identifiers",
+          "path": "/emails/campaign_id_xrefs",
+          "responseKey": "xrefs",
+          "fields": {
+            "campaign_activity_id": "campaign_activity_id",
+            "campaign_id": "campaign_id",
+            "v2_email_campaign_id": "v2_email_campaign_id"
+          }
+        },
+        "contact_custom_fields": {
+          "displayName": "Contact Custom Fields",
+          "path": "/contact_custom_fields",
+          "responseKey": "custom_fields",
+          "fields": {
+            "created_at": "created_at",
+            "custom_field_id": "custom_field_id",
+            "label": "label",
+            "name": "name",
+            "type": "type",
+            "updated_at": "updated_at"
+          }
+        },
+        "contact_id_xrefs": {
+          "displayName": "Contact Identifiers",
+          "path": "/contacts/contact_id_xrefs",
+          "responseKey": "xrefs",
+          "fields": {
+            "contact_id": "contact_id",
+            "sequence_id": "sequence_id"
+          }
+        },
+        "contact_lists": {
+          "displayName": "Contact Lists",
+          "path": "/contact_lists",
+          "responseKey": "lists",
+          "fields": {
+            "created_at": "created_at",
+            "deleted_at": "deleted_at",
+            "description": "description",
+            "favorite": "favorite",
+            "list_id": "list_id",
+            "membership_count": "membership_count",
+            "name": "name",
+            "updated_at": "updated_at"
+          }
+        },
+        "contact_tags": {
+          "displayName": "Contact Tags",
+          "path": "/contact_tags",
+          "responseKey": "tags",
+          "fields": {
+            "contacts_count": "contacts_count",
+            "created_at": "created_at",
+            "name": "name",
+            "tag_id": "tag_id",
+            "tag_source": "tag_source",
+            "updated_at": "updated_at"
+          }
+        },
+        "contacts": {
+          "displayName": "Contacts",
+          "path": "/contacts",
+          "responseKey": "contacts",
+          "fields": {
+            "anniversary": "anniversary",
+            "birthday_day": "birthday_day",
+            "birthday_month": "birthday_month",
+            "company_name": "company_name",
+            "contact_id": "contact_id",
+            "create_source": "create_source",
+            "created_at": "created_at",
+            "custom_fields": "custom_fields",
+            "deleted_at": "deleted_at",
+            "email_address": "email_address",
+            "first_name": "first_name",
+            "job_title": "job_title",
+            "last_name": "last_name",
+            "list_memberships": "list_memberships",
+            "notes": "notes",
+            "phone_numbers": "phone_numbers",
+            "sms_channel": "sms_channel",
+            "street_addresses": "street_addresses",
+            "taggings": "taggings",
+            "update_source": "update_source",
+            "updated_at": "updated_at"
+          }
+        },
+        "email_campaign_summaries": {
+          "displayName": "Email Campaign Summaries",
+          "path": "/reports/summary_reports/email_campaign_summaries",
+          "responseKey": "bulk_email_campaign_summaries",
+          "fields": {
+            "campaign_id": "campaign_id",
+            "campaign_type": "campaign_type",
+            "last_sent_date": "last_sent_date",
+            "unique_counts": "unique_counts"
+          }
+        },
+        "email_campaigns": {
+          "displayName": "Email Campaigns",
+          "path": "/emails",
+          "responseKey": "campaigns",
+          "fields": {
+            "campaign_id": "campaign_id",
+            "created_at": "created_at",
+            "current_status": "current_status",
+            "name": "name",
+            "type": "type",
+            "type_code": "type_code",
+            "updated_at": "updated_at"
+          }
+        },
+        "list_id_xrefs": {
+          "displayName": "List Identifiers",
+          "path": "/contact_lists/list_id_xrefs",
+          "responseKey": "xrefs",
+          "fields": {
+            "list_id": "list_id",
+            "sequence_id": "sequence_id"
+          }
+        },
+        "privileges": {
+          "displayName": "Privileges",
+          "path": "/account/user/privileges",
+          "responseKey": "",
+          "fields": {
+            "privilege_id": "privilege_id",
+            "privilege_name": "privilege_name"
+          }
+        },
+        "segments": {
+          "displayName": "Segments",
+          "path": "/segments",
+          "responseKey": "segments",
+          "fields": {
+            "created_at": "created_at",
+            "edited_at": "edited_at",
+            "name": "name",
+            "segment_id": "segment_id"
+          }
+        },
+        "subscriptions": {
+          "displayName": "Subscriptions",
+          "path": "/partner/webhooks/subscriptions",
+          "responseKey": "",
+          "fields": {
+            "hook_uri": "hook_uri",
+            "topic_description": "topic_description",
+            "topic_id": "topic_id",
+            "topic_name": "topic_name"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/constantcontact/metadata/scraping.go
+++ b/providers/constantcontact/metadata/scraping.go
@@ -1,0 +1,20 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/constantcontact/objectNames.go
+++ b/providers/constantcontact/objectNames.go
@@ -1,0 +1,29 @@
+package constantcontact
+
+import (
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/constantcontact/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
+
+// ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
+var ObjectNameToResponseField = datautils.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
+	"campaign_id_xrefs":        "xrefs",
+	"contact_id_xrefs":         "xrefs",
+	"list_id_xrefs":            "xrefs",
+	"accounts":                 "site_owner_list",
+	"email_campaign_summaries": "bulk_email_campaign_summaries",
+	"contact_tags":             "tags",
+	"contact_lists":            "lists",
+	"contact_custom_fields":    "custom_fields",
+	"email_campaigns":          "campaigns",
+	"account_emails":           "", // response is already an array, empty refers to current
+	"privileges":               "",
+	"subscriptions":            "",
+},
+	func(objectName string) (fieldName string) {
+		return objectName
+	},
+)

--- a/providers/constantcontact/params.go
+++ b/providers/constantcontact/params.go
@@ -1,0 +1,41 @@
+package constantcontact
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"golang.org/x/oauth2"
+)
+
+// DefaultPageSize is number of elements per page.
+const DefaultPageSize = 50
+
+// Option is a function which mutates the connector configuration.
+type Option = func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
+) Option {
+	return func(params *parameters) {
+		params.WithOauthClient(ctx, client, config, token, opts...)
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
+	}
+}

--- a/providers/constantcontact/parse.go
+++ b/providers/constantcontact/parse.go
@@ -1,0 +1,37 @@
+package constantcontact
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/spyzhov/ajson"
+)
+
+func makeNextRecordsURL(baseURL string) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		href, err := jsonquery.New(node, "_links", "next").StrWithDefault("href", "")
+		if err != nil {
+			return "", err
+		}
+
+		if len(href) == 0 {
+			// Next page doesn't exist
+			return "", nil
+		}
+
+		fullURL := baseURL + href
+
+		url, err := urlbuilder.New(fullURL)
+		if err != nil {
+			return "", err
+		}
+
+		// Cursor is base64 encoded,
+		// therefore it may contain symbols that should be exempt from escaping.
+		url.AddEncodingExceptions(map[string]string{
+			"%3D": "=",
+		})
+
+		return url.String(), nil
+	}
+}

--- a/providers/constantcontact/read.go
+++ b/providers/constantcontact/read.go
@@ -1,0 +1,36 @@
+package constantcontact
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if err := config.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	url, err := c.getURL(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	responseFieldName := ObjectNameToResponseField.Get(config.ObjectName)
+
+	return common.ParseResult(res,
+		common.GetOptionalRecordsUnderJSONPath(responseFieldName),
+		makeNextRecordsURL(c.BaseURL),
+		common.GetMarshaledData,
+		config.Fields,
+	)
+}

--- a/providers/constantcontact/read_test.go
+++ b/providers/constantcontact/read_test.go
@@ -1,0 +1,151 @@
+package constantcontact
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseContactIDsError := testutils.DataFromFile(t, "read-contact-ids-error.json")
+	responseContactsFirstPage := testutils.DataFromFile(t, "read-contacts-1-first-page.json")
+	responseContactsLastPage := testutils.DataFromFile(t, "read-contacts-2-second-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "activities"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.ReadParams{ObjectName: "orders", Fields: connectors.Fields("id")},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+		{
+			Name:  "Error response is parsed",
+			Input: common.ReadParams{ObjectName: "contact_id_xrefs", Fields: connectors.Fields("contact_id")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseContactIDsError),
+			}.Server(),
+			ExpectedErrs: []error{
+				errors.New("Sequence ID is invalid."), // nolint:goerr113
+				common.ErrBadRequest,
+			},
+		},
+		{
+			Name: "Read contacts first page",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("first_name", "last_name"),
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseContactsFirstPage),
+			}.Server(),
+			Comparator: readComparator,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"first_name": "Debora",
+						"last_name":  "Lang",
+					},
+					Raw: map[string]any{
+						"company_name": "Acme Corp.",
+						"contact_id":   "af73e650-96f0-11ef-b2a0-fa163eafb85e",
+					},
+				}},
+				NextPage: "{{testServerURL}}/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read contacts second page without next cursor",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("first_name", "last_name"),
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseContactsLastPage),
+			}.Server(),
+			Comparator: readComparator,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"first_name": "John",
+						"last_name":  "Doe",
+					},
+					Raw: map[string]any{
+						"create_source": "Account",
+						"contact_id":    "832444c0-4392-11ef-95d3-fa163e761ca9",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
+}
+
+func readComparator(baseURL string, actual, expected *common.ReadResult) bool {
+	expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
+
+	return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+		mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+		actual.NextPage.String() == expectedNextPage &&
+		actual.Rows == expected.Rows &&
+		actual.Done == expected.Done
+}

--- a/providers/constantcontact/test/read-contact-ids-error.json
+++ b/providers/constantcontact/test/read-contact-ids-error.json
@@ -1,0 +1,6 @@
+[
+  {
+    "error_key": "contacts.api.bad_request",
+    "error_message": "Sequence ID is invalid."
+  }
+]

--- a/providers/constantcontact/test/read-contacts-1-first-page.json
+++ b/providers/constantcontact/test/read-contacts-1-first-page.json
@@ -1,0 +1,31 @@
+{
+  "contacts": [
+    {
+      "contact_id": "af73e650-96f0-11ef-b2a0-fa163eafb85e",
+      "email_address": {
+        "address": "dlang@example.com",
+        "permission_to_send": "implicit",
+        "created_at": "2024-10-30T18:56:35Z",
+        "updated_at": "2024-10-30T18:56:35Z",
+        "opt_in_source": "Account",
+        "opt_in_date": "2024-10-30T18:56:35Z",
+        "confirm_status": "off"
+      },
+      "first_name": "Debora",
+      "last_name": "Lang",
+      "job_title": "Musician",
+      "company_name": "Acme Corp.",
+      "birthday_month": 11,
+      "birthday_day": 24,
+      "anniversary": "2006-11-15",
+      "create_source": "Account",
+      "created_at": "2024-10-30T18:56:35Z",
+      "updated_at": "2024-10-30T18:56:35Z"
+    }
+  ],
+  "_links": {
+    "next": {
+      "href": "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI="
+    }
+  }
+}

--- a/providers/constantcontact/test/read-contacts-2-second-page.json
+++ b/providers/constantcontact/test/read-contacts-2-second-page.json
@@ -1,0 +1,23 @@
+{
+  "contacts": [
+    {
+      "contact_id": "832444c0-4392-11ef-95d3-fa163e761ca9",
+      "email_address": {
+        "address": "john.doe@withampersand.com",
+        "permission_to_send": "implicit",
+        "created_at": "2024-07-16T16:43:21Z",
+        "updated_at": "2024-07-16T16:43:21Z",
+        "opt_in_source": "Account",
+        "opt_in_date": "2024-07-16T16:43:21Z",
+        "confirm_status": "off"
+      },
+      "first_name": "John",
+      "last_name": "Doe",
+      "update_source": "Account",
+      "create_source": "Account",
+      "created_at": "2024-07-16T16:43:21Z",
+      "updated_at": "2024-07-16T16:43:21Z"
+    }
+  ],
+  "_links": {}
+}

--- a/test/constantcontact/connector.go
+++ b/test/constantcontact/connector.go
@@ -1,0 +1,46 @@
+package journeysapp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/constantcontact"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetConstantContactConnector(ctx context.Context) *constantcontact.Connector {
+	filePath := credscanning.LoadPath(providers.ConstantContact)
+	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+
+	conn, err := constantcontact.NewConnector(
+		constantcontact.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail("error creating Constant Contract connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://authz.constantcontact.com/oauth2/default/v1/authorize",
+			TokenURL:  "https://authz.constantcontact.com/oauth2/default/v1/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		RedirectURL: "http://localhost:8080/callbacks/v1/oauth",
+		Scopes: []string{
+			"account_read",
+			"account_update",
+			"contact_data",
+			"offline_access",
+			"campaign_data",
+		},
+	}
+}

--- a/test/constantcontact/read/main.go
+++ b/test/constantcontact/read/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/constantcontact"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetConstantContactConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("first_name"),
+	})
+	if err != nil {
+		utils.Fail("error reading from ConstantContact", "error", err)
+	}
+
+	slog.Info("Reading contacts..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Description

Mock tests demonstrate the reading of contacts, pagination using an optional href, and handling of erroneous responses represented as an array.

schema.json is created using OpenAPI file. This file will be added in different PR focusing on ListObjectMetadata.

# Response

![image](https://github.com/user-attachments/assets/6a84f18f-4769-4fdf-befe-22923dd26785)
![image](https://github.com/user-attachments/assets/e5f18343-fc30-46a1-9e22-3f1e878aee4f)
