### PR TITLE
feat(openapi): Array schema autoselect

### DIFF
--- a/tools/fileconv/api3/README.md
+++ b/tools/fileconv/api3/README.md
@@ -68,6 +68,12 @@ openapi.FileManager.GetExplorer(
     api3.WithParameterFilterGetMethod(
         api3.OnlyOptionalQueryParameters        		
     )
+    api3.WithMediaType("application/vnd.api+json"),
+    api3.WithPropertyFlattening(func(objectName, fieldName string) bool {
+        // Nested attributes object holds most important fields.
+        return fieldName == "attributes"
+    }),
+    api3.WithArrayItemAutoSelection(),
 )
 ```
 **Display Name.**
@@ -77,3 +83,12 @@ Of course, a single method will suffice, but chained processors allow for better
 
 **Parameter Filter.**
 Some GET methods can be ignored based on the endpoint's input parameters. For example, retain endpoints that have exclusively optional query parameters.
+
+**Media Type.**
+By default, the API response is in `application/json`, but this can be configured as needed.
+
+**Property Flattening.**
+You can specify a field name for flattening, which will relocate nested fields to the top level.
+
+**Array Item auto Selection.**
+Enabling this flag allows for automatic selection of the object schema when the response contains a single array. If the response includes multiple arrays, the `objectArrayLocator` will still be invoked to resolve any ambiguity. 

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -3,6 +3,7 @@ package api3
 import (
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
 )
@@ -99,6 +100,7 @@ type parameters struct {
 	operationMethodFilter ReadOperationMethodFilter
 	propertyFlattener     PropertyFlattener
 	mediaType             string
+	autoSelectArrayItem   *bool
 }
 
 type Option = func(params *parameters)
@@ -131,6 +133,11 @@ func createParams(opts []Option) *parameters {
 
 	if len(params.mediaType) == 0 {
 		params.mediaType = "application/json"
+	}
+
+	if params.autoSelectArrayItem == nil {
+		// By default, auto selection is off.
+		params.autoSelectArrayItem = goutils.Pointer(false)
 	}
 
 	return &params
@@ -172,5 +179,18 @@ func WithMediaType(mediaType string) Option {
 func WithPropertyFlattening(propertyFlattener PropertyFlattener) Option {
 	return func(params *parameters) {
 		params.propertyFlattener = propertyFlattener
+	}
+}
+
+// WithArrayItemAutoSelection enables automatic selection of the array field in API responses
+// if it is the only array type present.
+// Default: Disabled.
+//
+// Use Case: This is helpful when APIs have inconsistent response field names, making it
+// tedious to map each object name to its array field. If the response contains only one
+// array property and each array represents the API resource schema, this option should be selected.
+func WithArrayItemAutoSelection() Option {
+	return func(params *parameters) {
+		params.autoSelectArrayItem = goutils.Pointer(true)
 	}
 }

--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -82,6 +82,7 @@ func (e Explorer) ReadObjects(
 			e.operationMethodFilter,
 			e.propertyFlattener,
 			e.mediaType,
+			*e.autoSelectArrayItem,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Before
The response schema may include multiple array properties. To determine the correct one, a callback ObjectArrayLocator was always used. This effectively created a mapping between the object name and the desired array property.

# Problem
Not all APIs adhere to consistent property naming conventions. While most inconsistencies can be addressed by modifying the object name, others must be hardcoded as a last resort. Creating such mappings is often tedious and, in many cases, impractical.

# Solution
The OpenAPI explorer now includes an additional configuration option: `ArrayItemAutoSelection`.
If the response schema contains only one array property, it will be selected automatically. For ambiguous multi-array responses, however, the mapping via ObjectArrayLocator will still be required.
