### PR TITLE
Feat: Hubspot write method now returns full record

### DIFF
--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -1,5 +1,7 @@
 package datautils
 
+import "encoding/json"
+
 // Map is a generic version of map with useful methods.
 // It can return Keys as a slice or a Set.
 type Map[K comparable, V any] map[K]V
@@ -63,4 +65,21 @@ func (m DefaultMap[K, V]) Get(key K) V { // nolint:ireturn
 	var empty V
 
 	return empty
+}
+
+// Convert a struct to a map of string to any.
+func StructToMap(obj any) (map[string]any, error) {
+	var result map[string]any
+
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(jsonBytes, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/providers/hubspot/write.go
+++ b/providers/hubspot/write.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
 )
 
 type writeResponse struct {
@@ -51,9 +52,14 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
+	record, err := datautils.StructToMap(*rsp)
+	if err != nil {
+		return nil, err
+	}
+
 	return &common.WriteResult{
 		RecordId: rsp.ID,
 		Success:  true,
-		Data:     rsp.Properties,
+		Data:     record,
 	}, nil
 }


### PR DESCRIPTION
Previously Hubspot write was only returning the `properties` of the record, whereas it should return the full record (which includes associations). 

This is technically a breaking change, but I checked the logs and there aren't any write API calls for Hubspot in the last 14 days, so doesn't appear like this is being actively used. 