### PR TITLE
[CON-186] Keap - read with custom fields

### DIFF
--- a/common/jsonquery/converters.go
+++ b/common/jsonquery/converters.go
@@ -1,6 +1,7 @@
 package jsonquery
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/spyzhov/ajson"
@@ -65,4 +66,24 @@ func (convertor) ObjectToMap(node *ajson.Node) (map[string]any, error) {
 	}
 
 	return result, nil
+}
+
+func ParseNode[T any](node *ajson.Node) (*T, error) {
+	var template T
+
+	raw, err := node.Unpack()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &template); err != nil {
+		return nil, err
+	}
+
+	return &template, nil
 }

--- a/providers/keap/README.md
+++ b/providers/keap/README.md
@@ -1,0 +1,62 @@
+# Custom Fields
+
+The `Read` operation will return custom fields alongside other native properties.
+Keap API indexes custom fields using numbered identifiers without including human-readable names.
+This issue is addressed in the implementation.
+
+
+## Example
+```json
+{
+  "id": 22,
+  "given_name": "Erica",
+  "jobtitle": "Product Owner" // custom field
+} 
+```
+
+
+## Explanation
+[List Contacts](https://developer.keap.com/docs/rest/#tag/Contact/operation/listContactsUsingGET)
+When requesting the contacts resource, the response includes custom fields as follows:
+```json
+{
+  "contacts": [
+    {
+      "id": 22,
+      "given_name": "Erica",
+      "custom_fields": [
+        {
+          "id": 6, // Obscure field name.
+          "content": "Product Owner"
+        },
+      ]
+    }
+  ]
+}
+```
+[Contacts Model](https://developer.keap.com/docs/rest/#tag/Contact/operation/retrieveContactModelUsingGET)
+To determine the meaning of `"id": 6`, you can query the contacts model, which provides additional details:
+```json
+{
+  "custom_fields": [
+    {
+      "id": 6,
+      "label": "title",
+      "options": [],
+      "record_type": "CONTACT",
+      "field_type": "Text",
+      "field_name": "jobtitle", // Prefered field name.
+      "default_value": null
+    },
+  ],
+  "optional_properties": []
+}
+```
+Combining both results, the connector's `Read` will return the following:
+```json
+{
+  "id": 22,
+  "given_name": "Erica",
+  "jobtitle": "Product Owner"
+} 
+```

--- a/providers/keap/README.md
+++ b/providers/keap/README.md
@@ -5,7 +5,7 @@ Keap API indexes custom fields using numbered identifiers without including huma
 This issue is addressed in the implementation.
 
 
-## Example
+## Original record
 ```json
 {
   "id": 22,
@@ -15,7 +15,7 @@ This issue is addressed in the implementation.
 ```
 
 
-## Explanation
+## Normal response
 [List Contacts](https://developer.keap.com/docs/rest/#tag/Contact/operation/listContactsUsingGET)
 When requesting the contacts resource, the response includes custom fields as follows:
 ```json

--- a/providers/keap/objectNames.go
+++ b/providers/keap/objectNames.go
@@ -203,3 +203,25 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 		},
 	),
 }
+
+var objectsWithCustomFields = map[common.ModuleID]datautils.StringSet{ // nolint:gochecknoglobals
+	ModuleV1: datautils.NewStringSet(
+		objectNameAffiliates,
+		objectNameAppointments,
+		objectNameCompanies,
+		objectNameContacts,
+		objectNameNotes,
+		objectNameOpportunities,
+		objectNameOrders,
+		objectNameSubscriptions,
+		objectNameTasks,
+	),
+	ModuleV2: datautils.NewStringSet(
+		objectNameAffiliates,
+		objectNameContacts,
+		objectNameNotes,
+		objectNameOrders,
+		objectNameSubscriptions,
+		objectNameTasks,
+	),
+}

--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -1,6 +1,8 @@
 package keap
 
 import (
+	"context"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/spyzhov/ajson"
@@ -14,4 +16,71 @@ func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
 
 		return jsonquery.New(node).StrWithDefault("next_page_token", "")
 	}
+}
+
+// Before parsing the records if applicable API will be called one time to get model describing custom fields.
+// Object will then be enhanced using model.
+func (c *Connector) parseReadRecords(
+	ctx context.Context, config common.ReadParams, jsonPath string,
+) common.RecordsFunc {
+	return func(node *ajson.Node) ([]map[string]any, error) {
+		arr, err := jsonquery.New(node).Array(jsonPath, true)
+		if err != nil {
+			return nil, err
+		}
+
+		customFields, err := c.requestCustomFields(ctx, config.ObjectName)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make([]map[string]any, len(arr))
+
+		for index, object := range arr {
+			item, err := c.enhanceObjectWithCustomFieldNames(object, customFields)
+			if err != nil {
+				return nil, err
+			}
+
+			result[index] = item
+		}
+
+		return result, nil
+	}
+}
+
+// In general this does the usual JSON parsing.
+// However, those objects that contain "custom_fields" are processed as follows:
+// * Locate custom fields in JSON read response.
+// * Replace ids with human-readable names, which is provided as argument.
+// * Place fields at the top level of the object.
+func (c *Connector) enhanceObjectWithCustomFieldNames(
+	node *ajson.Node,
+	fields map[int]modelCustomField,
+) (map[string]any, error) {
+	object, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(fields) == 0 {
+		// no custom fields, the object is ready as is.
+		return object, nil
+	}
+
+	customFieldsResponse, err := jsonquery.ParseNode[readCustomFieldsResponse](node)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace identifiers with human-readable field names which were found by making a call to "/model".
+	for _, field := range customFieldsResponse.CustomFields {
+		if model, ok := fields[field.ID]; ok {
+			object[model.FieldName] = field.Content
+		}
+	}
+
+	delete(object, "custom_fields")
+
+	return object, nil
 }

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -98,6 +98,19 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"jobdescription": "AI application in commerce",
 						"experience":     "8 years in 3 companies",
 						"age":            float64(32),
+						"custom_fields": []any{map[string]any{
+							"id":      float64(12),
+							"content": "8 years in 3 companies",
+						}, map[string]any{
+							"id":      float64(6),
+							"content": "Product Owner",
+						}, map[string]any{
+							"id":      float64(8),
+							"content": "AI application in commerce",
+						}, map[string]any{
+							"id":      float64(14),
+							"content": float64(32),
+						}},
 					},
 				}, {
 					Fields: map[string]any{

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -18,6 +18,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	errorBadRequest := testutils.DataFromFile(t, "get-with-req-body-not-allowed.html")
 	errorNotFound := testutils.DataFromFile(t, "url-not-found.html")
+	responseContactsModel := testutils.DataFromFile(t, "custom-fields-contacts.json")
 	responseContactsFirstPage := testutils.DataFromFile(t, "read-contacts-1-first-page-v1.json")
 	responseContactsEmptyPage := testutils.DataFromFile(t, "read-contacts-2-empty-page-v1.json")
 
@@ -71,12 +72,17 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name: "Contacts first page has a link to next",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
-				Fields:     connectors.Fields("given_name"),
+				Fields:     connectors.Fields("given_name", "jobtitle"),
 			},
-			Server: mockserver.Conditional{
+			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.PathSuffix("/crm/rest/v1/contacts"),
-				Then:  mockserver.Response(http.StatusOK, responseContactsFirstPage),
+				Cases: []mockserver.Case{{
+					If:   mockcond.PathSuffix("/crm/rest/v1/contacts"),
+					Then: mockserver.Response(http.StatusOK, responseContactsFirstPage),
+				}, {
+					If:   mockcond.PathSuffix("/crm/rest/v1/contacts/model"),
+					Then: mockserver.Response(http.StatusOK, responseContactsModel),
+				}},
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
@@ -84,18 +90,26 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"given_name": "Erica",
+						"jobtitle":   "Product Owner",
 					},
 					Raw: map[string]any{
-						"id":          float64(22),
-						"family_name": "Lewis",
+						"id":             float64(22),
+						"family_name":    "Lewis",
+						"jobdescription": "AI application in commerce",
+						"experience":     "8 years in 3 companies",
+						"age":            float64(32),
 					},
 				}, {
 					Fields: map[string]any{
 						"given_name": "John",
+						"jobtitle":   nil,
 					},
 					Raw: map[string]any{
-						"id":          float64(20),
-						"family_name": "Doe",
+						"id":             float64(20),
+						"family_name":    "Doe",
+						"jobdescription": nil,
+						"experience":     nil,
+						"age":            nil,
 					},
 				}},
 				NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=2&since=2024-06-03T22:17:59.039Z&order=id", // nolint:lll

--- a/providers/keap/test/custom-fields-contacts.json
+++ b/providers/keap/test/custom-fields-contacts.json
@@ -1,0 +1,63 @@
+{
+  "custom_fields": [
+    {
+      "id": 6,
+      "label": "title",
+      "options": [],
+      "record_type": "CONTACT",
+      "field_type": "Text",
+      "field_name": "jobtitle",
+      "default_value": null
+    },
+    {
+      "id": 8,
+      "label": "job_description",
+      "options": [],
+      "record_type": "CONTACT",
+      "field_type": "Text",
+      "field_name": "jobdescription",
+      "default_value": null
+    },
+    {
+      "id": 12,
+      "label": "experience",
+      "options": [],
+      "record_type": "CONTACT",
+      "field_type": "Text",
+      "field_name": "experience",
+      "default_value": null
+    },
+    {
+      "id": 14,
+      "label": "age",
+      "options": [],
+      "record_type": "CONTACT",
+      "field_type": "WholeNumber",
+      "field_name": "age",
+      "default_value": null
+    }
+  ],
+  "optional_properties": [
+    "company_name",
+    "opt_in_reason",
+    "origin",
+    "relationships",
+    "fax_numbers",
+    "social_accounts",
+    "contact_type",
+    "lead_source_id",
+    "birthday",
+    "preferred_name",
+    "prefix",
+    "suffix",
+    "notes",
+    "time_zone",
+    "website",
+    "job_title",
+    "preferred_locale",
+    "source_type",
+    "custom_fields",
+    "spouse_name",
+    "anniversary"
+  ]
+}

--- a/providers/keap/test/read-contacts-1-first-page-v1.json
+++ b/providers/keap/test/read-contacts-1-first-page-v1.json
@@ -6,10 +6,10 @@
       "company": null,
       "email_opted_in": false,
       "email_status": "NonMarketable",
-      "date_created": "2024-11-07T20:35:13.000+0000",
-      "last_updated": "2024-11-07T20:35:13.000+0000",
-      "ScoreValue": null,
-      "last_updated_utc_millis": 1731011713217,
+      "date_created": "2024-11-20T18:34:12.000+0000",
+      "last_updated": "2024-11-20T18:34:12.000+0000",
+      "ScoreValue": "0",
+      "last_updated_utc_millis": 1732127651841,
       "email_addresses": [
         {
           "email": "erica.lewis@gmail.com",
@@ -21,7 +21,25 @@
       "given_name": "Erica",
       "family_name": "Lewis",
       "middle_name": null,
-      "owner_id": null
+      "owner_id": null,
+      "custom_fields": [
+        {
+          "id": 12,
+          "content": "8 years in 3 companies"
+        },
+        {
+          "id": 6,
+          "content": "Product Owner"
+        },
+        {
+          "id": 8,
+          "content": "AI application in commerce"
+        },
+        {
+          "id": 14,
+          "content": 32
+        }
+      ]
     },
     {
       "tag_ids": [],
@@ -44,7 +62,25 @@
       "given_name": "John",
       "family_name": "Doe",
       "middle_name": null,
-      "owner_id": null
+      "owner_id": null,
+      "custom_fields": [
+        {
+          "id": 12,
+          "content": null
+        },
+        {
+          "id": 6,
+          "content": null
+        },
+        {
+          "id": 8,
+          "content": null
+        },
+        {
+          "id": 14,
+          "content": null
+        }
+      ]
     }
   ],
   "count": 2,

--- a/scripts/openapi/keap/metadata/v1/objects.go
+++ b/scripts/openapi/keap/metadata/v1/objects.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	ignoreEndpoints = []string{ // nolint:gochecknoglobals
-		// endpoint for creating fields
+		// endpoints for creating fields
 		"/v1/appointments/model/customFields",
 		"/v1/notes/model/customFields",
 		"/v1/tasks/model/customFields",

--- a/scripts/openapi/keap/metadata/v2/objects.go
+++ b/scripts/openapi/keap/metadata/v2/objects.go
@@ -11,9 +11,14 @@ import (
 
 var (
 	ignoreEndpoints = []string{ // nolint:gochecknoglobals
+		// endpoints for creating fields
+		"/v2/notes/model/customFields",
+		"/v2/tasks/model/customFields",
 		// custom fields and models endpoints to create them are not read candidates
-		"*/model",
-		"*/customFields",
+		"/v2/affiliates/model", // array located at "custom_fields"
+		"/v2/contacts/model",   // array located at "custom_fields"
+		"/v2/notes/model",      // array located at "custom_fields"
+		"/v2/tasks/model",      // array located at "custom_fields"
 		// singular object
 		"/v2/businessProfile",
 		// misc

--- a/test/keap/read/main.go
+++ b/test/keap/read/main.go
@@ -25,8 +25,8 @@ func main() {
 	defer utils.Close(conn)
 
 	res, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: "emails",
-		Fields:     connectors.Fields("id", "subject", "sent_from_address"),
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("id"),
 	})
 	if err != nil {
 		utils.Fail("error reading from Keap", "error", err)


### PR DESCRIPTION
# Description

Include custom fields as part of `Read` response alongside the native fields.

[How to create/update/delete custom fields?](https://help.keap.com/help/create-custom-fields) This can be done via dashboard. I noticed that update and delete are absent in REST APIs, therefore managing custom fields via dashboard is preferred.


# Review

Check the `README.md` for how the read output is effected, as well as tests.


