### PR TITLE
feat: Klaviyo (Read)

### DIFF
--- a/common/interpreter/error_test.go
+++ b/common/interpreter/error_test.go
@@ -97,6 +97,19 @@ func TestErrorHandler(t *testing.T) { //nolint:funlen
 			},
 			expectedErr: []error{ErrCustomHTML},
 		},
+		{
+			name: "Custom response is handled using custom handler",
+			server: mockserver.Fixed{
+				Setup:  mockserver.ContentMIME("application/special-media"),
+				Always: mockserver.Response(http.StatusNotFound),
+			}.Server(),
+			handler: ErrorHandler{
+				Custom: map[Mime]FaultyResponseHandler{
+					"application/special-media": handlerReturningError(ErrCustomJSON),
+				},
+			},
+			expectedErr: []error{ErrCustomJSON},
+		},
 	}
 
 	for _, tt := range tests {

--- a/common/types.go
+++ b/common/types.go
@@ -96,16 +96,25 @@ var (
 type ReadParams struct {
 	// The name of the object we are reading, e.g. "Account"
 	ObjectName string // required
+
 	// The fields we are reading from the object, e.g. ["Id", "Name", "BillingCity"]
 	Fields datautils.StringSet // required, at least one field needed
+
 	// NextPage is an opaque token that can be used to get the next page of results.
 	NextPage NextPageToken // optional, only set this if you want to read the next page of results
+
 	// Since is a timestamp that can be used to get only records that have changed since that time.
 	Since time.Time // optional, omit this to fetch all records
+
 	// Deleted is true if we want to read deleted records instead of active records.
 	Deleted bool // optional, defaults to false
-	// Filter is only supported for salesforce. It is a SOQL string that comes after the WHERE clause
-	// which will be used to filter the records.
+
+	// Filter is supported for the following connectors:
+	//	* Salesforce: it is a SOQL string that comes after the WHERE clause which will be used to filter the records.
+	//		Reference: https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm
+	//	* Klaviyo: comma separated methods following JSON:API filtering syntax.
+	//		Note: timing is already handled by Since argument.
+	//		Reference: https://developers.klaviyo.com/en/docs/filtering_
 	Filter string // optional
 }
 

--- a/providers/klaviyo/client.go
+++ b/providers/klaviyo/client.go
@@ -1,0 +1,18 @@
+package klaviyo
+
+import (
+	"github.com/amp-labs/connectors/common"
+)
+
+// JSONHTTPClient returns the underlying JSON HTTP client.
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.Client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.Client.HTTPClient
+}
+
+func (c *Connector) Close() error {
+	return nil
+}

--- a/providers/klaviyo/connector.go
+++ b/providers/klaviyo/connector.go
@@ -1,0 +1,74 @@
+package klaviyo
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
+)
+
+type Connector struct {
+	BaseURL string
+	Client  *common.JSONHTTPClient
+	Module  common.Module
+}
+
+func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+	defer common.PanicRecovery(func(cause error) {
+		outErr = cause
+		conn = nil
+	})
+
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(Module2024Oct15))
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := params.Client.Caller
+	conn = &Connector{
+		Client: &common.JSONHTTPClient{
+			HTTPClient: httpClient,
+		},
+		Module: params.Module.Selection,
+	}
+
+	// Read provider info
+	providerInfo, err := providers.ReadInfo(conn.Provider())
+	if err != nil {
+		return nil, err
+	}
+
+	// connector and its client must mirror base url and provide its own error parser
+	conn.setBaseURL(providerInfo.BaseURL)
+	conn.Client.HTTPClient.ErrorHandler = interpreter.ErrorHandler{
+		Custom: map[string]interpreter.FaultyResponseHandler{
+			"application/vnd.api+json": interpreter.NewFaultyResponder(errorFormats, nil),
+		},
+	}.Handle
+
+	return conn, nil
+}
+
+func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.BaseURL, path)
+}
+
+func (c *Connector) setBaseURL(newURL string) {
+	c.BaseURL = newURL
+	c.Client.HTTPClient.Base = newURL
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return providers.Klaviyo
+}
+
+func (c *Connector) String() string {
+	return c.Provider() + ".Connector"
+}

--- a/providers/klaviyo/errors.go
+++ b/providers/klaviyo/errors.go
@@ -1,0 +1,58 @@
+package klaviyo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	Errors []ErrorDetails `json:"errors"`
+}
+
+type ErrorDetails struct {
+	Id     string `json:"id"`
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+	Source any    `json:"source"`
+	Meta   any    `json:"meta"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	if len(r.Errors) == 0 {
+		return base
+	}
+
+	messages := make([]string, len(r.Errors))
+	for i, obj := range r.Errors {
+		messages[i] = obj.makeMessage()
+	}
+
+	return fmt.Errorf("%w: %v", base, strings.Join(messages, ", "))
+}
+
+func (d ErrorDetails) makeMessage() string {
+	if len(d.Detail) == 0 {
+		return d.Title
+	}
+
+	if d.Title == d.Detail {
+		return d.Title
+	}
+
+	title, _ := strings.CutSuffix(d.Title, ".") // remove dot at the end.
+
+	return title + ": " + d.Detail
+}

--- a/providers/klaviyo/metadata/metadata.go
+++ b/providers/klaviyo/metadata/metadata.go
@@ -1,0 +1,20 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/klaviyo/metadata/schemas.json
+++ b/providers/klaviyo/metadata/schemas.json
@@ -1,0 +1,647 @@
+{
+  "modules": {
+    "2024-10-15": {
+      "id": "2024-10-15",
+      "path": "/api",
+      "objects": {
+        "accounts": {
+          "displayName": "Accounts",
+          "path": "/accounts",
+          "responseKey": "data",
+          "fields": {
+            "contact_information": "contact_information",
+            "id": "id",
+            "industry": "industry",
+            "links": "links",
+            "locale": "locale",
+            "preferred_currency": "preferred_currency",
+            "public_api_key": "public_api_key",
+            "test_account": "test_account",
+            "timezone": "timezone",
+            "type": "type"
+          }
+        },
+        "campaigns": {
+          "displayName": "Campaigns",
+          "path": "/campaigns",
+          "responseKey": "data",
+          "fields": {
+            "archived": "archived",
+            "audiences": "audiences",
+            "created_at": "created_at",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "scheduled_at": "scheduled_at",
+            "send_options": "send_options",
+            "send_strategy": "send_strategy",
+            "send_time": "send_time",
+            "status": "status",
+            "tracking_options": "tracking_options",
+            "type": "type",
+            "updated_at": "updated_at"
+          }
+        },
+        "catalog-categories": {
+          "displayName": "Catalog Categories",
+          "path": "/catalog-categories",
+          "responseKey": "data",
+          "fields": {
+            "external_id": "external_id",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "catalog-category-bulk-create-jobs": {
+          "displayName": "Catalog Category Bulk Create Jobs",
+          "path": "/catalog-category-bulk-create-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-category-bulk-delete-jobs": {
+          "displayName": "Catalog Category Bulk Delete Jobs",
+          "path": "/catalog-category-bulk-delete-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-category-bulk-update-jobs": {
+          "displayName": "Catalog Category Bulk Update Jobs",
+          "path": "/catalog-category-bulk-update-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-item-bulk-create-jobs": {
+          "displayName": "Catalog Item Bulk Create Jobs",
+          "path": "/catalog-item-bulk-create-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-item-bulk-delete-jobs": {
+          "displayName": "Catalog Item Bulk Delete Jobs",
+          "path": "/catalog-item-bulk-delete-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-item-bulk-update-jobs": {
+          "displayName": "Catalog Item Bulk Update Jobs",
+          "path": "/catalog-item-bulk-update-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-items": {
+          "displayName": "Catalog Items",
+          "path": "/catalog-items",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "custom_metadata": "custom_metadata",
+            "description": "description",
+            "external_id": "external_id",
+            "id": "id",
+            "image_full_url": "image_full_url",
+            "image_thumbnail_url": "image_thumbnail_url",
+            "images": "images",
+            "links": "links",
+            "price": "price",
+            "published": "published",
+            "relationships": "relationships",
+            "title": "title",
+            "type": "type",
+            "updated": "updated",
+            "url": "url"
+          }
+        },
+        "catalog-variant-bulk-create-jobs": {
+          "displayName": "Catalog Variant Bulk Create Jobs",
+          "path": "/catalog-variant-bulk-create-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-variant-bulk-delete-jobs": {
+          "displayName": "Catalog Variant Bulk Delete Jobs",
+          "path": "/catalog-variant-bulk-delete-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-variant-bulk-update-jobs": {
+          "displayName": "Catalog Variant Bulk Update Jobs",
+          "path": "/catalog-variant-bulk-update-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "catalog-variants": {
+          "displayName": "Catalog Variants",
+          "path": "/catalog-variants",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "custom_metadata": "custom_metadata",
+            "description": "description",
+            "external_id": "external_id",
+            "id": "id",
+            "image_full_url": "image_full_url",
+            "image_thumbnail_url": "image_thumbnail_url",
+            "images": "images",
+            "inventory_policy": "inventory_policy",
+            "inventory_quantity": "inventory_quantity",
+            "links": "links",
+            "price": "price",
+            "published": "published",
+            "relationships": "relationships",
+            "sku": "sku",
+            "title": "title",
+            "type": "type",
+            "updated": "updated",
+            "url": "url"
+          }
+        },
+        "coupon-code-bulk-create-jobs": {
+          "displayName": "Coupon Code Bulk Create Jobs",
+          "path": "/coupon-code-bulk-create-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "errors": "errors",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "coupon-codes": {
+          "displayName": "Coupon Codes",
+          "path": "/coupon-codes",
+          "responseKey": "data",
+          "fields": {
+            "expires_at": "expires_at",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "status": "status",
+            "type": "type",
+            "unique_code": "unique_code"
+          }
+        },
+        "coupons": {
+          "displayName": "Coupons",
+          "path": "/coupons",
+          "responseKey": "data",
+          "fields": {
+            "description": "description",
+            "external_id": "external_id",
+            "id": "id",
+            "links": "links",
+            "type": "type"
+          }
+        },
+        "events": {
+          "displayName": "Events",
+          "path": "/events",
+          "responseKey": "data",
+          "fields": {
+            "datetime": "datetime",
+            "event_properties": "event_properties",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "timestamp": "timestamp",
+            "type": "type",
+            "uuid": "uuid"
+          }
+        },
+        "flows": {
+          "displayName": "Flows",
+          "path": "/flows",
+          "responseKey": "data",
+          "fields": {
+            "archived": "archived",
+            "created": "created",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "status": "status",
+            "trigger_type": "trigger_type",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "forms": {
+          "displayName": "Forms",
+          "path": "/forms",
+          "responseKey": "data",
+          "fields": {
+            "ab_test": "ab_test",
+            "created_at": "created_at",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "status": "status",
+            "type": "type",
+            "updated_at": "updated_at"
+          }
+        },
+        "images": {
+          "displayName": "Images",
+          "path": "/images",
+          "responseKey": "data",
+          "fields": {
+            "format": "format",
+            "hidden": "hidden",
+            "id": "id",
+            "image_url": "image_url",
+            "links": "links",
+            "name": "name",
+            "size": "size",
+            "type": "type",
+            "updated_at": "updated_at"
+          }
+        },
+        "lists": {
+          "displayName": "Lists",
+          "path": "/lists",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "opt_in_process": "opt_in_process",
+            "relationships": "relationships",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "metrics": {
+          "displayName": "Metrics",
+          "path": "/metrics",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "id": "id",
+            "integration": "integration",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "profile-bulk-import-jobs": {
+          "displayName": "Profile Bulk Import Jobs",
+          "path": "/profile-bulk-import-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "expires_at": "expires_at",
+            "failed_count": "failed_count",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "started_at": "started_at",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "profile-suppression-bulk-create-jobs": {
+          "displayName": "Profile Suppression Bulk Create Jobs",
+          "path": "/profile-suppression-bulk-create-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "skipped_count": "skipped_count",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "profile-suppression-bulk-delete-jobs": {
+          "displayName": "Profile Suppression Bulk Delete Jobs",
+          "path": "/profile-suppression-bulk-delete-jobs",
+          "responseKey": "data",
+          "fields": {
+            "completed_at": "completed_at",
+            "completed_count": "completed_count",
+            "created_at": "created_at",
+            "id": "id",
+            "links": "links",
+            "relationships": "relationships",
+            "skipped_count": "skipped_count",
+            "status": "status",
+            "total_count": "total_count",
+            "type": "type"
+          }
+        },
+        "profiles": {
+          "displayName": "Profiles",
+          "path": "/profiles",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "email": "email",
+            "external_id": "external_id",
+            "first_name": "first_name",
+            "id": "id",
+            "image": "image",
+            "last_event_date": "last_event_date",
+            "last_name": "last_name",
+            "links": "links",
+            "locale": "locale",
+            "location": "location",
+            "organization": "organization",
+            "phone_number": "phone_number",
+            "predictive_analytics": "predictive_analytics",
+            "properties": "properties",
+            "relationships": "relationships",
+            "subscriptions": "subscriptions",
+            "title": "title",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "reviews": {
+          "displayName": "Reviews",
+          "path": "/reviews",
+          "responseKey": "data",
+          "fields": {
+            "author": "author",
+            "content": "content",
+            "created": "created",
+            "email": "email",
+            "id": "id",
+            "images": "images",
+            "links": "links",
+            "product": "product",
+            "public_reply": "public_reply",
+            "rating": "rating",
+            "relationships": "relationships",
+            "review_type": "review_type",
+            "smart_quote": "smart_quote",
+            "status": "status",
+            "title": "title",
+            "type": "type",
+            "updated": "updated",
+            "verified": "verified"
+          }
+        },
+        "segments": {
+          "displayName": "Segments",
+          "path": "/segments",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "definition": "definition",
+            "id": "id",
+            "is_active": "is_active",
+            "is_processing": "is_processing",
+            "is_starred": "is_starred",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "tag-groups": {
+          "displayName": "Tag Groups",
+          "path": "/tag-groups",
+          "responseKey": "data",
+          "fields": {
+            "default": "default",
+            "exclusive": "exclusive",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type"
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "/tags",
+          "responseKey": "data",
+          "fields": {
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type"
+          }
+        },
+        "template-universal-content": {
+          "displayName": "Template Universal Content",
+          "path": "/template-universal-content",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "definition": "definition",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "screenshot_status": "screenshot_status",
+            "screenshot_url": "screenshot_url",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "templates": {
+          "displayName": "Templates",
+          "path": "/templates",
+          "responseKey": "data",
+          "fields": {
+            "created": "created",
+            "editor_type": "editor_type",
+            "html": "html",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "text": "text",
+            "type": "type",
+            "updated": "updated"
+          }
+        },
+        "tracking-settings": {
+          "displayName": "Tracking Settings",
+          "path": "/tracking-settings",
+          "responseKey": "data",
+          "fields": {
+            "auto_add_parameters": "auto_add_parameters",
+            "custom_parameters": "custom_parameters",
+            "id": "id",
+            "links": "links",
+            "type": "type",
+            "utm_campaign": "utm_campaign",
+            "utm_id": "utm_id",
+            "utm_medium": "utm_medium",
+            "utm_source": "utm_source",
+            "utm_term": "utm_term"
+          }
+        },
+        "webhook-topics": {
+          "displayName": "Webhook Topics",
+          "path": "/webhook-topics",
+          "responseKey": "data",
+          "fields": {
+            "id": "id",
+            "links": "links",
+            "type": "type"
+          }
+        },
+        "webhooks": {
+          "displayName": "Webhooks",
+          "path": "/webhooks",
+          "responseKey": "data",
+          "fields": {
+            "created_at": "created_at",
+            "description": "description",
+            "enabled": "enabled",
+            "endpoint_url": "endpoint_url",
+            "id": "id",
+            "links": "links",
+            "name": "name",
+            "relationships": "relationships",
+            "type": "type",
+            "updated_at": "updated_at"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/klaviyo/modules.go
+++ b/providers/klaviyo/modules.go
@@ -1,0 +1,16 @@
+package klaviyo
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
+)
+
+const (
+	// Module2024Oct15 is the latest stable version of API as of the date of writing.
+	// https://developers.klaviyo.com/en/reference/api_overview
+	Module2024Oct15 common.ModuleID = "2024-10-15"
+)
+
+// SupportedModules represents currently working and supported modules within the Klaviyo connector.
+// Modules are added to schema.json file using OpenAPI script.
+var SupportedModules = metadata.Schemas.ModuleRegistry() // nolint: gochecknoglobals

--- a/providers/klaviyo/objectNames.go
+++ b/providers/klaviyo/objectNames.go
@@ -1,0 +1,43 @@
+package klaviyo
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
+
+var prioritySinceFieldsForRead = []string{ //nolint:gochecknoglobals
+	"updated_at", // most desired field for incremental readin
+	"updated",
+	"datetime",
+	"completed_at", // for Bulk Jobs
+	"created_at",
+	"created", // least preferred field
+}
+
+var objectsNameToSinceFieldName = make(map[common.ModuleID]map[string]string) //nolint:gochecknoglobals
+
+func init() {
+	// Every object should be associated with a fieldName which will be used for iterative reading via Since parameter.
+	// Instead of recalculating this over and over on package start we can "find" fields of interest.
+	// There is a preferred choice when it comes to time filtering represented by `prioritySinceFieldsForRead`.
+	for moduleID, module := range metadata.Schemas.Modules {
+		objectsNameToSinceFieldName[moduleID] = make(map[string]string)
+
+		for objectName, object := range module.Objects {
+		Search:
+			for _, preferredSinceField := range prioritySinceFieldsForRead {
+				for currentField := range object.FieldsMap {
+					if preferredSinceField == currentField {
+						objectsNameToSinceFieldName[moduleID][objectName] = preferredSinceField
+
+						// break search for this object
+						break Search
+					}
+				}
+			}
+		}
+	}
+}

--- a/providers/klaviyo/params.go
+++ b/providers/klaviyo/params.go
@@ -1,0 +1,46 @@
+package klaviyo
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"golang.org/x/oauth2"
+)
+
+// Option is a function which mutates the connector configuration.
+type Option = func(params *parameters)
+
+type parameters struct {
+	paramsbuilder.Client
+	paramsbuilder.Module
+}
+
+func (p parameters) ValidateParams() error {
+	return errors.Join(
+		p.Client.ValidateParams(),
+	)
+}
+
+func WithClient(ctx context.Context, client *http.Client,
+	config *oauth2.Config, token *oauth2.Token, opts ...common.OAuthOption,
+) Option {
+	return func(params *parameters) {
+		params.WithOauthClient(ctx, client, config, token, opts...)
+	}
+}
+
+func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
+	return func(params *parameters) {
+		params.WithAuthenticatedClient(client)
+	}
+}
+
+// WithModule sets the Atlassian API module to use for the connector. It's required.
+func WithModule(module common.ModuleID) Option {
+	return func(params *parameters) {
+		params.WithModule(module, SupportedModules, Module2024Oct15)
+	}
+}

--- a/providers/klaviyo/parse.go
+++ b/providers/klaviyo/parse.go
@@ -1,0 +1,73 @@
+package klaviyo
+
+import (
+	"github.com/amp-labs/connectors/common/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// Every object has special field attributes which holds all the object specific fields.
+// Therefore, nested "attributes" will be removed and fields will be moved to the top level of the object.
+//
+// Example accounts(shortened response):
+//
+//	 "data": [
+//	    {
+//	        "type": "",
+//	        "id": "",
+//	        "attributes": {
+//	            "test_account": false,
+//	            "contact_information": {},
+//	            "locale": ""
+//	        },
+//	        "links": {}
+//	    }
+//	],
+//
+// The resulting fields for the above will be: type, id, test_account, contact_information, locale, links.
+func getRecords(node *ajson.Node) ([]map[string]any, error) {
+	arr, err := jsonquery.New(node).Array("data", true)
+	if err != nil {
+		return nil, err
+	}
+
+	return flattenRecords(arr)
+}
+
+func flattenRecords(arr []*ajson.Node) ([]map[string]any, error) {
+	result := make([]map[string]any, len(arr))
+
+	for index, element := range arr {
+		const keyAttributes = "attributes"
+
+		attributes, err := jsonquery.New(element).Object(keyAttributes, true)
+		if err != nil {
+			return nil, err
+		}
+
+		original, err := jsonquery.Convertor.ObjectToMap(element)
+		if err != nil {
+			return nil, err
+		}
+
+		nested, err := jsonquery.Convertor.ObjectToMap(attributes)
+		if err != nil {
+			return nil, err
+		}
+
+		// Attributes object must be removed.
+		delete(original, keyAttributes)
+
+		// Fields from attributes are moved to the top level.
+		for key, value := range nested {
+			original[key] = value
+		}
+
+		result[index] = original
+	}
+
+	return result, nil
+}
+
+func getNextRecordsURL(node *ajson.Node) (string, error) {
+	return jsonquery.New(node, "links").StrWithDefault("next", "")
+}

--- a/providers/klaviyo/read.go
+++ b/providers/klaviyo/read.go
@@ -1,0 +1,91 @@
+package klaviyo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	if err := config.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	url, err := c.buildReadURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Client.Get(ctx, url.String(), common.Header{
+		Key:   "revision",
+		Value: string(c.Module.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(res,
+		getRecords,
+		getNextRecordsURL,
+		common.GetMarshaledData,
+		config.Fields,
+	)
+}
+
+func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
+	if len(config.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(config.NextPage.String())
+	}
+
+	// First page
+	url, err := c.getURL(config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := filterBuilder{
+		custom: config.Filter,
+	}
+
+	if !config.Since.IsZero() {
+		if sinceField, found := objectsNameToSinceFieldName[c.Module.ID][config.ObjectName]; found {
+			// Documentation about filtering: https://developers.klaviyo.com/en/docs/filtering_
+			// Ex: ?filter=greater-than(datetime,2023-03-01T01:00:00Z)
+			sinceValue := datautils.Time.FormatRFC3339inUTC(config.Since)
+			filter.since = fmt.Sprintf("greater-than(%v,%v)", sinceField, sinceValue)
+		}
+	}
+
+	if queryParam := filter.queryParameter(); len(queryParam) != 0 {
+		url.WithQueryParam("filter", queryParam)
+	}
+
+	return url, nil
+}
+
+type filterBuilder struct {
+	since  string
+	custom string
+}
+
+func (b filterBuilder) queryParameter() string {
+	if len(b.since) == 0 {
+		return b.custom
+	}
+
+	if len(b.custom) == 0 {
+		return b.since
+	}
+
+	// Both values are set. As per documentation these values can be comma separated.
+	// Reference: https://developers.klaviyo.com/en/docs/filtering_
+	return b.since + "," + b.custom
+}

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -1,0 +1,159 @@
+package klaviyo
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	errorUnsupportedPagination := testutils.DataFromFile(t, "read-unsupported-pagination.json")
+	responseCampaigns := testutils.DataFromFile(t, "read-campaigns.json")
+	responseProfilesFirstPage := testutils.DataFromFile(t, "read-profiles-1-first-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "accounts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.ReadParams{ObjectName: "orders", Fields: connectors.Fields("id")},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+		{
+			Name:  "Error response when pagination is not available for the object",
+			Input: common.ReadParams{ObjectName: "accounts", Fields: connectors.Fields("id")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentMIME("application/vnd.api+json"),
+				Always: mockserver.Response(http.StatusBadRequest, errorUnsupportedPagination),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New( // nolint:goerr113
+					"Invalid input: 'page_size' is not a valid field for the resource 'list'."),
+			},
+		},
+		{
+			Name: "Profiles first page has a link to the next",
+			Input: common.ReadParams{
+				ObjectName: "profiles",
+				Fields:     connectors.Fields("email"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME("application/vnd.api+json"),
+				If:    mockcond.PathSuffix("/api/profiles"),
+				Then:  mockserver.Response(http.StatusOK, responseProfilesFirstPage),
+			}.Server(),
+			Comparator: readComparator,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"email": "jennifer@gmail.com",
+					},
+					Raw: map[string]any{
+						"id":      "01HSXWNWF52J5PJG45BW383RMV",
+						"created": "2024-03-26T17:24:42+00:00",
+						"updated": "2024-03-26T17:24:42+00:00",
+					},
+				}},
+				NextPage: "https://a.klaviyo.com/api/profiles?page%5Bsize%5D=1&page%5Bcursor%5D=bmV4dDo6aWQ6OjAxSFNYV05XRjUySjVQSkc0NUJXMzgzUk1W", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Incremental read of campaigns with required filter",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("name"),
+				Since:      time.Date(2024, 3, 4, 8, 22, 56, 0, time.UTC),
+				Filter:     "equals(messages.channel,'email')",
+			},
+			Comparator: readComparator,
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME("application/vnd.api+json"),
+				If: mockcond.And{
+					mockcond.PathSuffix("/api/campaigns"),
+					mockcond.QueryParam("filter",
+						"greater-than(updated_at,2024-03-04T08:22:56Z),equals(messages.channel,'email')"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCampaigns),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "Email Campaign - Nov 15, 2024, 1:18 AM",
+					},
+					Raw: map[string]any{
+						"status":       "Scheduled",
+						"created_at":   "2024-11-14T23:18:34.827140+00:00",
+						"scheduled_at": "2024-11-14T23:20:02.718919+00:00",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		tt := tt // rebind, omit loop side effects for parallel goroutine
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		WithAuthenticatedClient(http.DefaultClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.setBaseURL(serverURL)
+
+	return connector, nil
+}
+
+func readComparator(baseURL string, actual, expected *common.ReadResult) bool {
+	return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+		mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+		actual.NextPage.String() == expected.NextPage.String() &&
+		actual.Rows == expected.Rows &&
+		actual.Done == expected.Done
+}

--- a/providers/klaviyo/test/read-campaigns.json
+++ b/providers/klaviyo/test/read-campaigns.json
@@ -1,0 +1,65 @@
+{
+  "data" : [ {
+    "type" : "campaign",
+    "id" : "01JCPFHB29QZ1NDPR3GCGQS5G2",
+    "attributes" : {
+      "name" : "Email Campaign - Nov 15, 2024, 1:18 AM",
+      "status" : "Scheduled",
+      "archived" : false,
+      "audiences" : {
+        "included" : [ "XzKvNz" ],
+        "excluded" : [ ]
+      },
+      "send_options" : {
+        "use_smart_sending" : true,
+        "ignore_unsubscribes" : false
+      },
+      "tracking_options" : {
+        "add_tracking_params" : false,
+        "custom_tracking_params" : [ ],
+        "is_tracking_clicks" : true,
+        "is_tracking_opens" : true
+      },
+      "send_strategy" : {
+        "method" : "static",
+        "options_static" : {
+          "datetime" : "2024-11-30T18:15:00+00:00",
+          "is_local" : true,
+          "send_past_recipients_immediately" : true
+        },
+        "options_throttled" : null,
+        "options_sto" : null
+      },
+      "created_at" : "2024-11-14T23:18:34.827140+00:00",
+      "scheduled_at" : "2024-11-14T23:20:02.718919+00:00",
+      "updated_at" : "2024-11-14T23:20:32.232276+00:00",
+      "send_time" : "2024-11-30T18:15:00+00:00"
+    },
+    "relationships" : {
+      "campaign-messages" : {
+        "data" : [ {
+          "type" : "campaign-message",
+          "id" : "01JCPFHB2F7J0J2R2HC8GNNC3Z"
+        } ],
+        "links" : {
+          "self" : "https://a.klaviyo.com/api/campaigns/01JCPFHB29QZ1NDPR3GCGQS5G2/relationships/campaign-messages/",
+          "related" : "https://a.klaviyo.com/api/campaigns/01JCPFHB29QZ1NDPR3GCGQS5G2/campaign-messages/"
+        }
+      },
+      "tags" : {
+        "links" : {
+          "self" : "https://a.klaviyo.com/api/campaigns/01JCPFHB29QZ1NDPR3GCGQS5G2/relationships/tags/",
+          "related" : "https://a.klaviyo.com/api/campaigns/01JCPFHB29QZ1NDPR3GCGQS5G2/tags/"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://a.klaviyo.com/api/campaigns/01JCPFHB29QZ1NDPR3GCGQS5G2/"
+    }
+  } ],
+  "links" : {
+    "self" : "https://a.klaviyo.com/api/campaigns?filter=greater-than%28updated_at%2C2024-11-14T22%3A27%3A51Z%29%2Cequals%28messages.channel%2C%27email%27%29",
+    "next" : null,
+    "prev" : null
+  }
+}

--- a/providers/klaviyo/test/read-profiles-1-first-page.json
+++ b/providers/klaviyo/test/read-profiles-1-first-page.json
@@ -1,0 +1,64 @@
+{
+  "data": [
+    {
+      "type": "profile",
+      "id": "01HSXWNWF52J5PJG45BW383RMV",
+      "attributes": {
+        "email": "jennifer@gmail.com",
+        "phone_number": null,
+        "external_id": null,
+        "anonymous_id": null,
+        "first_name": null,
+        "last_name": null,
+        "organization": null,
+        "locale": null,
+        "title": null,
+        "image": null,
+        "created": "2024-03-26T17:24:42+00:00",
+        "updated": "2024-03-26T17:24:42+00:00",
+        "last_event_date": "2024-03-26T17:24:41+00:00",
+        "location": {
+          "city": null,
+          "zip": null,
+          "country": null,
+          "longitude": null,
+          "address2": null,
+          "address1": null,
+          "region": null,
+          "latitude": null,
+          "timezone": null,
+          "ip": null
+        },
+        "properties": {}
+      },
+      "relationships": {
+        "lists": {
+          "links": {
+            "self": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/relationships/lists/",
+            "related": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/lists/"
+          }
+        },
+        "segments": {
+          "links": {
+            "self": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/relationships/segments/",
+            "related": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/segments/"
+          }
+        },
+        "conversation": {
+          "links": {
+            "self": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/relationships/conversation/",
+            "related": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/conversation/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://a.klaviyo.com/api/profiles/01HSXWNWF52J5PJG45BW383RMV/"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://a.klaviyo.com/api/profiles?page[size]=1",
+    "next": "https://a.klaviyo.com/api/profiles?page%5Bsize%5D=1&page%5Bcursor%5D=bmV4dDo6aWQ6OjAxSFNYV05XRjUySjVQSkc0NUJXMzgzUk1W",
+    "prev": null
+  }
+}

--- a/providers/klaviyo/test/read-unsupported-pagination.json
+++ b/providers/klaviyo/test/read-unsupported-pagination.json
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "id": "6cdf7bc5-cd5e-420e-9220-d47b70e16d1f",
+      "status": 400,
+      "code": "invalid",
+      "title": "Invalid input.",
+      "detail": "'page_size' is not a valid field for the resource 'list'.",
+      "source": {
+        "pointer": "/data/attributes/page_size"
+      },
+      "meta": {}
+    }
+  ]
+}

--- a/test/klaviyo/connector.go
+++ b/test/klaviyo/connector.go
@@ -1,0 +1,77 @@
+package dynamicscrm
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/klaviyo"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetKlaviyoConnector(ctx context.Context) *klaviyo.Connector {
+	filePath := credscanning.LoadPath(providers.Klaviyo)
+	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+
+	conn, err := klaviyo.NewConnector(
+		klaviyo.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail("error creating Klaviyo connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		RedirectURL:  "http://localhost:8080/callbacks/v1/oauth",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://www.klaviyo.com/oauth/authorize",
+			TokenURL:  "https://a.klaviyo.com/oauth/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"accounts:write",
+			"flows:write",
+			"segments:write",
+			"segments:read",
+			"data-privacy:read",
+			"images:read",
+			"metrics:read",
+			"profiles:read",
+			"catalogs:read",
+			"push-tokens:read",
+			"push-tokens:write",
+			"templates:read",
+			"tags:read",
+			"templates:write",
+			"coupons:read",
+			"events:read",
+			"images:write",
+			"lists:read",
+			"catalogs:write",
+			"coupon-codes:read",
+			"campaigns:write",
+			"flows:read",
+			"subscriptions:read",
+			"conversations:write",
+			"coupons:write",
+			"campaigns:read",
+			"lists:write",
+			"data-privacy:write",
+			"events:write",
+			"subscriptions:write",
+			"profiles:write",
+			"tags:write",
+			"accounts:read",
+			"conversations:read",
+			"coupon-codes:write",
+			"metrics:write",
+		},
+	}
+}

--- a/test/klaviyo/read/main.go
+++ b/test/klaviyo/read/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/klaviyo"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetKlaviyoConnector(ctx)
+	defer utils.Close(conn)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "accounts",
+		Fields:     connectors.Fields("contact_information"),
+	})
+	if err != nil {
+		utils.Fail("error reading from Klaviyo", "error", err)
+	}
+
+	fmt.Println("Reading accounts..")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/utils/mockutils/mockserver/handlers.go
+++ b/test/utils/mockutils/mockserver/handlers.go
@@ -23,6 +23,13 @@ func ContentHTML() http.HandlerFunc {
 	}
 }
 
+// ContentMIME is a setup handler, which configures custom media type.
+func ContentMIME(mediaType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", mediaType)
+	}
+}
+
 // Response is used to configure server response with HTTP status and body data.
 // Data is optional.
 func Response(status int, data ...[]byte) http.HandlerFunc {


### PR DESCRIPTION
# Description

## ReadParams

* Since - incremental read uses unique to that object field name. Providing missing field in query will produce the error, thats why on package startup I go over each object known by Read/Metadata and select desired field for Since. 
Note: If no such field exists then nothing it is a no-op.
* Filter - Klaviyo requires filter query parameter for some objects to perform read. This means Salesforce would be not the only one to utilize `common.ReadParams.Filter`. 

Both Since and Filter arguments will be combined and properly passed via `filter` query parameter. They are allowed to be comma separated as per documentation. This falls under custom mime type: "application/vnd.api+json".

## schema.json

Another PR focuses on processing OpenAPI and produces schema.json which we rely uppon.

## Modules

Every API request requires custom header: `revision: 2024-10-15`. This is the latest date/version. This is the only supported. For others we would need to download new openApi file and create matching module name.

# Test Results

![image](https://github.com/user-attachments/assets/0d0da041-4280-4df3-b1ae-69aed8d3d19a)
