### PR TITLE
[ENG-1707] Hubspot connector method to verify webhook. 

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -274,4 +275,13 @@ type SubscriptionEvent interface {
 	RawEventName() (string, error)
 	ObjectName() (string, error)
 	Workspace() (string, error)
+}
+
+// WebhookVerificationParameters is a struct that contains the parameters required to verify a webhook.
+type WebhookVerificationParameters struct {
+	Headers      http.Header
+	Body         []byte
+	URL          string
+	ClientSecret string
+	Method       string
 }

--- a/connectors.go
+++ b/connectors.go
@@ -86,7 +86,7 @@ type AuthMetadataConnector interface {
 	GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error)
 }
 
-type WebhookVerifiableConnector interface {
+type WebhookVerifierConnector interface {
 	Connector
 
 	// VerifyWebhookMessage verifies the signature of a webhook message.

--- a/connectors.go
+++ b/connectors.go
@@ -86,6 +86,13 @@ type AuthMetadataConnector interface {
 	GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error)
 }
 
+type WebhookVerifiableConnector interface {
+	Connector
+
+	// VerifyWebhookMessage verifies the signature of a webhook message.
+	VerifyWebhookMessage(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
+}
+
 // We re-export the following types so that they can be used by consumers of this library.
 type (
 	ReadParams               = common.ReadParams

--- a/providers/hubspot/subscriptionEvent.go
+++ b/providers/hubspot/subscriptionEvent.go
@@ -44,7 +44,7 @@ func (c *Connector) GetRecordFromSubscriptionEvent(
 }
 
 // GetRecordFromSubscriptionEvent fetches a record from the Hubspot API using the data from a subscription event.
-func (c *Connector) VerifyWebhookMessage(
+func VerifyWebhookMessage(
 	_ context.Context, params *common.WebhookVerificationParameters,
 ) (bool, error) {
 	ts := params.Headers.Get("X-Hubspot-Request-Timestamp")

--- a/providers/hubspot/subscriptionEvent.go
+++ b/providers/hubspot/subscriptionEvent.go
@@ -44,7 +44,7 @@ func (c *Connector) GetRecordFromSubscriptionEvent(
 }
 
 // GetRecordFromSubscriptionEvent fetches a record from the Hubspot API using the data from a subscription event.
-func VerifyWebhookMessage(
+func (c *Connector) VerifyWebhookMessage(
 	_ context.Context, params *common.WebhookVerificationParameters,
 ) (bool, error) {
 	ts := params.Headers.Get("X-Hubspot-Request-Timestamp")

--- a/providers/hubspot/subscriptionEvent.go
+++ b/providers/hubspot/subscriptionEvent.go
@@ -43,11 +43,11 @@ func (c *Connector) GetRecordFromSubscriptionEvent(
 	return c.GetRecord(ctx, objectName, recordId)
 }
 
-// GetRecordFromSubscriptionEvent fetches a record from the Hubspot API using the data from a subscription event.
+// VerifyWebhookMessage verifies the signature of a webhook message from Hubspot.
 func (c *Connector) VerifyWebhookMessage(
 	_ context.Context, params *common.WebhookVerificationParameters,
 ) (bool, error) {
-	ts := params.Headers.Get("X-Hubspot-Request-Timestamp")
+	ts := params.Headers.Get(string(xHubspotRequestTimestamp))
 
 	rawString := params.Method + params.URL + string(params.Body) + ts
 
@@ -55,7 +55,7 @@ func (c *Connector) VerifyWebhookMessage(
 	mac.Write([]byte(rawString))
 	expectedMAC := mac.Sum(nil)
 
-	signature := params.Headers.Get("X-Hubspot-Signature-V3")
+	signature := params.Headers.Get(string(xHubspotSignatureV3))
 
 	decodedSignature, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {

--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -87,3 +87,10 @@ type ObjectType string
 const (
 	ObjectTypeContact ObjectType = "contacts"
 )
+
+type hubspotHeaderKey string
+
+const (
+	xHubspotRequestTimestamp hubspotHeaderKey = "X-Hubspot-Request-Timestamp"
+	xHubspotSignatureV3      hubspotHeaderKey = "X-Hubspot-Signature-V3"
+)

--- a/providers/kit/read_test.go
+++ b/providers/kit/read_test.go
@@ -183,5 +183,4 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			})
 		})
 	}
-
 }

--- a/test/kit/write/main.go
+++ b/test/kit/write/main.go
@@ -39,6 +39,7 @@ func MainFn() int {
 
 func testCustomfields(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the customfields")
 
 	params := common.WriteParams{
@@ -86,6 +87,7 @@ func testCustomfields(ctx context.Context) error {
 
 func testSubscribers(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the subscribers")
 
 	params := common.WriteParams{
@@ -141,6 +143,7 @@ func testSubscribers(ctx context.Context) error {
 
 func testTags(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the tags")
 
 	params := common.WriteParams{


### PR DESCRIPTION
Webhooks from providers need to be verified. This PR creates types for the verification params, and defines method for Hubspot to verify webhook. 