### PR TITLE
[CON-2] Gong returns empty ReadResult on not-found

### DIFF
--- a/common/interpreter/statusCode.go
+++ b/common/interpreter/statusCode.go
@@ -2,6 +2,7 @@ package interpreter
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
@@ -18,7 +19,7 @@ func DefaultStatusCodeMappingToErr(res *http.Response, body []byte) error { // n
 	case http.StatusForbidden:
 		return common.ErrForbidden
 	case http.StatusNotFound:
-		return common.ErrBadRequest // TODO more specific error
+		return fmt.Errorf("%w: %w", common.ErrBadRequest, common.ErrNotFound)
 	case http.StatusMethodNotAllowed:
 		return common.ErrBadRequest // TODO more specific error
 	case http.StatusRequestTimeout:

--- a/common/types.go
+++ b/common/types.go
@@ -70,6 +70,9 @@ var (
 	// ErrBadRequest is returned when we get a 400 response from the provider.
 	ErrBadRequest = errors.New("bad request")
 
+	// ErrNotFound is returned when we get a 404 response from the provider.
+	ErrNotFound = errors.New("not found")
+
 	// ErrMissingExpectedValues is returned when response data doesn't have values expected for processing.
 	ErrMissingExpectedValues = errors.New("response data is missing expected values")
 

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -2,6 +2,7 @@ package gong
 
 import (
 	"context"
+	"errors"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -34,6 +35,15 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	res, err := c.Client.Get(ctx, url.String())
 	if err != nil {
+		if errors.Is(err, common.ErrNotFound) {
+			return &common.ReadResult{
+				Rows:     0,
+				Data:     make([]common.ReadResultRow, 0),
+				NextPage: "",
+				Done:     true,
+			}, nil
+		}
+
 		return nil, err
 	}
 

--- a/test/gong/read/read.go
+++ b/test/gong/read/read.go
@@ -24,7 +24,7 @@ func main() {
 	conn := connTest.GetGongConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: "calls", // could be calls, users
+		ObjectName: "calls",
 		Fields:     connectors.Fields("url"),
 	})
 	if err != nil {


### PR DESCRIPTION
# Description

Core code mapping to error messages is modified such that 404 is distinguished from other 4xx.
Gong read has a check returning empty ReadResult on error not found.

# Test
Modified Read script to do the most recent incremental read. Using debug tools verified that the correct code branch is visited:
![image](https://github.com/user-attachments/assets/36b732c2-c237-4e37-9735-5ad26e61034c)

# Suggestions
This PR focuses on Gong only as per ticket.
I left the TODO on better error handling a while ago, it seems this could be a good time to think what errors are expected to be returned by connectors library. Also, treating not-found error as success may only apply to Gong but not other connectors. 

@laurenzlong let me know in slack if there are any plans on universal error format by Ampersand connectors and what is the priority for this.
