### PR TITLE
feat: Keap (Read)

### DIFF
--- a/common/module.go
+++ b/common/module.go
@@ -51,14 +51,14 @@ func (a Module) Path() string {
 //	Then:	It will be represented as follows:
 //
 //		ModuleObjectNameToFieldName{
-//			ModuleCommerce: handy.NewDefaultMap(map[string]string{
+//			ModuleCommerce: datautils.NewDefaultMap(map[string]string{
 //				"carts": "carts",
 //			},
 //				func(objectName string) string {
 //					return "data" // always under "data" field {"data": [{},{},...]}
 //				},
 //			),
-//			ModuleHelpCenter: handy.NewDefaultMap(map[string]string{
+//			ModuleHelpCenter: datautils.NewDefaultMap(map[string]string{
 //				"chats":        "active_chats",
 //			}, func(objectName string) string {
 //				fieldName := objectName // Object "messages" is stored under {"messages": [{},{},...]}

--- a/providers/keap/client.go
+++ b/providers/keap/client.go
@@ -1,0 +1,18 @@
+package keap
+
+import (
+	"github.com/amp-labs/connectors/common"
+)
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/providers/keap/connector.go
+++ b/providers/keap/connector.go
@@ -1,0 +1,75 @@
+package keap
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/keap/metadata"
+)
+
+const ApiPathPrefix = "crm/rest"
+
+type Connector struct {
+	BaseURL string
+	Client  *common.JSONHTTPClient
+	Module  common.Module
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(ModuleV1))
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := params.Client.Caller
+	conn = &Connector{
+		Client: &common.JSONHTTPClient{
+			HTTPClient: httpClient,
+		},
+		Module: params.Selection,
+	}
+
+	// Read provider info
+	providerInfo, err := providers.ReadInfo(conn.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	// connector and its client must mirror base url and provide its own error parser
+	conn.setBaseURL(providerInfo.BaseURL)
+	conn.Client.HTTPClient.ErrorHandler = interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		HTML: &interpreter.DirectFaultyResponder{Callback: conn.interpretHTMLError},
+	}.Handle
+
+	return conn, nil
+}
+
+func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.BaseURL, ApiPathPrefix, path)
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return providers.Keap
+}
+
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}

--- a/providers/keap/errors.go
+++ b/providers/keap/errors.go
@@ -1,0 +1,66 @@
+package keap
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	Detail string `json:"message"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, r.Detail)
+}
+
+func (c *Connector) interpretHTMLError(res *http.Response, body []byte) error {
+	base := interpreter.DefaultStatusCodeMappingToErr(res, body)
+
+	document, err := goquery.NewDocumentFromReader(bytes.NewReader(body))
+	if err != nil {
+		// ignore HTML that cannot be understood
+		return base
+	}
+
+	// Several HTML errors have different formats, given a small sample -- it is safe to use
+	// title as primary message; h2 may hold better description.
+	// For examples refer to the `test` directory which has `.html` samples used in unit testing.
+	message := document.Find("title").Text()
+	h2 := document.Find("h2").Text()
+
+	if len(h2) != 0 {
+		message += ": " + h2
+	}
+
+	message = cleanMessage(message)
+
+	return fmt.Errorf("%w: %v", base, message)
+}
+
+func cleanMessage(message string) string {
+	// Remove new lines and double spaces.
+	r := strings.NewReplacer("\n", "", "  ", "")
+
+	size := 0
+	for size != len(message) {
+		// Replace until nothing changes.
+		size = len(message)
+		message = r.Replace(message)
+	}
+
+	return message
+}

--- a/providers/keap/metadata/schemas.json
+++ b/providers/keap/metadata/schemas.json
@@ -1,0 +1,597 @@
+{
+  "modules": {
+    "version1": {
+      "id": "version1",
+      "path": "/v1",
+      "objects": {
+        "affiliates": {
+          "displayName": "Affiliates",
+          "path": "/affiliates",
+          "responseKey": "affiliates",
+          "fields": {
+            "code": "code",
+            "contact_id": "contact_id",
+            "id": "id",
+            "name": "name",
+            "notify_on_lead": "notify_on_lead",
+            "notify_on_sale": "notify_on_sale",
+            "parent_id": "parent_id",
+            "status": "status",
+            "track_leads_for": "track_leads_for"
+          }
+        },
+        "appointments": {
+          "displayName": "Appointments",
+          "path": "/appointments",
+          "responseKey": "appointments",
+          "fields": {
+            "contact_id": "contact_id",
+            "description": "description",
+            "end_date": "end_date",
+            "location": "location",
+            "remind_time": "remind_time",
+            "start_date": "start_date",
+            "title": "title",
+            "user": "user"
+          }
+        },
+        "campaigns": {
+          "displayName": "Campaigns",
+          "path": "/campaigns",
+          "responseKey": "campaigns",
+          "fields": {
+            "created_by_global_id": "created_by_global_id",
+            "date_created": "date_created",
+            "error_message": "error_message",
+            "goals": "goals",
+            "id": "id",
+            "locked": "locked",
+            "name": "name",
+            "published_date": "published_date",
+            "published_status": "published_status",
+            "published_time_zone": "published_time_zone",
+            "sequences": "sequences",
+            "time_zone": "time_zone"
+          }
+        },
+        "commissions": {
+          "displayName": "Commissions",
+          "path": "/affiliates/commissions",
+          "responseKey": "commissions",
+          "fields": {
+            "amount_earned": "amount_earned",
+            "contact_first_name": "contact_first_name",
+            "contact_id": "contact_id",
+            "contact_last_name": "contact_last_name",
+            "date_earned": "date_earned",
+            "description": "description",
+            "invoice_id": "invoice_id",
+            "product_name": "product_name",
+            "sales_affiliate_id": "sales_affiliate_id",
+            "sold_by_first_name": "sold_by_first_name",
+            "sold_by_last_name": "sold_by_last_name"
+          }
+        },
+        "companies": {
+          "displayName": "Companies",
+          "path": "/companies",
+          "responseKey": "companies",
+          "fields": {
+            "address": "address",
+            "company_name": "company_name",
+            "custom_fields": "custom_fields",
+            "email_address": "email_address",
+            "email_opted_in": "email_opted_in",
+            "email_status": "email_status",
+            "fax_number": "fax_number",
+            "id": "id",
+            "notes": "notes",
+            "phone_number": "phone_number",
+            "website": "website"
+          }
+        },
+        "contacts": {
+          "displayName": "Contacts",
+          "path": "/contacts",
+          "responseKey": "contacts",
+          "fields": {
+            "ScoreValue": "ScoreValue",
+            "addresses": "addresses",
+            "anniversary": "anniversary",
+            "birthday": "birthday",
+            "company": "company",
+            "company_name": "company_name",
+            "contact_type": "contact_type",
+            "custom_fields": "custom_fields",
+            "date_created": "date_created",
+            "email_addresses": "email_addresses",
+            "email_opted_in": "email_opted_in",
+            "email_status": "email_status",
+            "family_name": "family_name",
+            "fax_numbers": "fax_numbers",
+            "given_name": "given_name",
+            "id": "id",
+            "job_title": "job_title",
+            "last_updated": "last_updated",
+            "lead_source_id": "lead_source_id",
+            "middle_name": "middle_name",
+            "owner_id": "owner_id",
+            "phone_numbers": "phone_numbers",
+            "preferred_locale": "preferred_locale",
+            "preferred_name": "preferred_name",
+            "prefix": "prefix",
+            "social_accounts": "social_accounts",
+            "source_type": "source_type",
+            "spouse_name": "spouse_name",
+            "suffix": "suffix",
+            "time_zone": "time_zone",
+            "website": "website"
+          }
+        },
+        "emails": {
+          "displayName": "Emails",
+          "path": "/emails",
+          "responseKey": "emails",
+          "fields": {
+            "clicked_date": "clicked_date",
+            "contact_id": "contact_id",
+            "headers": "headers",
+            "id": "id",
+            "opened_date": "opened_date",
+            "original_provider": "original_provider",
+            "original_provider_id": "original_provider_id",
+            "received_date": "received_date",
+            "sent_date": "sent_date",
+            "sent_from_address": "sent_from_address",
+            "sent_from_reply_address": "sent_from_reply_address",
+            "sent_to_address": "sent_to_address",
+            "sent_to_bcc_addresses": "sent_to_bcc_addresses",
+            "sent_to_cc_addresses": "sent_to_cc_addresses",
+            "subject": "subject"
+          }
+        },
+        "files": {
+          "displayName": "Files",
+          "path": "/files",
+          "responseKey": "files",
+          "fields": {
+            "category": "category",
+            "contact_id": "contact_id",
+            "created_by": "created_by",
+            "date_created": "date_created",
+            "download_url": "download_url",
+            "file_box_type": "file_box_type",
+            "file_name": "file_name",
+            "file_size": "file_size",
+            "id": "id",
+            "last_updated": "last_updated",
+            "public": "public",
+            "remote_file_key": "remote_file_key"
+          }
+        },
+        "hooks": {
+          "displayName": "Hooks",
+          "path": "/hooks",
+          "responseKey": "",
+          "fields": {
+            "eventKey": "eventKey",
+            "hookUrl": "hookUrl",
+            "key": "key",
+            "status": "status"
+          }
+        },
+        "merchants": {
+          "displayName": "Merchants",
+          "path": "/merchants",
+          "responseKey": "merchant_accounts",
+          "fields": {
+            "account_name": "account_name",
+            "id": "id",
+            "is_test": "is_test",
+            "type": "type"
+          }
+        },
+        "notes": {
+          "displayName": "Notes",
+          "path": "/notes",
+          "responseKey": "notes",
+          "fields": {
+            "body": "body",
+            "contact_id": "contact_id",
+            "date_created": "date_created",
+            "id": "id",
+            "last_updated": "last_updated",
+            "last_updated_by": "last_updated_by",
+            "title": "title",
+            "type": "type",
+            "user_id": "user_id"
+          }
+        },
+        "opportunities": {
+          "displayName": "Opportunities",
+          "path": "/opportunities",
+          "responseKey": "opportunities",
+          "fields": {
+            "affiliate_id": "affiliate_id",
+            "contact": "contact",
+            "custom_fields": "custom_fields",
+            "date_created": "date_created",
+            "estimated_close_date": "estimated_close_date",
+            "id": "id",
+            "include_in_forecast": "include_in_forecast",
+            "last_updated": "last_updated",
+            "next_action_date": "next_action_date",
+            "next_action_notes": "next_action_notes",
+            "opportunity_notes": "opportunity_notes",
+            "opportunity_title": "opportunity_title",
+            "projected_revenue_high": "projected_revenue_high",
+            "projected_revenue_low": "projected_revenue_low",
+            "stage": "stage",
+            "user": "user"
+          }
+        },
+        "orders": {
+          "displayName": "Orders",
+          "path": "/orders",
+          "responseKey": "orders",
+          "fields": {
+            "allow_payment": "allow_payment",
+            "allow_paypal": "allow_paypal",
+            "contact": "contact",
+            "contact_id": "contact_id",
+            "creation_date": "creation_date",
+            "id": "id",
+            "invoice_number": "invoice_number",
+            "lead_affiliate_id": "lead_affiliate_id",
+            "modification_date": "modification_date",
+            "notes": "notes",
+            "order_date": "order_date",
+            "order_items": "order_items",
+            "order_type": "order_type",
+            "payment_plan": "payment_plan",
+            "product_id": "product_id",
+            "recurring": "recurring",
+            "refund_total": "refund_total",
+            "sales_affiliate_id": "sales_affiliate_id",
+            "shipping_information": "shipping_information",
+            "source_type": "source_type",
+            "status": "status",
+            "terms": "terms",
+            "title": "title",
+            "total": "total",
+            "total_due": "total_due",
+            "total_paid": "total_paid"
+          }
+        },
+        "products": {
+          "displayName": "Products",
+          "path": "/products",
+          "responseKey": "products",
+          "fields": {
+            "id": "id",
+            "product_desc": "product_desc",
+            "product_name": "product_name",
+            "product_options": "product_options",
+            "product_price": "product_price",
+            "product_short_desc": "product_short_desc",
+            "sku": "sku",
+            "status": "status",
+            "subscription_only": "subscription_only",
+            "subscription_plans": "subscription_plans",
+            "url": "url"
+          }
+        },
+        "programs": {
+          "displayName": "Programs",
+          "path": "/affiliates/programs",
+          "responseKey": "programs",
+          "fields": {
+            "affiliate_id": "affiliate_id",
+            "id": "id",
+            "name": "name",
+            "notes": "notes",
+            "priority": "priority"
+          }
+        },
+        "redirectlinks": {
+          "displayName": "Redirects",
+          "path": "/affiliates/redirectlinks",
+          "responseKey": "redirects",
+          "fields": {
+            "affiliate_id": "affiliate_id",
+            "id": "id",
+            "local_url_code": "local_url_code",
+            "name": "name",
+            "program_ids": "program_ids",
+            "redirect_url": "redirect_url"
+          }
+        },
+        "stage_pipeline": {
+          "displayName": "Stage Pipelines",
+          "path": "/opportunity/stage_pipeline",
+          "responseKey": "",
+          "fields": {
+            "end_stage": "end_stage",
+            "is_default": "is_default",
+            "stage_count": "stage_count",
+            "stage_id": "stage_id",
+            "stage_name": "stage_name",
+            "stage_order": "stage_order"
+          }
+        },
+        "subscriptions": {
+          "displayName": "Subscriptions",
+          "path": "/subscriptions",
+          "responseKey": "subscriptions",
+          "fields": {
+            "active": "active",
+            "allow_tax": "allow_tax",
+            "auto_charge": "auto_charge",
+            "billing_amount": "billing_amount",
+            "billing_cycle": "billing_cycle",
+            "billing_frequency": "billing_frequency",
+            "contact_id": "contact_id",
+            "credit_card_id": "credit_card_id",
+            "end_date": "end_date",
+            "id": "id",
+            "next_bill_date": "next_bill_date",
+            "payment_gateway_id": "payment_gateway_id",
+            "product_id": "product_id",
+            "quantity": "quantity",
+            "sale_affiliate_id": "sale_affiliate_id",
+            "start_date": "start_date",
+            "subscription_plan_id": "subscription_plan_id",
+            "use_default_payment_gateway": "use_default_payment_gateway"
+          }
+        },
+        "summaries": {
+          "displayName": "Summaries",
+          "path": "/affiliates/summaries",
+          "responseKey": "summaries",
+          "fields": {
+            "affiliate_id": "affiliate_id",
+            "amount_earned": "amount_earned",
+            "balance": "balance",
+            "clawbacks": "clawbacks"
+          }
+        },
+        "synced_products": {
+          "displayName": "Product Statuses",
+          "path": "/products/sync",
+          "responseKey": "product_statuses",
+          "fields": {
+            "product": "product",
+            "status": "status"
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "/tags",
+          "responseKey": "tags",
+          "fields": {
+            "category": "category",
+            "description": "description",
+            "id": "id",
+            "name": "name"
+          }
+        },
+        "tasks": {
+          "displayName": "Tasks",
+          "path": "/tasks",
+          "responseKey": "tasks",
+          "fields": {
+            "completed": "completed",
+            "completion_date": "completion_date",
+            "contact": "contact",
+            "creation_date": "creation_date",
+            "description": "description",
+            "due_date": "due_date",
+            "funnel_id": "funnel_id",
+            "jgraph_id": "jgraph_id",
+            "modification_date": "modification_date",
+            "priority": "priority",
+            "remind_time": "remind_time",
+            "title": "title",
+            "type": "type",
+            "url": "url",
+            "user_id": "user_id"
+          }
+        },
+        "transactions": {
+          "displayName": "Transactions",
+          "path": "/transactions",
+          "responseKey": "transactions",
+          "fields": {
+            "amount": "amount",
+            "collection_method": "collection_method",
+            "contact_id": "contact_id",
+            "currency": "currency",
+            "errors": "errors",
+            "gateway": "gateway",
+            "gateway_account_name": "gateway_account_name",
+            "id": "id",
+            "order_ids": "order_ids",
+            "orders": "orders",
+            "paymentDate": "paymentDate",
+            "status": "status",
+            "test": "test",
+            "transaction_date": "transaction_date",
+            "type": "type"
+          }
+        },
+        "users": {
+          "displayName": "Users",
+          "path": "/users",
+          "responseKey": "users",
+          "fields": {
+            "address": "address",
+            "company_name": "company_name",
+            "created_by": "created_by",
+            "date_created": "date_created",
+            "email_address": "email_address",
+            "family_name": "family_name",
+            "fax_numbers": "fax_numbers",
+            "given_name": "given_name",
+            "global_user_id": "global_user_id",
+            "id": "id",
+            "infusionsoft_id": "infusionsoft_id",
+            "job_title": "job_title",
+            "last_updated": "last_updated",
+            "last_updated_by": "last_updated_by",
+            "middle_name": "middle_name",
+            "partner": "partner",
+            "phone_numbers": "phone_numbers",
+            "preferred_name": "preferred_name",
+            "status": "status",
+            "time_zone": "time_zone",
+            "website": "website"
+          }
+        }
+      }
+    },
+    "version2": {
+      "id": "version2",
+      "path": "/v2",
+      "objects": {
+        "automation_categories": {
+          "displayName": "Automation Categories",
+          "path": "/automationCategory",
+          "responseKey": "automation_categories",
+          "fields": {
+            "automation_count": "automation_count",
+            "id": "id",
+            "name": "name"
+          }
+        },
+        "automations": {
+          "displayName": "Automations",
+          "path": "/automations",
+          "responseKey": "automations",
+          "fields": {
+            "active_contacts": "active_contacts",
+            "categories": "categories",
+            "error_message": "error_message",
+            "id": "id",
+            "locked": "locked",
+            "published_by": "published_by",
+            "published_date": "published_date",
+            "published_timezone": "published_timezone",
+            "status": "status",
+            "title": "title"
+          }
+        },
+        "campaigns": {
+          "displayName": "Campaigns",
+          "path": "/campaigns",
+          "responseKey": "campaigns",
+          "fields": {
+            "active_contact_count": "active_contact_count",
+            "completed_contact_count": "completed_contact_count",
+            "created_by_global_id": "created_by_global_id",
+            "date_created": "date_created",
+            "error_message": "error_message",
+            "goals": "goals",
+            "id": "id",
+            "locked": "locked",
+            "name": "name",
+            "published_date": "published_date",
+            "published_status": "published_status",
+            "published_time_zone": "published_time_zone",
+            "sequences": "sequences",
+            "time_zone": "time_zone"
+          }
+        },
+        "companies": {
+          "displayName": "Companies",
+          "path": "/companies",
+          "responseKey": "companies",
+          "fields": {
+            "address": "address",
+            "company_name": "company_name",
+            "create_time": "create_time",
+            "custom_fields": "custom_fields",
+            "email_address": "email_address",
+            "fax_number": "fax_number",
+            "id": "id",
+            "notes": "notes",
+            "phone_number": "phone_number",
+            "update_time": "update_time",
+            "website": "website"
+          }
+        },
+        "contact_link_types": {
+          "displayName": "Contact Link Types",
+          "path": "/contacts/links/types",
+          "responseKey": "contact_link_types",
+          "fields": {
+            "id": "id",
+            "max_links": "max_links",
+            "name": "name"
+          }
+        },
+        "contacts": {
+          "displayName": "Contacts",
+          "path": "/contacts",
+          "responseKey": "contacts",
+          "fields": {
+            "addresses": "addresses",
+            "anniversary_date": "anniversary_date",
+            "birth_date": "birth_date",
+            "company": "company",
+            "contact_type": "contact_type",
+            "create_time": "create_time",
+            "custom_fields": "custom_fields",
+            "email_addresses": "email_addresses",
+            "family_name": "family_name",
+            "fax_numbers": "fax_numbers",
+            "given_name": "given_name",
+            "id": "id",
+            "job_title": "job_title",
+            "leadsource_id": "leadsource_id",
+            "links": "links",
+            "middle_name": "middle_name",
+            "origin": "origin",
+            "owner_id": "owner_id",
+            "phone_numbers": "phone_numbers",
+            "preferred_locale": "preferred_locale",
+            "preferred_name": "preferred_name",
+            "prefix": "prefix",
+            "referral_code": "referral_code",
+            "score_value": "score_value",
+            "social_accounts": "social_accounts",
+            "source_type": "source_type",
+            "spouse_name": "spouse_name",
+            "suffix": "suffix",
+            "tag_ids": "tag_ids",
+            "time_zone": "time_zone",
+            "update_time": "update_time",
+            "utm_parameters": "utm_parameters",
+            "website": "website"
+          }
+        },
+        "tag_categories": {
+          "displayName": "Tag Categories",
+          "path": "/tags/categories",
+          "responseKey": "tag_categories",
+          "fields": {
+            "category": "category",
+            "description": "description",
+            "id": "id",
+            "name": "name"
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "/tags",
+          "responseKey": "tags",
+          "fields": {
+            "category": "category",
+            "description": "description",
+            "id": "id",
+            "name": "name"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/keap/metadata/scraping.go
+++ b/providers/keap/metadata/scraping.go
@@ -1,0 +1,20 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/keap/modules.go
+++ b/providers/keap/modules.go
@@ -1,0 +1,19 @@
+package keap
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/keap/metadata"
+)
+
+const (
+	// ModuleV1 is a grouping of V1 API endpoints.
+	// https://developer.keap.com/docs/rest/
+	ModuleV1 common.ModuleID = "version1"
+	// ModuleV2 is a grouping of V2 API endpoints.
+	// https://developer.keap.com/docs/restv2/
+	ModuleV2 common.ModuleID = "version2"
+)
+
+// SupportedModules represents currently working and supported modules within the Keap connector.
+// Modules are added to schema.json file using OpenAPI script.
+var SupportedModules = metadata.Schemas.ModuleRegistry() // nolint: gochecknoglobals

--- a/providers/keap/objectNames.go
+++ b/providers/keap/objectNames.go
@@ -1,0 +1,6 @@
+package keap
+
+import "github.com/amp-labs/connectors/providers/keap/metadata"
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals

--- a/providers/keap/params.go
+++ b/providers/keap/params.go
@@ -1,0 +1,49 @@
+package keap
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"golang.org/x/oauth2"
+)
+
+// DefaultPageSize is number of elements per page.
+const DefaultPageSize = 50
+
+// Option is a function which mutates the connector configuration.
+type Option = func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
+	paramsbuilder.Module
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+		p.Module.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
+) Option {
+	return func(params *parameters) {
+		params.WithOauthClient(ctx, client, config, token, opts...)
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
+	}
+}
+
+func WithModule(module common.ModuleID) Option {
+	return func(params *parameters) {
+		params.WithModule(module, SupportedModules, ModuleV1)
+	}
+}

--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -1,0 +1,17 @@
+package keap
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		if moduleID == ModuleV1 {
+			return jsonquery.New(node).StrWithDefault("next", "")
+		}
+
+		return jsonquery.New(node).StrWithDefault("next_page_token", "")
+	}
+}

--- a/providers/keap/read.go
+++ b/providers/keap/read.go
@@ -1,0 +1,69 @@
+package keap
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/keap/metadata"
+)
+
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if err := config.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	url, err := c.buildReadURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, config.ObjectName)
+
+	return common.ParseResult(res,
+		common.GetOptionalRecordsUnderJSONPath(responseFieldName),
+		makeNextRecordsURL(c.Module.ID),
+		common.GetMarshaledData,
+		config.Fields,
+	)
+}
+
+func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
+	if len(config.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(config.NextPage.String())
+	}
+
+	// First page
+	url, err := c.getURL(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Module.ID == ModuleV1 {
+		url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
+
+		if !config.Since.IsZero() {
+			url.WithQueryParam("since", datautils.Time.FormatRFC3339inUTC(config.Since))
+		}
+	} else if c.Module.ID == ModuleV2 {
+		if config.ObjectName == "contact_link_types" {
+			url.WithQueryParam("pageSize", strconv.Itoa(DefaultPageSize))
+		} else {
+			url.WithQueryParam("page_size", strconv.Itoa(DefaultPageSize))
+		}
+	}
+
+	return url, nil
+}

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -1,0 +1,211 @@
+package keap
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	errorBadRequest := testutils.DataFromFile(t, "get-with-req-body-not-allowed.html")
+	errorNotFound := testutils.DataFromFile(t, "url-not-found.html")
+	responseContactsFirstPage := testutils.DataFromFile(t, "read-contacts-1-first-page-v1.json")
+	responseContactsEmptyPage := testutils.DataFromFile(t, "read-contacts-2-empty-page-v1.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "messages"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.ReadParams{ObjectName: "messages", Fields: connectors.Fields("id")},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+		{
+			Name:  "Error cannot send request body on GET operation",
+			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("id")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentHTML(),
+				Always: mockserver.Response(http.StatusBadRequest, errorBadRequest),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("400 Bad Request: Your client has issued a malformed or illegal request."), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Error page not found",
+			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("id")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentHTML(),
+				Always: mockserver.Response(http.StatusNotFound, errorNotFound),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Keap - Page Not Found"), // nolint:goerr113
+			},
+		},
+		{
+			Name: "Contacts first page has a link to next",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("given_name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/crm/rest/v1/contacts"),
+				Then:  mockserver.Response(http.StatusOK, responseContactsFirstPage),
+			}.Server(),
+			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
+				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+					actual.NextPage.String() == expected.NextPage.String() &&
+					actual.Rows == expected.Rows &&
+					actual.Done == expected.Done
+			},
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"given_name": "Erica",
+					},
+					Raw: map[string]any{
+						"id":          float64(22),
+						"family_name": "Lewis",
+					},
+				}, {
+					Fields: map[string]any{
+						"given_name": "John",
+					},
+					Raw: map[string]any{
+						"id":          float64(20),
+						"family_name": "Doe",
+					},
+				}},
+				NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=2&since=2024-06-03T22:17:59.039Z&order=id", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read contacts empty page",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("given_name"),
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseContactsEmptyPage),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows:     0,
+				Data:     []common.ReadResultRow{},
+				NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=4&since=2024-06-03T22:17:59.039Z&order=id", // nolint:lll
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL, ModuleV1)
+			})
+		})
+	}
+}
+
+func TestReadV2(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseTags := testutils.DataFromFile(t, "read-tags-v2.json")
+
+	tests := []testroutines.Read{
+		{
+			Name: "Tags page has a link to next",
+			Input: common.ReadParams{
+				ObjectName: "tags",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/crm/rest/v2/tags"),
+				Then:  mockserver.Response(http.StatusOK, responseTags),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "Nurture Subscriber",
+					},
+					Raw: map[string]any{
+						"id":          "91",
+						"name":        "Nurture Subscriber",
+						"description": "",
+						"category": map[string]any{
+							"id": "10",
+						},
+					},
+				}},
+				NextPage: "https://api.infusionsoft.com/crm/rest/v2/tags/?page_size=1&page_token=91", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL, ModuleV2)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string, moduleID common.ModuleID) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+		WithModule(moduleID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/providers/keap/test/get-with-req-body-not-allowed.html
+++ b/providers/keap/test/get-with-req-body-not-allowed.html
@@ -1,0 +1,14 @@
+<html>
+
+<head>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8">
+    <title>400 Bad Request</title>
+</head>
+
+<body text=#000000 bgcolor=#ffffff>
+<h1>Error: Bad Request</h1>
+<h2>Your client has issued a malformed or illegal request.</h2>
+<h2></h2>
+</body>
+
+</html>

--- a/providers/keap/test/read-contacts-1-first-page-v1.json
+++ b/providers/keap/test/read-contacts-1-first-page-v1.json
@@ -1,0 +1,53 @@
+{
+  "contacts": [
+    {
+      "tag_ids": [],
+      "id": 22,
+      "company": null,
+      "email_opted_in": false,
+      "email_status": "NonMarketable",
+      "date_created": "2024-11-07T20:35:13.000+0000",
+      "last_updated": "2024-11-07T20:35:13.000+0000",
+      "ScoreValue": null,
+      "last_updated_utc_millis": 1731011713217,
+      "email_addresses": [
+        {
+          "email": "erica.lewis@gmail.com",
+          "field": "EMAIL1"
+        }
+      ],
+      "addresses": [],
+      "phone_numbers": [],
+      "given_name": "Erica",
+      "family_name": "Lewis",
+      "middle_name": null,
+      "owner_id": null
+    },
+    {
+      "tag_ids": [],
+      "id": 20,
+      "company": null,
+      "email_opted_in": false,
+      "email_status": "NonMarketable",
+      "date_created": "2024-11-07T20:35:09.000+0000",
+      "last_updated": "2024-11-07T20:35:09.000+0000",
+      "ScoreValue": null,
+      "last_updated_utc_millis": 1731011708544,
+      "email_addresses": [
+        {
+          "email": "john.doe@gmail.com",
+          "field": "EMAIL1"
+        }
+      ],
+      "addresses": [],
+      "phone_numbers": [],
+      "given_name": "John",
+      "family_name": "Doe",
+      "middle_name": null,
+      "owner_id": null
+    }
+  ],
+  "count": 2,
+  "next": "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=2&since=2024-06-03T22:17:59.039Z&order=id",
+  "previous": "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=0&since=2024-06-03T22:17:59.039Z&order=id"
+}

--- a/providers/keap/test/read-contacts-2-empty-page-v1.json
+++ b/providers/keap/test/read-contacts-2-empty-page-v1.json
@@ -1,0 +1,6 @@
+{
+  "contacts": [],
+  "count": 2,
+  "next": "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=4&since=2024-06-03T22:17:59.039Z&order=id",
+  "previous": "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=0&since=2024-06-03T22:17:59.039Z&order=id"
+}

--- a/providers/keap/test/read-tags-v2.json
+++ b/providers/keap/test/read-tags-v2.json
@@ -1,0 +1,13 @@
+{
+  "tags": [
+    {
+      "id": "91",
+      "name": "Nurture Subscriber",
+      "description": "",
+      "category": {
+        "id": "10"
+      }
+    }
+  ],
+  "next_page_token": "https://api.infusionsoft.com/crm/rest/v2/tags/?page_size=1&page_token=91"
+}

--- a/providers/keap/test/url-not-found.html
+++ b/providers/keap/test/url-not-found.html
@@ -1,0 +1,77 @@
+<html>
+
+<head>
+    <link href="/css/sink_css.jsp?b=1.70.0.733045-hf-202411041931" media="screen" rel="stylesheet" type="text/css"/>
+    <script type="text/javascript">
+      (function () {
+        var styleArray = ["/css/sink_css.jsp"];
+        if (window.Infusion) {
+          Infusion.stylesLoaded(styleArray);
+        } else if (window.InfusionStyles) {
+          window.InfusionStyles.concat(styleArray);
+        } else {
+          window.InfusionStyles = styleArray;
+        }
+      })();
+    </script>
+    <style type="text/css">
+        p {
+            font-size: 14px;
+            color: #666666;
+            width: 500px;
+            text-align: left;
+            margin-bottom: 14px;
+        }
+
+        a {
+            font-size: 14px;
+        }
+    </style>
+
+    <!-- Javascript includes -->
+    <script src="/js/sink_jq.jsp?b=1.70.0.733045-hf-202411041931" type="text/javascript"></script>
+    <script src="/js/sink_js.jsp?b=1.70.0.733045-hf-202411041931" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://infusionmedia.s3.amazonaws.com/app/login-screen/holiday.css" type="text/css"
+          media="screen"/>
+    <title>
+        Keap - Page Not Found</title>
+</head>
+
+<body bgcolor="#E4E4E4" class="loginPage">
+<div id="content">
+    <div style="width:350px;">
+        <noscript>
+
+
+            <div class="alert-message block-notice-div warning" id="notice">You must enable Javascript to use Keap!
+            </div>
+
+
+        </noscript>
+    </div>
+    <table height="100%" width="100%" cellspacing="0" border="0" cellpadding="0">
+        <tr>
+            <td width="100%" height="100%" align="center">
+                <div class="loginBox">
+                    <div style="margin-bottom:35px">
+                        <a href="http://www.infusionsoft.com">
+                            <img src="https://files.infusionsoft.com/keap/infusionsoft-by-keap.svg?b=1.70.0.733045-hf-202411041931"
+                                 style="height : 50px" alt="Keap" border="0"/></a>
+                    </div>
+                    <div style="margin-bottom:35px">
+                        <img src="/images/error/page-not-found-text.png?b=1.70.0.733045-hf-202411041931"
+                             alt="Page Not Found"/></div>
+                    <p>
+                        We're sorry to say this, but the page you're looking for can't be found. This usually
+                        happens if you click on a broken or incorrectly-formatted link, or enter the wrong web
+                        address.</p>
+                    <p>
+                        If you're the owner of this account, <a href="/">click here to login</a>.</p>
+                </div>
+            </td>
+        </tr>
+    </table>
+</div>
+</body>
+
+</html>

--- a/test/keap/connector.go
+++ b/test/keap/connector.go
@@ -1,0 +1,39 @@
+package dynamicscrm
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/keap"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetKeapConnector(ctx context.Context) *keap.Connector {
+	filePath := credscanning.LoadPath(providers.Keap)
+	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+
+	conn, err := keap.NewConnector(
+		keap.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail("error creating microsoft CRM connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		RedirectURL:  "http://localhost:8080/callbacks/v1/oauth",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://accounts.infusionsoft.com/app/oauth/authorize",
+			TokenURL:  "https://api.infusionsoft.com/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+}

--- a/test/keap/read/main.go
+++ b/test/keap/read/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/keap"
+	connTest "github.com/amp-labs/connectors/test/keap"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetKeapConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "emails",
+		Fields:     connectors.Fields("id", "subject", "sent_from_address"),
+	})
+	if err != nil {
+		utils.Fail("error reading from microsoft CRM", "error", err)
+	}
+
+	fmt.Println("Reading emails..")
+	utils.DumpJSON(res, os.Stdout)
+
+	if res.Rows > keap.DefaultPageSize {
+		utils.Fail(fmt.Sprintf("expected max %v rows", keap.DefaultPageSize))
+	}
+}


### PR DESCRIPTION



# Notes

Some error response from provider are either in JSON or HTML format. 
`schema.json` produced from OpenAPI is added illustrating the support for read objects.

Depending on the Module the Read is affected such that `limit` == `page_size` query parameter. Next page is located under either "next" or "next_page_token".
Since parameter is available for V1 only.

# Test Results
Listing emails:
![image](https://github.com/user-attachments/assets/07811a39-ac60-4d7c-9c12-2291e5c614b9)


