### PR TITLE
feat(scripts): PKCE for AuthCode grant type

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -226,10 +226,10 @@ func (i *ProviderInfo) NewClient(ctx context.Context, params *NewClientParams) (
 		}
 
 		switch i.Oauth2Opts.GrantType {
+		case AuthorizationCodePKCE:
+			fallthrough
 		case AuthorizationCode:
 			return createOAuth2AuthCodeHTTPClient(ctx, params.Client, params.Debug, params.OAuth2AuthCodeCreds)
-		case AuthorizationCodePKCE:
-			return nil, fmt.Errorf("%w: %s", ErrClient, "Authorization code + PKCE grant type not supported")
 		case ClientCredentials:
 			return createOAuth2ClientCredentialsHTTPClient(ctx, params.Client, params.Debug, params.OAuth2ClientCreds)
 		case Password:

--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -121,6 +121,8 @@ func main() {
 		switch info.Oauth2Opts.GrantType {
 		case providers.ClientCredentials:
 			mainOAuth2ClientCreds(ctx, provider, catalogVariables)
+		case providers.AuthorizationCodePKCE:
+			fallthrough
 		case providers.AuthorizationCode:
 			mainOAuth2AuthCode(ctx, provider, catalogVariables)
 		case providers.Password:


### PR DESCRIPTION
# Description

Modified `token` script to generate authentication token using AuthCode grant type with PKCE. 
I am able to generate auth token for Klaviyo. Additionally checked ConstantContact which for backwards compatability, and the script works as expected.

For `proxy` the script was modified to allow requests through without the proper refresh strategy. For local testing I just recreate access token manually. For deep Klaviyo connector implementation  it is sufficient.
