### PR TITLE
[CON-100] tidy: ConstantContact: Prune dubious objects

### DIFF
--- a/providers/constantcontact/metadata/schemas.json
+++ b/providers/constantcontact/metadata/schemas.json
@@ -18,19 +18,6 @@
             "roles": "roles"
           }
         },
-        "accounts": {
-          "displayName": "Accounts",
-          "path": "/partner/accounts",
-          "responseKey": "site_owner_list",
-          "fields": {
-            "billing_status": "billing_status",
-            "encoded_account_id": "encoded_account_id",
-            "last_login_date": "last_login_date",
-            "organization_name": "organization_name",
-            "site_owner_name": "site_owner_name",
-            "subscriber_count": "subscriber_count"
-          }
-        },
         "activities": {
           "displayName": "Activities",
           "path": "/activities",
@@ -49,16 +36,6 @@
             "updated_at": "updated_at"
           }
         },
-        "campaign_id_xrefs": {
-          "displayName": "Email Campaign Identifiers",
-          "path": "/emails/campaign_id_xrefs",
-          "responseKey": "xrefs",
-          "fields": {
-            "campaign_activity_id": "campaign_activity_id",
-            "campaign_id": "campaign_id",
-            "v2_email_campaign_id": "v2_email_campaign_id"
-          }
-        },
         "contact_custom_fields": {
           "displayName": "Contact Custom Fields",
           "path": "/contact_custom_fields",
@@ -70,15 +47,6 @@
             "name": "name",
             "type": "type",
             "updated_at": "updated_at"
-          }
-        },
-        "contact_id_xrefs": {
-          "displayName": "Contact Identifiers",
-          "path": "/contacts/contact_id_xrefs",
-          "responseKey": "xrefs",
-          "fields": {
-            "contact_id": "contact_id",
-            "sequence_id": "sequence_id"
           }
         },
         "contact_lists": {
@@ -162,15 +130,6 @@
             "updated_at": "updated_at"
           }
         },
-        "list_id_xrefs": {
-          "displayName": "List Identifiers",
-          "path": "/contact_lists/list_id_xrefs",
-          "responseKey": "xrefs",
-          "fields": {
-            "list_id": "list_id",
-            "sequence_id": "sequence_id"
-          }
-        },
         "privileges": {
           "displayName": "Privileges",
           "path": "/account/user/privileges",
@@ -189,17 +148,6 @@
             "edited_at": "edited_at",
             "name": "name",
             "segment_id": "segment_id"
-          }
-        },
-        "subscriptions": {
-          "displayName": "Subscriptions",
-          "path": "/partner/webhooks/subscriptions",
-          "responseKey": "",
-          "fields": {
-            "hook_uri": "hook_uri",
-            "topic_description": "topic_description",
-            "topic_id": "topic_id",
-            "topic_name": "topic_name"
           }
         }
       }

--- a/providers/constantcontact/objectNames.go
+++ b/providers/constantcontact/objectNames.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	objectNameAccountEmails           = "account_emails"
-	objectNameAccounts                = "accounts"
 	objectNameContactCustomFields     = "contact_custom_fields"
 	objectNameContactLists            = "contact_lists"
 	objectNameContactTags             = "contact_tags"
@@ -16,7 +15,11 @@ const (
 	objectNameEmailCampaignActivities = "email_campaign_activities"
 	objectNameEmailCampaigns          = "email_campaigns"
 	objectNameSegments                = "segments"
-	objectNameSubscriptions           = "subscriptions"
+
+	// Partner accounts and subscriptions need special handling. Ignored for now.
+	// https://v3.developer.constantcontact.com/api_guide/partners_accts_get.html
+	// objectNameAccounts                = "accounts"
+	// objectNameSubscriptions           = "subscriptions".
 )
 
 // Supported object names can be found under schemas.json.
@@ -27,7 +30,7 @@ var supportedObjectsByCreate = datautils.NewSet(
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Account_Services/addAccountEmailAddress
 	objectNameAccountEmails,
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Technology_Partners/provision
-	objectNameAccounts,
+	// objectNameAccounts,
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Contacts_Custom_Fields/postCustomFields
 	objectNameContactCustomFields,
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Contact_Lists/createList
@@ -59,7 +62,7 @@ var supportedObjectsByUpdate = datautils.NewSet(
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Segments/updateSegment
 	objectNameSegments,
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Technology_Partners_Webhooks/putWebhooksTopic
-	objectNameSubscriptions,
+	// objectNameSubscriptions,
 )
 
 // nolint: lll,gochecknoglobals
@@ -77,7 +80,7 @@ var supportedObjectsByDelete = datautils.NewStringSet(
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Segments/deleteSegment
 	objectNameSegments,
 	// https://v3.developer.constantcontact.com/api_reference/index.html#!/Technology_Partners_Webhooks/deleteWebhooksSubscriptions
-	objectNameSubscriptions,
+	// objectNameSubscriptions,
 )
 
 var objectNameToWritePath = map[string]string{ //nolint:gochecknoglobals
@@ -87,14 +90,14 @@ var objectNameToWritePath = map[string]string{ //nolint:gochecknoglobals
 }
 
 var objectNameToWriteResponseIdentifier = datautils.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
-	objectNameAccounts:                "encoded_account_id",
+	// objectNameAccounts: "encoded_account_id",
+	// objectNameSubscriptions: "topic_id",
 	objectNameAccountEmails:           "email_id",
 	objectNameContactLists:            "list_id",
 	objectNameContactTags:             "tag_id",
 	objectNameContactCustomFields:     "custom_field_id",
 	objectNameEmailCampaigns:          "campaign_id",
 	objectNameEmailCampaignActivities: "campaign_activity_id",
-	objectNameSubscriptions:           "topic_id",
 },
 	func(objectName string) (id string) {
 		return naming.NewSingularString(objectName).String() + "_id"

--- a/providers/constantcontact/read_test.go
+++ b/providers/constantcontact/read_test.go
@@ -45,13 +45,13 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		},
 		{
 			Name:  "Error response is parsed",
-			Input: common.ReadParams{ObjectName: "contact_id_xrefs", Fields: connectors.Fields("contact_id")},
+			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("contact_id")},
 			Server: mockserver.Fixed{
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusBadRequest, responseContactIDsError),
 			}.Server(),
 			ExpectedErrs: []error{
-				errors.New("Sequence ID is invalid."), // nolint:goerr113
+				errors.New("Descriptive error message."), // nolint:goerr113
 				common.ErrBadRequest,
 			},
 		},

--- a/providers/constantcontact/test/read-contact-ids-error.json
+++ b/providers/constantcontact/test/read-contact-ids-error.json
@@ -1,6 +1,6 @@
 [
   {
-    "error_key": "contacts.api.bad_request",
-    "error_message": "Sequence ID is invalid."
+    "error_key": "contacts.api.validation.error",
+    "error_message": "Descriptive error message."
   }
 ]

--- a/scripts/openapi/constantcontact/metadata/main.go
+++ b/scripts/openapi/constantcontact/metadata/main.go
@@ -19,20 +19,26 @@ var (
 		"/account/summary",                  // returns single customer
 		"/account/summary/physical_address", // returns single address
 		"/contacts/counts",                  // object describing statistics on contacts
+		// Requires query parameters
+		"/emails/campaign_id_xrefs",
+		"/contacts/contact_id_xrefs",
+		"/contact_lists/list_id_xrefs",
+		// Partner accounts need auth token to be in 2 headers, usual auth and custom x-api-key.
+		"/partner/*",
 	}
 	objectEndpoints = map[string]string{
 		"/account/emails": "account_emails",
 		"/emails":         "email_campaigns",
 	}
 	displayNameOverride = map[string]string{
-		"campaign_id_xrefs": "Email Campaign Identifiers",
-		"contact_id_xrefs":  "Contact Identifiers",
-		"list_id_xrefs":     "List Identifiers",
+		// "campaign_id_xrefs": "Email Campaign Identifiers",
+		// "contact_id_xrefs":  "Contact Identifiers",
+		// "list_id_xrefs":     "List Identifiers",
 	}
 	objectNameToResponseField = datautils.NewDefaultMap(map[string]string{
-		"campaign_id_xrefs":        "xrefs",
-		"contact_id_xrefs":         "xrefs",
-		"list_id_xrefs":            "xrefs",
+		// "campaign_id_xrefs":        "xrefs",
+		// "contact_id_xrefs":         "xrefs",
+		// "list_id_xrefs":            "xrefs",
 		"accounts":                 "site_owner_list",
 		"email_campaign_summaries": "bulk_email_campaign_summaries",
 		"contact_tags":             "tags",


### PR DESCRIPTION
# Description

Removed objects that either require extra query parameters or are part of `partner` APIs which need passing JWT token not only in auth header but custom header.