### PR TITLE
[CON-25] feat: enable Airtable proxy

### DIFF
--- a/providers/airtable.go
+++ b/providers/airtable.go
@@ -35,7 +35,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Testing
### GET
<img width="1151" alt="Screenshot 2024-12-04 at 13 29 44" src="https://github.com/user-attachments/assets/16d8b484-280f-4346-a625-aab63530a315">

### POST
<img width="1149" alt="Screenshot 2024-12-04 at 13 43 53" src="https://github.com/user-attachments/assets/73559dbb-b7f0-431b-89e2-5d8905b98edc">

### PATCH
<img width="1149" alt="Screenshot 2024-12-05 at 12 23 29" src="https://github.com/user-attachments/assets/7b15178a-8d68-4d06-b238-56f6980de0e9">

### DELETE
<img width="1153" alt="Screenshot 2024-12-05 at 12 31 06" src="https://github.com/user-attachments/assets/f575a244-95f3-40a3-b159-cdb7ae43f434">

### Invalid requests
Wrong verb applied, invalid path.
<img width="1148" alt="Screenshot 2024-12-05 at 12 32 19" src="https://github.com/user-attachments/assets/15ee661c-2c72-4278-b65d-51ded671f25c">

## Pagination
A response having the `offset` indicates there is a next page.
<img width="1152" alt="Screenshot 2024-12-05 at 12 33 43" src="https://github.com/user-attachments/assets/bcc46896-b25d-4f74-982a-9fdabbab9d8f">

Using the `offset` to access the next-page
<img width="1147" alt="Screenshot 2024-12-05 at 12 30 29" src="https://github.com/user-attachments/assets/9724e04a-62f7-4394-b488-4d3efbd36d7e">

## Successful console operation (operation & events)
<img width="963" alt="Screenshot 2024-12-05 at 12 35 21" src="https://github.com/user-attachments/assets/da0d0df8-903d-46fb-9594-be573e664a44">

## Failed console operation (operation & events)
<img width="969" alt="Screenshot 2024-12-05 at 12 35 34" src="https://github.com/user-attachments/assets/8552acb7-0d91-4c5d-8607-99f3e834ace0">

