### PR TITLE
[CON-186] Keap: remove objects - required QueryParams

### DIFF
--- a/providers/keap/metadata/schemas.json
+++ b/providers/keap/metadata/schemas.json
@@ -344,26 +344,6 @@
             "use_default_payment_gateway": "use_default_payment_gateway"
           }
         },
-        "summaries": {
-          "displayName": "Summaries",
-          "path": "/affiliates/summaries",
-          "responseKey": "summaries",
-          "fields": {
-            "affiliate_id": "affiliate_id",
-            "amount_earned": "amount_earned",
-            "balance": "balance",
-            "clawbacks": "clawbacks"
-          }
-        },
-        "synced_products": {
-          "displayName": "Product Statuses",
-          "path": "/products/sync",
-          "responseKey": "product_statuses",
-          "fields": {
-            "product": "product",
-            "status": "status"
-          }
-        },
         "tags": {
           "displayName": "Tags",
           "path": "/tags",

--- a/scripts/openapi/keap/metadata/v1/objects.go
+++ b/scripts/openapi/keap/metadata/v1/objects.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 )
 
+// nolint:lll
 var (
 	ignoreEndpoints = []string{ // nolint:gochecknoglobals
 		// endpoints for creating fields
@@ -27,6 +28,9 @@ var (
 		"/v1/tasks/model",         // array located at "custom_fields"
 		// duplicates
 		"/v1/tasks/search", // covered by "/tasks"
+		// requires query parameters
+		"/v1/affiliates/summaries", // https://developer.infusionsoft.com/docs/rest/#tag/Affiliate/operation/listSummariesUsingGET
+		"/v1/products/sync",        // additionally, it is deprecated: https://developer.infusionsoft.com/docs/rest/#tag/Product/operation/listProductsFromSyncTokenUsingGET
 		// not applicable
 		"/v1/setting/application/enabled",       // retrieves application status
 		"/v1/setting/application/configuration", // retrieves application configuration
@@ -37,19 +41,19 @@ var (
 		"/v1/locales/countries",                 // countries is an object not array
 	}
 	objectEndpoints = map[string]string{ // nolint:gochecknoglobals
-		"/v1/products/sync": "synced_products",
+		// "/v1/products/sync": "synced_products",
 	}
 	displayNameOverride = map[string]string{ // nolint:gochecknoglobals
 		"commissions": "Commissions",
 		"emails":      "Emails",
 		"merchants":   "Merchants",
 		"programs":    "Programs",
-		"summaries":   "Summaries",
+		// "summaries":   "Summaries",
 	}
 	objectNameToResponseField = datautils.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
-		"merchants":       "merchant_accounts",
-		"redirectlinks":   "redirects",
-		"synced_products": "product_statuses",
+		"merchants":     "merchant_accounts",
+		"redirectlinks": "redirects",
+		// "synced_products": "product_statuses",
 	},
 		func(objectName string) (fieldName string) {
 			return objectName


### PR DESCRIPTION
# Description
I went over each and every Keap object and discovered only 2 couldn't be supported. 
Query parameters give required context to call those endpoints. As of now such Read objects are not supported.