### PR TITLE
feat: (apollo) update sequences object support

### DIFF
--- a/providers/apollo/types.go
+++ b/providers/apollo/types.go
@@ -11,16 +11,14 @@ var (
 
 type ObjectType string
 
-// postSearchObjects represents the objects that uses the searching endpoint,
-// POST method for requesting records.
+// postSearchObjects represents the objects that uses the searching endpoint,POST method.
 var postSearchObjects = []ObjectType{ //nolint:gochecknoglobals
 	"mixed_people", "mixed_companies", "contacts",
-	"accounts", "emails_campaigns",
+	"accounts", "tasks",
 }
 
-// getSearchObjects represents the objects that uses the searching endpoint, GET method
-// for requesting records.Tasks has a query parameter `open_factor_names` requirement.
-var getSearchObjects = []ObjectType{"opportunities", "users"} //nolint:gochecknoglobals
+// getSearchObjects represents the objects that uses the searching endpoint, GET method.
+var getSearchObjects = []ObjectType{"opportunities", "users", "emailer_campaigns"} //nolint:gochecknoglobals
 
 // responseKey represent the results key fields in the response.
 // some endpoints have more than one, data fields returned.

--- a/test/apollo/read/read.go
+++ b/test/apollo/read/read.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -73,7 +72,6 @@ func testReadEmailAccounts(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "email_accounts",
 		Fields:     connectors.Fields("user_id", "id", "email"),
-		Since:      time.Now().Add(-1800 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)
@@ -97,7 +95,6 @@ func testReadCustomFields(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "typed_custom_fields",
 		Fields:     connectors.Fields("type", "id", "modality"),
-		Since:      time.Now().Add(-1800 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)
@@ -121,7 +118,6 @@ func testReadSequences(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "emailer_campaigns",
 		Fields:     connectors.Fields("id", "name", "archived"),
-		Since:      time.Now().Add(-1800 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)

--- a/test/apollo/read/read.go
+++ b/test/apollo/read/read.go
@@ -38,6 +38,11 @@ func MainFn() int {
 		return 1
 	}
 
+	err = testReadSequences(ctx, conn)
+	if err != nil {
+		return 1
+	}
+
 	return 0
 }
 
@@ -92,6 +97,30 @@ func testReadCustomFields(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "typed_custom_fields",
 		Fields:     connectors.Fields("type", "id", "modality"),
+		Since:      time.Now().Add(-1800 * time.Hour),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testReadSequences(ctx context.Context, conn *ap.Connector) error {
+	params := common.ReadParams{
+		ObjectName: "emailer_campaigns",
+		Fields:     connectors.Fields("id", "name", "archived"),
 		Since:      time.Now().Add(-1800 * time.Hour),
 	}
 


### PR DESCRIPTION
This adds
-  support for reading sequence (emailer_campaigns) object in apollo. It uses reading by search but does not have the 50K display limitations. So this can currently be supported.

- reading the tasks object, can now be supported by the Search method.

Testing reading the `emailer_campaigns`
<img width="1198" alt="Screenshot 2024-12-13 at 21 27 13" src="https://github.com/user-attachments/assets/3d010fd4-95e2-4782-aa6d-eea2a602fc49" />
