### PR TITLE
fix: Return shallow copy of Metadata

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         continue-on-error: false
         with:
-          version: v1.62.0
+          version: "v1.62.0"
       - name: Install gci
         run: "go install github.com/daixiang0/gci@latest"
       - name: List files with wrong format

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ format: fix
 test:
 	go test -v ./...
 
+.PHONY: test-parallel
+test-parallel:
+	go test -v ./... -parallel=8 -count=3
+
 # Creates PR URLs for each template
 # Click on one of them or manually add ?template=<file.md> to the URL if you are creating a PR via the Github website
 # Templates: Under github/PULL_REQUEST_TEMPLATE directory you can add more templates

--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -52,7 +52,7 @@ func (m Map[K, V]) Has(key K) bool {
 func (m Map[K, V]) Values() []V {
 	values := make([]V, 0, len(m))
 
-	for key := range m {
+	for key := range m { // nolint:ireturn
 		values = append(values, m[key])
 	}
 

--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -6,6 +6,30 @@ import "encoding/json"
 // It can return Keys as a slice or a Set.
 type Map[K comparable, V any] map[K]V
 
+// FromMap converts golang map into Map resolving generic types on its own.
+// Example:
+//
+//	Given:
+//		dictionary = make(map[string]string)
+//	Then statements are equivalent:
+//		datautils.Map[string,string](golangMap)
+//		datautils.FromMap(dictionary)
+func FromMap[K comparable, V any](source map[K]V) Map[K, V] {
+	return source
+}
+
+// ShallowCopy performs copying which should cover most cases.
+// For deep copy you could use goutils.Clone.
+func (m Map[K, V]) ShallowCopy() Map[K, V] {
+	result := make(map[K]V)
+
+	for key, value := range m {
+		result[key] = value
+	}
+
+	return result
+}
+
 func (m Map[K, V]) Keys() []K {
 	keys := make([]K, 0)
 	for k := range m {

--- a/internal/staticschema/convertors.go
+++ b/internal/staticschema/convertors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
 )
 
 var ErrObjectNotFound = errors.New("object not found")
@@ -37,7 +38,7 @@ func (r *Metadata) Select(
 			// move metadata from scrapper object to common object
 			list.Result[objectName] = common.ObjectMetadata{
 				DisplayName: v.DisplayName,
-				FieldsMap:   v.FieldsMap,
+				FieldsMap:   datautils.FromMap(v.FieldsMap).ShallowCopy(),
 			}
 		} else {
 			return nil, fmt.Errorf("%w: unknown object [%v]", ErrObjectNotFound, objectName)


### PR DESCRIPTION
# Description
Noticed that a test would fail under parallel execution: https://github.com/amp-labs/connectors/actions/runs/12360650495/job/34496076253?pr=1220#step:5:1728

# Fix
Located an issue shared by connectors that create `*common.ListObjectMetadataResult` relying on shared static schema. A copy of the map is now used to construct object metadata.
