### PR TITLE
[CON-376] Twitter Ads connector

### DIFF
--- a/providers/twitterAds.go
+++ b/providers/twitterAds.go
@@ -1,0 +1,44 @@
+// nolint:lll
+package providers
+
+const TwitterAds Provider = "twitterAds"
+
+func init() { // nolint:funlen
+	SetInfo(TwitterAds, ProviderInfo{
+		DisplayName: "Twitter Ads",
+		AuthType:    Oauth2,
+		//BaseURL:  "https://ads-api.x.com",
+		//BaseURL:  "https://ads-api.twitter.com",
+		BaseURL: "https://api.twitter.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCodePKCE,
+			AuthURL:                   "https://twitter.com/i/oauth2/authorize",
+			TokenURL:                  "https://api.twitter.com/2/oauth2/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+			DocsURL:                   "https://developer.x.com/en/docs/authentication/api-reference",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733936359/media/twitterAds_1733936358.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733936359/media/twitterAds_1733936358.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733936180/media/twitterAds_1733936179.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733936180/media/twitterAds_1733936179.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Testing
## GET
URL: <http://localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

## POST
URL: <http://localhost:4444/v2/some-api-call>
Postman screenshot (must show the request URL, the response status code & body clearly)

<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>

# Pagination
Please add screenshots that show successful pagination using the connector.

## Raw token response
{
  "token_type" : "bearer",
  "access_token" : "...",
  "refresh_token" : "...",
  "scope": "users.read tweet.read offline.access",
  "expires_in" : "7200"
}

# Logo & Icons
![image](https://github.com/user-attachments/assets/8d969c93-f28e-4711-8434-340e80549f6e)
![image](https://github.com/user-attachments/assets/f4965a1c-5ba7-4f5e-8177-a83c9152f15e)

