### PR TITLE
feat(openapi): Configure custom media type

### DIFF
--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -77,7 +77,10 @@ func (e Explorer) ReadObjects(
 
 	for _, path := range e.GetPathItems(pathMatcher, objectEndpoints) {
 		schema, found, err := path.RetrieveSchemaOperation(operationName,
-			displayNameOverride, locator, e.displayPostProcessing, e.parameterFilter,
+			displayNameOverride, locator,
+			e.displayPostProcessing,
+			e.operationMethodFilter,
+			e.mediaType,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

Klaviyo is the first connector that uses `"application/vnd.api+json"` as response MIME type.
This PR adds configuration to specify your own MIME. By default we are looking for `"application/json"`