### PR TITLE
feat(jsonquery): Soft string requirement

### DIFF
--- a/common/jsonquery/defaults.go
+++ b/common/jsonquery/defaults.go
@@ -1,5 +1,10 @@
 package jsonquery
 
+import (
+	"errors"
+	"strconv"
+)
+
 func (q *Query) IntegerWithDefault(key string, defaultValue int64) (int64, error) {
 	result, err := q.Integer(key, true)
 	if err != nil {
@@ -24,6 +29,34 @@ func (q *Query) StrWithDefault(key string, defaultValue string) (string, error) 
 	}
 
 	return *result, nil
+}
+
+// TextWithDefault returns a string under the key regardless of JSON data type.
+// If data is not a string it will be converted to such.
+func (q *Query) TextWithDefault(key string, defaultValue string) (string, error) {
+	result, err := q.StrWithDefault(key, defaultValue)
+	if err != nil {
+		if !errors.Is(err, ErrNotString) {
+			// Any error that is not due to non-string type is critical.
+			return "", err
+		}
+
+		// Current data under `key` is not a string.
+		// Explore other data types.
+		// NOTE: as of now we check only if it is an integer.
+		number, err := q.Integer(key, true)
+		if err != nil {
+			return "", err
+		}
+
+		if number == nil {
+			return defaultValue, nil
+		}
+
+		return strconv.FormatInt(*number, 10), nil
+	}
+
+	return result, nil
 }
 
 func (q *Query) BoolWithDefault(key string, defaultValue bool) (bool, error) {

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -176,12 +176,12 @@ func (r *Metadata) ModuleRegistry() common.Modules {
 
 // LookupArrayFieldName will give you the field name which holds the array of objects in provider response.
 // Ex: CustomerSubscriptions is located under field name subscriptions => { "subscriptions": [{},{},{}] }.
-func (r *Metadata) LookupArrayFieldName(moduleID common.ModuleID, objectName string) (string, error) {
+func (r *Metadata) LookupArrayFieldName(moduleID common.ModuleID, objectName string) string {
 	moduleID = moduleIdentifier(moduleID)
 
 	fieldName := r.Modules[moduleID].Objects[objectName].ResponseKey
 
-	return fieldName, nil
+	return fieldName
 }
 
 func (m *Module) withPath(path string) {


### PR DESCRIPTION
# Description

Identifiers in provider responses may be of either string or integer types. This adds a utility that surfaces that value as string.

The strict attitude of what JSON data type we expect is not relevant. Instead with a new method we are asking give me data as "Text" regardless of what it is.