### PR TITLE
feat(tests): Common unit test comparators

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -57,6 +57,12 @@ func ParseResult(
 		nextPage = ""
 	}
 
+	if len(marshaledData) == 0 {
+		// Either a JSON array is empty or it was nil.
+		// For consistency return nil for missing records.
+		marshaledData = nil
+	}
+
 	return &ReadResult{
 		Rows:     int64(len(marshaledData)),
 		Data:     marshaledData,

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -66,9 +65,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseIssueSchema),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"issue": {

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -88,9 +87,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createIssueResponse),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "10004",

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -55,9 +54,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, webhooksresponse),
 				}},
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"objects": {

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -47,11 +47,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, `{"data":[]}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Rows: 0,
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Rows: 0, Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/constantcontact/read_test.go
+++ b/providers/constantcontact/read_test.go
@@ -3,12 +3,10 @@ package constantcontact
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -65,7 +63,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsFirstPage),
 			}.Server(),
-			Comparator: readComparator,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -78,7 +76,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"contact_id":   "af73e650-96f0-11ef-b2a0-fa163eafb85e",
 					},
 				}},
-				NextPage: "{{testServerURL}}/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=",
+				NextPage: testroutines.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -93,7 +91,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsLastPage),
 			}.Server(),
-			Comparator: readComparator,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -137,14 +135,4 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector.setBaseURL(serverURL)
 
 	return connector, nil
-}
-
-func readComparator(baseURL string, actual, expected *common.ReadResult) bool {
-	expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-
-	return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-		mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-		actual.NextPage.String() == expectedNextPage &&
-		actual.Rows == expected.Rows &&
-		actual.Done == expected.Done
 }

--- a/providers/constantcontact/write_test.go
+++ b/providers/constantcontact/write_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -48,7 +47,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContact),
 			}.Server(),
-			Comparator: writeComparator,
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "af73e650-96f0-11ef-b2a0-fa163eafb85e",
@@ -76,7 +75,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContact),
 			}.Server(),
-			Comparator: writeComparator,
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "af73e650-96f0-11ef-b2a0-fa163eafb85e",
@@ -103,7 +102,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateEmailCampaign),
 			}.Server(),
-			Comparator: writeComparator,
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "987cb9ab-ad0c-4087-bd46-2e2ad241221f",
@@ -130,7 +129,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateEmailCampaign),
 			}.Server(),
-			Comparator: writeComparator,
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "987cb9ab-ad0c-4087-bd46-2e2ad241221f",
@@ -153,8 +152,4 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			})
 		})
 	}
-}
-
-func writeComparator(serverURL string, actual, expected *common.WriteResult) bool {
-	return mockutils.WriteResultComparator.SubsetData(actual, expected)
 }

--- a/providers/customerapp/read_test.go
+++ b/providers/customerapp/read_test.go
@@ -2,12 +2,10 @@ package customerapp
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -63,15 +61,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNewslettersFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expectedNextPage &&
-					actual.Rows == expected.Rows &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -85,7 +75,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"created":        float64(1724072465),
 					},
 				}},
-				NextPage: "{{testServerURL}}/v1/newsletters?limit=50&start=MQ==",
+				NextPage: testroutines.URLTestServer + "/v1/newsletters?limit=50&start=MQ==",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -100,12 +90,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNewslettersEmptyPage),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Rows:     0,
-				Data:     []common.ReadResultRow{},
-				NextPage: "",
-				Done:     true,
-			},
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -118,12 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseExportsEmpty),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Rows:     0,
-				Data:     []common.ReadResultRow{},
-				NextPage: "",
-				Done:     true,
-			},
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 	}

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -77,9 +76,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				}},
 				Default: mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {

--- a/providers/dynamicscrm/read_test.go
+++ b/providers/dynamicscrm/read_test.go
@@ -77,10 +77,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					"value": []
 				}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -28,12 +27,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
 		{
-			Name:   "Successfully describe one object with metadata",
-			Input:  []string{"calls"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe one object with metadata",
+			Input:      []string{"calls"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"calls": {
@@ -56,12 +53,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"workspaces", "users"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"workspaces", "users"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"workspaces": {

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -38,7 +38,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		if errors.Is(err, common.ErrNotFound) {
 			return &common.ReadResult{
 				Rows:     0,
-				Data:     make([]common.ReadResultRow, 0),
+				Data:     nil,
 				NextPage: "",
 				Done:     true,
 			}, nil

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -90,10 +90,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					},
 					"calls": []}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -110,10 +107,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:   mockcond.QueryParam("fromDateTime", "2024-09-19T12:30:45Z"),
 				Then: mockserver.Response(http.StatusOK, fakeServerResp),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.ReadResult) bool {
-				return actual.Rows == expected.Rows
-			},
-			Expected:     &common.ReadResult{Rows: 2},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -28,12 +27,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"campaigns", "emails"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"campaigns", "emails"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"emails": {

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -99,11 +98,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
 				_, _ = writer.Write([]byte(data))
 			}),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
+				Rows:     DefaultPageSize,
 				NextPage: "test-placeholder?limit=100&skip=800",
 				Done:     false,
 			},
@@ -119,16 +116,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, "[]"),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := ""
-
-				return actual.NextPage.String() == expectedNextPage &&
-					actual.Done == expected.Done
-			},
-			Expected: &common.ReadResult{
-				NextPage: "{{testServerURL}}/v1/campaign/list?limit=100&skip=100",
-				Done:     true,
-			},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -141,11 +130,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseCampaigns),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -165,7 +150,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"name": "My Campaign",
 					},
 				}},
-				Done: false,
+				NextPage: testroutines.URLTestServer + "/v1/campaign/list?limit=100&skip=100",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -179,12 +165,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseTags),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"label":       "High Delivery 3",
@@ -206,7 +189,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"description":     "High Delivery Accounts 2",
 					},
 				}},
-				Done: false,
+				NextPage: testroutines.URLTestServer + "/v1/custom-tag?limit=100&skip=100",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -3,14 +3,12 @@ package intercom
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -98,10 +96,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "data": []
 				}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -113,11 +108,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Header(testApiVersionHeader),
 				Then:  mockserver.Response(http.StatusOK, responseNotesSecondPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// response doesn't matter much, as soon as we don't have errors we are good
-				return actual.Done == expected.Done
-			},
-			Expected:     &common.ReadResult{Done: true},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -128,11 +120,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNotesFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String()
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
+				Rows:     2,
 				NextPage: "https://api.intercom.io/contacts/6643703ffae7834d1792fd30/notes?per_page=2&page=2",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -143,13 +135,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-				return actual.NextPage.String() == expectedNextPage // nolint:nlreturn
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
-				NextPage: "{{testServerURL}}/contacts?per_page=60&starting_after=" +
+				Rows: 1,
+				NextPage: testroutines.URLTestServer + "/contacts?per_page=60&starting_after=" +
 					"WzE3MTU2OTU2NzkwMDAsIjY2NDM3MDNmZmFlNzgzNGQxNzkyZmQzMCIsMl0=",
+				Done: false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -161,11 +152,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNotesSecondPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
-			Expected:     &common.ReadResult{NextPage: "", Done: true},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -175,11 +163,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsThirdPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
-			Expected:     &common.ReadResult{NextPage: "", Done: true},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -192,15 +177,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsSecondPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expectedNextPage &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"name":  "Patrick",
@@ -217,7 +196,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"updated_at": float64(1715706939),
 					},
 				}},
-				NextPage: "{{testServerURL}}/contacts?per_page=60&starting_after=" +
+				NextPage: testroutines.URLTestServer + "/contacts?per_page=60&starting_after=" +
 					"Wy0xLCI2NjQzOWI5NDdiYjA5NWE2ODFmN2ZkOWUiLDNd",
 				Done: false,
 			},
@@ -233,20 +212,21 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseReadConversations),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done &&
-					actual.Rows == expected.Rows
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"state": "closed",
 					},
+					Raw: map[string]any{
+						"state": "closed",
+					},
 				}, {
 					Fields: map[string]any{
+						"state": "open",
+					},
+					Raw: map[string]any{
 						"state": "open",
 					},
 				}},
@@ -268,14 +248,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.BodyBytes(requestSearchConversations),
 				Then:  mockserver.Response(http.StatusOK, responseSearchConversations),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expectedNextPage &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -290,7 +263,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"updated_at":            float64(1726752145),
 					},
 				}},
-				NextPage: "{{testServerURL}}/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
+				NextPage: testroutines.URLTestServer + "/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
 				Done:     false,
 			},
 			ExpectedErrs: nil,

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -81,9 +80,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createArticle),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9333081",

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -28,12 +27,10 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"campaigns", "products"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"campaigns", "products"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {
@@ -78,12 +75,10 @@ func TestListObjectMetadataV2(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	tests := []testroutines.Metadata{
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"automation_categories", "tags"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"automation_categories", "tags"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"automation_categories": {

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -79,13 +78,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.PathSuffix("/crm/rest/v1/contacts"),
 				Then:  mockserver.Response(http.StatusOK, responseContactsFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Rows == expected.Rows &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -120,12 +113,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsEmptyPage),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Rows:     0,
-				Data:     []common.ReadResultRow{},
-				NextPage: "", // nolint:lll
-				Done:     true,
-			},
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 	}

--- a/providers/keap/write_test.go
+++ b/providers/keap/write_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -87,9 +86,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "30",

--- a/providers/kit/metadata_test.go
+++ b/providers/kit/metadata_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -71,9 +70,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, webhooksresponse),
 				}},
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"broadcasts": {

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -28,12 +27,10 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"campaigns", "lists"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"campaigns", "lists"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -68,7 +67,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.PathSuffix("/api/profiles"),
 				Then:  mockserver.Response(http.StatusOK, responseProfilesFirstPage),
 			}.Server(),
-			Comparator: readComparator,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -94,7 +93,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Since:      time.Date(2024, 3, 4, 8, 22, 56, 0, time.UTC),
 				Filter:     "equals(messages.channel,'email')",
 			},
-			Comparator: readComparator,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentMIME("application/vnd.api+json"),
 				If: mockcond.And{
@@ -147,12 +146,4 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector.setBaseURL(serverURL)
 
 	return connector, nil
-}
-
-func readComparator(baseURL string, actual, expected *common.ReadResult) bool {
-	return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-		mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-		actual.NextPage.String() == expected.NextPage.String() &&
-		actual.Rows == expected.Rows &&
-		actual.Done == expected.Done
 }

--- a/providers/klaviyo/write_test.go
+++ b/providers/klaviyo/write_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -121,9 +120,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateTag),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9891d452-56fe-4397-b431-a92e79cdc980",

--- a/providers/pipedrive/read_test.go
+++ b/providers/pipedrive/read_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -147,14 +146,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, leads),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"channel": nil,
@@ -186,7 +180,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"was_seen":            true,
 					},
 				}},
-				Done: true,
+				NextPage: "",
+				Done:     true,
 			},
 			ExpectedErrs: nil,
 		},

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -87,10 +86,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "data": []
 				}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -100,11 +96,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseProfilesFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String() // nolint:nlreturn
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
+				Rows:     2,
 				NextPage: "WyIwMDAwMDAwMC0wMDAwLTAwMDEtMDAwMS0wMDAwMDAwMDhlOTciXQ==",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -115,11 +111,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseProfilesLastPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
-			Expected:     &common.ReadResult{NextPage: "", Done: true},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -132,14 +125,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseProfilesSecondPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"name":     "Lang_DefaultProfileAllUsers",

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -102,9 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateNote),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",
@@ -129,9 +126,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPATCH(),
 				Then:  mockserver.Response(http.StatusOK, responseUpdateNote),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -76,10 +75,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "records": []
 				}`),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -89,11 +85,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseLeadsFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String()
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
+				Rows:     8,
 				NextPage: "/services/data/v59.0/query/01g3A00007lZwLKQA0-2000",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -107,14 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseListContacts),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done &&
-					actual.Rows == expected.Rows
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 20,
 				Data: []common.ReadResultRow{{

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -3,7 +3,6 @@ package salesloft
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -88,10 +87,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseEmptyRead),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -101,12 +97,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				expectedNextPage := strings.ReplaceAll(expected.NextPage.String(), "{{testServerURL}}", baseURL)
-				return actual.NextPage.String() == expectedNextPage // nolint:nlreturn
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
-				NextPage: "{{testServerURL}}/v2/people?page=2&per_page=100",
+				Rows:     25,
+				NextPage: testroutines.URLTestServer + "/v2/people?page=2&per_page=100",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -117,16 +112,14 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.Done == expected.Done &&
-					actual.Rows == expected.Rows
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 25,
 				// We are only interested to validate only first Read Row!
 				Data: []common.ReadResultRow{{
-					Fields: map[string]any{},
+					Fields: map[string]any{
+						"id": float64(164510523),
+					},
 					Raw: map[string]any{
 						"first_name":             "Lynnelle",
 						"email_address":          "losbourn29@paypal.com",
@@ -134,7 +127,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"person_company_website": "http://paypal.com",
 					},
 				}},
-				Done: false,
+				NextPage: testroutines.URLTestServer + "/v2/people?page=2&per_page=100",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -148,11 +142,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 25,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"email_address":          "losbourn29@paypal.com",
@@ -165,6 +157,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"person_company_website": "http://paypal.com",
 					},
 				}},
+				NextPage: testroutines.URLTestServer + "/v2/people?page=2&per_page=100",
+				Done:     false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -178,10 +172,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseListUsers),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -196,7 +187,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 				}},
 				NextPage: "",
-				Done:     false,
+				Done:     true,
 			},
 			ExpectedErrs: nil,
 		},
@@ -208,12 +199,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParamsMissing("updated_at[gte]"),
 				Then:  mockserver.Response(http.StatusOK, responseListAccounts),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.Rows == expected.Rows
-			},
-			Expected: &common.ReadResult{
-				Rows: 4,
-			},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 4, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -228,12 +215,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("updated_at[gte]", "2024-06-07T10:51:20.851224-04:00"),
 				Then:  mockserver.Response(http.StatusOK, responseListAccountsSince),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.Rows == expected.Rows
-			},
-			Expected: &common.ReadResult{
-				Rows: 2,
-			},
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 	}

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -77,9 +76,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createAccountRes),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1",
@@ -102,9 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createTaskRes),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "175204275",
@@ -126,9 +121,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				Then: mockserver.ResponseString(http.StatusOK, `{"data":{"id":22463,"view":"companies",
 					"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "22463",

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -28,12 +27,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
 		},
 		{
-			Name:   "Successfully describe multiple objects with metadata",
-			Input:  []string{"campaigns", "leads"},
-			Server: mockserver.Dummy(),
-			Comparator: func(baseURL string, actual, expected *common.ListObjectMetadataResult) bool {
-				return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
-			},
+			Name:       "Successfully describe multiple objects with metadata",
+			Input:      []string{"campaigns", "leads"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -68,12 +67,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseCampaignsEmpty),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Rows:     0,
-				Data:     []common.ReadResultRow{},
-				NextPage: "",
-				Done:     true,
-			},
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -83,13 +77,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseCampaigns),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -93,10 +92,7 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsersEmptyPage),
 			}.Server(),
-			Expected: &common.ReadResult{
-				Data: []common.ReadResultRow{},
-				Done: true,
-			},
+			Expected:     &common.ReadResult{Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -106,12 +102,12 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsersFirstPage),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				return actual.NextPage.String() == expected.NextPage.String()
-			},
+			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
+				Rows: 3,
 				NextPage: "https://d3v-ampersand.zendesk.com/api/v2/users" +
 					"?page%5Bafter%5D=eyJvIjoiaWQiLCJ2IjoiYVJOc1cwVDZGd0FBIn0%3D&page%5Bsize%5D=3",
+				Done: false,
 			},
 			ExpectedErrs: nil,
 		},
@@ -126,14 +122,9 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 				If:    mockcond.PathSuffix("/v2/tickets"),
 				Then:  mockserver.Response(http.StatusOK, responseReadTickets),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"type":    "incident",
@@ -190,14 +181,9 @@ func TestReadHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,ma
 				If:    mockcond.PathSuffix("/v2/community/posts"),
 				Then:  mockserver.Response(http.StatusOK, responseReadPosts),
 			}.Server(),
-			Comparator: func(baseURL string, actual, expected *common.ReadResult) bool {
-				// custom comparison focuses on subset of fields to keep the test short
-				return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
-					mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
-					actual.NextPage.String() == expected.NextPage.String() &&
-					actual.Done == expected.Done
-			},
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
+				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"title":    "How do I get around the community?",

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -120,9 +119,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createBrand),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "31207417638931",
@@ -169,9 +166,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreatePost),
 			}.Server(),
-			Comparator: func(serverURL string, actual, expected *common.WriteResult) bool {
-				return mockutils.WriteResultComparator.SubsetData(actual, expected)
-			},
+			Comparator: testroutines.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "33507191590803",

--- a/test/utils/mockutils/writeResult.go
+++ b/test/utils/mockutils/writeResult.go
@@ -17,15 +17,6 @@ func (writeResultComparator) SubsetData(actual, expected *common.WriteResult) bo
 		return false
 	}
 
-	// strict comparison
-	ok := actual.Success == expected.Success &&
-		actual.RecordId == expected.RecordId &&
-		reflect.DeepEqual(actual.Errors, expected.Errors)
-
-	if !ok {
-		return false
-	}
-
 	for k, expectedValue := range expected.Data {
 		actualValue, ok := actual.Data[k]
 		if !ok {
@@ -38,4 +29,9 @@ func (writeResultComparator) SubsetData(actual, expected *common.WriteResult) bo
 	}
 
 	return true
+}
+
+// ExactErrors uses strict error comparison.
+func (writeResultComparator) ExactErrors(actual, expected *common.WriteResult) bool {
+	return reflect.DeepEqual(actual.Errors, expected.Errors)
 }

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -1,0 +1,60 @@
+package testroutines
+
+import (
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+)
+
+// URLTestServer is an alias to mock server BaseURL.
+// For usage please refer to ComparatorPagination.
+const URLTestServer = "{{testServerURL}}"
+
+// Comparator is an equality function with custom rules.
+// This package provides the most commonly used comparators.
+type Comparator[Output any] func(serverURL string, actual, expected Output) bool
+
+// ComparatorSubsetRead ensures that a subset of fields or raw data is present in the response.
+// This is convenient for cases where the returned data is large,
+// allowing for a more concise test that still validates the desired behavior.
+func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult) bool {
+	return mockutils.ReadResultComparator.SubsetFields(actual, expected) &&
+		mockutils.ReadResultComparator.SubsetRaw(actual, expected) &&
+		ComparatorPagination(serverURL, actual, expected)
+}
+
+// ComparatorPagination will check pagination related fields.
+// Note: you may use an alias for Mock-Server-URL which will be dynamically resolved at runtime.
+// Example:
+//
+//		common.ReadResult{
+//			NextPage: testroutines.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI="
+//	 }
+//
+// At runtime this may look as follows: http://127.0.0.1:38653/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=.
+func ComparatorPagination(serverURL string, actual *common.ReadResult, expected *common.ReadResult) bool {
+	expectedNextPage := resolveTestServerURL(expected.NextPage.String(), serverURL)
+
+	return actual.NextPage.String() == expectedNextPage &&
+		actual.Rows == expected.Rows &&
+		actual.Done == expected.Done
+}
+
+// ComparatorSubsetWrite ensures that only the specified metadata objects are present,
+// while other values are verified through an exact match..
+func ComparatorSubsetWrite(_ string, actual, expected *common.WriteResult) bool {
+	return mockutils.WriteResultComparator.SubsetData(actual, expected) &&
+		mockutils.WriteResultComparator.ExactErrors(actual, expected) &&
+		actual.Success == expected.Success &&
+		actual.RecordId == expected.RecordId
+}
+
+// ComparatorSubsetMetadata will check a subset of fields is present.
+func ComparatorSubsetMetadata(_ string, actual, expected *common.ListObjectMetadataResult) bool {
+	return mockutils.MetadataResultComparator.SubsetFields(actual, expected)
+}
+
+func resolveTestServerURL(urlTemplate string, serverURL string) string {
+	return strings.ReplaceAll(urlTemplate, URLTestServer, serverURL)
+}

--- a/test/utils/testroutines/outline.go
+++ b/test/utils/testroutines/outline.go
@@ -20,7 +20,7 @@ type TestCase[Input any, Output any] struct {
 	// Mock Server which connector will call.
 	Server *httptest.Server
 	// Custom Comparator of how expected output agrees with actual output.
-	Comparator func(serverURL string, actual, expected Output) bool
+	Comparator Comparator[Output]
 	// Expected return value.
 	Expected Output
 	// ExpectedErrs is a list of errors that must be present in error output.


### PR DESCRIPTION
# Description
Refactored repetitive, duplicated comparison methods for unit tests.

# Review
First commit has all the important changes with an updated README.
Second commit is using these methods for all providers.

# Future considerations
To simplify debugging of test I think it would be nice to add loging within comparators.
This should tell the exact reason of what mistmatched speeding up unit test development.
