### PR TITLE
feat: Allow a module to override base URL

### DIFF
--- a/providers/atlassian/modules.go
+++ b/providers/atlassian/modules.go
@@ -9,6 +9,8 @@ const (
 	ModuleEmpty common.ModuleID = ""
 	// ModuleJira is the module used for listing Jira issues.
 	ModuleJira common.ModuleID = "jira"
+	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
+	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
 )
 
 // supportedModules represents currently working and supported modules within the Atlassian connector.
@@ -21,6 +23,11 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 	},
 	ModuleJira: {
 		ID:      ModuleJira,
+		Label:   "rest/api",
+		Version: "3",
+	},
+	ModuleAtlassianJiraConnect: {
+		ID:      ModuleAtlassianJiraConnect,
 		Label:   "rest/api",
 		Version: "3",
 	},

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -446,3 +446,23 @@ func (i *ProviderInfo) GetApiKeyHeader(apiKey string) (string, string, error) {
 
 	return headerName, headerValue, nil
 }
+
+// Override can be used to override the base URL of the provider, and could be
+// used for other fields in the future.
+func (i *ProviderInfo) Override(override *ProviderInfo) *ProviderInfo {
+	if i == nil {
+		return &ProviderInfo{}
+	}
+
+	// Return the original if the override is nil.
+	if override == nil {
+		return i
+	}
+
+	// Only allow overriding the base URL for now.
+	if override.BaseURL != "" {
+		i.BaseURL = override.BaseURL
+	}
+
+	return i
+}


### PR DESCRIPTION
Atlassian connect has a different base URL than the usual atlassian API (read more @ https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#authentication), but we need this to function in the same connector. This PR enables the atlassian connector to use a module which overrides the base URL and lets it makes calls to the Connect API. If we like this pattern, we can add it into modules