### PR TITLE
fix: (pipedrive) make data field values optional

### DIFF
--- a/providers/pipedrive/read.go
+++ b/providers/pipedrive/read.go
@@ -26,7 +26,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	return common.ParseResult(resp,
-		common.GetRecordsUnderJSONPath("data"),
+		common.GetOptionalRecordsUnderJSONPath("data"),
 		nextRecordsURL(url),
 		common.GetMarshaledData,
 		config.Fields,


### PR DESCRIPTION
The API returns a `null` data response value when there is no data to return. This was causing errors in the tests. 

This PR makes this field optional so when it's null, we return an  empty list.

<img width="1157" alt="Screenshot 2024-12-05 at 16 49 26" src="https://github.com/user-attachments/assets/af233cb5-a3f1-45cc-a4f5-1973afc21589">
