### PR TITLE
fix: Update hubspot.GetResultId to look for ID in the raw object

### DIFF
--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -141,6 +141,7 @@ func getMarshalledData(records []map[string]interface{}, fields []string) ([]com
 }
 
 // GetLastResultId returns the last row's id from a result.
+// nolint:cyclop
 func GetLastResultId(result *common.ReadResult) string {
 	if result == nil {
 		return ""

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -142,18 +142,41 @@ func getMarshalledData(records []map[string]interface{}, fields []string) ([]com
 
 // GetLastResultId returns the last row's id from a result.
 func GetLastResultId(result *common.ReadResult) string {
+	if result == nil {
+		return ""
+	}
+
 	numRecords := len(result.Data)
 	if numRecords == 0 {
 		return ""
 	}
 
-	// Get the last row and get the hs_object_id field's value
+	// Get the last row
 	lastRow := result.Data[numRecords-1]
 
-	lastRowId, ok := lastRow.Fields[string(ObjectFieldHsObjectId)].(string)
-	if !ok {
+	// Attempt to get it from the fields
+	if idValue, ok := lastRow.Fields[string(ObjectFieldId)].(string); ok && idValue != "" {
+		return idValue
+	} else if idValue, ok = lastRow.Fields[string(ObjectFieldHsObjectId)].(string); ok && idValue != "" {
+		return idValue
+	}
+
+	// Attempt to get it from raw
+	if idValue, ok := lastRow.Raw[string(ObjectFieldId)].(string); ok && idValue != "" {
+		return idValue
+	}
+
+	// Attempt to get the properties map
+	propertiesValue, ok := lastRow.Raw[string(ObjectFieldProperties)].(map[string]any)
+	if !ok || propertiesValue == nil {
 		return ""
 	}
 
-	return lastRowId
+	// Attempt to get the ObjectFieldHsObjectId from the properties map
+	if hsObjectId, ok := propertiesValue[string(ObjectFieldHsObjectId)].(string); ok && hsObjectId != "" {
+		return hsObjectId
+	}
+
+	// If everything fails, return an empty string
+	return ""
 }

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -140,35 +140,27 @@ func getMarshalledData(records []map[string]interface{}, fields []string) ([]com
 	return data, nil
 }
 
-// GetLastResultId returns the last row's id from a result.
+// GetResultId returns the id of a hubspot result row.
 // nolint:cyclop
-func GetLastResultId(result *common.ReadResult) string {
-	if result == nil {
+func GetResultId(row *common.ReadResultRow) string {
+	if row == nil {
 		return ""
 	}
-
-	numRecords := len(result.Data)
-	if numRecords == 0 {
-		return ""
-	}
-
-	// Get the last row
-	lastRow := result.Data[numRecords-1]
 
 	// Attempt to get it from the fields
-	if idValue, ok := lastRow.Fields[string(ObjectFieldId)].(string); ok && idValue != "" {
+	if idValue, ok := row.Fields[string(ObjectFieldId)].(string); ok && idValue != "" {
 		return idValue
-	} else if idValue, ok = lastRow.Fields[string(ObjectFieldHsObjectId)].(string); ok && idValue != "" {
+	} else if idValue, ok = row.Fields[string(ObjectFieldHsObjectId)].(string); ok && idValue != "" {
 		return idValue
 	}
 
 	// Attempt to get it from raw
-	if idValue, ok := lastRow.Raw[string(ObjectFieldId)].(string); ok && idValue != "" {
+	if idValue, ok := row.Raw[string(ObjectFieldId)].(string); ok && idValue != "" {
 		return idValue
 	}
 
 	// Attempt to get the properties map
-	propertiesValue, ok := lastRow.Raw[string(ObjectFieldProperties)].(map[string]any)
+	propertiesValue, ok := row.Raw[string(ObjectFieldProperties)].(map[string]any)
 	if !ok || propertiesValue == nil {
 		return ""
 	}

--- a/providers/hubspot/parse_test.go
+++ b/providers/hubspot/parse_test.go
@@ -12,7 +12,7 @@ func TestGetLastResultId(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		input    *common.ReadResult
+		input    *common.ReadResultRow
 		expected string
 	}{
 		{
@@ -22,60 +22,40 @@ func TestGetLastResultId(t *testing.T) {
 		},
 		{
 			name:     "Empty Data",
-			input:    &common.ReadResult{Data: []common.ReadResultRow{}},
+			input:    &common.ReadResultRow{},
 			expected: "",
 		},
 		{
 			name: "Valid Fields[id]",
-			input: &common.ReadResult{
-				Data: []common.ReadResultRow{
-					{Fields: map[string]any{string(ObjectFieldId): "12345"}},
-				},
+			input: &common.ReadResultRow{
+				Fields: map[string]any{string(ObjectFieldId): "12345"},
 			},
 			expected: "12345",
 		},
 		{
 			name: "Valid Fields[hs_object_id]",
-			input: &common.ReadResult{
-				Data: []common.ReadResultRow{
-					{Fields: map[string]any{string(ObjectFieldHsObjectId): "67890"}},
-				},
+			input: &common.ReadResultRow{
+				Fields: map[string]any{string(ObjectFieldHsObjectId): "67890"},
 			},
 			expected: "67890",
 		},
 		{
 			name: "Valid Raw[id]",
-			input: &common.ReadResult{
-				Data: []common.ReadResultRow{
-					{Raw: map[string]any{string(ObjectFieldId): "abcdef"}},
-				},
+			input: &common.ReadResultRow{
+				Raw: map[string]any{string(ObjectFieldId): "abcdef"},
 			},
 			expected: "abcdef",
 		},
 		{
 			name: "Valid Raw[properties][hs_object_id]",
-			input: &common.ReadResult{
-				Data: []common.ReadResultRow{
-					{
-						Raw: map[string]any{
-							string(ObjectFieldProperties): map[string]any{
-								string(ObjectFieldHsObjectId): "ghijkl",
-							},
-						},
+			input: &common.ReadResultRow{
+				Raw: map[string]any{
+					string(ObjectFieldProperties): map[string]any{
+						string(ObjectFieldHsObjectId): "ghijkl",
 					},
 				},
 			},
 			expected: "ghijkl",
-		},
-		{
-			name: "Multiple Records - Returns ID from the last row",
-			input: &common.ReadResult{
-				Data: []common.ReadResultRow{
-					{Raw: map[string]any{string(ObjectFieldId): "first-id"}},
-					{Raw: map[string]any{string(ObjectFieldProperties): map[string]any{string(ObjectFieldHsObjectId): "last-id"}}},
-				},
-			},
-			expected: "last-id",
 		},
 	}
 
@@ -83,7 +63,7 @@ func TestGetLastResultId(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := GetLastResultId(test.input)
+			result := GetResultId(test.input)
 			if result != test.expected {
 				t.Errorf("expected %q, got %q", test.expected, result)
 			}

--- a/providers/hubspot/parse_test.go
+++ b/providers/hubspot/parse_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
+// nolint:funlen
 func TestGetLastResultId(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    *common.ReadResult
@@ -78,6 +81,8 @@ func TestGetLastResultId(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := GetLastResultId(test.input)
 			if result != test.expected {
 				t.Errorf("expected %q, got %q", test.expected, result)

--- a/providers/hubspot/parse_test.go
+++ b/providers/hubspot/parse_test.go
@@ -57,6 +57,27 @@ func TestGetLastResultId(t *testing.T) {
 			},
 			expected: "ghijkl",
 		},
+		{
+			name: "Dummy hubspot test",
+			input: &common.ReadResultRow{
+				Fields: map[string]any{
+					"lifecyclestage": "lead",
+				},
+				Raw: map[string]any{
+					"archived":  false,
+					"createdAt": "2010-12-08T06:13:17.698Z",
+					"id":        "15237",
+					"properties": map[string]any{
+						"createdate":       "2010-12-08T06:13:17.698Z",
+						"hs_object_id":     "15237",
+						"lastmodifieddate": "2010-12-04T11:18:28.697Z",
+						"lifecyclestage":   "lead",
+					},
+					"updatedAt": "2010-12-04T11:18:28.697Z",
+				},
+			},
+			expected: "15237",
+		},
 	}
 
 	for _, test := range tests {

--- a/providers/hubspot/parse_test.go
+++ b/providers/hubspot/parse_test.go
@@ -1,0 +1,87 @@
+package hubspot
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestGetLastResultId(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *common.ReadResult
+		expected string
+	}{
+		{
+			name:     "Nil Input",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "Empty Data",
+			input:    &common.ReadResult{Data: []common.ReadResultRow{}},
+			expected: "",
+		},
+		{
+			name: "Valid Fields[id]",
+			input: &common.ReadResult{
+				Data: []common.ReadResultRow{
+					{Fields: map[string]any{string(ObjectFieldId): "12345"}},
+				},
+			},
+			expected: "12345",
+		},
+		{
+			name: "Valid Fields[hs_object_id]",
+			input: &common.ReadResult{
+				Data: []common.ReadResultRow{
+					{Fields: map[string]any{string(ObjectFieldHsObjectId): "67890"}},
+				},
+			},
+			expected: "67890",
+		},
+		{
+			name: "Valid Raw[id]",
+			input: &common.ReadResult{
+				Data: []common.ReadResultRow{
+					{Raw: map[string]any{string(ObjectFieldId): "abcdef"}},
+				},
+			},
+			expected: "abcdef",
+		},
+		{
+			name: "Valid Raw[properties][hs_object_id]",
+			input: &common.ReadResult{
+				Data: []common.ReadResultRow{
+					{
+						Raw: map[string]any{
+							string(ObjectFieldProperties): map[string]any{
+								string(ObjectFieldHsObjectId): "ghijkl",
+							},
+						},
+					},
+				},
+			},
+			expected: "ghijkl",
+		},
+		{
+			name: "Multiple Records - Returns ID from the last row",
+			input: &common.ReadResult{
+				Data: []common.ReadResultRow{
+					{Raw: map[string]any{string(ObjectFieldId): "first-id"}},
+					{Raw: map[string]any{string(ObjectFieldProperties): map[string]any{string(ObjectFieldHsObjectId): "last-id"}}},
+				},
+			},
+			expected: "last-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetLastResultId(test.input)
+			if result != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, result)
+			}
+		})
+	}
+}

--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -78,6 +78,8 @@ const (
 	ObjectFieldHsObjectId         ObjectField = "hs_object_id"
 	ObjectFieldHsLastModifiedDate ObjectField = "hs_lastmodifieddate"
 	ObjectFieldLastModifiedDate   ObjectField = "lastmodifieddate"
+	ObjectFieldId                 ObjectField = "id"
+	ObjectFieldProperties         ObjectField = "properties"
 )
 
 type ObjectType string


### PR DESCRIPTION
* We added the `Raw` field to `ReadResult` after this function was originally introduced. At the time, it looked for ID inside the fields object
*  This function needs to look for the ID of a record in the `Raw` object, and not the `Fields` object, since `Fields` may or may not have the ID field
* The `Raw` response will always have the ID inside `Raw.properties`

This test should help clarify the required output - https://github.com/amp-labs/connectors/pull/1186/files#diff-24f929d222aa9a04a0837d0f97a1b5c230629c1420ae254486acefc9b10f2a00R61