### PR TITLE
fix: pipedrive scope requirement

### DIFF
--- a/providers/pipedrive.go
+++ b/providers/pipedrive.go
@@ -12,7 +12,7 @@ func init() {
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://oauth.pipedrive.com/oauth/authorize",
 			TokenURL:                  "https://oauth.pipedrive.com/oauth/token",
-			ExplicitScopesRequired:    true,
+			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
 		Support: Support{


### PR DESCRIPTION
Providing scopes in the Authorization call is not a mandatory requirement. There is a step in the App creation in which you should select the scopes that will be used for the Application, And they can not be altered by the scopes provided in the Authorization call.
ref: https://devcommunity.pipedrive.com/t/can-i-specify-scopes-when-authorizing-oauth/3244/2