### PR TITLE
[ENG-1729] feat: Atlassian JWT client

### DIFF
--- a/common/jwt.go
+++ b/common/jwt.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"context"
+)
+
+// NewJwtAuthHTTPClient returns a new http client, with automatic Jwt generation &
+// authentication. Specifically this means that the client will automatically
+// add the Jwt (as a header) to every request, based on the given secret and claims.
+func NewJwtAuthHTTPClient( //nolint:ireturn
+	ctx context.Context,
+	opts ...HeaderAuthClientOption,
+) (AuthenticatedHTTPClient, error) {
+	return NewHeaderAuthHTTPClient(ctx, opts...)
+}

--- a/common/scanning/credscanning/fields.go
+++ b/common/scanning/credscanning/fields.go
@@ -32,6 +32,7 @@ var Fields = struct { // nolint:gochecknoglobals
 	// Oauth2
 	State  Field
 	Scopes Field
+	Secret Field
 }{
 	Provider: Field{
 		Name:      "provider",
@@ -98,6 +99,11 @@ var Fields = struct { // nolint:gochecknoglobals
 		PathJSON:  "scopes",
 		SuffixENV: "SCOPES",
 	},
+	Secret: Field{
+		Name:      "secret",
+		PathJSON:  "secret",
+		SuffixENV: "SECRET",
+	},
 }
 
 type Field struct {
@@ -121,6 +127,7 @@ func (f Field) GetENVReader(providerName string) *scanning.EnvReader {
 	}
 }
 
+// nolint:cyclop
 func getFields(info providers.ProviderInfo,
 	withRequiredAccessToken, withRequiredWorkspace bool,
 ) (datautils.NamedLists[Field], error) {
@@ -143,6 +150,8 @@ func getFields(info providers.ProviderInfo,
 	case providers.None:
 	case providers.Oauth2:
 		lists.Add(requiredType, Fields.ClientId, Fields.ClientSecret)
+	case providers.Jwt:
+		lists.Add(requiredType, Fields.Secret)
 	default:
 		return nil, ErrProviderInfo
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/providers/atlassian/jwt.go
+++ b/providers/atlassian/jwt.go
@@ -1,0 +1,171 @@
+package atlassian
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var jwtExpiryPeriod = 180 * time.Second // nolint:gochecknoglobals
+const QuerySeparator = "&"              // nolint:gochecknoglobals
+
+// Documentation:
+// https://developer.atlassian.com/cloud/bitbucket/query-string-hash
+
+// JwtTokenGenerator generates the claims on a per-request basis for Atlassian Connect. The JWT needs
+// a query request hash, an issued time and an expiration time. The implementation has been adapted
+// from https://bitbucket.org/atlassian/atlassian-jwt-js.git.
+func JwtTokenGenerator(payload map[string]any, secret string) common.DynamicHeadersGenerator {
+	return func(req http.Request) ([]common.Header, error) {
+		claims := make(map[string]any)
+		queryParams := make(map[string][]string)
+
+		claims["iat"] = time.Now().Unix()
+		claims["exp"] = time.Now().Add(jwtExpiryPeriod).Unix()
+
+		for k, v := range req.URL.Query() {
+			queryParams[k] = v
+		}
+
+		claims["qsh"] = createQueryStringHash(
+			req.Method,
+			req.URL.Path,
+			queryParams,
+		)
+
+		// Add any input payload too
+		for k, v := range payload {
+			claims[k] = v
+		}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString([]byte(secret))
+		if err != nil {
+			return nil, err
+		}
+
+		return []common.Header{
+			{
+				Key:   "Authorization",
+				Value: "JWT " + tokenString,
+			},
+		}, nil
+	}
+}
+
+// createQueryStringHash computes the SHA256 hash of the canonical request string.
+func createQueryStringHash(
+	method,
+	path string,
+	query map[string][]string,
+) string {
+	canonicalRequest := createCanonicalRequest(method, path, query)
+	hash := sha256.Sum256([]byte(canonicalRequest))
+
+	return hex.EncodeToString(hash[:])
+}
+
+// createCanonicalRequest generates the canonical request string.
+func createCanonicalRequest(
+	method,
+	path string,
+	query map[string][]string,
+) string {
+	return canonicalizeMethod(method) +
+		QuerySeparator +
+		canonicalizeURI(path) +
+		QuerySeparator +
+		canonicalizeQueryString(query)
+}
+
+// canonicalizeMethod converts the HTTP method to uppercase.
+func canonicalizeMethod(method string) string {
+	return strings.ToUpper(method)
+}
+
+func canonicalizeURI(path string) string {
+	// Early exit.
+	if path == "" {
+		return "/"
+	}
+
+	// Replace '&' with '%26'.
+	path = strings.ReplaceAll(path, "&", "%26")
+
+	// Ensure the path starts with '/'.
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Remove trailing '/' if path length > 1.
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = strings.TrimSuffix(path, "/")
+	}
+
+	return path
+}
+
+// canonicalizeQueryString generates the canonical query string.
+func canonicalizeQueryString(query map[string][]string) string {
+	// Step 1: Filter out the 'jwt' parameter.
+	filteredQuery := make(map[string][]string)
+
+	for k, v := range query {
+		if k != "jwt" {
+			filteredQuery[k] = v
+		}
+	}
+
+	// Step 2: Encode parameter names and values.
+	paramStrings := make([]string, 0, len(filteredQuery))
+
+	for paramName, paramValues := range filteredQuery {
+		// URL-encode parameter name.
+		encodedName := encodeRFC3986(paramName)
+
+		// URL-encode parameter values.
+		var encodedValues []string
+		for _, val := range paramValues {
+			encodedValues = append(encodedValues, encodeRFC3986(val))
+		}
+
+		// Step 3: Sort parameter values.
+		sort.Strings(encodedValues)
+
+		// Step 4: Join values with ','.
+		concatenatedValues := strings.Join(encodedValues, ",")
+
+		// Step 5: Form 'name=value' string.
+		paramString := encodedName + "=" + concatenatedValues
+
+		// Collect the parameter string.
+		paramStrings = append(paramStrings, paramString)
+	}
+
+	// Step 6: Sort parameter strings by encoded parameter names.
+	sort.Strings(paramStrings)
+
+	// Step 7: Concatenate parameter strings with '&'.
+	canonicalQueryString := strings.Join(paramStrings, "&")
+
+	return canonicalQueryString
+}
+
+func encodeRFC3986(str string) string {
+	// Use url.QueryEscape to encode special characters.
+	encoded := url.QueryEscape(str)
+
+	// Replace '+' with '%20' to encode spaces correctly.
+	encoded = strings.ReplaceAll(encoded, "+", "%20")
+
+	return encoded
+}

--- a/providers/atlassian/jwt_test.go
+++ b/providers/atlassian/jwt_test.go
@@ -1,0 +1,78 @@
+package atlassian
+
+import (
+	"testing"
+)
+
+// Test cases for createQueryStringHash.
+func TestCreateQueryStringHash(t *testing.T) { // nolint: funlen
+	t.Parallel()
+
+	tests := []struct {
+		method string
+		path   string
+		query  map[string][]string
+
+		// These have been computed using atlassian's official jwt library
+		expected string
+	}{
+		{
+			method: "GET",
+			path:   "/",
+			query: map[string][]string{
+				"param": {"value"},
+			},
+			expected: "f0ac26e46a317ce416f2c00803c685edc2aaea1e7212e6b7ef916a6f50ba2dd6",
+		},
+		{
+			method: "post",
+			path:   "/api/resource",
+			query: map[string][]string{
+				"action": {"create"},
+				"id":     {"123"},
+			},
+			expected: "48afa36ccd6c9e8988d19a31ee9d492d964e31b63115ef722d4c8ef94f6dc843",
+		},
+		{
+			method: "GET",
+			path:   "/api/resource/",
+			query: map[string][]string{
+				"param": {"value1", "value2"},
+				"jwt":   {"token123"},
+			},
+			expected: "0f93a4689832e5d5c9ec52448be868b5be2d4bca9d113f99d88f93b67d0d9ed0",
+		},
+		{
+			method: "get",
+			path:   "/path/with&special=chars",
+			query: map[string][]string{
+				"param": {"value with spaces", "special&chars"},
+				"jwt":   {"token"},
+			},
+			expected: "8fac2e94d5cb524f65d99d47dfbacb8701798fb5e4c607a7ddef8f86e2ed8029",
+		},
+		{
+			method: "POST",
+			path:   "/api/resource/with special&chars/",
+			query: map[string][]string{
+				"param1":  {"value1", "value2"},
+				"param2":  {"value with spaces", "special&chars"},
+				"param&3": {"value=equals", "value?question"},
+				"param+4": {"value/slash", "value\\backslash"},
+				"jwt":     {"token"}, // Should be filtered out
+			},
+			expected: "b5bc15c45a7d471c3c1df8d283e02c754b36fbf138468e785a0fccad363d7cd0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			t.Parallel()
+
+			result := createQueryStringHash(tt.method, tt.path, tt.query)
+			if result != tt.expected {
+				t.Errorf("Expected hash %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -19,6 +19,7 @@ const (
 const (
 	ApiKey AuthType = "apiKey"
 	Basic  AuthType = "basic"
+	Jwt    AuthType = "jwt"
 	None   AuthType = "none"
 	Oauth2 AuthType = "oauth2"
 )

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -254,6 +254,7 @@ func (i *ProviderInfo) NewClient(ctx context.Context, params *NewClientParams) (
 
 		return createApiKeyHTTPClient(ctx, params.Client, params.Debug, i, params.ApiKey)
 	case Jwt:
+		// We shouldn't hit this case, because no providerInfo has auth type set to JWT yet.
 		fallthrough
 	default:
 		return nil, fmt.Errorf("%w: unsupported auth type %q", ErrClient, i.AuthType)

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -253,6 +253,8 @@ func (i *ProviderInfo) NewClient(ctx context.Context, params *NewClientParams) (
 		}
 
 		return createApiKeyHTTPClient(ctx, params.Client, params.Debug, i, params.ApiKey)
+	case Jwt:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("%w: unsupported auth type %q", ErrClient, i.AuthType)
 	}

--- a/test/atlassian/jwt/main.go
+++ b/test/atlassian/jwt/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := connTest.GetAtlassianConnectConnector(ctx, map[string]any{
+		"iss": "example",
+	})
+
+	// Use conn
+	res, err := conn.Read(ctx, connectors.ReadParams{
+		Fields: connectors.Fields("id", "project", "description"),
+		Since:  time.Now().Add(-time.Hour * 24),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res)
+}


### PR DESCRIPTION
- Adds a JWT client that can be used with Atlassian's Connect module 
- This client, for every request, generates a signed token based on the current time, the actual request and some fixed claim data (`iss` to be exact)
- **Note:** The current connector ONLY supports `issues` though, so this will also only support issues for now. 

I need to do more testing around writes, but reads work just like usual.

## Test
<img width="1088" alt="Screenshot 2024-12-05 at 4 27 54 AM" src="https://github.com/user-attachments/assets/2103b1b3-b2ba-4975-ad3f-9789856cf7a1">
