### PR TITLE
[ENG-1268] fix: Update google auth params

### DIFF
--- a/providers/google.go
+++ b/providers/google.go
@@ -13,7 +13,7 @@ func init() {
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://accounts.google.com/o/oauth2/v2/auth",
-			AuthURLParams:             map[string]string{"access_type": "offline"},
+			AuthURLParams:             map[string]string{"access_type": "offline", "prompt": "consent"},
 			TokenURL:                  "https://oauth2.googleapis.com/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,


### PR DESCRIPTION
Google OAuth2 seems to have some <sub><sup>ridiculous</sup></sub> undocumented behavior.

## Normal flow
If a user grants access to a Google app via the standard OAuth flow, setting the `access_type` set to `offline`, we receive a set of access and refresh tokens. However, during subsequent OAuth flows for the same Google app, the oauth flow will automatically bypass the allow/consent screen. This is google's way of speeding up the flow since it knows that you already consent to the app. 

## Catch
The catch is that Google seems to ignore requests for refresh tokens during the second type of oauth flows, i.e. when it skips past the consent screen for you.

## Solution
To fix this, we need to force Google to always display the consent screen and therefore, make it always honor the request for a refresh token. This issue is easy to encounter if you test your app in development mode and then switch to production.

> In some cases, we may need to ask the user to de-authorize the app from the google account before going through the flow again

This is also available as [oauth2.ApprovalForce](https://pkg.go.dev/golang.org/x/oauth2#AuthCodeOption), but making it a default option is not a good idea, because some providers error out when there's extra params in a auth code URL. 

## Screenshots
### Old Auth URL
<img width="642" alt="Screenshot 2024-11-27 at 6 39 18 PM" src="https://github.com/user-attachments/assets/887a2467-9c9f-4afe-a09d-aa80ac4b0c31">

### First grant - token comes with refresh token
<img width="262" alt="Screenshot 2024-11-27 at 6 40 14 PM" src="https://github.com/user-attachments/assets/33991d41-95a4-4b4c-83ac-10d7dc9d79cd">

### Second grant - token has no refresh token
<img width="226" alt="Screenshot 2024-11-27 at 6 40 55 PM" src="https://github.com/user-attachments/assets/0f2faeff-7734-422b-9de0-13c62e348344">

### After adding `prompt: consent` to the auth URL
<img width="231" alt="Screenshot 2024-11-27 at 6 47 05 PM" src="https://github.com/user-attachments/assets/c9015c19-2c1a-4d68-a877-62bb80731149">

### Sources
https://github.com/googleapis/google-api-python-client/issues/213
https://github.com/googleapis/oauth2client/issues/453
https://github.com/zquestz/omniauth-google-oauth2/issues/467