### PR TITLE
feat(openapi): Option for Fields flattening

### DIFF
--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -80,6 +80,7 @@ func (e Explorer) ReadObjects(
 			displayNameOverride, locator,
 			e.displayPostProcessing,
 			e.operationMethodFilter,
+			e.propertyFlattener,
 			e.mediaType,
 		)
 		if err != nil {


### PR DESCRIPTION
# Description

Klaviyo consistently returns objects with the following fields:
```json
{
    "type": "account",
    "id": "W4D9sr",
    "attributes": {},
    "links": {}
}
```
This PR adds an option to move fields located under certain nested key (in our case "attributes") to the top level. For the accounts object we will get:
```json
{
    "type": "account",
    "id": "W4D9sr",

    "test_account": false,
    "contact_information": {},
    "industry": null,
    "timezone": "US/Eastern",
    "preferred_currency": "USD",
    "public_api_key": "W4D9sr",
    "locale": "en-US",

    "links": {}
}
```