### PR TITLE
[ENG-1637] Parse webhook types from message for hubspot

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -247,3 +247,12 @@ type PostAuthInfo struct {
 	CatalogVars *map[string]string
 	RawResponse *JSONHTTPResponse
 }
+
+type WebhookEventType string
+
+const (
+	WebhookEventTypeCreate      WebhookEventType = "create"
+	WebhookEventTypeUpdate      WebhookEventType = "update"
+	WebhookEventTypeDelete      WebhookEventType = "delete"
+	WebhookEventtypePassThrough WebhookEventType = "passThrough"
+)

--- a/common/types.go
+++ b/common/types.go
@@ -251,8 +251,8 @@ type PostAuthInfo struct {
 type WebhookEventType string
 
 const (
-	WebhookEventTypeCreate      WebhookEventType = "create"
-	WebhookEventTypeUpdate      WebhookEventType = "update"
-	WebhookEventTypeDelete      WebhookEventType = "delete"
-	WebhookEventtypePassThrough WebhookEventType = "passThrough"
+	WebhookEventTypeCreate WebhookEventType = "create"
+	WebhookEventTypeUpdate WebhookEventType = "update"
+	WebhookEventTypeDelete WebhookEventType = "delete"
+	WebhookEventTypeOther  WebhookEventType = "other"
 )

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -40,10 +40,17 @@ func (c *Connector) GetRecordFromWebhookMessage(
 	return c.GetRecord(ctx, objectName, recordId)
 }
 
-var errWebhookNotSupportedForObject = errors.New("webhook is not supported for the object")
+var (
+	errWebhookNotSupportedForObject            = errors.New("webhook is not supported for the object")
+	errExtractinctObjectNameFromWebhookMessage = errors.New("error extracting object name from webhook message")
+)
 
 func (c *Connector) ExtractObjectNameFromWebhookMessage(msg *WebhookMessage) (string, error) {
 	parts := strings.Split(msg.SubscriptionType, ".")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("%w from event type: %s", errExtractinctObjectNameFromWebhookMessage, msg.SubscriptionType)
+	}
+
 	if !getRecordSupportedObjectsSet.Has(parts[0]) {
 		return "", fmt.Errorf("%w '%s'", errWebhookNotSupportedForObject, parts[0])
 	}

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -40,17 +40,10 @@ func (c *Connector) GetRecordFromWebhookMessage(
 	return c.GetRecord(ctx, objectName, recordId)
 }
 
-var (
-	errWebhookNotSupportedForObject            = errors.New("webhook is not supported for the object")
-	errExtractinctObjectNameFromWebhookMessage = errors.New("error extracting object name from webhook message")
-)
+var errWebhookNotSupportedForObject = errors.New("webhook is not supported for the object")
 
 func (c *Connector) ExtractObjectNameFromWebhookMessage(msg *WebhookMessage) (string, error) {
 	parts := strings.Split(msg.SubscriptionType, ".")
-	if len(parts) == 0 {
-		return "", fmt.Errorf("%w from event type: %s", errExtractinctObjectNameFromWebhookMessage, msg.SubscriptionType)
-	}
-
 	if !getRecordSupportedObjectsSet.Has(parts[0]) {
 		return "", fmt.Errorf("%w '%s'", errWebhookNotSupportedForObject, parts[0])
 	}

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -40,6 +40,24 @@ func (c *Connector) GetRecordFromWebhookMessage(
 	return c.GetRecord(ctx, objectName, recordId)
 }
 
+func (c *Connector) GetEventTypeFromWebhookMessage(msg *WebhookMessage) (common.WebhookEventType, error) {
+	parts := strings.Split(msg.SubscriptionType, ".")
+	if !getRecordSupportedObjectsSet.Has(parts[0]) {
+		return "", errWebhookNotSupportedForObject
+	}
+
+	switch parts[1] {
+	case "creation":
+		return common.WebhookEventTypeCreate, nil
+	case "propertyChange":
+		return common.WebhookEventTypeUpdate, nil
+	case "deletion":
+		return common.WebhookEventTypeDelete, nil
+	default:
+		return common.WebhookEventtypePassThrough, nil
+	}
+}
+
 var errWebhookNotSupportedForObject = errors.New("webhook is not supported for the object")
 
 func (c *Connector) ExtractObjectNameFromWebhookMessage(msg *WebhookMessage) (string, error) {

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -40,7 +40,7 @@ func (c *Connector) GetRecordFromWebhookMessage(
 	return c.GetRecord(ctx, objectName, recordId)
 }
 
-func (c *Connector) GetEventTypeFromWebhookMessage(msg *WebhookMessage) (common.WebhookEventType, error) {
+func (c *Connector) ExtractEventTypeFromWebhookMessage(msg *WebhookMessage) (common.WebhookEventType, error) {
 	parts := strings.Split(msg.SubscriptionType, ".")
 	if !getRecordSupportedObjectsSet.Has(parts[0]) {
 		return "", errWebhookNotSupportedForObject
@@ -51,7 +51,7 @@ func (c *Connector) GetEventTypeFromWebhookMessage(msg *WebhookMessage) (common.
 		return common.WebhookEventTypeCreate, nil
 	case "propertyChange":
 		return common.WebhookEventTypeUpdate, nil
-	case "deletion":
+	case "deletion", "privacyDeletion":
 		return common.WebhookEventTypeDelete, nil
 	default:
 		return common.WebhookEventtypePassThrough, nil

--- a/providers/hubspot/webhook_test.go
+++ b/providers/hubspot/webhook_test.go
@@ -93,7 +93,7 @@ func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
 		t.Fatalf("error extracting object name from webhook message: %s", err)
 	}
 
-	assert.Equal(t, evtTypeCreate, common.WebhookEventTypeCreate, "object type should be parsedCorrectly")
+	assert.Equal(t, evtTypeCreate, common.WebhookEventTypeCreate, "event type should be parsed Correctly")
 
 	deleteMessage := &WebhookMessage{
 		AppId:            1,
@@ -111,10 +111,10 @@ func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
 
 	evtTypeDelete, err := conn.ExtractEventTypeFromWebhookMessage(deleteMessage)
 	if err != nil {
-		t.Fatalf("error extracting object name from webhook message: %s", err)
+		t.Fatalf("error extracting eventTye from webhook message: %s", err)
 	}
 
-	assert.Equal(t, evtTypeDelete, common.WebhookEventTypeDelete, "object type should be parsedCorrectly")
+	assert.Equal(t, evtTypeDelete, common.WebhookEventTypeDelete, "event type should be parsed correctly")
 
 	updateMessage := &WebhookMessage{
 		AppId:            1,
@@ -132,27 +132,10 @@ func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
 
 	evtTypeUpdate, err := conn.ExtractEventTypeFromWebhookMessage(updateMessage)
 	if err != nil {
-		t.Fatalf("error extracting object name from webhook message: %s", err)
+		t.Fatalf("error extracting eventTye from webhook message: %s", err)
 	}
 
-	assert.Equal(t, evtTypeUpdate, common.WebhookEventTypeUpdate, "object type should be parsedCorrectly")
-
-	unsupportedObjectMessage := &WebhookMessage{
-		AppId:            1,
-		EventId:          1,
-		SubscriptionId:   1,
-		PortalId:         1,
-		OccurredAt:       1,
-		SubscriptionType: "someObject.creation",
-		AttemptNumber:    1,
-		ObjectId:         1,
-		ChangeSource:     "CRM",
-		PropertyName:     "message",
-		PropertyValue:    "sample-value",
-	}
-
-	_, err = conn.ExtractEventTypeFromWebhookMessage(unsupportedObjectMessage)
-	assert.ErrorIs(t, err, errWebhookNotSupportedForObject)
+	assert.Equal(t, evtTypeUpdate, common.WebhookEventTypeUpdate, "event type should be parsed correctly")
 
 	emptyObjectMessage := &WebhookMessage{
 		AppId:            1,
@@ -169,5 +152,5 @@ func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
 	}
 
 	_, err = conn.ExtractEventTypeFromWebhookMessage(emptyObjectMessage)
-	assert.ErrorIs(t, err, errWebhookNotSupportedForObject)
+	assert.ErrorIs(t, err, errUnexpectedWebhookEventType)
 }

--- a/providers/hubspot/webhook_test.go
+++ b/providers/hubspot/webhook_test.go
@@ -68,6 +68,7 @@ func TestExtractObjectNameFromWebhookMessage(t *testing.T) {
 	assert.ErrorContains(t, err, "webhook is not supported for the object ''")
 }
 
+//nolint:funlen
 func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
 	t.Parallel()
 

--- a/providers/hubspot/webhook_test.go
+++ b/providers/hubspot/webhook_test.go
@@ -3,10 +3,11 @@ package hubspot
 import (
 	"testing"
 
+	"github.com/amp-labs/connectors/common"
 	"gotest.tools/v3/assert"
 )
 
-func TestWebhook(t *testing.T) {
+func TestExtractObjectNameFromWebhookMessage(t *testing.T) {
 	t.Parallel()
 
 	correctMessage := &WebhookMessage{
@@ -65,4 +66,107 @@ func TestWebhook(t *testing.T) {
 
 	_, err = conn.ExtractObjectNameFromWebhookMessage(emptyObjectMessage)
 	assert.ErrorContains(t, err, "webhook is not supported for the object ''")
+}
+
+func TestExtractEventTypeFromWebhookMessage(t *testing.T) {
+	t.Parallel()
+
+	createMessage := &WebhookMessage{
+		AppId:            1,
+		EventId:          1,
+		SubscriptionId:   1,
+		PortalId:         1,
+		OccurredAt:       1,
+		SubscriptionType: "contact.creation",
+		AttemptNumber:    1,
+		ObjectId:         1,
+		ChangeSource:     "CRM",
+		PropertyName:     "message",
+		PropertyValue:    "sample-value",
+	}
+
+	conn := &Connector{}
+
+	evtTypeCreate, err := conn.ExtractEventTypeFromWebhookMessage(createMessage)
+	if err != nil {
+		t.Fatalf("error extracting object name from webhook message: %s", err)
+	}
+
+	assert.Equal(t, evtTypeCreate, common.WebhookEventTypeCreate, "object type should be parsedCorrectly")
+
+	deleteMessage := &WebhookMessage{
+		AppId:            1,
+		EventId:          1,
+		SubscriptionId:   1,
+		PortalId:         1,
+		OccurredAt:       1,
+		SubscriptionType: "contact.deletion",
+		AttemptNumber:    1,
+		ObjectId:         1,
+		ChangeSource:     "CRM",
+		PropertyName:     "message",
+		PropertyValue:    "sample-value",
+	}
+
+	evtTypeDelete, err := conn.ExtractEventTypeFromWebhookMessage(deleteMessage)
+	if err != nil {
+		t.Fatalf("error extracting object name from webhook message: %s", err)
+	}
+
+	assert.Equal(t, evtTypeDelete, common.WebhookEventTypeDelete, "object type should be parsedCorrectly")
+
+	updateMessage := &WebhookMessage{
+		AppId:            1,
+		EventId:          1,
+		SubscriptionId:   1,
+		PortalId:         1,
+		OccurredAt:       1,
+		SubscriptionType: "contact.propertyChange",
+		AttemptNumber:    1,
+		ObjectId:         1,
+		ChangeSource:     "CRM",
+		PropertyName:     "message",
+		PropertyValue:    "sample-value",
+	}
+
+	evtTypeUpdate, err := conn.ExtractEventTypeFromWebhookMessage(updateMessage)
+	if err != nil {
+		t.Fatalf("error extracting object name from webhook message: %s", err)
+	}
+
+	assert.Equal(t, evtTypeUpdate, common.WebhookEventTypeUpdate, "object type should be parsedCorrectly")
+
+	unsupportedObjectMessage := &WebhookMessage{
+		AppId:            1,
+		EventId:          1,
+		SubscriptionId:   1,
+		PortalId:         1,
+		OccurredAt:       1,
+		SubscriptionType: "someObject.creation",
+		AttemptNumber:    1,
+		ObjectId:         1,
+		ChangeSource:     "CRM",
+		PropertyName:     "message",
+		PropertyValue:    "sample-value",
+	}
+
+	_, err = conn.ExtractEventTypeFromWebhookMessage(unsupportedObjectMessage)
+	assert.ErrorIs(t, err, errWebhookNotSupportedForObject)
+
+	emptyObjectMessage := &WebhookMessage{
+		AppId:            1,
+		EventId:          1,
+		SubscriptionId:   1,
+		PortalId:         1,
+		OccurredAt:       1,
+		SubscriptionType: "",
+		AttemptNumber:    1,
+		ObjectId:         1,
+		ChangeSource:     "CRM",
+		PropertyName:     "message",
+		PropertyValue:    "sample-value",
+	}
+
+	_, err = conn.ExtractEventTypeFromWebhookMessage(emptyObjectMessage)
+	assert.ErrorIs(t, err, errWebhookNotSupportedForObject)
 }


### PR DESCRIPTION
Added webhook types including create,delete,update, pathThrough

added hubspot webhook type parsing and unit test. 