### PR TITLE
[CON-186] Keap: fix since time format

### DIFF
--- a/internal/datautils/timing.go
+++ b/internal/datautils/timing.go
@@ -18,3 +18,11 @@ func (timing) FormatRFC3339inUTC(input time.Time) string {
 
 	return utcTime.Format("2006-01-02T15:04:05Z")
 }
+
+// FormatRFC3339inUTCWithMilliseconds similar to FormatRFC3339inUTC but adds milliseconds.
+// 15:04:05.039 => milliseconds is a decimal part of seconds.
+func (timing) FormatRFC3339inUTCWithMilliseconds(input time.Time) string {
+	utcTime := input.UTC()
+
+	return utcTime.Format("2006-01-02T15:04:05.000Z")
+}

--- a/providers/keap/read.go
+++ b/providers/keap/read.go
@@ -65,9 +65,10 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
 
 		if !config.Since.IsZero() {
-			url.WithQueryParam("since", datautils.Time.FormatRFC3339inUTC(config.Since))
+			url.WithQueryParam("since", datautils.Time.FormatRFC3339inUTCWithMilliseconds(config.Since))
 		}
 	} else if c.Module.ID == ModuleV2 {
+		// Since parameter is not applicable to objects in Module V2.
 		if config.ObjectName == "contact_link_types" {
 			url.WithQueryParam("pageSize", strconv.Itoa(DefaultPageSize))
 		} else {

--- a/test/keap/read/main.go
+++ b/test/keap/read/main.go
@@ -27,6 +27,8 @@ func main() {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "contacts",
 		Fields:     connectors.Fields("id"),
+		// Since:      time.Now().Add(-30 * time.Minute),
+		// NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=1&offset=50&since=2024-12-17T21:39:36.099Z&order=id",
 	})
 	if err != nil {
 		utils.Fail("error reading from Keap", "error", err)


### PR DESCRIPTION
# Description
Using the date format provided in the documentation didn't work. Found out on Keap forum that timestmap must include milliseconds.
![image](https://github.com/user-attachments/assets/ece82104-5f6e-456a-8458-87f922ba80dc)

# Fix
Added new time format as suggested by https://integration.keap.com/t/getting-invalid-date-format-while-creating-appointment/71578/3.

# Testing
Modified a mock test to expect the time format in the query parameter and ran the script with desired output:
![image](https://github.com/user-attachments/assets/ba4e3f1f-7d3c-4e83-92b6-d0f21adb630b)
VS output prior to fix:
![image](https://github.com/user-attachments/assets/7f7be921-818f-4d85-ac1b-c07faff039dd)


