### PR TITLE
[ENG-1652] Introduce a method to transform the webhook payload into a ReadResultRow

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -294,6 +294,7 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 		return nil, nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
+	// fmt.Println(res)
 	// Check the response status code
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		if h.ErrorHandler != nil {

--- a/common/http.go
+++ b/common/http.go
@@ -294,7 +294,6 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 		return nil, nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
-	// fmt.Println(res)
 	// Check the response status code
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		if h.ErrorHandler != nil {

--- a/providers/hubspot/errors.go
+++ b/providers/hubspot/errors.go
@@ -52,11 +52,7 @@ type ErrLinks struct {
 
 func (c *Connector) interpretError(res *http.Response, body []byte) error {
 	mediaType, _, err := mime.ParseMediaType(res.Header.Get("Content-Type"))
-	if err != nil {
-		return fmt.Errorf("mime.ParseMediaType failed: %w", err)
-	}
-
-	if mediaType == "application/json" {
+	if err == nil && mediaType == "application/json" {
 		return c.interpretJSONError(res, body)
 	}
 

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -11,6 +11,15 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
+//nolint:gochecknoglobals
+var (
+	getRecordSupportedObjectsSet = datautils.NewStringSet(
+		"company", "contact", "deal", "ticket", "line_item", "product",
+	)
+
+	errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
+)
+
 /*
    docs:
    https://developers.hubspot.com/beta-docs/reference/api/crm/objects/companies
@@ -21,15 +30,7 @@ import (
    https://developers.hubspot.com/beta-docs/reference/api/crm/objects/products
 */
 
-//nolint:gochecknoglobals
-var (
-	getRecordSupportedObjectsSet = datautils.NewStringSet(
-		"company", "contact", "deal", "ticket", "line_item", "product",
-	)
-
-	errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
-)
-
+// GetRecord returns a record from the object with the given ID and object name.
 func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResultRow, error) {
 	if !getRecordSupportedObjectsSet.Has(objectName) {
 		return nil, fmt.Errorf("%w %s", errGerRecordNotSupportedForObject, objectName)

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -31,7 +31,7 @@ var getRecordSupportedObjectsToPathMap = map[string]string{
 
 var ErrUnsupportedObject = errors.New("unsupported object")
 
-func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResult, error) {
+func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResultRow, error) {
 	objectNameInPath, ok := getRecordSupportedObjectsToPathMap[objectName]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedObject, objectName)
@@ -49,10 +49,7 @@ func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId s
 		return nil, fmt.Errorf("error parsing record: %w", err)
 	}
 
-	return &common.ReadResult{
-		Rows: 1,
-		Data: []common.ReadResultRow{
-			{Raw: *record},
-		},
+	return &common.ReadResultRow{
+		Raw: *record,
 	}, nil
 }

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -9,6 +9,16 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
+/*
+   docs:
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/companies
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/contacts
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/deals
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/tickets
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/line_items
+   https://developers.hubspot.com/beta-docs/reference/api/crm/objects/products
+*/
+
 var getRecordSupportedObjectsToPathMap = map[string]string{
 	"company":   "companies",
 	"contact":   "contacts",

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -1,0 +1,47 @@
+package hubspot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+var getRecordSupportedObjectsToPathMap = map[string]string{
+	"company":   "companies",
+	"contact":   "contacts",
+	"deal":      "deals",
+	"ticket":    "tickets",
+	"line_item": "line_items",
+	"product":   "products",
+}
+
+var ErrUnsupportedObject = errors.New("unsupported object")
+
+func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResult, error) {
+	objectNameInPath, ok := getRecordSupportedObjectsToPathMap[objectName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedObject, objectName)
+	}
+
+	relativePath := path.Join("/crm/v3/objects", objectNameInPath, recordId)
+
+	resp, err := c.Client.Get(ctx, c.getURL(relativePath))
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := common.UnmarshalJSON[map[string]any](resp)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing record: %w", err)
+	}
+
+	return &common.ReadResult{
+		Rows: 1,
+		Data: []common.ReadResultRow{
+			{Raw: *record},
+		},
+	}, nil
+}

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/internal/datautils"
 )
 
 /*
@@ -21,20 +22,16 @@ import (
 */
 
 //nolint:gochecknoglobals
-var getRecordSupportedObjects = map[string]bool{
-	"company":   true,
-	"contact":   true,
-	"deal":      true,
-	"ticket":    true,
-	"line_item": true,
-	"product":   true,
-}
+var (
+	getRecordSupportedObjectsSet = datautils.NewStringSet(
+		"company", "contact", "deal", "ticket", "line_item", "product",
+	)
 
-var errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
+	errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
+)
 
 func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResultRow, error) {
-	_, supported := getRecordSupportedObjects[objectName]
-	if !supported {
+	if !getRecordSupportedObjectsSet.Has(objectName) {
 		return nil, fmt.Errorf("%w %s", errGerRecordNotSupportedForObject, objectName)
 	}
 

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -21,7 +21,7 @@ import (
 */
 
 //nolint:gochecknoglobals
-var getRecordSupportedObjectsToPathMap = map[string]bool{
+var getRecordSupportedObjects = map[string]bool{
 	"company":   true,
 	"contact":   true,
 	"deal":      true,
@@ -33,7 +33,7 @@ var getRecordSupportedObjectsToPathMap = map[string]bool{
 var errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
 
 func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId string) (*common.ReadResultRow, error) {
-	_, supported := getRecordSupportedObjectsToPathMap[objectName]
+	_, supported := getRecordSupportedObjects[objectName]
 	if !supported {
 		return nil, fmt.Errorf("%w %s", errGerRecordNotSupportedForObject, objectName)
 	}

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -19,6 +19,7 @@ import (
    https://developers.hubspot.com/beta-docs/reference/api/crm/objects/products
 */
 
+//nolint:gochecknoglobals
 var getRecordSupportedObjectsToPathMap = map[string]string{
 	"company":   "companies",
 	"contact":   "contacts",
@@ -36,7 +37,7 @@ func (c *Connector) GetRecord(ctx context.Context, objectName string, recordId s
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedObject, objectName)
 	}
 
-	relativePath := path.Join("/crm/v3/objects", objectNameInPath, recordId)
+	relativePath := path.Join("/objects", objectNameInPath, recordId)
 
 	resp, err := c.Client.Get(ctx, c.getURL(relativePath))
 	if err != nil {

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -6,5 +6,6 @@ import (
 
 // getURL is a helper to return the full URL considering the base URL & module.
 func (c *Connector) getURL(arg string) string {
+	// TODO: use url package to join paths and avoid issues with slashes in another PR
 	return c.BaseURL + "/" + path.Join(c.Module.Path(), arg)
 }

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -1,10 +1,10 @@
 package hubspot
 
 import (
-	"strings"
+	"path"
 )
 
 // getURL is a helper to return the full URL considering the base URL & module.
 func (c *Connector) getURL(arg string) string {
-	return strings.Join([]string{c.BaseURL, c.Module.Path(), arg}, "/")
+	return c.BaseURL + "/" + path.Join(c.Module.Path(), arg)
 }

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -22,26 +22,13 @@ type WebhookMessage struct {
 	PropertyValue    string `json:"propertyValue"`
 }
 
-type WebhookResult struct {
-	WebhookMessage *WebhookMessage       `json:"webhookMessage"`
-	Record         *common.ReadResultRow `json:"record"`
-}
-
-func (c *Connector) GetWebhookResultFromWebhookMessage(
+func (c *Connector) GetRecordFromWebhookMessage(
 	ctx context.Context, msg *WebhookMessage,
-) (*WebhookResult, error) {
+) (*common.ReadResultRow, error) {
 	// Transform the webhook message into a ReadResult.
 	objectName := strings.Split(msg.SubscriptionType, ".")[0]
 	recordId := strconv.Itoa(msg.ObjectId)
 
 	// Since the webhook message doesn't contain the record data, we need to fetch it.
-	recordResultRow, err := c.GetRecord(ctx, objectName, recordId)
-	if err != nil {
-		return nil, err
-	}
-
-	return &WebhookResult{
-		WebhookMessage: msg,
-		Record:         recordResultRow,
-	}, nil
+	return c.GetRecord(ctx, objectName, recordId)
 }

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -23,8 +23,8 @@ type WebhookMessage struct {
 }
 
 type WebhookResult struct {
-	WebhookMessage *WebhookMessage    `json:"webhookMessage"`
-	Record         *common.ReadResult `json:"record"`
+	WebhookMessage *WebhookMessage       `json:"webhookMessage"`
+	Record         *common.ReadResultRow `json:"record"`
 }
 
 func (c *Connector) GetWebhookResultFromWebhookMessage(
@@ -35,13 +35,13 @@ func (c *Connector) GetWebhookResultFromWebhookMessage(
 	recordId := strconv.Itoa(msg.ObjectId)
 
 	// Since the webhook message doesn't contain the record data, we need to fetch it.
-	recordResult, err := c.GetRecord(ctx, objectName, recordId)
+	recordResultRow, err := c.GetRecord(ctx, objectName, recordId)
 	if err != nil {
 		return nil, err
 	}
 
 	return &WebhookResult{
 		WebhookMessage: msg,
-		Record:         recordResult,
+		Record:         recordResultRow,
 	}, nil
 }

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -22,6 +22,7 @@ type WebhookMessage struct {
 	PropertyValue    string `json:"propertyValue"`
 }
 
+// GetRecordFromWebhookMessage fetches a record from the Hubspot API using the data from a webhook message.
 func (c *Connector) GetRecordFromWebhookMessage(
 	ctx context.Context, msg *WebhookMessage,
 ) (*common.ReadResultRow, error) {

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -13,7 +13,7 @@ type WebhookMessage struct {
 	EventId          int    `json:"eventId"`
 	SubscriptionId   int    `json:"subscriptionId"`
 	PortalId         int    `json:"portalId"`
-	OccurredAt       string `json:"occurredAt"`
+	OccurredAt       int    `json:"occurredAt"`
 	SubscriptionType string `json:"subscriptionType"`
 	AttemptNumber    int    `json:"attemptNumber"`
 	ObjectId         int    `json:"objectId"`
@@ -22,7 +22,14 @@ type WebhookMessage struct {
 	PropertyValue    string `json:"propertyValue"`
 }
 
-func (c *Connector) TransformWebhookMessageToReadResult(ctx context.Context, msg WebhookMessage) (*common.ReadResult, error) {
+type WebhookResult struct {
+	WebhookMessage *WebhookMessage    `json:"webhookMessage"`
+	Record         *common.ReadResult `json:"record"`
+}
+
+func (c *Connector) GetWebhookResultFromWebhookMessage(
+	ctx context.Context, msg *WebhookMessage,
+) (*WebhookResult, error) {
 	// Transform the webhook message into a ReadResult.
 	objectName := strings.Split(msg.SubscriptionType, ".")[0]
 	recordId := strconv.Itoa(msg.ObjectId)
@@ -33,5 +40,8 @@ func (c *Connector) TransformWebhookMessageToReadResult(ctx context.Context, msg
 		return nil, err
 	}
 
-	return recordResult, nil
+	return &WebhookResult{
+		WebhookMessage: msg,
+		Record:         recordResult,
+	}, nil
 }

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -24,10 +24,10 @@ type WebhookMessage struct {
 
 func (c *Connector) TransformWebhookMessageToReadResult(ctx context.Context, msg WebhookMessage) (*common.ReadResult, error) {
 	// Transform the webhook message into a ReadResult.
-	// This is a placeholder implementation.
 	objectName := strings.Split(msg.SubscriptionType, ".")[0]
 	recordId := strconv.Itoa(msg.ObjectId)
 
+	// Since the webhook message doesn't contain the record data, we need to fetch it.
 	recordResult, err := c.GetRecord(ctx, objectName, recordId)
 	if err != nil {
 		return nil, err

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -1,0 +1,37 @@
+package hubspot
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+type WebhookMessage struct {
+	AppId            int    `json:"appId"`
+	EventId          int    `json:"eventId"`
+	SubscriptionId   int    `json:"subscriptionId"`
+	PortalId         int    `json:"portalId"`
+	OccurredAt       string `json:"occurredAt"`
+	SubscriptionType string `json:"subscriptionType"`
+	AttemptNumber    int    `json:"attemptNumber"`
+	ObjectId         int    `json:"objectId"`
+	ChangeSource     string `json:"changeSource"`
+	PropertyName     string `json:"propertyName"`
+	PropertyValue    string `json:"propertyValue"`
+}
+
+func (c *Connector) TransformWebhookMessageToReadResult(ctx context.Context, msg WebhookMessage) (*common.ReadResult, error) {
+	// Transform the webhook message into a ReadResult.
+	// This is a placeholder implementation.
+	objectName := strings.Split(msg.SubscriptionType, ".")[0]
+	recordId := strconv.Itoa(msg.ObjectId)
+
+	recordResult, err := c.GetRecord(ctx, objectName, recordId)
+	if err != nil {
+		return nil, err
+	}
+
+	return recordResult, nil
+}

--- a/providers/hubspot/write.go
+++ b/providers/hubspot/write.go
@@ -3,7 +3,7 @@ package hubspot
 import (
 	"context"
 	"fmt"
-	"strings"
+	"path"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -25,7 +25,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 
 	var write common.WriteMethod
 
-	relativeURL := strings.Join([]string{"objects", config.ObjectName}, "/")
+	relativeURL := path.Join("objects", config.ObjectName)
 	url := c.getURL(relativeURL)
 
 	if config.RecordId != "" {

--- a/test/hubspot/record/main.go
+++ b/test/hubspot/record/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/providers/hubspot"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+const samplePropertyChange = `{
+  "appId": 4210286,
+  "eventId": 100,
+  "subscriptionId": 2902227,
+  "portalId": 44237313,
+  "occurredAt": 1730750483646,
+  "subscriptionType": "contact.propertyChange",
+  "attemptNumber": 0,
+  "objectId": 74999542704,
+  "changeSource": "CRM",
+  "propertyName": "message",
+  "propertyValue": "sample-value"
+}`
+
+const sampleRecordContact = `{
+  "success": true,
+  "recordId": "74999542704",
+  "data": {
+    "company": "Personalis",
+    "createdate": "2024-11-04T21:51:26.472Z",
+    "email": "lestermertz@larson.org",
+    "firstname": "Lucious",
+    "hs_all_contact_vids": "74999542704",
+    "hs_calculated_phone_number": "+17087038093",
+    "hs_calculated_phone_number_country_code": "US",
+    "hs_currently_enrolled_in_prospecting_agent": "false",
+    "hs_email_domain": "larson.org",
+    "hs_is_contact": "true",
+    "hs_is_unworked": "true",
+    "hs_lifecyclestage_lead_date": "2024-11-04T21:51:26.472Z",
+    "hs_membership_has_accessed_private_content": "0",
+    "hs_object_id": "74999542704",
+    "hs_object_source": "INTEGRATION",
+    "hs_object_source_id": "2317233",
+    "hs_object_source_label": "INTEGRATION",
+    "hs_pipeline": "contacts-lifecycle-pipeline",
+    "hs_registered_member": "0",
+    "hs_searchable_calculated_phone_number": "7087038093",
+    "lastmodifieddate": "2024-11-04T21:51:26.472Z",
+    "lastname": "Spencer",
+    "lifecyclestage": "lead",
+    "phone": "7087038093",
+    "website": "https://www.directcutting-edge.net/granular/reintermediate/infomediaries"
+  }
+}`
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	// Get the Hubspot connector.
+	conn := connTest.GetHubspotConnector(ctx)
+	defer utils.Close(conn)
+
+	propMsg := hubspot.WebhookMessage{}
+
+	if err := json.Unmarshal([]byte(samplePropertyChange), &propMsg); err != nil {
+		utils.Fail("error unmarshalling property change message", "error", err)
+	}
+
+	recordResult, err := conn.GetWebhookResultFromWebhookMessage(ctx, &propMsg)
+	if err != nil {
+		utils.Fail("error getting record from webhook message", "error", err)
+	}
+
+	utils.DumpJSON(recordResult, os.Stdout)
+}

--- a/test/hubspot/record/main.go
+++ b/test/hubspot/record/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -58,8 +57,6 @@ func main() {
 	if err != nil {
 		utils.Fail("error writing to hubspot", "error", err)
 	}
-
-	fmt.Println(writeresult.RecordId)
 
 	propMsg := hubspot.WebhookMessage{}
 

--- a/test/hubspot/record/main.go
+++ b/test/hubspot/record/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	propMsg.ObjectId = recordId
 
-	recordResult, err := conn.GetWebhookResultFromWebhookMessage(ctx, &propMsg)
+	recordResult, err := conn.GetRecordFromWebhookMessage(ctx, &propMsg)
 	if err != nil {
 		utils.Fail("error getting record from webhook message", "error", err)
 	}

--- a/test/hubspot/record/main.go
+++ b/test/hubspot/record/main.go
@@ -42,7 +42,7 @@ func main() {
 	defer utils.Close(conn)
 
 	// Write an artificial contact to Hubspot.
-	writeresult, err := conn.Write(ctx, common.WriteParams{
+	writeResult, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: "contacts",
 		RecordId:   "",
 		RecordData: map[string]any{
@@ -64,7 +64,7 @@ func main() {
 		utils.Fail("error unmarshalling property change message", "error", err)
 	}
 
-	recordId, err := strconv.Atoi(writeresult.RecordId)
+	recordId, err := strconv.Atoi(writeResult.RecordId)
 	if err != nil {
 		utils.Fail("error converting record id to int", "error", err)
 	}

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -36,7 +36,6 @@ func main() {
 	if err := readLeads(ctx, conn); err != nil {
 		slog.Error(err.Error())
 	}
-
 }
 
 func readContacts(ctx context.Context, conn connectors.ReadConnector) error {


### PR DESCRIPTION
## About this PR

This PR implements a Connector method for HubSpot that transforms webhook messages to `WebhookResult` which will contain original record data. In order to achieve that, this PR introduces `GetRecord(...)` method that takes `recordId` and `objectName` as arguments and returns `ReadResultRow` which will have raw data. 


## Test Result
```
jaehyunlim@Jaehyuns-MacBook-Pro connectors % go run test/hubspot/record/main.go  
time=2024-11-04T16:29:05.992-08:00 level=DEBUG msg="loading credentials file" path=./hubspot-creds.json
{
  "webhookMessage": {
    "appId": 4210286,
    "eventId": 100,
    "subscriptionId": 2902227,
    "portalId": 44237313,
    "occurredAt": 1730750483646,
    "subscriptionType": "contact.propertyChange",
    "attemptNumber": 0,
    "objectId": 75032904814,
    "changeSource": "CRM",
    "propertyName": "message",
    "propertyValue": "sample-value"
  },
  "record": {
    "fields": null,
    "raw": {
      "archived": false,
      "createdAt": "2024-11-05T00:29:06.427Z",
      "id": "75032904814",
      "properties": {
        "createdate": "2024-11-05T00:29:06.427Z",
        "email": "evertaufderhar@robel.org",
        "firstname": "Geovanni",
        "hs_object_id": "75032904814",
        "lastmodifieddate": "2024-11-05T00:29:06.427Z",
        "lastname": "Veum"
      },
      "updatedAt": "2024-11-05T00:29:06.427Z"
    }
  }
}
```