### PR TITLE
feat: Bump go to version 1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version: ">=1.23.3"
           cache: false
 
       - name: Build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,18 +8,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.0"
+          go-version: "1.23.3"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         continue-on-error: false
         with:
-          version: v1.56.2
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21.0"
-          cache: false
+          version: v1.62.0
       - name: Install gci
         run: "go install github.com/daixiang0/gci@latest"
       - name: List files with wrong format

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,26 +7,6 @@ linters:
   disable:
     # Disabled because we use inits all over the place
     - gochecknoinits
-    # Abandoned, replaced by unused
-    - varcheck
-    # Abandoned, replaced by unused
-    - structcheck
-    # Abandoned, replaced by unused
-    - deadcode
-    # Author archived it, and suggests to not use it in real-world applications
-    - interfacer
-    # Abandoned, replaced by revive
-    - nosnakecase
-    # Abandoned, replaced by revive
-    - golint
-    # Abandoned, replaced by exhaustruct
-    - exhaustivestruct
-    # Deprecated by owner
-    - ifshort
-    # Archived by owner, replaced by govet
-    - maligned
-    # Deprecated by owner, replaced with exportloopref
-    - scopelint
     # Highly annoying. We'd need to whitelist all packages we import, which is a lot of work and adds very little value.
     - depguard
     # Annoying and unhelpful. Assumes uninitialized (zero-valued) fields are always a bug, which is plain wrong.
@@ -41,6 +21,8 @@ linters:
     - nolintlint
     # Named returns are helpful if there are multiple return values of the same type, and acts as self-documentation of the function.
     - nonamedreturns
+    # No longer relevant in newer versions of Go
+    - exportloopref
 linters-settings:
   # See https://golangci-lint.run/usage/linters#revive
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,7 @@
 run:
   timeout: 5m
-  skip-dirs:
-    - "playground"
-    - "test"
 output:
-  format: github-actions
+  formats: colored-line-number
 linters:
   enable-all: true
   disable:
@@ -62,6 +59,9 @@ linters-settings:
     max-distance: 10
 
 issues:
+  exclude-dirs:
+    - "playground"
+    - "test"
   exclude-rules:
     - text: "don't use ALL_CAPS in Go names"
       linters:

--- a/common/interpreter/error_test.go
+++ b/common/interpreter/error_test.go
@@ -112,9 +112,8 @@ func TestErrorHandler(t *testing.T) { //nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/interpreter/formatSwitch_test.go
+++ b/common/interpreter/formatSwitch_test.go
@@ -97,7 +97,6 @@ func TestFormatSwitchParseJSON(t *testing.T) { //nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/json_test.go
+++ b/common/json_test.go
@@ -57,7 +57,6 @@ func TestUnmarshalJSON(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -119,7 +119,6 @@ func TestQueryInteger(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -214,7 +213,6 @@ func TestQueryString(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -309,7 +307,6 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -408,9 +405,8 @@ func TestQueryArray(t *testing.T) { // nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -497,7 +493,6 @@ func TestQueryObject(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/naming/plural.go
+++ b/common/naming/plural.go
@@ -6,9 +6,10 @@ import "encoding/json"
 // It is capable of self conversion to singular form.
 // You can use it as keys in maps, values, and it knows how to Marshal itself like a string.
 // Unmarshalling will apply plural formating.
-type PluralString struct {
+type PluralString struct { //nolint:recvcheck
 	text string
 }
+
 type PluralStrings []PluralString
 
 func NewPluralString(str string) PluralString {

--- a/common/naming/singular.go
+++ b/common/naming/singular.go
@@ -13,7 +13,7 @@ var pluralizer = pluralize.NewClient() // nolint:gochecknoglobals
 // It is capable of self conversion to plural form.
 // You can use it as keys in maps, values, and it knows how to Marshal itself like a string.
 // Unmarshalling will apply singular formating.
-type SingularString struct {
+type SingularString struct { //nolint:recvcheck
 	text string
 }
 

--- a/common/naming/singular_test.go
+++ b/common/naming/singular_test.go
@@ -31,9 +31,8 @@ func TestSingularString(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -153,7 +152,6 @@ func TestSingularMarshal(t *testing.T) { // nolint:funlen
 	}
 
 	for _, tt := range tests {
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/paramsbuilder/catalogVariable_test.go
+++ b/common/paramsbuilder/catalogVariable_test.go
@@ -39,7 +39,6 @@ func TestNewCatalogVariables(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -76,7 +75,6 @@ func TestNewCatalogSubstitutionRegistry(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/substitutions/substitutions.go
+++ b/common/substitutions/substitutions.go
@@ -10,7 +10,8 @@ import (
 // using the substitutions map.
 func substituteStruct(input interface{}, substitutions map[string]string) (err error) { //nolint:gocognit,cyclop,lll
 	configStruct := reflect.ValueOf(input).Elem()
-	for i := 0; i < configStruct.NumField(); i++ {
+
+	for i := range configStruct.NumField() {
 		field := configStruct.Field(i)
 
 		// If the field is a string, perform substitution on it.

--- a/common/urlbuilder/url_test.go
+++ b/common/urlbuilder/url_test.go
@@ -33,9 +33,8 @@ func TestNewURL(t *testing.T) { // nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -96,9 +95,8 @@ func TestWithQueryParam(t *testing.T) { // nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -168,9 +166,8 @@ func TestAddPath(t *testing.T) { // nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/common/xquery/queries_test.go
+++ b/common/xquery/queries_test.go
@@ -93,9 +93,8 @@ func TestXMLSetVariousData(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/connectors.go
+++ b/connectors.go
@@ -96,7 +96,7 @@ type (
 	DeleteResult             = common.DeleteResult
 	ListObjectMetadataResult = common.ListObjectMetadataResult
 
-	ErrorWithStatus = common.HTTPStatusError
+	ErrorWithStatus = common.HTTPStatusError //nolint:errname
 )
 
 var Fields = datautils.NewStringSet // nolint:gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amp-labs/connectors
 
-go 1.21.0
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.9.2

--- a/internal/datautils/set_test.go
+++ b/internal/datautils/set_test.go
@@ -34,7 +34,6 @@ func TestStringSet(t *testing.T) {
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/datautils/timing_test.go
+++ b/internal/datautils/timing_test.go
@@ -49,7 +49,6 @@ func TestTimingFormatRFC3339inUTC(t *testing.T) {
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -219,7 +219,7 @@ func commonPrefix(a, b string) string {
 
 	result := ""
 
-	for i := 0; i < shortestLength; i++ {
+	for i := range shortestLength {
 		if first[i] != second[i] {
 			return result
 		}

--- a/providers/atlassian/authmetadata_test.go
+++ b/providers/atlassian/authmetadata_test.go
@@ -64,9 +64,8 @@ func TestGetPostAuthInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -58,7 +58,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -100,7 +100,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -275,7 +275,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -103,7 +103,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -65,7 +65,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/customerapp/read_test.go
+++ b/providers/customerapp/read_test.go
@@ -130,7 +130,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/docusign/metadata.go
+++ b/providers/docusign/metadata.go
@@ -70,7 +70,7 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 		}
 
 		if baseURLWithoutHTTPS := strings.TrimPrefix(baseURIString, "https://"); baseURLWithoutHTTPS != baseURIString {
-			if parts := strings.SplitN(baseURLWithoutHTTPS, ".", 2); len(parts) > 1 { // nolint:gomnd
+			if parts := strings.SplitN(baseURLWithoutHTTPS, ".", 2); len(parts) > 1 { // nolint:gomnd,mnd
 				postAuthInfo.CatalogVars = AuthMetadataVars{
 					Server: parts[0],
 				}.AsMap()

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -59,7 +59,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -107,7 +107,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/dynamicscrm/read_test.go
+++ b/providers/dynamicscrm/read_test.go
@@ -130,7 +130,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/dynamicscrm/url_test.go
+++ b/providers/dynamicscrm/url_test.go
@@ -40,7 +40,6 @@ func TestConstructURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -74,7 +74,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -91,7 +91,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -205,7 +205,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -71,7 +71,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/hubspot/webhook.go
+++ b/providers/hubspot/webhook.go
@@ -42,11 +42,12 @@ func (c *Connector) GetRecordFromWebhookMessage(
 
 var errUnexpectedWebhookEventType = errors.New("unexpected webhook event type")
 
+const minParts = 2
+
 func (c *Connector) ExtractEventTypeFromWebhookMessage(msg *WebhookMessage) (common.WebhookEventType, error) {
 	parts := strings.Split(msg.SubscriptionType, ".")
 
-	//nolint:gomnd
-	if len(parts) < 2 {
+	if len(parts) < minParts {
 		// this should never happen unless the provider changes webhook message format
 		return common.WebhookEventTypeOther, fmt.Errorf("%w: '%s'", errUnexpectedWebhookEventType, msg.SubscriptionType)
 	}

--- a/providers/instantly/delete_test.go
+++ b/providers/instantly/delete_test.go
@@ -69,7 +69,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -63,7 +63,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -86,16 +86,18 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage:   "test-placeholder?skip=700",
 				Fields:     connectors.Fields("id"),
 			},
-			Server: mockserver.NewServer(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
+			Server: mockserver.NewServer(func(writer http.ResponseWriter, r *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
 				// Create fake response big enough to conclude that next page exists.
 				manyCampaigns := make([]string, DefaultPageSize)
-				for i := 0; i < DefaultPageSize; i++ {
+
+				for i := range DefaultPageSize {
 					manyCampaigns[i] = "{}"
 				}
+
 				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
-				_, _ = w.Write([]byte(data))
+				_, _ = writer.Write([]byte(data))
 			}),
 			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
 				return actual.NextPage.String() == expected.NextPage.String() &&
@@ -212,7 +214,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -156,7 +156,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -60,7 +60,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/intercom/metadata_test.go
+++ b/providers/intercom/metadata_test.go
@@ -86,7 +86,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/intercom/objectNames.go
+++ b/providers/intercom/objectNames.go
@@ -39,7 +39,7 @@ var objectNameToURLPath = datautils.NewDefaultMap(map[string]string{ //nolint:go
 	return obj
 })
 
-// nolint:gomnd
+// nolint:gomnd,mnd
 var incrementalSearchObjectPagination = datautils.NewDefaultMap(map[string]int{ //nolint:gochecknoglobals
 	// https://developers.intercom.com/docs/references/rest-api/api.intercom.io/conversations/searchconversations
 	"conversations": 150,

--- a/providers/intercom/parse.go
+++ b/providers/intercom/parse.go
@@ -118,7 +118,7 @@ func extractListFieldName(node *ajson.Node) (string, error) {
 	//		event.summary => events
 
 	parts := strings.Split(name, ".")
-	if len(parts) == 2 { // nolint:gomnd
+	if len(parts) == 2 { // nolint:gomnd,mnd
 		// custom name is used when it has 2 parts
 		return applyPluralForm(parts[0]), nil
 	}

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -299,7 +299,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/intercom/url_test.go
+++ b/providers/intercom/url_test.go
@@ -37,7 +37,6 @@ func TestConstructURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -103,7 +103,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -63,7 +63,6 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -113,7 +112,6 @@ func TestListObjectMetadataV2(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -132,7 +132,6 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -184,7 +183,6 @@ func TestReadV2(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/klaviyo/delete_test.go
+++ b/providers/klaviyo/delete_test.go
@@ -69,7 +69,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -78,7 +78,6 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -125,7 +125,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/klaviyo/write_test.go
+++ b/providers/klaviyo/write_test.go
@@ -140,7 +140,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipedrive/metadata_test.go
+++ b/providers/pipedrive/metadata_test.go
@@ -134,7 +134,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipedrive/read_test.go
+++ b/providers/pipedrive/read_test.go
@@ -194,7 +194,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipeliner/delete_test.go
+++ b/providers/pipeliner/delete_test.go
@@ -44,7 +44,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipeliner/metadata_test.go
+++ b/providers/pipeliner/metadata_test.go
@@ -115,7 +115,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -174,7 +174,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -148,7 +148,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/bulk-delete_test.go
+++ b/providers/salesforce/bulk-delete_test.go
@@ -56,7 +56,6 @@ func TestBulkDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/bulk-info_test.go
+++ b/providers/salesforce/bulk-info_test.go
@@ -49,7 +49,6 @@ func TestJobInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -87,7 +86,6 @@ func TestGetBulkQueryInfo(t *testing.T) { // nolint:dupl
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -179,7 +177,6 @@ func TestJobResults(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -211,7 +208,6 @@ func TestGetSuccessfulJobResults(t *testing.T) { // nolint:dupl
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -243,7 +239,6 @@ func TestGetBulkQueryResults(t *testing.T) { // nolint:dupl
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/bulk-query_test.go
+++ b/providers/salesforce/bulk-query_test.go
@@ -88,7 +88,6 @@ func TestBulkQuery(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/bulk-read_test.go
+++ b/providers/salesforce/bulk-read_test.go
@@ -81,7 +81,6 @@ func TestBulkRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/bulk-write_test.go
+++ b/providers/salesforce/bulk-write_test.go
@@ -160,7 +160,6 @@ func TestBulkWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests { // nolint:dupl
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -275,7 +275,7 @@ func (c *Connector) postToSFAPI(ctx context.Context, body any, path string, enti
 		return nil, err
 	}
 
-	if res.Warnings != nil && len(res.Warnings) > 0 {
+	if len(res.Warnings) > 0 {
 		slog.Warn(entity, "warnings", res.Warnings)
 	}
 

--- a/providers/salesforce/metadataApi_test.go
+++ b/providers/salesforce/metadataApi_test.go
@@ -72,9 +72,8 @@ func TestCreateMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -114,7 +114,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -138,7 +138,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -116,7 +116,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -57,7 +57,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesloft/metadata_test.go
+++ b/providers/salesloft/metadata_test.go
@@ -92,7 +92,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -240,7 +240,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -145,7 +145,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -66,7 +66,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -67,7 +67,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -120,7 +120,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -119,7 +119,6 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -63,9 +63,8 @@ func TestNewCustomCatalog(t *testing.T) { //nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -160,9 +159,8 @@ func TestReadInfo(t *testing.T) { // nolint:funlen
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:varnamelen
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -60,7 +60,6 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -96,7 +96,6 @@ func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -162,7 +161,6 @@ func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,goc
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -157,7 +157,6 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -221,7 +220,6 @@ func TestReadHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,ma
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -142,7 +142,6 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -189,7 +188,6 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/scripts/openapi/marketo/metadata/metadata.go
+++ b/scripts/openapi/marketo/metadata/metadata.go
@@ -24,12 +24,12 @@ func main() {
 	//  read the definitions in the specification file.
 	// 5 represents the amount of substrings that will be generated
 	// when path of interest is split using `/`
-	def, docA, err := constructDefinitions(assets, 5) //nolint:gomnd
+	def, docA, err := constructDefinitions(assets, 5) //nolint:gomnd,mnd
 	goutils.MustBeNil(err)
 
 	// 4 represents the amount of substrings that will be generated
 	// when path of interest is split using `/`
-	ldef, docL, err := constructDefinitions(leads, 4) //nolint:gomnd
+	ldef, docL, err := constructDefinitions(leads, 4) //nolint:gomnd,mnd
 	goutils.MustBeNil(err)
 
 	// Initializes an empty ObjectMetadata variable

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -169,7 +169,7 @@ func getSectionLinks() []string {
 }
 
 func getPercentage(i int, i2 int) float64 {
-	return (float64(i+1) / float64(i2)) * 100 // nolint:gomnd
+	return (float64(i+1) / float64(i2)) * 100 // nolint:gomnd,mnd
 }
 
 // List of exceptions:

--- a/tools/fileconv/api3/strategy_test.go
+++ b/tools/fileconv/api3/strategy_test.go
@@ -55,7 +55,6 @@ func TestStarRulePathResolver(t *testing.T) { // nolint:funlen
 
 	for _, tt := range tests {
 		// nolint:varnamelen
-		tt := tt // rebind, omit loop side effects for parallel goroutine
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tools/scrapper/models.go
+++ b/tools/scrapper/models.go
@@ -131,19 +131,19 @@ func (s *QueryParamStats) SaveParameterStats(queryParamName string, objectNames 
 
 	s.Data = append(s.Data, queryParamObjectStats{
 		Name:         queryParamName,
-		Frequency:    roundFloat(freq, 4), // nolint:gomnd
+		Frequency:    roundFloat(freq, 4), // nolint:gomnd,mnd
 		TotalObjects: num,
 		Objects:      objectNames,
 	})
 }
 
 func roundFloat(f float64, decPlaces int) float64 {
-	target := math.Pow(10, float64(decPlaces)) // nolint:gomnd
+	target := math.Pow(10, float64(decPlaces)) // nolint:gomnd,mnd
 
 	return float64(int(f*target)) / target
 }
 
-type DateTime struct {
+type DateTime struct { //nolint:recvcheck
 	Time time.Time
 }
 
@@ -156,7 +156,7 @@ func (s DateTime) MarshalJSON() ([]byte, error) {
 func (s *DateTime) UnmarshalJSON(bytes []byte) error {
 	str := string(bytes)
 	// remove string quotes
-	if len(str) < 2 { // nolint:gomnd
+	if len(str) < 2 { // nolint:gomnd,mnd
 		return errors.New("date time has no quotes") // nolint:goerr113
 	}
 


### PR DESCRIPTION
This PR bumps go to version 1.23. It also bumps the linter to a version which works with go 1.23, and makes linter-related fixes.