### PR TITLE
fix: Close scope requirement

### DIFF
--- a/providers/close.go
+++ b/providers/close.go
@@ -12,7 +12,7 @@ func init() {
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://app.close.com/oauth2/authorize",
 			TokenURL:                  "https://api.close.com/oauth2/token",
-			ExplicitScopesRequired:    false,
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			TokenMetadataFields: TokenMetadataFields{
 				ConsumerRefField:  "user_id",


### PR DESCRIPTION
This updates the close configurations. We need to explicitly provide scopes.
Ref:  https://developer.close.com/topics/authentication-oauth2/#refresh-access-token
The slab indicates this as well.