### PR TITLE
fix: (closeCRM) update objects supporting incremental read

### DIFF
--- a/providers/closecrm/read.go
+++ b/providers/closecrm/read.go
@@ -19,7 +19,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	// The searching API supports the incremental read using dates only.
 	// The API has a limit of 10K records when paginating.
 	// doc: https://developer.close.com/resources/advanced-filtering/
-	if !config.Since.IsZero() {
+	if !config.Since.IsZero() && supportsFiltering(config.ObjectName) {
 		return c.Search(ctx, SearchParams{
 			ObjectName: config.ObjectName,
 			Fields:     config.Fields.List(),

--- a/providers/closecrm/types.go
+++ b/providers/closecrm/types.go
@@ -1,10 +1,17 @@
 package closecrm
 
 import (
+	"slices"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
 )
+
+var advancedFilteringObjects = []string{"lead", "contact", "opportunity"} //nolint:gochecknoglobals
+
+func supportsFiltering(objectName string) bool {
+	return slices.Contains(advancedFilteringObjects, objectName)
+}
 
 type SearchParams struct {
 	ObjectName string

--- a/test/closecrm/read/read.go
+++ b/test/closecrm/read/read.go
@@ -41,6 +41,7 @@ func main() {
 func readActivities(ctx context.Context, conn *closecrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "activity",
+		Since:      time.Now().Add(-72 * time.Hour),
 		Fields:     connectors.Fields("user_id", "user_name", "source", "id"),
 	}
 
@@ -86,8 +87,7 @@ func readLeads(ctx context.Context, conn *closecrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "lead",
 		Since:      time.Now().Add(-72 * time.Hour),
-		// NextPage:   "eyJza2lwIjo0fQ.ZyJitQ.4Mg19Fds1IrDqBmI8UZ0U-mbsT8",
-		Fields: connectors.Fields("display_name", "description", "name", "id"),
+		Fields:     connectors.Fields("display_name", "description", "name", "id"),
 	}
 
 	result, err := conn.Read(ctx, config)


### PR DESCRIPTION
The objects: Leads, Contacts & Opportunities are the only Objects supporting the Advanced Filtering Query. Doc [Link](https://developer.close.com/resources/advanced-filtering/).  These filtering queries can in turn be used for the incremental read support.

This PR adds a check to confirm objects support when `since` parameter is provided. 