### PR TITLE
[ENG-1662] chore: Remove io.Closer dependency from connectors

### DIFF
--- a/connector/client.go
+++ b/connector/client.go
@@ -11,7 +11,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/connectors.go
+++ b/connectors.go
@@ -3,7 +3,6 @@ package connectors
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -14,7 +13,6 @@ import (
 // basic configuration about the provider.
 type Connector interface {
 	fmt.Stringer
-	io.Closer
 
 	// JSONHTTPClient returns the underlying JSON HTTP client. This is useful for
 	// testing, or for calling methods that aren't exposed by the Connector

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -54,10 +54,6 @@ func (c *Connector) String() string {
 	return "mock"
 }
 
-func (c *Connector) Close() error {
-	return nil
-}
-
 func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 	return c.client
 }

--- a/providers/apollo/client.go
+++ b/providers/apollo/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/atlassian/client.go
+++ b/providers/atlassian/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/attio/client.go
+++ b/providers/attio/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/closecrm/client.go
+++ b/providers/closecrm/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/customerapp/client.go
+++ b/providers/customerapp/client.go
@@ -12,7 +12,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/docusign/client.go
+++ b/providers/docusign/client.go
@@ -15,10 +15,6 @@ func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
 
-func (c *Connector) Close() error {
-	return nil
-}
-
 func (c *Connector) String() string {
 	return c.Provider() + ".Connector"
 }

--- a/providers/dynamicscrm/client.go
+++ b/providers/dynamicscrm/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/gong/client.go
+++ b/providers/gong/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/hubspot/client.go
+++ b/providers/hubspot/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/instantly/client.go
+++ b/providers/instantly/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/intercom/client.go
+++ b/providers/intercom/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/marketo/client.go
+++ b/providers/marketo/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/outreach/client.go
+++ b/providers/outreach/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/pipedrive/client.go
+++ b/providers/pipedrive/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/pipeliner/client.go
+++ b/providers/pipeliner/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/salesforce/client.go
+++ b/providers/salesforce/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/salesloft/client.go
+++ b/providers/salesloft/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/smartlead/client.go
+++ b/providers/smartlead/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/zendesksupport/client.go
+++ b/providers/zendesksupport/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/providers/zohocrm/client.go
+++ b/providers/zohocrm/client.go
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/test/atlassian/auth-metadata/main.go
+++ b/test/atlassian/auth-metadata/main.go
@@ -20,7 +20,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetAtlassianConnector(ctx)
-	defer utils.Close(conn)
 
 	info, err := conn.GetPostAuthInfo(ctx)
 	if err != nil || info.CatalogVars == nil {

--- a/test/atlassian/metadata/main.go
+++ b/test/atlassian/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetAtlassianConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{})
 	if err != nil {

--- a/test/atlassian/read/main.go
+++ b/test/atlassian/read/main.go
@@ -22,7 +22,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetAtlassianConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		Fields: connectors.Fields("id", "summary", "status"),

--- a/test/atlassian/write-delete/main.go
+++ b/test/atlassian/write-delete/main.go
@@ -43,7 +43,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetAtlassianConnector(ctx)
-	defer utils.Close(conn)
 
 	slog.Info("> TEST Create/Update/Delete issue")
 	slog.Info("Creating issue")

--- a/test/closecrm/metadata/metadata.go
+++ b/test/closecrm/metadata/metadata.go
@@ -20,8 +20,6 @@ func main() {
 
 	conn := closecrm.GetCloseConnector(ctx)
 
-	defer utils.Close(conn)
-
 	m, err := conn.ListObjectMetadata(ctx, []string{"lead", "contact", "activity", "task"})
 	if err != nil {
 		utils.Fail("error listing metadata for Close", "error", err)

--- a/test/closecrm/read/read.go
+++ b/test/closecrm/read/read.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := closecrm.GetCloseConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := readActivities(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/test/closecrm/write/write.go
+++ b/test/closecrm/write/write.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := closecrm.GetCloseConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := createLead(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/test/customerio/journeysapp/metadata/main.go
+++ b/test/customerio/journeysapp/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetCustomerJourneysAppConnector(ctx)
-	defer utils.Close(conn)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
 		objectName,

--- a/test/customerio/journeysapp/read/main.go
+++ b/test/customerio/journeysapp/read/main.go
@@ -22,7 +22,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetCustomerJourneysAppConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "segments",

--- a/test/docusign/constructor/main.go
+++ b/test/docusign/constructor/main.go
@@ -18,8 +18,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetDocusignConnector(ctx)
-	defer utils.Close(conn)
+	connTest.GetDocusignConnector(ctx)
 
 	slog.Info("constructor finished")
 }

--- a/test/dynamicscrm/metadata/main.go
+++ b/test/dynamicscrm/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetMSDynamics365CRMConnector(ctx)
-	defer utils.Close(conn)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
 		objectName,

--- a/test/dynamicscrm/read/main.go
+++ b/test/dynamicscrm/read/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetMSDynamics365CRMConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/dynamicscrm/write-delete/main.go
+++ b/test/dynamicscrm/write-delete/main.go
@@ -40,7 +40,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetMSDynamics365CRMConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Update/Delete lead")
 	fmt.Println("Creating lead")

--- a/test/gong/metadata/main.go
+++ b/test/gong/metadata/main.go
@@ -26,7 +26,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetGongConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -22,7 +22,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetGongConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "calls", // could be calls, users

--- a/test/gong/write/main.go
+++ b/test/gong/write/main.go
@@ -42,7 +42,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetGongConnector(ctx)
-	defer utils.Close(conn)
 
 	slog.Info("TEST Create Call")
 	slog.Info("Creating Call")

--- a/test/hubspot/record/main.go
+++ b/test/hubspot/record/main.go
@@ -39,7 +39,6 @@ func main() {
 
 	// Get the Hubspot connector.
 	conn := connTest.GetHubspotConnector(ctx)
-	defer utils.Close(conn)
 
 	// Write an artificial contact to Hubspot.
 	writeResult, err := conn.Write(ctx, common.WriteParams{

--- a/test/hubspot/write/main.go
+++ b/test/hubspot/write/main.go
@@ -35,7 +35,6 @@ func main() {
 
 	// Get the Hubspot connector.
 	conn := connTest.GetHubspotConnector(ctx)
-	defer utils.Close(conn)
 
 	// Write an artificial contact to Hubspot.
 	result, err := conn.Write(ctx, common.WriteParams{

--- a/test/instantly/metadata/main.go
+++ b/test/instantly/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetInstantlyConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/instantly/read/main.go
+++ b/test/instantly/read/main.go
@@ -26,7 +26,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetInstantlyConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/instantly/write-delete/main.go
+++ b/test/instantly/write-delete/main.go
@@ -30,7 +30,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetInstantlyConnector(ctx)
-	defer utils.Close(conn)
 
 	slog.Info("> TEST Create/Update/Delete tags")
 	slog.Info("Creating tags")

--- a/test/intercom/metadata/main.go
+++ b/test/intercom/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetIntercomConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/intercom/read/main.go
+++ b/test/intercom/read/main.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetIntercomConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "conversations",

--- a/test/intercom/search/main.go
+++ b/test/intercom/search/main.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetIntercomConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "conversations",

--- a/test/intercom/write-delete/main.go
+++ b/test/intercom/write-delete/main.go
@@ -29,7 +29,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetIntercomConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Update/Delete Article")
 	fmt.Println("Prepare by getting first admin user id")

--- a/test/outreach/metadata/metadata.go
+++ b/test/outreach/metadata/metadata.go
@@ -19,7 +19,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetOutreachConnector(ctx)
-	defer utils.Close(conn)
 
 	m, err := conn.ListObjectMetadata(ctx, []string{"sequences"})
 	if err != nil {

--- a/test/outreach/read/read.go
+++ b/test/outreach/read/read.go
@@ -22,7 +22,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetOutreachConnector(ctx)
-	defer utils.Close(conn)
 
 	var err error
 

--- a/test/outreach/write/write.go
+++ b/test/outreach/write/write.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetOutreachConnector(ctx)
-	defer utils.Close(conn)
 
 	err := testWriteConnector(context.Background(), conn)
 	if err != nil {

--- a/test/pipedrive/metadata/metadata.go
+++ b/test/pipedrive/metadata/metadata.go
@@ -19,7 +19,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := pipedrive.GetPipedriveConnector(ctx)
-	defer utils.Close(conn)
 
 	m, err := conn.ListObjectMetadata(ctx, []string{"activities", "callLogs", "currencies", "deals"})
 	if err != nil {

--- a/test/pipedrive/read/read.go
+++ b/test/pipedrive/read/read.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := pipedrive.GetPipedriveConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := readActivities(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/test/pipedrive/write/write.go
+++ b/test/pipedrive/write/write.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := pipedrive.GetPipedriveConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := createActivity(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/test/pipeliner/metadata/main.go
+++ b/test/pipeliner/metadata/main.go
@@ -26,7 +26,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetPipelinerConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/pipeliner/read/main.go
+++ b/test/pipeliner/read/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetPipelinerConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/pipeliner/write-delete/main.go
+++ b/test/pipeliner/write-delete/main.go
@@ -31,7 +31,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetPipelinerConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Update/Delete Notes")
 	fmt.Println("Creating Notes")

--- a/test/salesforce/bulk/delete/main.go
+++ b/test/salesforce/bulk/delete/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	// We first create objects in Salesforce,
 	// and then we generate an in-memory CSV of the Salesforce IDs of the newly created objects,

--- a/test/salesforce/bulk/query/main.go
+++ b/test/salesforce/bulk/query/main.go
@@ -21,7 +21,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	query := "SELECT Id, Name FROM Account LIMIT 1000"
 

--- a/test/salesforce/bulk/read/main.go
+++ b/test/salesforce/bulk/read/main.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.BulkRead(ctx, common.ReadParams{
 		ObjectName: "Account",

--- a/test/salesforce/bulk/write/main.go
+++ b/test/salesforce/bulk/write/main.go
@@ -59,7 +59,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	logs := tests.Run(ctx, conn)
 

--- a/test/salesforce/event-flow/main.go
+++ b/test/salesforce/event-flow/main.go
@@ -24,7 +24,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	uniqueString := strconv.Itoa(int(time.Now().UnixMilli()))
 

--- a/test/salesforce/metadata-read/main.go
+++ b/test/salesforce/metadata-read/main.go
@@ -27,7 +27,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/salesforce/metadata-write/main.go
+++ b/test/salesforce/metadata-write/main.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	connTest "github.com/amp-labs/connectors/test/salesforce"
-	"github.com/amp-labs/connectors/test/utils"
 )
 
 func main() {
@@ -25,7 +24,6 @@ func main() {
 	slog.SetDefault(logger)
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	input := []byte(`
 <createMetadata>

--- a/test/salesforce/read-write/accounts/main.go
+++ b/test/salesforce/read-write/accounts/main.go
@@ -30,7 +30,6 @@ func mainFn() int { //nolint:funlen
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := testReadConnector(ctx, conn); err != nil {
 		slog.Error("Error testing", "connector", conn, "error", err)

--- a/test/salesforce/read-write/attachments/main.go
+++ b/test/salesforce/read-write/attachments/main.go
@@ -27,7 +27,6 @@ func main() { //nolint:funlen
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesforceConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("Lookup account")
 

--- a/test/salesloft/metadata/main.go
+++ b/test/salesloft/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSalesloftConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectNamePlural,

--- a/test/salesloft/read/main.go
+++ b/test/salesloft/read/main.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetSalesloftConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "people",

--- a/test/salesloft/write-delete/main.go
+++ b/test/salesloft/write-delete/main.go
@@ -30,7 +30,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := msTest.GetSalesloftConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Update/Delete ListView")
 	fmt.Println("Creating ListView")

--- a/test/smartlead/metadata/main.go
+++ b/test/smartlead/metadata/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSmartleadConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/smartlead/read/main.go
+++ b/test/smartlead/read/main.go
@@ -24,7 +24,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSmartleadConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/smartlead/write-delete/main.go
+++ b/test/smartlead/write-delete/main.go
@@ -28,7 +28,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetSmartleadConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Delete campaign")
 	fmt.Println("Creating campaign")

--- a/test/zendesksupport/metadata/main.go
+++ b/test/zendesksupport/metadata/main.go
@@ -26,7 +26,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetZendeskSupportConnector(ctx)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/zendesksupport/read/main.go
+++ b/test/zendesksupport/read/main.go
@@ -25,7 +25,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetZendeskSupportConnector(ctx)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/zendesksupport/write-delete/main.go
+++ b/test/zendesksupport/write-delete/main.go
@@ -36,7 +36,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := connTest.GetZendeskSupportConnector(ctx)
-	defer utils.Close(conn)
 
 	fmt.Println("> TEST Create/Update/Delete brands")
 

--- a/test/zohocrm/metadata/metadata.go
+++ b/test/zohocrm/metadata/metadata.go
@@ -19,7 +19,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := zohocrm.GetZohoConnector(ctx)
-	defer utils.Close(conn)
 
 	m, err := conn.ListObjectMetadata(ctx, []string{"leads", "deals", "contacts"})
 	if err != nil {

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := zohocrm.GetZohoConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := readContacts(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -23,7 +23,6 @@ func main() {
 	utils.SetupLogging()
 
 	conn := zohocrm.GetZohoConnector(ctx)
-	defer utils.Close(conn)
 
 	if err := createDeals(ctx, conn); err != nil {
 		slog.Error(err.Error())

--- a/tools/connectorgen/template/base/client.go.tmpl
+++ b/tools/connectorgen/template/base/client.go.tmpl
@@ -10,7 +10,3 @@ func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
 func (c *Connector) HTTPClient() *common.HTTPClient {
 	return c.Client.HTTPClient
 }
-
-func (c *Connector) Close() error {
-	return nil
-}

--- a/tools/connectorgen/template/test/metadata/main.go.tmpl
+++ b/tools/connectorgen/template/test/metadata/main.go.tmpl
@@ -34,7 +34,6 @@ func main() {
 	}
 
 	conn := connTest.Get{{ .Provider }}Connector(ctx, filePath)
-	defer utils.Close(conn)
 
 	response, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName, // TODO check endpoint path

--- a/tools/connectorgen/template/test/read/main.go.tmpl
+++ b/tools/connectorgen/template/test/read/main.go.tmpl
@@ -32,7 +32,6 @@ func main() {
 	}
 
 	conn := connTest.Get{{ .Provider }}Connector(ctx, filePath)
-	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName, // TODO check endpoint path

--- a/tools/connectorgen/template/test/write-delete/main.go.tmpl
+++ b/tools/connectorgen/template/test/write-delete/main.go.tmpl
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	conn := connTest.Get{{ .Provider }}Connector(ctx, filePath)
-	defer utils.Close(conn)
+
 
 	fmt.Println("> TEST Create/Update/Delete {{ .ObjectName }}")
 	fmt.Println("Creating {{ .ObjectName }}")


### PR DESCRIPTION
This was meant to be a good to have for when we need to close a long lived connection. But since we don't have any usage for it yet, it's become a no-op boilerplate. We can reintroduce in the specific interface we need it in.