### PR TITLE
tidy: Scope panic recovery to Options constructor

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -37,17 +37,6 @@ func InterpretError(res *http.Response, body []byte) error {
 	return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrUnknown, string(body)))
 }
 
-func PanicRecovery(wrapup func(cause error)) {
-	if re := recover(); re != nil {
-		err, ok := re.(error)
-		if !ok {
-			panic(re)
-		}
-
-		wrapup(err)
-	}
-}
-
 type ErrorPostProcessor struct {
 	Process func(err error) error
 }

--- a/common/paramsbuilder/params.go
+++ b/common/paramsbuilder/params.go
@@ -4,6 +4,8 @@
 // and exposed to end user via delegation. Most would do delegation only.
 package paramsbuilder
 
+import "github.com/amp-labs/connectors/internal/goutils"
+
 // ParamAssurance checks that param data is valid
 // Every param instance must implement it.
 type ParamAssurance interface {
@@ -20,7 +22,12 @@ type ParamAssurance interface {
 func Apply[P ParamAssurance](params P,
 	opts []func(params *P),
 	defaultOpts ...func(params *P),
-) (*P, error) {
+) (output *P, err error) {
+	defer goutils.PanicRecovery(func(cause error) {
+		err = cause
+		output = nil
+	})
+
 	for _, opt := range defaultOpts {
 		opt(&params)
 	}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -16,11 +16,6 @@ func NewConnector(
 	provider providers.Provider,
 	opts ...Option,
 ) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{provider: provider}, opts)
 	if err != nil {
 		return nil, err

--- a/internal/goutils/utils.go
+++ b/internal/goutils/utils.go
@@ -11,3 +11,15 @@ func MustBeNil(err error) {
 		panic(err)
 	}
 }
+
+// PanicRecovery catches the cause of panic and passes it to the callback.
+func PanicRecovery(wrapup func(cause error)) {
+	if re := recover(); re != nil {
+		err, ok := re.(error)
+		if !ok {
+			panic(re)
+		}
+
+		wrapup(err)
+	}
+}

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -17,27 +18,16 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
-	params := &mockParams{
-		read: func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
+	params, err := paramsbuilder.Apply(parameters{}, opts,
+		WithRead(func(context.Context, common.ReadParams) (*common.ReadResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "read")
-		},
-		write: func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
+		}),
+		WithWrite(func(context.Context, common.WriteParams) (*common.WriteResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "write")
-		},
-		listObjectMetadata: func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error) {
+		}),
+		WithListObjectMetadata(func(context.Context, []string) (*common.ListObjectMetadataResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "listObjectMetadata")
-		},
-	}
-	for _, opt := range opts {
-		opt(params)
-	}
-
-	params, err := params.prepare()
+		}))
 	if err != nil {
 		return nil, err
 	}

--- a/mock/params.go
+++ b/mock/params.go
@@ -9,18 +9,18 @@ import (
 )
 
 // Option is a function which mutates the hubspot connector configuration.
-type Option func(params *mockParams)
+type Option = func(params *parameters)
 
 // WithClient sets the http client to use for the connector. Saves some boilerplate.
 func WithClient(client *http.Client) Option {
-	return func(params *mockParams) {
+	return func(params *parameters) {
 		WithAuthenticatedClient(client)(params)
 	}
 }
 
 // WithAuthenticatedClient sets the http client to use for the connector. Its usage is optional.
 func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
-	return func(params *mockParams) {
+	return func(params *parameters) {
 		params.client = &common.JSONHTTPClient{
 			HTTPClient: &common.HTTPClient{
 				Client: client,
@@ -31,14 +31,14 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 // WithRead sets the read function for the connector.
 func WithRead(read func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)) Option {
-	return func(params *mockParams) {
+	return func(params *parameters) {
 		params.read = read
 	}
 }
 
 // WithWrite sets the write function for the connector.
 func WithWrite(write func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)) Option {
-	return func(params *mockParams) {
+	return func(params *parameters) {
 		params.write = write
 	}
 }
@@ -47,36 +47,35 @@ func WithWrite(write func(ctx context.Context, params common.WriteParams) (*comm
 func WithListObjectMetadata(
 	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error),
 ) Option {
-	return func(params *mockParams) {
+	return func(params *parameters) {
 		params.listObjectMetadata = listObjectMetadata
 	}
 }
 
-// mockParams is the internal configuration for the mock connector.
-type mockParams struct {
+// parameters is the internal configuration for the mock connector.
+type parameters struct {
 	client             *common.JSONHTTPClient // required
 	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
 	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
 	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
 }
 
-// prepare finalizes and validates the connector configuration, and returns an error if it's invalid.
-func (p *mockParams) prepare() (out *mockParams, err error) {
+func (p parameters) ValidateParams() error {
 	if p.client == nil {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "client")
+		return fmt.Errorf("%w: %s", ErrMissingParam, "client")
 	}
 
 	if p.read == nil {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "read")
+		return fmt.Errorf("%w: %s", ErrMissingParam, "read")
 	}
 
 	if p.write == nil {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "write")
+		return fmt.Errorf("%w: %s", ErrMissingParam, "write")
 	}
 
 	if p.listObjectMetadata == nil {
-		return nil, fmt.Errorf("%w: %s", ErrMissingParam, "listObjectMetadata")
+		return fmt.Errorf("%w: %s", ErrMissingParam, "listObjectMetadata")
 	}
 
-	return p, nil
+	return nil
 }

--- a/providers/apollo/connector.go
+++ b/providers/apollo/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 type operation string
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/atlassian/connector.go
+++ b/providers/atlassian/connector.go
@@ -24,11 +24,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		WithModule(ModuleEmpty), // The module is resolved on behalf of the user if the option is missing.
 	)

--- a/providers/attio/connector.go
+++ b/providers/attio/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/closecrm/connector.go
+++ b/providers/closecrm/connector.go
@@ -15,11 +15,6 @@ type Connector struct {
 
 // NewConnector returns a new Close connector.
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/constantcontact/connector.go
+++ b/providers/constantcontact/connector.go
@@ -18,11 +18,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/customerapp/connector.go
+++ b/providers/customerapp/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/docusign/connector.go
+++ b/providers/docusign/connector.go
@@ -12,11 +12,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/dynamicscrm/connector.go
+++ b/providers/dynamicscrm/connector.go
@@ -19,11 +19,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/gong/connector.go
+++ b/providers/gong/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -15,11 +15,6 @@ type Connector struct {
 
 // NewConnector returns a new Hubspot connector.
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		WithModule(ModuleEmpty), // The module is resolved on behalf of the user if the option is missing.
 	)

--- a/providers/instantly/connector.go
+++ b/providers/instantly/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/intercom/connector.go
+++ b/providers/intercom/connector.go
@@ -22,11 +22,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/keap/connector.go
+++ b/providers/keap/connector.go
@@ -18,11 +18,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(ModuleV1))
 	if err != nil {
 		return nil, err

--- a/providers/klaviyo/connector.go
+++ b/providers/klaviyo/connector.go
@@ -16,11 +16,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(Module2024Oct15))
 	if err != nil {
 		return nil, err

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -16,11 +16,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		WithModule(ModuleLeads), // The module is resolved on behalf of the user if the option is missing.
 	)

--- a/providers/outreach/connector.go
+++ b/providers/outreach/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/pipedrive/connector.go
+++ b/providers/pipedrive/connector.go
@@ -22,11 +22,6 @@ type Connector struct {
 // NewConnector constructs the Pipedrive Connector and returns it, Fails
 // if any of the required fields are not instantiated.
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/pipeliner/connector.go
+++ b/providers/pipeliner/connector.go
@@ -16,11 +16,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -30,11 +30,6 @@ func APIVersionSOAP() string {
 
 // NewConnector returns a new Salesforce connector.
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/salesloft/connector.go
+++ b/providers/salesloft/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/smartlead/connector.go
+++ b/providers/smartlead/connector.go
@@ -17,11 +17,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -16,11 +16,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		WithModule(ModuleTicketing), // The module is resolved on behalf of the user if the option is missing.
 	)

--- a/providers/zohocrm/connector.go
+++ b/providers/zohocrm/connector.go
@@ -15,11 +15,6 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	defer common.PanicRecovery(func(cause error) {
-		outErr = cause
-		conn = nil
-	})
-
 	params, err := paramsbuilder.Apply(parameters{}, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Goal

PanicRecover shouldn't be called from Connector constructor. Panics can be used within connector options. We have a more local place to call for panic recovery which is `paramsbuilder.Apply`. This should clean the code and hide this method.

# Changes
Review them by commits.

* https://github.com/amp-labs/connectors/pull/1175/commits/3f23dafaf16bcbcee9afa890742684924a4bb68c 
  * PanicRecovery is moved to `goutils`. It is not related to `common` package but provides a very general utility, it belongs to golang utility ("std library").
  * parambsbuilder.Apply uses recovery. The gist of PR.
* https://github.com/amp-labs/connectors/pull/1175/commits/d045b8a692c5b4e6c749a5c87889341d80dc494e
  *  removed panicrecovery from connectors because now it doesn't guard against anything.
* https://github.com/amp-labs/connectors/pull/1175/commits/f38a1d57b03cd38e3910501583022787a9c85521
  *  mock connector now uses paramsbuilder shortening the code in general. Default parameters values are supplied using default options WithRead/WithWrite/WithListObjectMetadata.
