### PR TITLE
tidy: Store JSON array path in schema.json

### DIFF
--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -41,6 +41,9 @@ type Object struct {
 	// It can be used to make request to "list objects".
 	URLPath string `json:"path"`
 
+	// A field name where the object is located within provider response.
+	ResponseKey string `json:"responseKey"`
+
 	// FieldsMap is a map of field names to field display names
 	FieldsMap map[string]string `json:"fields"`
 
@@ -52,7 +55,7 @@ type Object struct {
 // NOTE: empty module id is treated as root module.
 func (r *Metadata) Add(
 	moduleID common.ModuleID,
-	objectName, objectDisplayName, fieldName, urlPath string,
+	objectName, objectDisplayName, fieldName, urlPath, responseKey string,
 	docsURL *string,
 ) {
 	moduleID = moduleIdentifier(moduleID)
@@ -64,6 +67,7 @@ func (r *Metadata) Add(
 		data = Object{
 			DisplayName: objectDisplayName,
 			URLPath:     urlPath,
+			ResponseKey: responseKey,
 			FieldsMap:   make(map[string]string),
 			DocsURL:     docsURL,
 		}
@@ -168,6 +172,16 @@ func (r *Metadata) ModuleRegistry() common.Modules {
 	}
 
 	return result
+}
+
+// LookupArrayFieldName will give you the field name which holds the array of objects in provider response.
+// Ex: CustomerSubscriptions is located under field name subscriptions => { "subscriptions": [{},{},{}] }.
+func (r *Metadata) LookupArrayFieldName(moduleID common.ModuleID, objectName string) (string, error) {
+	moduleID = moduleIdentifier(moduleID)
+
+	fieldName := r.Modules[moduleID].Objects[objectName].ResponseKey
+
+	return fieldName, nil
 }
 
 func (m *Module) withPath(path string) {

--- a/providers/customerapp/metadata/schemas.json
+++ b/providers/customerapp/metadata/schemas.json
@@ -7,6 +7,7 @@
         "activities": {
           "displayName": "Activities",
           "path": "/activities",
+          "responseKey": "activities",
           "fields": {
             "customer_id": "customer_id",
             "customer_identifiers": "customer_identifiers",
@@ -21,6 +22,7 @@
         "broadcasts": {
           "displayName": "Broadcasts",
           "path": "/broadcasts",
+          "responseKey": "broadcasts",
           "fields": {
             "actions": "actions",
             "active": "active",
@@ -39,6 +41,7 @@
         "collections": {
           "displayName": "Collections",
           "path": "/collections",
+          "responseKey": "collections",
           "fields": {
             "bytes": "bytes",
             "created_at": "created_at",
@@ -52,6 +55,7 @@
         "exports": {
           "displayName": "Exports",
           "path": "/exports",
+          "responseKey": "exports",
           "fields": {
             "created_at": "created_at",
             "deduplicate_id": "deduplicate_id",
@@ -70,6 +74,7 @@
         "messages": {
           "displayName": "Messages",
           "path": "/messages",
+          "responseKey": "messages",
           "fields": {
             "action_id": "action_id",
             "broadcast_id": "broadcast_id",
@@ -95,6 +100,7 @@
         "newsletters": {
           "displayName": "Newsletters",
           "path": "/newsletters",
+          "responseKey": "newsletters",
           "fields": {
             "content_ids": "content_ids",
             "created": "created",
@@ -112,6 +118,7 @@
         "object_types": {
           "displayName": "Object Types",
           "path": "/object_types",
+          "responseKey": "types",
           "fields": {
             "enabled": "enabled",
             "icon": "icon",
@@ -125,6 +132,7 @@
         "reporting_webhooks": {
           "displayName": "Reporting Webhooks",
           "path": "/reporting_webhooks",
+          "responseKey": "reporting_webhooks",
           "fields": {
             "disabled": "disabled",
             "endpoint": "endpoint",
@@ -138,6 +146,7 @@
         "segments": {
           "displayName": "Segments",
           "path": "/segments",
+          "responseKey": "segments",
           "fields": {
             "deduplicate_id": "deduplicate_id",
             "description": "description",
@@ -152,6 +161,7 @@
         "sender_identities": {
           "displayName": "Sender Identities",
           "path": "/sender_identities",
+          "responseKey": "sender_identities",
           "fields": {
             "address": "address",
             "auto_generated": "auto_generated",
@@ -165,6 +175,7 @@
         "snippets": {
           "displayName": "Snippets",
           "path": "/snippets",
+          "responseKey": "snippets",
           "fields": {
             "name": "name",
             "updated_at": "updated_at",
@@ -174,6 +185,7 @@
         "subscription_topics": {
           "displayName": "Subscription Topics",
           "path": "/subscription_topics",
+          "responseKey": "topics",
           "fields": {
             "description": "description",
             "id": "id",
@@ -185,6 +197,7 @@
         "transactional": {
           "displayName": "Transactional",
           "path": "/transactional",
+          "responseKey": "messages",
           "fields": {
             "created_at": "created_at",
             "description": "description",
@@ -201,6 +214,7 @@
         "workspaces": {
           "displayName": "Workspaces",
           "path": "/workspaces",
+          "responseKey": "workspaces",
           "fields": {
             "billable_messages_sent": "billable_messages_sent",
             "id": "id",

--- a/providers/gong/metadata/schemas.json
+++ b/providers/gong/metadata/schemas.json
@@ -7,6 +7,7 @@
         "calls": {
           "displayName": "Calls",
           "path": "/calls",
+          "responseKey": "calls",
           "fields": {
             "calendarEventId": "calendarEventId",
             "clientUniqueId": "clientUniqueId",
@@ -33,6 +34,7 @@
         "users": {
           "displayName": "Users",
           "path": "/users",
+          "responseKey": "users",
           "fields": {
             "active": "active",
             "created": "created",
@@ -55,6 +57,7 @@
         "workspaces": {
           "displayName": "Workspaces",
           "path": "/workspaces",
+          "responseKey": "workspaces",
           "fields": {
             "description": "description",
             "id": "id",

--- a/providers/intercom/metadata/schemas.json
+++ b/providers/intercom/metadata/schemas.json
@@ -7,6 +7,7 @@
         "activity_logs": {
           "displayName": "Activity Logs",
           "path": "/admins/activity_logs",
+          "responseKey": "activity_logs",
           "fields": {
             "activity_description": "activity_description",
             "activity_type": "activity_type",
@@ -19,6 +20,7 @@
         "admins": {
           "displayName": "Admins",
           "path": "/admins",
+          "responseKey": "admins",
           "fields": {
             "avatar": "avatar",
             "away_mode_enabled": "away_mode_enabled",
@@ -36,6 +38,7 @@
         "articles": {
           "displayName": "Articles",
           "path": "/articles",
+          "responseKey": "data",
           "fields": {
             "author_id": "author_id",
             "body": "body",
@@ -58,6 +61,7 @@
         "collections": {
           "displayName": "Collections",
           "path": "/help_center/collections",
+          "responseKey": "data",
           "fields": {
             "created_at": "created_at",
             "default_locale": "default_locale",
@@ -77,6 +81,7 @@
         "companies": {
           "displayName": "Companies",
           "path": "/companies",
+          "responseKey": "data",
           "fields": {
             "app_id": "app_id",
             "company_id": "company_id",
@@ -102,6 +107,7 @@
         "contacts": {
           "displayName": "Contacts",
           "path": "/contacts",
+          "responseKey": "data",
           "fields": {
             "android_app_name": "android_app_name",
             "android_app_version": "android_app_version",
@@ -154,6 +160,7 @@
         "conversations": {
           "displayName": "Conversations",
           "path": "/conversations/search",
+          "responseKey": "conversations",
           "fields": {
             "admin_assignee_id": "admin_assignee_id",
             "ai_agent": "ai_agent",
@@ -186,6 +193,7 @@
         "data_attributes": {
           "displayName": "Data Attributes",
           "path": "/data_attributes",
+          "responseKey": "data",
           "fields": {
             "admin_id": "admin_id",
             "api_writable": "api_writable",
@@ -209,6 +217,7 @@
         "events": {
           "displayName": "Data Event Summary",
           "path": "/events",
+          "responseKey": "events",
           "fields": {
             "count": "count",
             "description": "description",
@@ -220,6 +229,7 @@
         "help_centers": {
           "displayName": "Help Centers",
           "path": "/help_center/help_centers",
+          "responseKey": "data",
           "fields": {
             "created_at": "created_at",
             "display_name": "display_name",
@@ -233,6 +243,7 @@
         "news_items": {
           "displayName": "News Items",
           "path": "/news/news_items",
+          "responseKey": "data",
           "fields": {
             "body": "body",
             "cover_image_url": "cover_image_url",
@@ -254,6 +265,7 @@
         "newsfeeds": {
           "displayName": "Newsfeeds",
           "path": "/news/newsfeeds",
+          "responseKey": "data",
           "fields": {
             "body": "body",
             "cover_image_url": "cover_image_url",
@@ -275,6 +287,7 @@
         "segments": {
           "displayName": "Segments",
           "path": "/segments",
+          "responseKey": "segments",
           "fields": {
             "count": "count",
             "created_at": "created_at",
@@ -288,6 +301,7 @@
         "subscription_types": {
           "displayName": "Subscription Types",
           "path": "/subscription_types",
+          "responseKey": "data",
           "fields": {
             "consent_type": "consent_type",
             "content_types": "content_types",
@@ -301,6 +315,7 @@
         "tags": {
           "displayName": "Tags",
           "path": "/tags",
+          "responseKey": "data",
           "fields": {
             "applied_at": "applied_at",
             "applied_by": "applied_by",
@@ -312,6 +327,7 @@
         "teams": {
           "displayName": "Teams",
           "path": "/teams",
+          "responseKey": "teams",
           "fields": {
             "admin_ids": "admin_ids",
             "admin_priority_level": "admin_priority_level",
@@ -323,6 +339,7 @@
         "ticket_types": {
           "displayName": "Ticket Types",
           "path": "/ticket_types",
+          "responseKey": "ticket_types",
           "fields": {
             "archived": "archived",
             "category": "category",
@@ -340,6 +357,7 @@
         "tickets": {
           "displayName": "Tickets",
           "path": "/tickets/search",
+          "responseKey": "tickets",
           "fields": {
             "admin_assignee_id": "admin_assignee_id",
             "category": "category",

--- a/providers/marketo/metadata/schemas.json
+++ b/providers/marketo/metadata/schemas.json
@@ -7,6 +7,7 @@
         "activities": {
           "displayName": "activities",
           "path": "/activities",
+          "responseKey": "",
           "fields": {
             "activityDate": "activityDate",
             "activityTypeId": "activityTypeId",
@@ -22,6 +23,7 @@
         "campaigns": {
           "displayName": "campaigns",
           "path": "/campaigns",
+          "responseKey": "",
           "fields": {
             "active": "active",
             "createdAt": "createdAt",
@@ -38,6 +40,7 @@
         "channels": {
           "displayName": "channels",
           "path": "/channels",
+          "responseKey": "",
           "fields": {
             "applicableProgramType": "applicableProgramType",
             "createdAt": "createdAt",
@@ -50,6 +53,7 @@
         "companies": {
           "displayName": "companies",
           "path": "/companies",
+          "responseKey": "",
           "fields": {
             "id": "id",
             "reasons": "reasons",
@@ -60,6 +64,7 @@
         "customobjects": {
           "displayName": "customobjects",
           "path": "/customobjects",
+          "responseKey": "",
           "fields": {
             "apiName": "apiName",
             "createdAt": "createdAt",
@@ -79,6 +84,7 @@
         "emailTemplates": {
           "displayName": "emailTemplates",
           "path": "/emailTemplates",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -95,6 +101,7 @@
         "emails": {
           "displayName": "emails",
           "path": "/emails",
+          "responseKey": "",
           "fields": {
             "autoCopyToText": "autoCopyToText",
             "ccFields": "ccFields",
@@ -123,6 +130,7 @@
         "files": {
           "displayName": "files",
           "path": "/files",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -138,6 +146,7 @@
         "folders": {
           "displayName": "folders",
           "path": "/folders",
+          "responseKey": "",
           "fields": {
             "accessZoneId": "accessZoneId",
             "createdAt": "createdAt",
@@ -158,6 +167,7 @@
         "forms": {
           "displayName": "forms",
           "path": "/forms",
+          "responseKey": "",
           "fields": {
             "buttonLabel": "buttonLabel",
             "buttonLocation": "buttonLocation",
@@ -184,6 +194,7 @@
         "landingPageDomains": {
           "displayName": "landingPageDomains",
           "path": "/landingPageDomains",
+          "responseKey": "",
           "fields": {
             "hostname": "hostname",
             "type": "type"
@@ -192,6 +203,7 @@
         "landingPageTemplates": {
           "displayName": "landingPageTemplates",
           "path": "/landingPageTemplates",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -209,6 +221,7 @@
         "landingPages": {
           "displayName": "landingPages",
           "path": "/landingPages",
+          "responseKey": "",
           "fields": {
             "URL": "URL",
             "computedUrl": "computedUrl",
@@ -233,6 +246,7 @@
         "leads": {
           "displayName": "leads",
           "path": "/leads",
+          "responseKey": "",
           "fields": {
             "id": "id",
             "membership": "membership",
@@ -243,6 +257,7 @@
         "lists": {
           "displayName": "lists",
           "path": "/lists",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -256,6 +271,7 @@
         "namedAccountLists": {
           "displayName": "namedAccountLists",
           "path": "/namedAccountLists",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "marketoGUID": "marketoGUID",
@@ -271,6 +287,7 @@
         "namedaccounts": {
           "displayName": "namedaccounts",
           "path": "/namedaccounts",
+          "responseKey": "",
           "fields": {
             "marketoGUID": "marketoGUID",
             "reasons": "reasons",
@@ -281,6 +298,7 @@
         "opportunities": {
           "displayName": "opportunities",
           "path": "/opportunities",
+          "responseKey": "",
           "fields": {
             "marketoGUID": "marketoGUID",
             "reasons": "reasons",
@@ -290,6 +308,7 @@
         "programs": {
           "displayName": "programs",
           "path": "/programs",
+          "responseKey": "",
           "fields": {
             "channel": "channel",
             "createdAt": "createdAt",
@@ -309,6 +328,7 @@
         "redirectRules": {
           "displayName": "redirectRules",
           "path": "/redirectRules",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "hostname": "hostname",
@@ -323,6 +343,7 @@
         "salespersons": {
           "displayName": "salespersons",
           "path": "/salespersons",
+          "responseKey": "",
           "fields": {
             "id": "id",
             "reasons": "reasons",
@@ -333,6 +354,7 @@
         "segmentation": {
           "displayName": "segmentation",
           "path": "/segmentation",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -348,6 +370,7 @@
         "smartCampaigns": {
           "displayName": "smartCampaigns",
           "path": "/smartCampaigns",
+          "responseKey": "",
           "fields": {
             "computedUrl": "computedUrl",
             "createdAt": "createdAt",
@@ -376,6 +399,7 @@
         "smartLists": {
           "displayName": "smartLists",
           "path": "/smartLists",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -390,6 +414,7 @@
         "snippets": {
           "displayName": "snippets",
           "path": "/snippets",
+          "responseKey": "",
           "fields": {
             "createdAt": "createdAt",
             "description": "description",
@@ -405,6 +430,7 @@
         "staticLists": {
           "displayName": "staticLists",
           "path": "/staticLists",
+          "responseKey": "",
           "fields": {
             "computedUrl": "computedUrl",
             "createdAt": "createdAt",
@@ -420,6 +446,7 @@
         "tagTypes": {
           "displayName": "tagTypes",
           "path": "/tagTypes",
+          "responseKey": "",
           "fields": {
             "applicableProgramTypes": "applicableProgramTypes",
             "required": "required",

--- a/providers/pipedrive/metadata/schemas.json
+++ b/providers/pipedrive/metadata/schemas.json
@@ -7,6 +7,7 @@
         "activities": {
           "displayName": "Activities",
           "path": "/activities",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -74,6 +75,7 @@
         "activityFields": {
           "displayName": "Activity Fields",
           "path": "/activityFields",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -104,6 +106,7 @@
         "activityTypes": {
           "displayName": "Activity Types",
           "path": "/activityTypes",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -120,6 +123,7 @@
         "callLogs": {
           "displayName": "Call Logs",
           "path": "/callLogs",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "company_id": "company_id",
@@ -142,21 +146,29 @@
         },
         "collection": {
           "displayName": "collection",
-          "path": "/persons/collection",
+          "path": "/organizations/collection",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
+            "address": "address",
+            "address_admin_area_level_1": "address_admin_area_level_1",
+            "address_admin_area_level_2": "address_admin_area_level_2",
+            "address_country": "address_country",
+            "address_formatted_address": "address_formatted_address",
+            "address_locality": "address_locality",
+            "address_postal_code": "address_postal_code",
+            "address_route": "address_route",
+            "address_street_number": "address_street_number",
+            "address_sublocality": "address_sublocality",
+            "address_subpremise": "address_subpremise",
             "cc_email": "cc_email",
             "delete_time": "delete_time",
-            "email": "email",
             "id": "id",
             "label": "label",
             "label_ids": "label_ids",
             "name": "name",
-            "org_id": "org_id",
             "owner_id": "owner_id",
-            "phone": "phone",
-            "picture_id": "picture_id",
             "update_time": "update_time",
             "visible_to": "visible_to"
           }
@@ -164,6 +176,7 @@
         "currencies": {
           "displayName": "Currencies",
           "path": "/currencies",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "code": "code",
@@ -177,6 +190,7 @@
         "deals": {
           "displayName": "Deals",
           "path": "/deals",
+          "responseKey": "data",
           "fields": {
             "active": "active",
             "activities_count": "activities_count",
@@ -250,6 +264,7 @@
         "files": {
           "displayName": "Files",
           "path": "/files",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "activity_id": "activity_id",
@@ -284,6 +299,7 @@
         "filters": {
           "displayName": "Filters",
           "path": "/filters",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -299,6 +315,7 @@
         "leadLabels": {
           "displayName": "Lead Labels",
           "path": "/leadLabels",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "color": "color",
@@ -310,6 +327,7 @@
         "leadSources": {
           "displayName": "Lead Sources",
           "path": "/leadSources",
+          "responseKey": "data",
           "fields": {
             "name": "name"
           }
@@ -317,6 +335,7 @@
         "leads": {
           "displayName": "Leads",
           "path": "/leads",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "cc_email": "cc_email",
@@ -344,6 +363,7 @@
         "legacyTeams": {
           "displayName": "Legacy Teams",
           "path": "/legacyTeams",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -359,6 +379,7 @@
         "mailThreads": {
           "displayName": "Mail Threads",
           "path": "/mailbox/mailThreads",
+          "responseKey": "data",
           "fields": {
             "account_id": "account_id",
             "add_time": "add_time",
@@ -402,6 +423,7 @@
         "noteFields": {
           "displayName": "Note Fields",
           "path": "/noteFields",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "bulk_edit_allowed": "bulk_edit_allowed",
@@ -417,6 +439,7 @@
         "notes": {
           "displayName": "Notes",
           "path": "/notes",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -441,6 +464,7 @@
         "organizationFields": {
           "displayName": "organization Fields",
           "path": "/organizationFields",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -471,6 +495,7 @@
         "organizationRelationships": {
           "displayName": "Organization Relationships",
           "path": "/organizationRelationships",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -487,6 +512,7 @@
         "organizations": {
           "displayName": "Organizations",
           "path": "/organizations",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "activities_count": "activities_count",
@@ -540,6 +566,7 @@
         "permissionSets": {
           "displayName": "Permission Sets",
           "path": "/permissionSets",
+          "responseKey": "data",
           "fields": {
             "app": "app",
             "assignment_count": "assignment_count",
@@ -552,6 +579,7 @@
         "personFields": {
           "displayName": "Person Fields",
           "path": "/personFields",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -582,6 +610,7 @@
         "persons": {
           "displayName": "Persons",
           "path": "/persons",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "activities_count": "activities_count",
@@ -630,6 +659,7 @@
         "phases": {
           "displayName": "Phases",
           "path": "/projects/phases",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "board_id": "board_id",
@@ -642,6 +672,7 @@
         "pipelines": {
           "displayName": "Pipelines",
           "path": "/pipelines",
+          "responseKey": "data",
           "fields": {
             "active": "active",
             "add_time": "add_time",
@@ -657,6 +688,7 @@
         "productFields": {
           "displayName": "product Fields",
           "path": "/productFields",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -682,6 +714,7 @@
         "products": {
           "displayName": "Products",
           "path": "/products",
+          "responseKey": "data",
           "fields": {
             "data": "data",
             "related_objects": "related_objects",
@@ -691,6 +724,7 @@
         "projectTemplates": {
           "displayName": "Project Templates",
           "path": "/projectTemplates",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "description": "description",
@@ -704,6 +738,7 @@
         "projects": {
           "displayName": "Projects",
           "path": "/projects",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "archive_time": "archive_time",
@@ -727,6 +762,7 @@
         "recents": {
           "displayName": "Recents",
           "path": "/recents",
+          "responseKey": "data",
           "fields": {
             "data": "data",
             "id": "id",
@@ -736,6 +772,7 @@
         "roles": {
           "displayName": "Roles",
           "path": "/roles",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "assignment_count": "assignment_count",
@@ -749,6 +786,7 @@
         "stages": {
           "displayName": "Stages",
           "path": "/stages",
+          "responseKey": "data",
           "fields": {
             "active_flag": "active_flag",
             "add_time": "add_time",
@@ -767,6 +805,7 @@
         "tasks": {
           "displayName": "Tasks",
           "path": "/tasks",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "assignee_id": "assignee_id",
@@ -785,6 +824,7 @@
         "users": {
           "displayName": "Users",
           "path": "/users",
+          "responseKey": "data",
           "fields": {
             "access": "access",
             "activated": "activated",
@@ -811,6 +851,7 @@
         "webhooks": {
           "displayName": "Webhooks",
           "path": "/webhooks",
+          "responseKey": "data",
           "fields": {
             "add_time": "add_time",
             "additional_data": "additional_data",

--- a/providers/pipeliner/metadata/schemas.json
+++ b/providers/pipeliner/metadata/schemas.json
@@ -7,6 +7,7 @@
         "AccountDataExRelations": {
           "displayName": "Account Data Ex Relations",
           "path": "/AccountDataExRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -24,6 +25,7 @@
         "AccountKPIs": {
           "displayName": "Account KPIs",
           "path": "/AccountKPIs",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -46,6 +48,7 @@
         "AccountRelationLabels": {
           "displayName": "Account Relation Labels",
           "path": "/AccountRelationLabels",
+          "responseKey": "data",
           "fields": {
             "account_relation": "account_relation",
             "account_relation_id": "account_relation_id",
@@ -62,6 +65,7 @@
         "AccountRelationTypes": {
           "displayName": "Account Relation Types",
           "path": "/AccountRelationTypes",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -76,6 +80,7 @@
         "AccountRelations": {
           "displayName": "Account Relations",
           "path": "/AccountRelations",
+          "responseKey": "data",
           "fields": {
             "account1": "account1",
             "account1_id": "account1_id",
@@ -92,6 +97,7 @@
         "AccountRoles": {
           "displayName": "Account Roles",
           "path": "/AccountRoles",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -106,6 +112,7 @@
         "AccountSharingClientRelations": {
           "displayName": "Account Sharing Client Relations",
           "path": "/AccountSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -123,6 +130,7 @@
         "AccountSharingSalesUnitRelations": {
           "displayName": "Account Sharing Sales Unit Relations",
           "path": "/AccountSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -140,6 +148,7 @@
         "AccountSocialRelations": {
           "displayName": "Account Social Relations",
           "path": "/AccountSocialRelations",
+          "responseKey": "data",
           "fields": {
             "angellist_url": "angellist_url",
             "created": "created",
@@ -178,6 +187,7 @@
         "AccountTypes": {
           "displayName": "Account Types",
           "path": "/AccountTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -197,6 +207,7 @@
         "Accounts": {
           "displayName": "Accounts",
           "path": "/Accounts",
+          "responseKey": "data",
           "fields": {
             "account_class": "account_class",
             "account_type": "account_type",
@@ -259,6 +270,7 @@
         "Activities": {
           "displayName": "Activities",
           "path": "/Activities",
+          "responseKey": "data",
           "fields": {
             "active_reminder": "active_reminder",
             "id": "id",
@@ -268,6 +280,7 @@
         "ActivityComments": {
           "displayName": "Activity Comments",
           "path": "/ActivityComments",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "appointment": "appointment",
@@ -286,6 +299,7 @@
         "ActivityDataExRelations": {
           "displayName": "Activity Data Ex Relations",
           "path": "/ActivityDataExRelations",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "appointment": "appointment",
@@ -304,6 +318,7 @@
         "ActivityKPIs": {
           "displayName": "Activity KPIs",
           "path": "/ActivityKPIs",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "application_id": "application_id",
@@ -327,6 +342,7 @@
         "ActivityRelations": {
           "displayName": "Activity Relations",
           "path": "/ActivityRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -358,6 +374,7 @@
         "AllowedAccountTypes": {
           "displayName": "Allowed Account Types",
           "path": "/AllowedAccountTypes",
+          "responseKey": "data",
           "fields": {
             "account_type": "account_type",
             "account_type_id": "account_type_id",
@@ -374,6 +391,7 @@
         "AllowedCompanyEmails": {
           "displayName": "Allowed Company Emails",
           "path": "/AllowedCompanyEmails",
+          "responseKey": "data",
           "fields": {
             "company_email": "company_email",
             "company_email_id": "company_email_id",
@@ -390,6 +408,7 @@
         "AllowedCompanyPhones": {
           "displayName": "Allowed Company Phones",
           "path": "/AllowedCompanyPhones",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -406,6 +425,7 @@
         "AllowedContactTypes": {
           "displayName": "Allowed Contact Types",
           "path": "/AllowedContactTypes",
+          "responseKey": "data",
           "fields": {
             "contact_type": "contact_type",
             "contact_type_id": "contact_type_id",
@@ -422,6 +442,7 @@
         "AllowedLeadTypes": {
           "displayName": "Allowed Lead Types",
           "path": "/AllowedLeadTypes",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -438,6 +459,7 @@
         "AllowedPipelines": {
           "displayName": "Allowed Pipelines",
           "path": "/AllowedPipelines",
+          "responseKey": "data",
           "fields": {
             "access_step_documents": "access_step_documents",
             "created": "created",
@@ -455,6 +477,7 @@
         "AllowedQuoteTypes": {
           "displayName": "Allowed Quote Types",
           "path": "/AllowedQuoteTypes",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -471,6 +494,7 @@
         "ApiAccesses": {
           "displayName": "API Accesses",
           "path": "/ApiAccesses",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email": "email",
@@ -490,6 +514,7 @@
         "AppointmentClientInviteesRelations": {
           "displayName": "Appointment Client Invitees Relations",
           "path": "/AppointmentClientInviteesRelations",
+          "responseKey": "data",
           "fields": {
             "appointment": "appointment",
             "appointment_id": "appointment_id",
@@ -507,6 +532,7 @@
         "AppointmentContactInviteesRelations": {
           "displayName": "Appointment Contact Invitees Relations",
           "path": "/AppointmentContactInviteesRelations",
+          "responseKey": "data",
           "fields": {
             "appointment": "appointment",
             "appointment_id": "appointment_id",
@@ -528,6 +554,7 @@
         "AppointmentReminders": {
           "displayName": "Appointment Reminders",
           "path": "/AppointmentReminders",
+          "responseKey": "data",
           "fields": {
             "appointment": "appointment",
             "appointment_id": "appointment_id",
@@ -547,6 +574,7 @@
         "AppointmentSchedules": {
           "displayName": "Appointment Schedules",
           "path": "/AppointmentSchedules",
+          "responseKey": "data",
           "fields": {
             "additional_fields_data": "additional_fields_data",
             "appointment_description": "appointment_description",
@@ -594,6 +622,7 @@
         "AppointmentTypes": {
           "displayName": "Appointment Types",
           "path": "/AppointmentTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -614,6 +643,7 @@
         "Appointments": {
           "displayName": "Appointments",
           "path": "/Appointments",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "active_reminder": "active_reminder",
@@ -673,6 +703,7 @@
         "ApprovalApprovers": {
           "displayName": "Approval Approvers",
           "path": "/ApprovalApprovers",
+          "responseKey": "data",
           "fields": {
             "approval": "approval",
             "approval_id": "approval_id",
@@ -691,6 +722,7 @@
         "ApprovalProcessActivityLogLines": {
           "displayName": "Approval Process Activity Log Lines",
           "path": "/ApprovalProcessActivityLogLines",
+          "responseKey": "data",
           "fields": {
             "approval": "approval",
             "approval_id": "approval_id",
@@ -710,6 +742,7 @@
         "ApprovalProcesses": {
           "displayName": "Approval Processes",
           "path": "/ApprovalProcesses",
+          "responseKey": "data",
           "fields": {
             "activity_logs": "activity_logs",
             "created": "created",
@@ -733,6 +766,7 @@
         "Approvals": {
           "displayName": "Approvals",
           "path": "/Approvals",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -768,6 +802,7 @@
         "Calls": {
           "displayName": "Calls",
           "path": "/Calls",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -796,6 +831,7 @@
         "ClientExcludedOppties": {
           "displayName": "Client Excluded Oppties",
           "path": "/ClientExcludedOppties",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -813,6 +849,7 @@
         "ClientFavorites": {
           "displayName": "Client Favorites",
           "path": "/ClientFavorites",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -847,6 +884,7 @@
         "ClientSettings": {
           "displayName": "Client Settings",
           "path": "/ClientSettings",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -863,6 +901,7 @@
         "ClientStoryReads": {
           "displayName": "Client Story Reads",
           "path": "/ClientStoryReads",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "appointment": "appointment",
@@ -885,6 +924,7 @@
         "Clients": {
           "displayName": "Clients",
           "path": "/Clients",
+          "responseKey": "data",
           "fields": {
             "account_favorite": "account_favorite",
             "appointment_favorite": "appointment_favorite",
@@ -929,6 +969,7 @@
         "CloudObjectFolders": {
           "displayName": "Cloud Object Folders",
           "path": "/CloudObjectFolders",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "entity_api_name": "entity_api_name",
@@ -946,6 +987,7 @@
         "CloudObjectRelations": {
           "displayName": "Cloud Object Relations",
           "path": "/CloudObjectRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -993,6 +1035,7 @@
         "CloudObjectStepRelations": {
           "displayName": "Cloud Object Step Relations",
           "path": "/CloudObjectStepRelations",
+          "responseKey": "data",
           "fields": {
             "cloud_object": "cloud_object",
             "cloud_object_id": "cloud_object_id",
@@ -1009,6 +1052,7 @@
         "CloudObjectTemplates": {
           "displayName": "Cloud Object Templates",
           "path": "/CloudObjectTemplates",
+          "responseKey": "data",
           "fields": {
             "application": "application",
             "application_id": "application_id",
@@ -1035,6 +1079,7 @@
         "CloudObjects": {
           "displayName": "Cloud Objects",
           "path": "/CloudObjects",
+          "responseKey": "data",
           "fields": {
             "application": "application",
             "application_id": "application_id",
@@ -1061,6 +1106,7 @@
         "CompanyEmails": {
           "displayName": "Company Emails",
           "path": "/CompanyEmails",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email": "email",
@@ -1081,6 +1127,7 @@
         "ContactAccountAccountRoleRelations": {
           "displayName": "Contact Account Account Role Relations",
           "path": "/ContactAccountAccountRoleRelations",
+          "responseKey": "data",
           "fields": {
             "account_role": "account_role",
             "account_role_id": "account_role_id",
@@ -1097,6 +1144,7 @@
         "ContactAccountRelations": {
           "displayName": "Contact Account Relations",
           "path": "/ContactAccountRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -1120,6 +1168,7 @@
         "ContactDataExRelations": {
           "displayName": "Contact Data Ex Relations",
           "path": "/ContactDataExRelations",
+          "responseKey": "data",
           "fields": {
             "contact": "contact",
             "contact_id": "contact_id",
@@ -1137,6 +1186,7 @@
         "ContactKPIs": {
           "displayName": "Contact KPIs",
           "path": "/ContactKPIs",
+          "responseKey": "data",
           "fields": {
             "application_id": "application_id",
             "client": "client",
@@ -1159,6 +1209,7 @@
         "ContactRelationLabels": {
           "displayName": "Contact Relation Labels",
           "path": "/ContactRelationLabels",
+          "responseKey": "data",
           "fields": {
             "contact_relation": "contact_relation",
             "contact_relation_id": "contact_relation_id",
@@ -1175,6 +1226,7 @@
         "ContactRelationTypes": {
           "displayName": "Contact Relation Types",
           "path": "/ContactRelationTypes",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -1189,6 +1241,7 @@
         "ContactRelations": {
           "displayName": "Contact Relations",
           "path": "/ContactRelations",
+          "responseKey": "data",
           "fields": {
             "contact1": "contact1",
             "contact1_id": "contact1_id",
@@ -1205,6 +1258,7 @@
         "ContactSharingClientRelations": {
           "displayName": "Contact Sharing Client Relations",
           "path": "/ContactSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -1222,6 +1276,7 @@
         "ContactSharingSalesUnitRelations": {
           "displayName": "Contact Sharing Sales Unit Relations",
           "path": "/ContactSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "contact": "contact",
             "contact_id": "contact_id",
@@ -1239,6 +1294,7 @@
         "ContactSocialRelations": {
           "displayName": "Contact Social Relations",
           "path": "/ContactSocialRelations",
+          "responseKey": "data",
           "fields": {
             "angellist_url": "angellist_url",
             "created": "created",
@@ -1277,6 +1333,7 @@
         "ContactTypes": {
           "displayName": "Contact Types",
           "path": "/ContactTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -1296,6 +1353,7 @@
         "Contacts": {
           "displayName": "Contacts",
           "path": "/Contacts",
+          "responseKey": "data",
           "fields": {
             "account_position": "account_position",
             "account_relations": "account_relations",
@@ -1359,6 +1417,7 @@
         "Currencies": {
           "displayName": "Currencies",
           "path": "/Currencies",
+          "responseKey": "data",
           "fields": {
             "code": "code",
             "created": "created",
@@ -1375,6 +1434,7 @@
         "CurrencyExchangeRates": {
           "displayName": "Currency Exchange Rates",
           "path": "/CurrencyExchangeRates",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "currency": "currency",
@@ -1392,6 +1452,7 @@
         "CurrencyExchangeRatesLists": {
           "displayName": "Currency Exchange Rates Lists",
           "path": "/CurrencyExchangeRatesLists",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "currency_exchange_rates": "currency_exchange_rates",
@@ -1406,6 +1467,7 @@
         "Data": {
           "displayName": "Data",
           "path": "/Data",
+          "responseKey": "data",
           "fields": {
             "calc_value": "calc_value",
             "created": "created",
@@ -1426,6 +1488,7 @@
         "DataRelations": {
           "displayName": "Data Relations",
           "path": "/DataRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -1444,6 +1507,7 @@
         "EmailContentSharingClientRelations": {
           "displayName": "Email Content Sharing Client Relations",
           "path": "/EmailContentSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -1460,6 +1524,7 @@
         "EmailContentSharingSalesUnitRelations": {
           "displayName": "Email Content Sharing Sales Unit Relations",
           "path": "/EmailContentSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email": "email",
@@ -1476,6 +1541,7 @@
         "EmailEvents": {
           "displayName": "Email Events",
           "path": "/EmailEvents",
+          "responseKey": "data",
           "fields": {
             "additional_data": "additional_data",
             "created": "created",
@@ -1492,6 +1558,7 @@
         "EmailSequenceActivityLogLines": {
           "displayName": "Email Sequence Activity Log Lines",
           "path": "/EmailSequenceActivityLogLines",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email_sequence_activity_log": "email_sequence_activity_log",
@@ -1509,6 +1576,7 @@
         "EmailSequenceActivityLogs": {
           "displayName": "Email Sequence Activity Logs",
           "path": "/EmailSequenceActivityLogs",
+          "responseKey": "data",
           "fields": {
             "actor": "actor",
             "actor_id": "actor_id",
@@ -1533,6 +1601,7 @@
         "EmailSequenceEnrolleds": {
           "displayName": "Email Sequence Enrolleds",
           "path": "/EmailSequenceEnrolleds",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -1571,6 +1640,7 @@
         "EmailSequences": {
           "displayName": "Email Sequences",
           "path": "/EmailSequences",
+          "responseKey": "data",
           "fields": {
             "activity_logs": "activity_logs",
             "created": "created",
@@ -1595,6 +1665,7 @@
         "EmailTemplateFolders": {
           "displayName": "Email Template Folders",
           "path": "/EmailTemplateFolders",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -1610,6 +1681,7 @@
         "EmailTemplateSharingClientRelations": {
           "displayName": "Email Template Sharing Client Relations",
           "path": "/EmailTemplateSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -1627,6 +1699,7 @@
         "EmailTemplateSharingSalesUnitRelations": {
           "displayName": "Email Template Sharing Sales Unit Relations",
           "path": "/EmailTemplateSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email_template": "email_template",
@@ -1644,6 +1717,7 @@
         "EmailTemplates": {
           "displayName": "Email Templates",
           "path": "/EmailTemplates",
+          "responseKey": "data",
           "fields": {
             "body": "body",
             "created": "created",
@@ -1668,6 +1742,7 @@
         "Emails": {
           "displayName": "Emails",
           "path": "/Emails",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "additional_headers": "additional_headers",
@@ -1725,6 +1800,7 @@
         "Entities": {
           "displayName": "Entities",
           "path": "/Entities",
+          "responseKey": "data",
           "fields": {
             "abstract_entity_id": "abstract_entity_id",
             "access_mode": "access_mode",
@@ -1751,6 +1827,7 @@
         "EntityFitnessIndicators": {
           "displayName": "Entity Fitness Indicators",
           "path": "/EntityFitnessIndicators",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "description": "description",
@@ -1774,6 +1851,7 @@
         "EntityFitnesses": {
           "displayName": "Entity Fitnesses",
           "path": "/EntityFitnesses",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "entity_type": "entity_type",
@@ -1793,6 +1871,7 @@
         "EntityHealths": {
           "displayName": "Entity Healths",
           "path": "/EntityHealths",
+          "responseKey": "data",
           "fields": {
             "calculation_progress": "calculation_progress",
             "created": "created",
@@ -1810,6 +1889,7 @@
         "EntityScorings": {
           "displayName": "Entity Scorings",
           "path": "/EntityScorings",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "entity_type": "entity_type",
@@ -1828,6 +1908,7 @@
         "FieldPermissions": {
           "displayName": "Field Permissions",
           "path": "/FieldPermissions",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "field": "field",
@@ -1847,6 +1928,7 @@
         "FieldSequences": {
           "displayName": "Field Sequences",
           "path": "/FieldSequences",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -1859,6 +1941,7 @@
         "Fields": {
           "displayName": "Fields",
           "path": "/Fields",
+          "responseKey": "data",
           "fields": {
             "advanced_formula": "advanced_formula",
             "api_name": "api_name",
@@ -1911,6 +1994,7 @@
         "Forecasts": {
           "displayName": "Forecasts",
           "path": "/Forecasts",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "description": "description",
@@ -1939,6 +2023,7 @@
         "FormViewSharingClientRelations": {
           "displayName": "Form View Sharing Client Relations",
           "path": "/FormViewSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -1956,6 +2041,7 @@
         "FormViewSharingSalesUnitRelations": {
           "displayName": "Form View Sharing Sales Unit Relations",
           "path": "/FormViewSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "form_view": "form_view",
@@ -1973,6 +2059,7 @@
         "FormViews": {
           "displayName": "Form Views",
           "path": "/FormViews",
+          "responseKey": "data",
           "fields": {
             "account_type": "account_type",
             "account_type_id": "account_type_id",
@@ -2003,6 +2090,7 @@
         "GhostContactAccountAccountRoleRelations": {
           "displayName": "Ghost Contact Account Account Role Relations",
           "path": "/GhostContactAccountAccountRoleRelations",
+          "responseKey": "data",
           "fields": {
             "account_role": "account_role",
             "account_role_id": "account_role_id",
@@ -2019,6 +2107,7 @@
         "GhostContactAccountRelations": {
           "displayName": "Ghost Contact Account Relations",
           "path": "/GhostContactAccountRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2040,6 +2129,7 @@
         "GhostContacts": {
           "displayName": "Ghost Contacts",
           "path": "/GhostContacts",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -2054,6 +2144,7 @@
         "GhostLeadOpptyContactRelations": {
           "displayName": "Ghost Lead Oppty Contact Relations",
           "path": "/GhostLeadOpptyContactRelations",
+          "responseKey": "data",
           "fields": {
             "comment": "comment",
             "created": "created",
@@ -2076,6 +2167,7 @@
         "GhostLeadOpptyContactSalesRoleRelations": {
           "displayName": "Ghost Lead Oppty Contact Sales Role Relations",
           "path": "/GhostLeadOpptyContactSalesRoleRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "ghost_lead_oppty_contact_relation": "ghost_lead_oppty_contact_relation",
@@ -2092,6 +2184,7 @@
         "ImportMappingMasks": {
           "displayName": "Import Mapping Masks",
           "path": "/ImportMappingMasks",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "entity_api_name": "entity_api_name",
@@ -2114,6 +2207,7 @@
         "InterfacePreviews": {
           "displayName": "Interface Previews",
           "path": "/InterfacePreviews",
+          "responseKey": "data",
           "fields": {
             "account_type": "account_type",
             "account_type_id": "account_type_id",
@@ -2155,6 +2249,7 @@
         "LeadOppties": {
           "displayName": "Lead Oppties",
           "path": "/LeadOppties",
+          "responseKey": "data",
           "fields": {
             "id": "id",
             "is_delete_protected": "is_delete_protected"
@@ -2163,6 +2258,7 @@
         "LeadOpptyAccountRelations": {
           "displayName": "Lead Oppty Account Relations",
           "path": "/LeadOpptyAccountRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2181,6 +2277,7 @@
         "LeadOpptyContactGroupRelations": {
           "displayName": "Lead Oppty Contact Group Relations",
           "path": "/LeadOpptyContactGroupRelations",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -2199,6 +2296,7 @@
         "LeadOpptyContactRelations": {
           "displayName": "Lead Oppty Contact Relations",
           "path": "/LeadOpptyContactRelations",
+          "responseKey": "data",
           "fields": {
             "comment": "comment",
             "contact": "contact",
@@ -2223,6 +2321,7 @@
         "LeadOpptyContactSalesRoleRelations": {
           "displayName": "Lead Oppty Contact Sales Role Relations",
           "path": "/LeadOpptyContactSalesRoleRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -2239,6 +2338,7 @@
         "LeadOpptyDataExRelations": {
           "displayName": "Lead Oppty Data Ex Relations",
           "path": "/LeadOpptyDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -2257,6 +2357,7 @@
         "LeadOpptyKPIs": {
           "displayName": "Lead Oppty KPIs",
           "path": "/LeadOpptyKPIs",
+          "responseKey": "data",
           "fields": {
             "application_id": "application_id",
             "client": "client",
@@ -2280,6 +2381,7 @@
         "LeadOpptySharingClientRelations": {
           "displayName": "Lead Oppty Sharing Client Relations",
           "path": "/LeadOpptySharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -2298,6 +2400,7 @@
         "LeadOpptySharingSalesUnitRelations": {
           "displayName": "Lead Oppty Sharing Sales Unit Relations",
           "path": "/LeadOpptySharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -2316,6 +2419,7 @@
         "LeadOpptyStepCheckListRelations": {
           "displayName": "Lead Oppty Step Check List Relations",
           "path": "/LeadOpptyStepCheckListRelations",
+          "responseKey": "data",
           "fields": {
             "activity_id": "activity_id",
             "appointment": "appointment",
@@ -2345,6 +2449,7 @@
         "LeadProcesses": {
           "displayName": "Lead Processes",
           "path": "/LeadProcesses",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -2361,6 +2466,7 @@
         "LeadTypes": {
           "displayName": "Lead Types",
           "path": "/LeadTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -2385,6 +2491,7 @@
         "Leads": {
           "displayName": "Leads",
           "path": "/Leads",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "contact_relations": "contact_relations",
@@ -2439,6 +2546,7 @@
         "MasterRights": {
           "displayName": "Master Rights",
           "path": "/MasterRights",
+          "responseKey": "data",
           "fields": {
             "access_account_relation_types": "access_account_relation_types",
             "access_accounts": "access_accounts",
@@ -2581,6 +2689,7 @@
         "MemoComments": {
           "displayName": "Memo Comments",
           "path": "/MemoComments",
+          "responseKey": "data",
           "fields": {
             "comment": "comment",
             "created": "created",
@@ -2598,6 +2707,7 @@
         "Memos": {
           "displayName": "Memos",
           "path": "/Memos",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "comments": "comments",
@@ -2625,6 +2735,7 @@
         "MessageRelations": {
           "displayName": "Message Relations",
           "path": "/MessageRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2653,6 +2764,7 @@
         "MessageSharingClientRelations": {
           "displayName": "Message Sharing Client Relations",
           "path": "/MessageSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -2670,6 +2782,7 @@
         "MessageSharingSalesUnitRelations": {
           "displayName": "Message Sharing Sales Unit Relations",
           "path": "/MessageSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "email": "email",
@@ -2687,6 +2800,7 @@
         "Notes": {
           "displayName": "Notes",
           "path": "/Notes",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2715,6 +2829,7 @@
         "OnlineFormActivityLogLines": {
           "displayName": "Online Form Activity Log Lines",
           "path": "/OnlineFormActivityLogLines",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "executed_at": "executed_at",
@@ -2733,6 +2848,7 @@
         "OnlineFormDataExRelations": {
           "displayName": "Online Form Data Ex Relations",
           "path": "/OnlineFormDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -2750,6 +2866,7 @@
         "OnlineFormRelations": {
           "displayName": "Online Form Relations",
           "path": "/OnlineFormRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2776,6 +2893,7 @@
         "OnlineFormTypeEmailRelations": {
           "displayName": "Online Form Type Email Relations",
           "path": "/OnlineFormTypeEmailRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -2799,6 +2917,7 @@
         "OnlineFormTypes": {
           "displayName": "Online Form Types",
           "path": "/OnlineFormTypes",
+          "responseKey": "data",
           "fields": {
             "activity_logs": "activity_logs",
             "auto_prefill_with_javascript": "auto_prefill_with_javascript",
@@ -2830,6 +2949,7 @@
         "OnlineForms": {
           "displayName": "Online Forms",
           "path": "/OnlineForms",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "contact_relations": "contact_relations",
@@ -2857,6 +2977,7 @@
         "Opportunities": {
           "displayName": "Opportunities",
           "path": "/Opportunities",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "active_quote": "active_quote",
@@ -2926,6 +3047,7 @@
         "OpportunityTypes": {
           "displayName": "Opportunity Types",
           "path": "/OpportunityTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -2953,6 +3075,7 @@
         "OpptyProductRelationDataExRelations": {
           "displayName": "Oppty Product Relation Data Ex Relations",
           "path": "/OpptyProductRelationDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -2970,6 +3093,7 @@
         "OpptyProductRelationRevenueSchedulePeriods": {
           "displayName": "Oppty Product Relation Revenue Schedule Periods",
           "path": "/OpptyProductRelationRevenueSchedulePeriods",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "date": "date",
@@ -2987,6 +3111,7 @@
         "OpptyProductRelationRevenueSchedules": {
           "displayName": "Oppty Product Relation Revenue Schedules",
           "path": "/OpptyProductRelationRevenueSchedules",
+          "responseKey": "data",
           "fields": {
             "cancelation_date": "cancelation_date",
             "created": "created",
@@ -3004,6 +3129,7 @@
         "OpptyProductRelationTypes": {
           "displayName": "Oppty Product Relation Types",
           "path": "/OpptyProductRelationTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -3025,6 +3151,7 @@
         "OpptyProductRelations": {
           "displayName": "Oppty Product Relations",
           "path": "/OpptyProductRelations",
+          "responseKey": "data",
           "fields": {
             "amount": "amount",
             "comment": "comment",
@@ -3057,6 +3184,7 @@
         "OpptyRecurrences": {
           "displayName": "Oppty Recurrences",
           "path": "/OpptyRecurrences",
+          "responseKey": "data",
           "fields": {
             "condition": "condition",
             "created": "created",
@@ -3083,6 +3211,7 @@
         "OpptyRevenueSchedulePeriods": {
           "displayName": "Oppty Revenue Schedule Periods",
           "path": "/OpptyRevenueSchedulePeriods",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "date": "date",
@@ -3100,6 +3229,7 @@
         "OpptyRevenueSchedules": {
           "displayName": "Oppty Revenue Schedules",
           "path": "/OpptyRevenueSchedules",
+          "responseKey": "data",
           "fields": {
             "cancelation_date": "cancelation_date",
             "created": "created",
@@ -3117,6 +3247,7 @@
         "ParentAccountRelationTypes": {
           "displayName": "Parent Account Relation Types",
           "path": "/ParentAccountRelationTypes",
+          "responseKey": "data",
           "fields": {
             "child_label": "child_label",
             "created": "created",
@@ -3131,6 +3262,7 @@
         "Phones": {
           "displayName": "Phones",
           "path": "/Phones",
+          "responseKey": "data",
           "fields": {
             "call_forwarding_phone": "call_forwarding_phone",
             "created": "created",
@@ -3151,6 +3283,7 @@
         "Pipelines": {
           "displayName": "Pipelines",
           "path": "/Pipelines",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -3167,6 +3300,7 @@
         "ProcessActivityLogLines": {
           "displayName": "Process Activity Log Lines",
           "path": "/ProcessActivityLogLines",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "executed_at": "executed_at",
@@ -3185,6 +3319,7 @@
         "ProcessActivityLogs": {
           "displayName": "Process Activity Logs",
           "path": "/ProcessActivityLogs",
+          "responseKey": "data",
           "fields": {
             "actor": "actor",
             "actor_id": "actor_id",
@@ -3211,6 +3346,7 @@
         "ProcessTemplates": {
           "displayName": "Process Templates",
           "path": "/ProcessTemplates",
+          "responseKey": "data",
           "fields": {
             "action_types": "action_types",
             "created": "created",
@@ -3228,6 +3364,7 @@
         "Processes": {
           "displayName": "Processes",
           "path": "/Processes",
+          "responseKey": "data",
           "fields": {
             "activity": "activity",
             "activity_logs": "activity_logs",
@@ -3252,6 +3389,7 @@
         "ProductCategories": {
           "displayName": "Product Categories",
           "path": "/ProductCategories",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3268,6 +3406,7 @@
         "ProductDataExRelations": {
           "displayName": "Product Data Ex Relations",
           "path": "/ProductDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -3285,6 +3424,7 @@
         "ProductPipelineRelations": {
           "displayName": "Product Pipeline Relations",
           "path": "/ProductPipelineRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3301,6 +3441,7 @@
         "ProductPriceListPrices": {
           "displayName": "Product Price List Prices",
           "path": "/ProductPriceListPrices",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "currency": "currency",
@@ -3320,6 +3461,7 @@
         "ProductPriceLists": {
           "displayName": "Product Price Lists",
           "path": "/ProductPriceLists",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "end_date": "end_date",
@@ -3336,6 +3478,7 @@
         "ProductTypes": {
           "displayName": "Product Types",
           "path": "/ProductTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -3357,6 +3500,7 @@
         "Products": {
           "displayName": "Products",
           "path": "/Products",
+          "responseKey": "data",
           "fields": {
             "allowed_pipelines": "allowed_pipelines",
             "created": "created",
@@ -3384,6 +3528,7 @@
         "ProfileSharingClientRelations": {
           "displayName": "Profile Sharing Client Relations",
           "path": "/ProfileSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -3400,6 +3545,7 @@
         "ProfileSharingSalesUnitRelations": {
           "displayName": "Profile Sharing Sales Unit Relations",
           "path": "/ProfileSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3416,6 +3562,7 @@
         "Profiles": {
           "displayName": "Profiles",
           "path": "/Profiles",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "entity": "entity",
@@ -3437,6 +3584,7 @@
         "ProjectContactRelations": {
           "displayName": "Project Contact Relations",
           "path": "/ProjectContactRelations",
+          "responseKey": "data",
           "fields": {
             "contact": "contact",
             "contact_id": "contact_id",
@@ -3454,6 +3602,7 @@
         "ProjectDataExRelations": {
           "displayName": "Project Data Ex Relations",
           "path": "/ProjectDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -3471,6 +3620,7 @@
         "ProjectKPIs": {
           "displayName": "Project KPIs",
           "path": "/ProjectKPIs",
+          "responseKey": "data",
           "fields": {
             "application_id": "application_id",
             "client": "client",
@@ -3493,6 +3643,7 @@
         "ProjectObjectives": {
           "displayName": "Project Objectives",
           "path": "/ProjectObjectives",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3509,6 +3660,7 @@
         "ProjectSharingClientRelations": {
           "displayName": "Project Sharing Client Relations",
           "path": "/ProjectSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -3526,6 +3678,7 @@
         "ProjectSharingSalesUnitRelations": {
           "displayName": "Project Sharing Sales Unit Relations",
           "path": "/ProjectSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3543,6 +3696,7 @@
         "ProjectTypes": {
           "displayName": "Project Types",
           "path": "/ProjectTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -3563,6 +3717,7 @@
         "Projects": {
           "displayName": "Projects",
           "path": "/Projects",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -3603,6 +3758,7 @@
         "QuoteAccountRelations": {
           "displayName": "Quote Account Relations",
           "path": "/QuoteAccountRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -3620,6 +3776,7 @@
         "QuoteContactRelations": {
           "displayName": "Quote Contact Relations",
           "path": "/QuoteContactRelations",
+          "responseKey": "data",
           "fields": {
             "contact": "contact",
             "contact_id": "contact_id",
@@ -3637,6 +3794,7 @@
         "QuoteDataExRelations": {
           "displayName": "Quote Data Ex Relations",
           "path": "/QuoteDataExRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "data": "data",
@@ -3654,6 +3812,7 @@
         "QuoteKPIs": {
           "displayName": "Quote KPIs",
           "path": "/QuoteKPIs",
+          "responseKey": "data",
           "fields": {
             "application_id": "application_id",
             "client": "client",
@@ -3676,6 +3835,7 @@
         "QuoteProcesses": {
           "displayName": "Quote Processes",
           "path": "/QuoteProcesses",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -3692,6 +3852,7 @@
         "QuoteSharingClientRelations": {
           "displayName": "Quote Sharing Client Relations",
           "path": "/QuoteSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -3709,6 +3870,7 @@
         "QuoteSharingSalesUnitRelations": {
           "displayName": "Quote Sharing Sales Unit Relations",
           "path": "/QuoteSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3726,6 +3888,7 @@
         "QuoteTypes": {
           "displayName": "Quote Types",
           "path": "/QuoteTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -3750,6 +3913,7 @@
         "Quotes": {
           "displayName": "Quotes",
           "path": "/Quotes",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "contact_relations": "contact_relations",
@@ -3807,6 +3971,7 @@
         "ReportFolders": {
           "displayName": "Report Folders",
           "path": "/ReportFolders",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3822,6 +3987,7 @@
         "ReportSchedules": {
           "displayName": "Report Schedules",
           "path": "/ReportSchedules",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "documents": "documents",
@@ -3840,6 +4006,7 @@
         "ReportSharingClientRelations": {
           "displayName": "Report Sharing Client Relations",
           "path": "/ReportSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -3857,6 +4024,7 @@
         "ReportSharingSalesUnitRelations": {
           "displayName": "Report Sharing Sales Unit Relations",
           "path": "/ReportSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3874,6 +4042,7 @@
         "Reports": {
           "displayName": "Reports",
           "path": "/Reports",
+          "responseKey": "data",
           "fields": {
             "access_link": "access_link",
             "created": "created",
@@ -3901,6 +4070,7 @@
         "SalesRoles": {
           "displayName": "Sales Roles",
           "path": "/SalesRoles",
+          "responseKey": "data",
           "fields": {
             "color_code": "color_code",
             "created": "created",
@@ -3915,6 +4085,7 @@
         "SalesUnitClientRelations": {
           "displayName": "Sales Unit Client Relations",
           "path": "/SalesUnitClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -3932,6 +4103,7 @@
         "SalesUnits": {
           "displayName": "Sales Units",
           "path": "/SalesUnits",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3949,6 +4121,7 @@
         "StepChecklistSalesRoleRelations": {
           "displayName": "Step Checklist Sales Role Relations",
           "path": "/StepChecklistSalesRoleRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -3965,6 +4138,7 @@
         "StepChecklists": {
           "displayName": "Step Checklists",
           "path": "/StepChecklists",
+          "responseKey": "data",
           "fields": {
             "activity_type_id": "activity_type_id",
             "appointment_type": "appointment_type",
@@ -4004,6 +4178,7 @@
         "Steps": {
           "displayName": "Steps",
           "path": "/Steps",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "description": "description",
@@ -4031,6 +4206,7 @@
         "TagRelations": {
           "displayName": "Tag Relations",
           "path": "/TagRelations",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -4055,6 +4231,7 @@
         "Tags": {
           "displayName": "Tags",
           "path": "/Tags",
+          "responseKey": "data",
           "fields": {
             "color": "color",
             "created": "created",
@@ -4073,6 +4250,7 @@
         "TargetRelations": {
           "displayName": "Target Relations",
           "path": "/TargetRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "group_target": "group_target",
@@ -4089,6 +4267,7 @@
         "Targets": {
           "displayName": "Targets",
           "path": "/Targets",
+          "responseKey": "data",
           "fields": {
             "calculation_type": "calculation_type",
             "child_targets": "child_targets",
@@ -4114,6 +4293,7 @@
         "TaskRecurrences": {
           "displayName": "Task Recurrences",
           "path": "/TaskRecurrences",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "day": "day",
@@ -4137,6 +4317,7 @@
         "TaskReminders": {
           "displayName": "Task Reminders",
           "path": "/TaskReminders",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -4155,6 +4336,7 @@
         "TaskSharingClientRelations": {
           "displayName": "Task Sharing Client Relations",
           "path": "/TaskSharingClientRelations",
+          "responseKey": "data",
           "fields": {
             "client": "client",
             "client_id": "client_id",
@@ -4172,6 +4354,7 @@
         "TaskSharingSalesUnitRelations": {
           "displayName": "Task Sharing Sales Unit Relations",
           "path": "/TaskSharingSalesUnitRelations",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -4189,6 +4372,7 @@
         "TaskTypes": {
           "displayName": "Task Types",
           "path": "/TaskTypes",
+          "responseKey": "data",
           "fields": {
             "can_change_readonly": "can_change_readonly",
             "created": "created",
@@ -4209,6 +4393,7 @@
         "Tasks": {
           "displayName": "Tasks",
           "path": "/Tasks",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "active_reminder": "active_reminder",
@@ -4258,6 +4443,7 @@
         "TextMessageConversationRelationses": {
           "displayName": "Text Message Conversation Relationses",
           "path": "/TextMessageConversationRelationses",
+          "responseKey": "data",
           "fields": {
             "account": "account",
             "account_id": "account_id",
@@ -4283,6 +4469,7 @@
         "TextMessageConversations": {
           "displayName": "Text Message Conversations",
           "path": "/TextMessageConversations",
+          "responseKey": "data",
           "fields": {
             "account_relations": "account_relations",
             "contact_relations": "contact_relations",
@@ -4309,6 +4496,7 @@
         "TextMessages": {
           "displayName": "Text Messages",
           "path": "/TextMessages",
+          "responseKey": "data",
           "fields": {
             "content": "content",
             "created": "created",
@@ -4328,6 +4516,7 @@
         "Timeframes": {
           "displayName": "Timeframes",
           "path": "/Timeframes",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -4346,6 +4535,7 @@
         "Translations": {
           "displayName": "Translations",
           "path": "/Translations",
+          "responseKey": "data",
           "fields": {
             "account_type": "account_type",
             "account_type_id": "account_type_id",
@@ -4388,6 +4578,7 @@
         "Types": {
           "displayName": "Types",
           "path": "/Types",
+          "responseKey": "data",
           "fields": {
             "container_size": "container_size",
             "default_value": "default_value",
@@ -4406,6 +4597,7 @@
         "UnsubscribedPhones": {
           "displayName": "Unsubscribed Phones",
           "path": "/UnsubscribedPhones",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "id": "id",
@@ -4419,6 +4611,7 @@
         "WebhookEvents": {
           "displayName": "Webhook Events",
           "path": "/WebhookEvents",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "event": "event",
@@ -4433,6 +4626,7 @@
         "Webhooks": {
           "displayName": "Webhooks",
           "path": "/Webhooks",
+          "responseKey": "data",
           "fields": {
             "application": "application",
             "application_id": "application_id",
@@ -4453,6 +4647,7 @@
         "Webresources": {
           "displayName": "Web Resources",
           "path": "/Webresources",
+          "responseKey": "data",
           "fields": {
             "created": "created",
             "display_param": "display_param",

--- a/providers/salesloft/metadata/index.json
+++ b/providers/salesloft/metadata/index.json
@@ -151,6 +151,11 @@
       "url": "https://developers.salesloft.com/docs/api/cadence-bulk-memberships-create"
     },
     {
+      "name": "cadence-export-downloads-create",
+      "displayName": "Create a cadence export download",
+      "url": "https://developers.salesloft.com/docs/api/cadence-export-downloads-create"
+    },
+    {
       "name": "cadence-exports-show",
       "displayName": "Export a cadence",
       "url": "https://developers.salesloft.com/docs/api/cadence-exports-show"
@@ -269,6 +274,11 @@
       "name": "conversations-transcriptions-find-one-transcript-sentences",
       "displayName": "Fetch a Transcription's sentences",
       "url": "https://developers.salesloft.com/docs/api/conversations-transcriptions-find-one-transcript-sentences"
+    },
+    {
+      "name": "crm-account-team-members-index",
+      "displayName": "List CRM Account Team Members",
+      "url": "https://developers.salesloft.com/docs/api/crm-account-team-members-index"
     },
     {
       "name": "crm-activities-index",
@@ -586,6 +596,56 @@
       "url": "https://developers.salesloft.com/docs/api/ongoing-actions-create"
     },
     {
+      "name": "opportunities-index",
+      "displayName": "List opportunities",
+      "url": "https://developers.salesloft.com/docs/api/opportunities-index"
+    },
+    {
+      "name": "opportunities-show",
+      "displayName": "Fetch an Opportunity",
+      "url": "https://developers.salesloft.com/docs/api/opportunities-show"
+    },
+    {
+      "name": "opportunity-people-create",
+      "displayName": "Create a Sales Opportunity Person",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-people-create"
+    },
+    {
+      "name": "opportunity-people-destroy",
+      "displayName": "Delete a Opportunity Association",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-people-destroy"
+    },
+    {
+      "name": "opportunity-people-index",
+      "displayName": "List opportunity/person associations",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-people-index"
+    },
+    {
+      "name": "opportunity-stages-create",
+      "displayName": "Create an Opportunity Stage",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-stages-create"
+    },
+    {
+      "name": "opportunity-stages-destroy",
+      "displayName": "Delete an Opportunity Stage",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-stages-destroy"
+    },
+    {
+      "name": "opportunity-stages-index",
+      "displayName": "List Opportunity Stages",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-stages-index"
+    },
+    {
+      "name": "opportunity-stages-show",
+      "displayName": "Fetch an Opportunity Stage",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-stages-show"
+    },
+    {
+      "name": "opportunity-stages-update",
+      "displayName": "Update an Opportunity Stage",
+      "url": "https://developers.salesloft.com/docs/api/opportunity-stages-update"
+    },
+    {
       "name": "pending-emails-index",
       "displayName": "List pending emails",
       "url": "https://developers.salesloft.com/docs/api/pending-emails-index"
@@ -669,6 +729,11 @@
       "name": "phone-numbers-recording-settings-show",
       "displayName": "Fetch recording setting",
       "url": "https://developers.salesloft.com/docs/api/phone-numbers-recording-settings-show"
+    },
+    {
+      "name": "profiles-index",
+      "displayName": "Fetch current user's profile",
+      "url": "https://developers.salesloft.com/docs/api/profiles-index"
     },
     {
       "name": "saved-list-views-create",

--- a/providers/salesloft/metadata/schemas.json
+++ b/providers/salesloft/metadata/schemas.json
@@ -7,6 +7,7 @@
         "account_stages": {
           "displayName": "Account Stages",
           "path": "/account_stages",
+          "locatedAt": "data",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -20,6 +21,7 @@
         "account_tiers": {
           "displayName": "Account Tiers",
           "path": "/account_tiers",
+          "locatedAt": "data",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -33,6 +35,7 @@
         "accounts": {
           "displayName": "Accounts",
           "path": "/accounts",
+          "locatedAt": "data",
           "fields": {
             "account_tier": "account_tier",
             "archived_at": "archived_at",
@@ -80,6 +83,7 @@
         "action_details_call_instructions": {
           "displayName": "Call Instructions",
           "path": "/action_details_call_instructions",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -91,6 +95,7 @@
         "actions": {
           "displayName": "Actions",
           "path": "/actions",
+          "locatedAt": "data",
           "fields": {
             "action_details": "action_details",
             "cadence": "cadence",
@@ -112,6 +117,7 @@
         "activities_calls": {
           "displayName": "Calls",
           "path": "/activities_calls",
+          "locatedAt": "data",
           "fields": {
             "action": "action",
             "cadence": "cadence",
@@ -135,6 +141,7 @@
         "activities_emails": {
           "displayName": "Emails",
           "path": "/activities_emails",
+          "locatedAt": "data",
           "fields": {
             "action": "action",
             "additional_recipients": "additional_recipients",
@@ -169,6 +176,7 @@
         "activity_histories": {
           "displayName": "Past Activities",
           "path": "/activity_histories",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "dynamic_data": "dynamic_data",
@@ -189,6 +197,7 @@
         "bulk_jobs": {
           "displayName": "Bulk Jobs",
           "path": "/bulk_jobs",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "errors": "errors",
@@ -210,6 +219,7 @@
         "bulk_jobs_job_data": {
           "displayName": "Job Data for a Bulk Job",
           "path": "/bulk_jobs_job_data",
+          "locatedAt": "data",
           "fields": {
             "error": "error",
             "id": "id",
@@ -222,6 +232,7 @@
         "bulk_jobs_results": {
           "displayName": "Job Data for a Completed Bulk Job.",
           "path": "/bulk_jobs_results",
+          "locatedAt": "data",
           "fields": {
             "error": "error",
             "id": "id",
@@ -234,6 +245,7 @@
         "cadence_memberships": {
           "displayName": "Cadence Memberships",
           "path": "/cadence_memberships",
+          "locatedAt": "data",
           "fields": {
             "added_at": "added_at",
             "cadence": "cadence",
@@ -253,6 +265,7 @@
         "cadences": {
           "displayName": "Cadences",
           "path": "/cadences",
+          "locatedAt": "data",
           "fields": {
             "added_stage": "added_stage",
             "archived": "archived",
@@ -289,6 +302,7 @@
         "calendar_events": {
           "displayName": "Calendar Events",
           "path": "/calendar_events",
+          "locatedAt": "data",
           "fields": {
             "all_day": "all_day",
             "attendees": "attendees",
@@ -324,6 +338,7 @@
         "call_data_records": {
           "displayName": "Call Data Records",
           "path": "/call_data_records",
+          "locatedAt": "data",
           "fields": {
             "call": "call",
             "call_type": "call_type",
@@ -348,6 +363,7 @@
         "call_dispositions": {
           "displayName": "Call Dispositions",
           "path": "/call_dispositions",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -359,6 +375,7 @@
         "call_sentiments": {
           "displayName": "Call Sentiments",
           "path": "/call_sentiments",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -367,9 +384,25 @@
           },
           "docs": "https://developers.salesloft.com/docs/api/call-sentiments-index"
         },
+        "crm_account_team_members": {
+          "displayName": "Crm Account Team Members",
+          "path": "/crm_account_team_members",
+          "locatedAt": "data",
+          "fields": {
+            "account_access_level": "account_access_level",
+            "account_crm_id": "account_crm_id",
+            "crm_id": "crm_id",
+            "id": "id",
+            "team_member_role": "team_member_role",
+            "user_crm_id": "user_crm_id",
+            "user_crm_name": "user_crm_name"
+          },
+          "docs": "https://developers.salesloft.com/docs/api/crm-account-team-members-index"
+        },
         "crm_activities": {
           "displayName": "Crm Activities",
           "path": "/crm_activities",
+          "locatedAt": "data",
           "fields": {
             "activity_type": "activity_type",
             "created_at": "created_at",
@@ -388,6 +421,7 @@
         "crm_activity_fields": {
           "displayName": "Crm Activity Fields",
           "path": "/crm_activity_fields",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "crm_object_type": "crm_object_type",
@@ -406,6 +440,7 @@
         "crm_users": {
           "displayName": "Crm Users",
           "path": "/crm_users",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "crm_id": "crm_id",
@@ -421,6 +456,7 @@
         "custom_fields": {
           "displayName": "Custom Fields",
           "path": "/custom_fields",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "field_type": "field_type",
@@ -434,6 +470,7 @@
         "custom_roles": {
           "displayName": "Custom Roles",
           "path": "/custom_roles",
+          "locatedAt": "data",
           "fields": {
             "id": "id",
             "name": "name"
@@ -443,6 +480,7 @@
         "data_control_requests": {
           "displayName": "Requests",
           "path": "/data_control_requests",
+          "locatedAt": "data",
           "fields": {
             "dry_run": "dry_run",
             "events": "events",
@@ -457,6 +495,7 @@
         "email_template_attachments": {
           "displayName": "Email Template Attachments",
           "path": "/email_template_attachments",
+          "locatedAt": "data",
           "fields": {
             "attachment_content_type": "attachment_content_type",
             "attachment_file_size": "attachment_file_size",
@@ -473,6 +512,7 @@
         "email_templates": {
           "displayName": "Email Templates",
           "path": "/email_templates",
+          "locatedAt": "data",
           "fields": {
             "_links": "_links",
             "archived_at": "archived_at",
@@ -499,6 +539,7 @@
         "external_configurations": {
           "displayName": "Team Configurations",
           "path": "/external_configurations",
+          "locatedAt": "data",
           "fields": {
             "deleted": "deleted",
             "external_type": "external_type",
@@ -512,6 +553,7 @@
         "external_mappings": {
           "displayName": "Team Mappings",
           "path": "/external_mappings",
+          "locatedAt": "data",
           "fields": {
             "deleted": "deleted",
             "external_id": "external_id",
@@ -527,6 +569,7 @@
         "groups": {
           "displayName": "Groups",
           "path": "/groups",
+          "locatedAt": "data",
           "fields": {
             "accessible_groups": "accessible_groups",
             "id": "id",
@@ -538,6 +581,7 @@
         "imports": {
           "displayName": "Imports",
           "path": "/imports",
+          "locatedAt": "data",
           "fields": {
             "created_at": "created_at",
             "current_people_count": "current_people_count",
@@ -554,6 +598,7 @@
         "integrations_signals_registrations": {
           "displayName": "Signal Registrations",
           "path": "/integrations_signals_registrations",
+          "locatedAt": "data",
           "fields": {
             "attribution": "attribution",
             "created_at": "created_at",
@@ -565,6 +610,7 @@
             "integration": "integration",
             "integration_slug": "integration_slug",
             "owner_user_guid": "owner_user_guid",
+            "signal_name": "signal_name",
             "type": "type"
           },
           "docs": "https://developers.salesloft.com/docs/api/integrations-signals-registrations-index"
@@ -572,6 +618,7 @@
         "integrations_signals_registrations_plays": {
           "displayName": "Play Registrations",
           "path": "/integrations_signals_registrations_plays",
+          "locatedAt": "data",
           "fields": {
             "attributes": "attributes",
             "created_at": "created_at",
@@ -594,6 +641,7 @@
         "meetings": {
           "displayName": "Meetings",
           "path": "/meetings",
+          "locatedAt": "data",
           "fields": {
             "account_id": "account_id",
             "all_day": "all_day",
@@ -644,6 +692,7 @@
         "notes": {
           "displayName": "Notes",
           "path": "/notes",
+          "locatedAt": "data",
           "fields": {
             "associated_type": "associated_type",
             "associated_with": "associated_with",
@@ -656,9 +705,80 @@
           },
           "docs": "https://developers.salesloft.com/docs/api/notes-index"
         },
+        "opportunities": {
+          "displayName": "Opportunities",
+          "path": "/opportunities",
+          "locatedAt": "data",
+          "fields": {
+            "account": "account",
+            "account_crm_id": "account_crm_id",
+            "account_name": "account_name",
+            "amount": "amount",
+            "close_date": "close_date",
+            "created_at": "created_at",
+            "created_by_crm_id": "created_by_crm_id",
+            "created_date": "created_date",
+            "creator": "creator",
+            "crm_id": "crm_id",
+            "crm_last_updated_date": "crm_last_updated_date",
+            "crm_type": "crm_type",
+            "crm_url": "crm_url",
+            "currency_iso_code": "currency_iso_code",
+            "custom_fields": "custom_fields",
+            "id": "id",
+            "is_closed": "is_closed",
+            "is_won": "is_won",
+            "most_recent_cadence": "most_recent_cadence",
+            "most_recent_step": "most_recent_step",
+            "most_recent_step_account": "most_recent_step_account",
+            "most_recent_step_number": "most_recent_step_number",
+            "name": "name",
+            "opportunity_type": "opportunity_type",
+            "opportunity_window_person_id": "opportunity_window_person_id",
+            "opportunity_window_started_at": "opportunity_window_started_at",
+            "owner": "owner",
+            "owner_crm_id": "owner_crm_id",
+            "owner_crm_name": "owner_crm_name",
+            "probability": "probability",
+            "stage_name": "stage_name",
+            "tags": "tags",
+            "updated_at": "updated_at"
+          },
+          "docs": "https://developers.salesloft.com/docs/api/opportunities-index"
+        },
+        "opportunity_people": {
+          "displayName": "Opportunity/Person Associations",
+          "path": "/opportunity_people",
+          "locatedAt": "data",
+          "fields": {
+            "created_at": "created_at",
+            "id": "id",
+            "opportunity_crm_id": "opportunity_crm_id",
+            "opportunity_id": "opportunity_id",
+            "person_crm_id": "person_crm_id",
+            "person_id": "person_id",
+            "updated_at": "updated_at"
+          },
+          "docs": "https://developers.salesloft.com/docs/api/opportunity-people-index"
+        },
+        "opportunity_stages": {
+          "displayName": "Opportunity Stages",
+          "path": "/opportunity_stages",
+          "locatedAt": "data",
+          "fields": {
+            "active": "active",
+            "created_at": "created_at",
+            "id": "id",
+            "name": "name",
+            "order": "order",
+            "updated_at": "updated_at"
+          },
+          "docs": "https://developers.salesloft.com/docs/api/opportunity-stages-index"
+        },
         "pending_emails": {
           "displayName": "Pending Emails",
           "path": "/pending_emails",
+          "locatedAt": "data",
           "fields": {
             "id": "id",
             "mailbox": "mailbox",
@@ -669,6 +789,7 @@
         "people": {
           "displayName": "People",
           "path": "/people",
+          "locatedAt": "data",
           "fields": {
             "account": "account",
             "account_crm_id": "account_crm_id",
@@ -690,6 +811,7 @@
             "first_name": "first_name",
             "full_email_address": "full_email_address",
             "home_phone": "home_phone",
+            "hot_lead": "hot_lead",
             "id": "id",
             "import": "import",
             "job_seniority": "job_seniority",
@@ -733,6 +855,7 @@
         "person_stages": {
           "displayName": "Person Stages",
           "path": "/person_stages",
+          "locatedAt": "data",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -746,6 +869,7 @@
         "phone_number_assignments": {
           "displayName": "Phone Number Assignments",
           "path": "/phone_number_assignments",
+          "locatedAt": "data",
           "fields": {
             "id": "id",
             "number": "number",
@@ -756,6 +880,7 @@
         "phone_numbers_caller_ids": {
           "displayName": "Caller Ids",
           "path": "/phone_numbers_caller_ids",
+          "locatedAt": "data",
           "fields": {
             "account_name": "account_name",
             "display_name": "display_name",
@@ -767,6 +892,7 @@
         "saved_list_views": {
           "displayName": "Saved List Views",
           "path": "/saved_list_views",
+          "locatedAt": "data",
           "fields": {
             "id": "id",
             "is_default": "is_default",
@@ -780,6 +906,7 @@
         "steps": {
           "displayName": "Steps",
           "path": "/steps",
+          "locatedAt": "data",
           "fields": {
             "cadence": "cadence",
             "created_at": "created_at",
@@ -799,6 +926,7 @@
         "successes": {
           "displayName": "Successes",
           "path": "/successes",
+          "locatedAt": "data",
           "fields": {
             "counts": "counts",
             "created_at": "created_at",
@@ -819,6 +947,7 @@
         "tags": {
           "displayName": "Team Tags",
           "path": "/tags",
+          "locatedAt": "data",
           "fields": {
             "id": "id",
             "name": "name"
@@ -828,6 +957,7 @@
         "tasks": {
           "displayName": "Tasks",
           "path": "/tasks",
+          "locatedAt": "data",
           "fields": {
             "completed_at": "completed_at",
             "completed_by": "completed_by",
@@ -852,6 +982,7 @@
         "team_template_attachments": {
           "displayName": "Team Template Attachments",
           "path": "/team_template_attachments",
+          "locatedAt": "data",
           "fields": {
             "attachment_file_size": "attachment_file_size",
             "attachment_id": "attachment_id",
@@ -865,6 +996,7 @@
         "team_templates": {
           "displayName": "Team Templates",
           "path": "/team_templates",
+          "locatedAt": "data",
           "fields": {
             "_links": "_links",
             "archived_at": "archived_at",
@@ -888,6 +1020,7 @@
         "users": {
           "displayName": "Users",
           "path": "/users",
+          "locatedAt": "data",
           "fields": {
             "email": "email",
             "guid": "guid",
@@ -899,6 +1032,7 @@
         "webhook_subscriptions": {
           "displayName": "Webhook Subscriptions",
           "path": "/webhook_subscriptions",
+          "locatedAt": "data",
           "fields": {
             "callback_token": "callback_token",
             "callback_url": "callback_url",

--- a/providers/zendesksupport/metadata/schemas.json
+++ b/providers/zendesksupport/metadata/schemas.json
@@ -7,6 +7,7 @@
         "article_labels": {
           "displayName": "Article Labels",
           "path": "/help_center/articles/labels",
+          "responseKey": "labels",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -18,6 +19,7 @@
         "articles": {
           "displayName": "Articles",
           "path": "/help_center/articles/search",
+          "responseKey": "results",
           "fields": {
             "author_id": "author_id",
             "body": "body",
@@ -49,6 +51,7 @@
         "community_posts": {
           "displayName": "Community Posts",
           "path": "/help_center/community_posts/search",
+          "responseKey": "results",
           "fields": {
             "author_id": "author_id",
             "closed": "closed",
@@ -75,6 +78,7 @@
         "posts": {
           "displayName": "Posts",
           "path": "/community/posts",
+          "responseKey": "posts",
           "fields": {
             "author_id": "author_id",
             "closed": "closed",
@@ -101,6 +105,7 @@
         "topics": {
           "displayName": "Topics",
           "path": "/community/topics",
+          "responseKey": "topics",
           "fields": {
             "created_at": "created_at",
             "description": "description",
@@ -118,6 +123,7 @@
         "user_segments": {
           "displayName": "User Segments",
           "path": "/help_center/user_segments",
+          "responseKey": "user_segments",
           "fields": {
             "built_in": "built_in",
             "created_at": "created_at",
@@ -140,6 +146,7 @@
         "activities": {
           "displayName": "Activities",
           "path": "/activities",
+          "responseKey": "activities",
           "fields": {
             "actor": "actor",
             "actor_id": "actor_id",
@@ -158,6 +165,7 @@
         "attributes": {
           "displayName": "Attributes",
           "path": "/routing/attributes",
+          "responseKey": "attributes",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -169,6 +177,7 @@
         "audit_logs": {
           "displayName": "Audit Logs",
           "path": "/audit_logs",
+          "responseKey": "audit_logs",
           "fields": {
             "action": "action",
             "action_label": "action_label",
@@ -187,6 +196,7 @@
         "automations": {
           "displayName": "Automations",
           "path": "/automations",
+          "responseKey": "automations",
           "fields": {
             "actions": "actions",
             "active": "active",
@@ -203,6 +213,7 @@
         "bookmarks": {
           "displayName": "Bookmarks",
           "path": "/bookmarks",
+          "responseKey": "bookmarks",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -213,6 +224,7 @@
         "brands": {
           "displayName": "Brands",
           "path": "/brands",
+          "responseKey": "brands",
           "fields": {
             "active": "active",
             "brand_url": "brand_url",
@@ -235,6 +247,7 @@
         "custom_objects": {
           "displayName": "Custom Objects",
           "path": "/custom_objects",
+          "responseKey": "custom_objects",
           "fields": {
             "created_at": "created_at",
             "created_by_user_id": "created_by_user_id",
@@ -253,6 +266,7 @@
         "custom_roles": {
           "displayName": "Custom Roles",
           "path": "/custom_roles",
+          "responseKey": "custom_roles",
           "fields": {
             "configuration": "configuration",
             "created_at": "created_at",
@@ -267,6 +281,7 @@
         "custom_statuses": {
           "displayName": "Custom Statuses",
           "path": "/custom_statuses",
+          "responseKey": "custom_statuses",
           "fields": {
             "active": "active",
             "agent_label": "agent_label",
@@ -287,6 +302,7 @@
         "deleted_tickets": {
           "displayName": "Deleted Tickets",
           "path": "/deleted_tickets",
+          "responseKey": "deleted_tickets",
           "fields": {
             "actor": "actor",
             "deleted_at": "deleted_at",
@@ -298,6 +314,7 @@
         "deleted_users": {
           "displayName": "Deleted Users",
           "path": "/deleted_users",
+          "responseKey": "deleted_users",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -319,6 +336,7 @@
         "deletion_schedules": {
           "displayName": "Deletion Schedules",
           "path": "/deletion_schedules",
+          "responseKey": "deletion_schedules",
           "fields": {
             "active": "active",
             "conditions": "conditions",
@@ -334,6 +352,7 @@
         "email_notifications": {
           "displayName": "Email Notifications",
           "path": "/email_notifications",
+          "responseKey": "email_notifications",
           "fields": {
             "comment_id": "comment_id",
             "created_at": "created_at",
@@ -349,6 +368,7 @@
         "group_memberships": {
           "displayName": "Group Memberships",
           "path": "/group_memberships",
+          "responseKey": "group_memberships",
           "fields": {
             "created_at": "created_at",
             "default": "default",
@@ -362,6 +382,7 @@
         "groups": {
           "displayName": "Groups",
           "path": "/groups",
+          "responseKey": "groups",
           "fields": {
             "created_at": "created_at",
             "default": "default",
@@ -377,6 +398,7 @@
         "job_statuses": {
           "displayName": "Job Statuses",
           "path": "/job_statuses",
+          "responseKey": "job_statuses",
           "fields": {
             "id": "id",
             "job_type": "job_type",
@@ -391,6 +413,7 @@
         "locales": {
           "displayName": "Locales",
           "path": "/locales",
+          "responseKey": "locales",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -403,6 +426,7 @@
         "macros": {
           "displayName": "Macros",
           "path": "/macros",
+          "responseKey": "macros",
           "fields": {
             "actions": "actions",
             "active": "active",
@@ -427,6 +451,7 @@
         "monitored_twitter_handles": {
           "displayName": "Monitored Twitter Handles",
           "path": "/channels/twitter/monitored_twitter_handles",
+          "responseKey": "monitored_twitter_handles",
           "fields": {
             "allow_reply": "allow_reply",
             "avatar_url": "avatar_url",
@@ -443,6 +468,7 @@
         "organization_fields": {
           "displayName": "Organization Fields",
           "path": "/organization_fields",
+          "responseKey": "organization_fields",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -467,6 +493,7 @@
         "organization_memberships": {
           "displayName": "Organization Memberships",
           "path": "/organization_memberships",
+          "responseKey": "organization_memberships",
           "fields": {
             "created_at": "created_at",
             "default": "default",
@@ -482,6 +509,7 @@
         "organization_subscriptions": {
           "displayName": "Organization Subscriptions",
           "path": "/organization_subscriptions",
+          "responseKey": "organization_subscriptions",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -492,6 +520,7 @@
         "organizations": {
           "displayName": "Organizations",
           "path": "/organizations",
+          "responseKey": "organizations",
           "fields": {
             "created_at": "created_at",
             "details": "details",
@@ -512,6 +541,7 @@
         "queues": {
           "displayName": "Queues",
           "path": "/queues",
+          "responseKey": "queues",
           "fields": {
             "created_at": "created_at",
             "definition": "definition",
@@ -529,6 +559,7 @@
         "recipient_addresses": {
           "displayName": "Recipient Addresses",
           "path": "/recipient_addresses",
+          "responseKey": "recipient_addresses",
           "fields": {
             "brand_id": "brand_id",
             "cname_status": "cname_status",
@@ -548,6 +579,7 @@
         "requests": {
           "displayName": "Requests",
           "path": "/requests",
+          "responseKey": "requests",
           "fields": {
             "assignee_id": "assignee_id",
             "can_be_solved_by_me": "can_be_solved_by_me",
@@ -579,6 +611,7 @@
         "resource_collections": {
           "displayName": "Resource Collections",
           "path": "/resource_collections",
+          "responseKey": "resource_collections",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -589,6 +622,7 @@
         "satisfaction_ratings": {
           "displayName": "Satisfaction Ratings",
           "path": "/satisfaction_ratings",
+          "responseKey": "satisfaction_ratings",
           "fields": {
             "assignee_id": "assignee_id",
             "comment": "comment",
@@ -608,6 +642,7 @@
         "satisfaction_reasons": {
           "displayName": "Satisfaction Rating Reasons",
           "path": "/satisfaction_reasons",
+          "responseKey": "reasons",
           "fields": {
             "created_at": "created_at",
             "deleted_at": "deleted_at",
@@ -622,6 +657,7 @@
         "search": {
           "displayName": "Search Results",
           "path": "/search",
+          "responseKey": "results",
           "fields": {
             "created_at": "created_at",
             "default": "default",
@@ -637,6 +673,7 @@
         "session": {
           "displayName": "Session",
           "path": "/users/me/session",
+          "responseKey": "session",
           "fields": {
             "authenticated_at": "authenticated_at",
             "id": "id",
@@ -648,6 +685,7 @@
         "sessions": {
           "displayName": "Sessions",
           "path": "/sessions",
+          "responseKey": "sessions",
           "fields": {
             "authenticated_at": "authenticated_at",
             "id": "id",
@@ -659,6 +697,7 @@
         "sharing_agreements": {
           "displayName": "Sharing Agreements",
           "path": "/sharing_agreements",
+          "responseKey": "sharing_agreements",
           "fields": {
             "created_at": "created_at",
             "id": "id",
@@ -674,6 +713,7 @@
         "suspended_tickets": {
           "displayName": "Suspended Tickets",
           "path": "/suspended_tickets",
+          "responseKey": "suspended_tickets",
           "fields": {
             "attachments": "attachments",
             "author": "author",
@@ -696,6 +736,7 @@
         "tags": {
           "displayName": "Tags",
           "path": "/tags",
+          "responseKey": "tags",
           "fields": {
             "count": "count",
             "name": "name"
@@ -704,6 +745,7 @@
         "target_failures": {
           "displayName": "Target Failures",
           "path": "/target_failures",
+          "responseKey": "target_failures",
           "fields": {
             "consecutive_failure_count": "consecutive_failure_count",
             "created_at": "created_at",
@@ -718,6 +760,7 @@
         "targets": {
           "displayName": "Targets",
           "path": "/targets",
+          "responseKey": "targets",
           "fields": {
             "account_name": "account_name",
             "active": "active",
@@ -759,6 +802,7 @@
         "ticket_audits": {
           "displayName": "Ticket Audits",
           "path": "/ticket_audits",
+          "responseKey": "audits",
           "fields": {
             "author_id": "author_id",
             "created_at": "created_at",
@@ -772,6 +816,7 @@
         "ticket_fields": {
           "displayName": "Ticket Fields",
           "path": "/ticket_fields",
+          "responseKey": "ticket_fields",
           "fields": {
             "active": "active",
             "agent_description": "agent_description",
@@ -808,6 +853,7 @@
         "ticket_forms": {
           "displayName": "Ticket Forms",
           "path": "/ticket_forms",
+          "responseKey": "ticket_forms",
           "fields": {
             "active": "active",
             "agent_conditions": "agent_conditions",
@@ -831,6 +877,7 @@
         "ticket_metrics": {
           "displayName": "Ticket Metrics",
           "path": "/ticket_metrics",
+          "responseKey": "ticket_metrics",
           "fields": {
             "agent_wait_time_in_minutes": "agent_wait_time_in_minutes",
             "assigned_at": "assigned_at",
@@ -861,6 +908,7 @@
         "tickets": {
           "displayName": "Tickets",
           "path": "/tickets",
+          "responseKey": "tickets",
           "fields": {
             "allow_attachments": "allow_attachments",
             "allow_channelback": "allow_channelback",
@@ -919,6 +967,7 @@
         "trigger_categories": {
           "displayName": "Trigger Categories",
           "path": "/trigger_categories",
+          "responseKey": "trigger_categories",
           "fields": {
             "active_count": "active_count",
             "created_at": "created_at",
@@ -932,6 +981,7 @@
         "triggers": {
           "displayName": "Triggers",
           "path": "/triggers",
+          "responseKey": "triggers",
           "fields": {
             "actions": "actions",
             "active": "active",
@@ -951,6 +1001,7 @@
         "user_fields": {
           "displayName": "User Fields",
           "path": "/user_fields",
+          "responseKey": "user_fields",
           "fields": {
             "active": "active",
             "created_at": "created_at",
@@ -975,6 +1026,7 @@
         "users": {
           "displayName": "Users",
           "path": "/users",
+          "responseKey": "users",
           "fields": {
             "active": "active",
             "alias": "alias",
@@ -1020,6 +1072,7 @@
         "views": {
           "displayName": "Views",
           "path": "/views",
+          "responseKey": "views",
           "fields": {
             "active": "active",
             "conditions": "conditions",
@@ -1037,6 +1090,7 @@
         "workspaces": {
           "displayName": "Workspaces",
           "path": "/workspaces",
+          "responseKey": "workspaces",
           "fields": {
             "activated": "activated",
             "apps": "apps",

--- a/scripts/openapi/customerio/journeysapp/metadata/main.go
+++ b/scripts/openapi/customerio/journeysapp/metadata/main.go
@@ -51,7 +51,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/gong/metadata/main.go
+++ b/scripts/openapi/gong/metadata/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/intercom/metadata/main.go
+++ b/scripts/openapi/intercom/metadata/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/pipedrive/metadata/main.go
+++ b/scripts/openapi/pipedrive/metadata/main.go
@@ -87,7 +87,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/pipeliner/metadata/main.go
+++ b/scripts/openapi/pipeliner/metadata/main.go
@@ -57,7 +57,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -33,7 +33,8 @@ func main() {
 			}
 
 			for _, field := range object.Fields {
-				schemas.Add(module, object.ObjectName, object.DisplayName, field, object.URLPath, nil)
+				schemas.Add(module, object.ObjectName, object.DisplayName,
+					field, object.URLPath, object.ResponseKey, nil)
 			}
 
 			for _, queryParam := range object.QueryParams {

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -89,7 +89,7 @@ func createSchemas() {
 						newDisplayName, isList := handleDisplayName(model.DisplayName)
 						if isList {
 							schemas.Add("", modelName,
-								newDisplayName, fieldName, fmt.Sprintf("/%v", modelName), &model.URL)
+								newDisplayName, fieldName, fmt.Sprintf("/%v", modelName), "data", &model.URL)
 						}
 					}
 				})


### PR DESCRIPTION
# Description

Added `locatedAt` field in schema.json.
This is present for those providers relying on OpenAPI or scrapping.

# Result
schema.json:
![image](https://github.com/user-attachments/assets/9ce9bb5e-92e5-43e6-a7e9-5c56d25e8806)

# Reason
LocatedAt indicates under which field name the array of object is located.
From schema.json it is easier to tell, what is the URL path, where the object is found from provider response and what fields it will returns. It captures all required information to see how Ampersand metadata is mapped to provider APIs.