### PR TITLE
chore: conditional formatting for hubspot.Write

### DIFF
--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -80,6 +80,7 @@ const (
 	ObjectFieldLastModifiedDate   ObjectField = "lastmodifieddate"
 	ObjectFieldId                 ObjectField = "id"
 	ObjectFieldProperties         ObjectField = "properties"
+	ObjectFieldAssociations       ObjectField = "associations"
 )
 
 type ObjectType string

--- a/providers/hubspot/write.go
+++ b/providers/hubspot/write.go
@@ -2,6 +2,7 @@ package hubspot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 
@@ -9,9 +10,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
-var (
-	ErrInvalidDataFormat = fmt.Errorf("data must be a map")
-)
+var ErrInvalidDataFormat = errors.New("data must be a map")
 
 type writeResponse struct {
 	CreatedAt             string         `json:"createdAt"`

--- a/providers/hubspot/write.go
+++ b/providers/hubspot/write.go
@@ -69,20 +69,20 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 
 // formatData formats the data to be written to Hubspot. If the data contains a "properties" key, it's assumed to be
 // formatted correctly. If not, it's wrapped in a "properties" object.
-func formatData(data any) (map[ObjectField]any, error) {
-	mapData, ok := data.(map[ObjectField]any)
+func formatData(data any) (map[string]any, error) {
+	mapData, ok := data.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%w: %T", ErrInvalidDataFormat, data)
 	}
 
 	// If the data has a "properties" / "associations" key, we assume it's formatted at the root level.
-	if _, ok := mapData[ObjectFieldProperties]; ok {
+	if _, ok := mapData[string(ObjectFieldProperties)]; ok {
 		return mapData, nil
-	} else if _, ok := mapData[ObjectFieldAssociations]; ok {
+	} else if _, ok := mapData[string(ObjectFieldAssociations)]; ok {
 		return mapData, nil
 	}
 
-	return map[ObjectField]any{
-		ObjectFieldProperties: data,
+	return map[string]any{
+		string(ObjectFieldProperties): data,
 	}, nil
 }

--- a/providers/hubspot/write_test.go
+++ b/providers/hubspot/write_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 )
 
-func TestFormatData(t *testing.T) {
+func TestFormatData(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		input       any
@@ -55,9 +57,10 @@ func TestFormatData(t *testing.T) {
 			name: "properties and associations, return as is",
 			input: map[string]any{
 				"properties": map[string]any{
-					"hs_timestamp":     1734527635844,
-					"hs_email_status":  "SENT",
-					"hs_email_headers": "{\"from\":{\"email\":null},\"to\":[{\"email\":null,\"firstName\":\"Some\",\"lastName\":\"Person\"}]}",
+					"hs_timestamp":    1734527635844,
+					"hs_email_status": "SENT",
+					"hs_email_headers": "" +
+						"{'from':{'email':null},'to':[{'email':null,'firstName':'Some','lastName':'Person'}]}",
 				},
 				"associations": []map[string]any{
 					{
@@ -77,9 +80,10 @@ func TestFormatData(t *testing.T) {
 			},
 			want: map[string]any{
 				"properties": map[string]any{
-					"hs_timestamp":     1734527635844,
-					"hs_email_status":  "SENT",
-					"hs_email_headers": "{\"from\":{\"email\":null},\"to\":[{\"email\":null,\"firstName\":\"Some\",\"lastName\":\"Person\"}]}",
+					"hs_timestamp":    1734527635844,
+					"hs_email_status": "SENT",
+					"hs_email_headers": "" +
+						"{'from':{'email':null},'to':[{'email':null,'firstName':'Some','lastName':'Person'}]}",
 				},
 				"associations": []map[string]any{
 					{
@@ -100,24 +104,25 @@ func TestFormatData(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt // pin variable
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := formatData(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("formatData() error = %v, wantErr %v", err, tt.wantErr)
+	for _, ttc := range tests {
+		t.Run(ttc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := formatData(ttc.input)
+			if (err != nil) != ttc.wantErr {
+				t.Fatalf("formatData() error = %v, wantErr %v", err, ttc.wantErr)
 			}
 
-			if tt.wantErr {
-				if !errors.Is(err, tt.expectedErr) {
-					t.Fatalf("formatData() error = %v, expectedErr %v", err, tt.expectedErr)
+			if ttc.wantErr {
+				if !errors.Is(err, ttc.expectedErr) {
+					t.Fatalf("formatData() error = %v, expectedErr %v", err, ttc.expectedErr)
 				}
 
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("formatData() = %#v, want %#v", got, tt.want)
+			if !reflect.DeepEqual(got, ttc.want) {
+				t.Errorf("formatData() = %#v, want %#v", got, ttc.want)
 			}
 		})
 	}

--- a/providers/hubspot/write_test.go
+++ b/providers/hubspot/write_test.go
@@ -1,0 +1,123 @@
+package hubspot
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestFormatData(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       any
+		want        map[string]any
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name: "invalid data format (not a map[string]any)",
+			input: map[int]string{
+				1: "value",
+			},
+			wantErr:     true,
+			expectedErr: ErrInvalidDataFormat,
+		},
+		{
+			name: "already has properties field",
+			input: map[string]any{
+				string(ObjectFieldProperties): map[string]any{"foo": "bar", "hs_object_id": "123"},
+			},
+			want: map[string]any{
+				string(ObjectFieldProperties): map[string]any{"foo": "bar", "hs_object_id": "123"},
+			},
+		},
+		{
+			name: "already has associations field",
+			input: map[string]any{
+				string(ObjectFieldAssociations): []any{"some_association"},
+			},
+			want: map[string]any{
+				string(ObjectFieldAssociations): []any{"some_association"},
+			},
+		},
+		{
+			name: "no properties or associations, wrap data in properties",
+			input: map[string]any{
+				"somekey": "somevalue",
+			},
+			want: map[string]any{
+				string(ObjectFieldProperties): map[string]any{
+					"somekey": "somevalue",
+				},
+			},
+		},
+		{
+			name: "properties and associations, return as is",
+			input: map[string]any{
+				"properties": map[string]any{
+					"hs_timestamp":     1734527635844,
+					"hs_email_status":  "SENT",
+					"hs_email_headers": "{\"from\":{\"email\":null},\"to\":[{\"email\":null,\"firstName\":\"Some\",\"lastName\":\"Person\"}]}",
+				},
+				"associations": []map[string]any{
+					{
+						"to": map[string]any{
+							"id": "85861910068",
+						},
+					},
+					{
+						"types": []map[string]any{
+							{
+								"associationCategory": "HUBSPOT_DEFINED",
+								"associationTypeId":   11,
+							},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"properties": map[string]any{
+					"hs_timestamp":     1734527635844,
+					"hs_email_status":  "SENT",
+					"hs_email_headers": "{\"from\":{\"email\":null},\"to\":[{\"email\":null,\"firstName\":\"Some\",\"lastName\":\"Person\"}]}",
+				},
+				"associations": []map[string]any{
+					{
+						"to": map[string]any{
+							"id": "85861910068",
+						},
+					},
+					{
+						"types": []map[string]any{
+							{
+								"associationCategory": "HUBSPOT_DEFINED",
+								"associationTypeId":   11,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // pin variable
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := formatData(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("formatData() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				if !errors.Is(err, tt.expectedErr) {
+					t.Fatalf("formatData() error = %v, expectedErr %v", err, tt.expectedErr)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("formatData() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/hubspot/write_test.go
+++ b/providers/hubspot/write_test.go
@@ -112,6 +112,7 @@ func TestFormatData(t *testing.T) {
 				if !errors.Is(err, tt.expectedErr) {
 					t.Fatalf("formatData() error = %v, expectedErr %v", err, tt.expectedErr)
 				}
+
 				return
 			}
 


### PR DESCRIPTION
Previously, hubspot only supported `properties` at the root level which is why it was safe to inject data to be written into `properties` directly, but now it seems that `associations` is also a supported key, so we add a check for the formatting. 