### PR TITLE
fix: Read empty rows, never nil

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -59,8 +59,8 @@ func ParseResult(
 
 	if len(marshaledData) == 0 {
 		// Either a JSON array is empty or it was nil.
-		// For consistency return nil for missing records.
-		marshaledData = nil
+		// For consistency return empty array for missing records.
+		marshaledData = make([]ReadResultRow, 0)
 	}
 
 	return &ReadResult{

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, `{"data":[]}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/customerapp/read_test.go
+++ b/providers/customerapp/read_test.go
@@ -90,7 +90,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNewslettersEmptyPage),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -103,7 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseExportsEmpty),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 	}

--- a/providers/dynamicscrm/read_test.go
+++ b/providers/dynamicscrm/read_test.go
@@ -77,7 +77,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					"value": []
 				}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -90,7 +90,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					},
 					"calls": []}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "data": []
 				}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -113,7 +113,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsEmptyPage),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 	}

--- a/providers/kit/read_test.go
+++ b/providers/kit/read_test.go
@@ -46,7 +46,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, `{"email_templates":[]}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -126,7 +126,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseEmptyPageTags),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{
@@ -165,5 +165,4 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			})
 		})
 	}
-
 }

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -86,7 +86,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "data": []
 				}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -75,7 +75,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "records": []
 				}`),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -87,7 +87,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseEmptyRead),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -67,7 +67,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseCampaignsEmpty),
 			}.Server(),
-			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -92,7 +92,7 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsersEmptyPage),
 			}.Server(),
-			Expected:     &common.ReadResult{Done: true},
+			Expected:     &common.ReadResult{Done: true, Data: []common.ReadResultRow{}},
 			ExpectedErrs: nil,
 		},
 		{

--- a/test/kit/write/main.go
+++ b/test/kit/write/main.go
@@ -39,6 +39,7 @@ func MainFn() int {
 
 func testCustomfields(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the customfields")
 
 	params := common.WriteParams{
@@ -86,6 +87,7 @@ func testCustomfields(ctx context.Context) error {
 
 func testSubscribers(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the subscribers")
 
 	params := common.WriteParams{
@@ -141,6 +143,7 @@ func testSubscribers(ctx context.Context) error {
 
 func testTags(ctx context.Context) error {
 	conn := kit.GetKitConnector(ctx)
+
 	slog.Info("Creating the tags")
 
 	params := common.WriteParams{


### PR DESCRIPTION
# Reason

Due to the concern on returning nil rows and marshalling cares about `nil` vs `[]` to be safe resort to returning empty slice for all Read operations.

Previously some connectors would return null or [], for consistent expection it will be `[]`.