### PR TITLE
[CON-892] feat: (apollo) support API product names

### DIFF
--- a/providers/apollo/connector.go
+++ b/providers/apollo/connector.go
@@ -54,7 +54,7 @@ func (c *Connector) Provider() providers.Provider {
 // Depending on the operation(read or write), some objects will need different endpoints.
 // That's the sole purpose of the variable ops.
 func (c *Connector) getAPIURL(objectName string, ops operation) (*urlbuilder.URL, error) {
-	objectName = constructObjectName(objectName)
+	objectName = constructSupportedObjectName(objectName)
 
 	relativePath := strings.Join([]string{restAPIPrefix, objectName}, "/")
 

--- a/providers/apollo/connector.go
+++ b/providers/apollo/connector.go
@@ -54,6 +54,8 @@ func (c *Connector) Provider() providers.Provider {
 // Depending on the operation(read or write), some objects will need different endpoints.
 // That's the sole purpose of the variable ops.
 func (c *Connector) getAPIURL(objectName string, ops operation) (*urlbuilder.URL, error) {
+	objectName = constructObjectName(objectName)
+
 	relativePath := strings.Join([]string{restAPIPrefix, objectName}, "/")
 
 	url, err := urlbuilder.New(c.BaseURL, relativePath)

--- a/providers/apollo/metadata.go
+++ b/providers/apollo/metadata.go
@@ -36,6 +36,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		// Limiting the response, so as we don't have to return 100 records of data
 		// when we just need 1.
 		url.WithQueryParam(perPage, metadataPageSize)
+
 		resp, err := c.Client.Get(ctx, url.String())
 		if err != nil {
 			metadataResult.Errors[objectName] = err

--- a/providers/apollo/metadata.go
+++ b/providers/apollo/metadata.go
@@ -65,7 +65,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 }
 
 func parseMetadataFromResponse(body *ajson.Node, objectName string) (*common.ObjectMetadata, error) {
-	objectName = constructObjectName(objectName)
+	objectName = constructSupportedObjectName(objectName)
 
 	arr, err := jsonquery.New(body).Array(objectName, true)
 	if err != nil {

--- a/providers/apollo/metadata.go
+++ b/providers/apollo/metadata.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
@@ -28,6 +29,16 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 	}
 
 	for _, objectName := range objectNames {
+		// we want to update the objectName if the provided objectName
+		// is the product name from the API docs to the supported objectName.
+		// Example: sequence would be mapped to emailer_campaigns.
+		// ref: https://docs.apollo.io/reference/search-for-sequences
+		mappedObjectName, ok := displayNameToObjectName[strings.ToLower(objectName)]
+		if ok {
+			// Renaming the Param ObjectName to the mapped object.
+			objectName = mappedObjectName
+		}
+
 		url, err := c.getAPIURL(objectName, readOp)
 		if err != nil {
 			return nil, err

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -52,7 +52,7 @@ func recordsWrapperFunc(obj string) common.RecordsFunc {
 func searchRecords(fld string) common.RecordsFunc {
 	var records []map[string]any
 
-	fld = constructObjectName(fld)
+	fld = constructSupportedObjectName(fld)
 
 	return func(node *ajson.Node) ([]map[string]any, error) {
 		result, err := jsonquery.New(node).Array(fld, true)

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -52,6 +52,7 @@ func recordsWrapperFunc(obj string) common.RecordsFunc {
 func searchRecords(fld string) common.RecordsFunc {
 	var records []map[string]any
 
+	fld = constructObjectName(fld)
 	return func(node *ajson.Node) ([]map[string]any, error) {
 		result, err := jsonquery.New(node).Array(fld, true)
 		if err != nil {

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -53,6 +53,7 @@ func searchRecords(fld string) common.RecordsFunc {
 	var records []map[string]any
 
 	fld = constructObjectName(fld)
+
 	return func(node *ajson.Node) ([]map[string]any, error) {
 		result, err := jsonquery.New(node).Array(fld, true)
 		if err != nil {

--- a/providers/apollo/read.go
+++ b/providers/apollo/read.go
@@ -2,7 +2,6 @@ package apollo
 
 import (
 	"context"
-	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -18,16 +17,6 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	if err := config.ValidateParams(true); err != nil {
 		return nil, err
-	}
-
-	// we want to update the objectName if the provided objectName
-	// is the product name from the API docs to the supported objectName.
-	// Example: sequence would be mapped to emailer_campaigns.
-	// ref: https://docs.apollo.io/reference/search-for-sequences
-	objectName, ok := displayNameToObjectName[strings.ToLower(config.ObjectName)]
-	if ok {
-		// Renaming the Param ObjectName to the mapped object.
-		config.ObjectName = objectName
 	}
 
 	url, err := c.getAPIURL(config.ObjectName, readOp)

--- a/providers/apollo/read.go
+++ b/providers/apollo/read.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -17,6 +18,16 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	if err := config.ValidateParams(true); err != nil {
 		return nil, err
+	}
+
+	// we want to update the objectName if the provided config.ObjectName
+	// is the displayname from the API docs to the supported objectName.
+	// Example: sequence would be mapped to emailer_campaigns.
+	// ref: https://docs.apollo.io/reference/search-for-sequences
+	objectName, ok := displayNameToObjectName[strings.ToLower(config.ObjectName)]
+	if ok {
+		// Renaming the Param ObjectName to the mapped object.
+		config.ObjectName = objectName
 	}
 
 	url, err := c.getAPIURL(config.ObjectName, readOp)

--- a/providers/apollo/read.go
+++ b/providers/apollo/read.go
@@ -20,8 +20,8 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	// we want to update the objectName if the provided config.ObjectName
-	// is the displayname from the API docs to the supported objectName.
+	// we want to update the objectName if the provided objectName
+	// is the product name from the API docs to the supported objectName.
 	// Example: sequence would be mapped to emailer_campaigns.
 	// ref: https://docs.apollo.io/reference/search-for-sequences
 	objectName, ok := displayNameToObjectName[strings.ToLower(config.ObjectName)]

--- a/providers/apollo/types.go
+++ b/providers/apollo/types.go
@@ -39,6 +39,9 @@ var productNameToObjectName = map[string]string{
 	"lists_and_tags": "labels",
 }
 
+// Apollo uses mismatched API object names and display names in the documentation.
+// We want to support both naming conventions. This function checks whether the provided objectName
+// is a display name, and if so, maps it to the corresponding API object name.
 func constructSupportedObjectName(obj string) string {
 	// we want to update the objectName if the provided objectName
 	// is the product name from the API docs to the supported objectName.

--- a/providers/apollo/types.go
+++ b/providers/apollo/types.go
@@ -1,5 +1,9 @@
 package apollo
 
+import (
+	"strings"
+)
+
 //nolint:gochecknoglobals
 var (
 	restAPIPrefix string    = "v1"
@@ -13,24 +17,38 @@ var (
 // readingSearchObjectGET represents objects that read by search and uses GET method.
 //
 //nolint:gochecknoglobals
-var readingSearchObjectsGET = []string{"opportunities", "users"}
+var readingSearchObjectsGET = []string{"opportunities", "users", "deals"}
 
 // readingSearchObjects represents objects that read by search and uses POST method.
 //
 //nolint:gochecknoglobals
-var readingSearchObjectsPOST = []string{"accounts", "contacts", "tasks", "emailer_campaigns"}
+var readingSearchObjectsPOST = []string{"accounts", "contacts", "tasks", "emailer_campaigns", "sequences"}
 
 // readingListObjects represents objects that read by listing.
 //
 //nolint:gochecknoglobals,lll
-var readingListObjects = []string{"contact_stages", "opportunity_stages", "account_stages", "email_accounts", "labels", "typed_custom_fields"}
+var readingListObjects = []string{"contact_stages", "opportunity_stages", "account_stages", "email_accounts", "labels", "typed_custom_fields", "deal_stages", "lists_and_tags"}
 
-// displayNameToObjectName represents a mapping between the docs displaynames to object names.
+// productNameToObjectName represents a mapping between the docs displaynames to object names.
 //
 //nolint:gochecknoglobals,lll
-var displayNameToObjectName = map[string]string{
+var productNameToObjectName = map[string]string{
 	"sequences":      "emailer_campaigns",
 	"deals":          "opportunities",
 	"deal_stages":    "opportunity_stages",
 	"lists_and_tags": "labels",
+}
+
+func constructObjectName(obj string) string {
+	// we want to update the objectName if the provided objectName
+	// is the product name from the API docs to the supported objectName.
+	// Example: sequence would be mapped to emailer_campaigns.
+	// ref: https://docs.apollo.io/reference/search-for-sequences
+	mappedObjectName, ok := productNameToObjectName[strings.ToLower(obj)]
+	if ok {
+		// Renaming the ObjectName to the mapped object.
+		obj = mappedObjectName
+	}
+
+	return obj
 }

--- a/providers/apollo/types.go
+++ b/providers/apollo/types.go
@@ -24,3 +24,13 @@ var readingSearchObjectsPOST = []string{"accounts", "contacts", "tasks", "emaile
 //
 //nolint:gochecknoglobals,lll
 var readingListObjects = []string{"contact_stages", "opportunity_stages", "account_stages", "email_accounts", "labels", "typed_custom_fields"}
+
+// displayNameToObjectName represents a mapping between the docs displaynames to object names.
+//
+//nolint:gochecknoglobals,lll
+var displayNameToObjectName = map[string]string{
+	"sequences":      "emailer_campaigns",
+	"deals":          "opportunities",
+	"deal_stages":    "opportunity_stages",
+	"lists_and_tags": "labels",
+}

--- a/providers/apollo/types.go
+++ b/providers/apollo/types.go
@@ -39,7 +39,7 @@ var productNameToObjectName = map[string]string{
 	"lists_and_tags": "labels",
 }
 
-func constructObjectName(obj string) string {
+func constructSupportedObjectName(obj string) string {
 	// we want to update the objectName if the provided objectName
 	// is the product name from the API docs to the supported objectName.
 	// Example: sequence would be mapped to emailer_campaigns.

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -2,7 +2,6 @@ package apollo
 
 import (
 	"context"
-	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
@@ -17,16 +16,6 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	var write common.WriteMethod
-
-	// we want to update the objectName if the provided objectName
-	// is the product name from the API docs to the supported objectName.
-	// Example: sequence would be mapped to emailer_campaigns.
-	// ref: https://docs.apollo.io/reference/search-for-sequences
-	objectName, ok := displayNameToObjectName[strings.ToLower(config.ObjectName)]
-	if ok {
-		// Renaming the Param ObjectName to the mapped object.
-		config.ObjectName = objectName
-	}
 
 	url, err := c.getAPIURL(config.ObjectName, writeOp)
 	if err != nil {
@@ -58,6 +47,8 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult, error) {
+	objName = constructObjectName(objName)
+
 	// API Response contains a json object having a singular objectName key with the
 	// created/updated details in it.
 	obj := naming.NewSingularString(objName)

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -47,7 +47,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult, error) {
-	objName = constructObjectName(objName)
+	objName = constructSupportedObjectName(objName)
 
 	// API Response contains a json object having a singular objectName key with the
 	// created/updated details in it.

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -2,6 +2,7 @@ package apollo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
@@ -16,6 +17,16 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	var write common.WriteMethod
+
+	// we want to update the objectName if the provided objectName
+	// is the product name from the API docs to the supported objectName.
+	// Example: sequence would be mapped to emailer_campaigns.
+	// ref: https://docs.apollo.io/reference/search-for-sequences
+	objectName, ok := displayNameToObjectName[strings.ToLower(config.ObjectName)]
+	if ok {
+		// Renaming the Param ObjectName to the mapped object.
+		config.ObjectName = objectName
+	}
 
 	url, err := c.getAPIURL(config.ObjectName, writeOp)
 	if err != nil {

--- a/test/apollo/metadata/metadata.go
+++ b/test/apollo/metadata/metadata.go
@@ -13,7 +13,7 @@ func main() {
 
 	conn := apollo.GetApolloConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"opportunities", "contact_stages", "email_accounts", "typed_custom_fields", "opportunity_stages", "users"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"opportunities", "contact_stages", "email_accounts", "typed_custom_fields", "opportunity_stages", "users", "deals"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/apollo/read/read.go
+++ b/test/apollo/read/read.go
@@ -37,12 +37,17 @@ func MainFn() int {
 		return 1
 	}
 
-	err = testReadSequences(ctx, conn)
+	err = testReadEmailerCampaigns(ctx, conn)
 	if err != nil {
 		return 1
 	}
 
 	err = testReadContacts(ctx, conn)
+	if err != nil {
+		return 1
+	}
+
+	err = testReadSequences(ctx, conn)
 	if err != nil {
 		return 1
 	}
@@ -119,7 +124,7 @@ func testReadCustomFields(ctx context.Context, conn *ap.Connector) error {
 	return nil
 }
 
-func testReadSequences(ctx context.Context, conn *ap.Connector) error {
+func testReadEmailerCampaigns(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "emailer_campaigns",
 		Fields:     connectors.Fields("id", "name", "archived"),
@@ -146,6 +151,29 @@ func testReadContacts(ctx context.Context, conn *ap.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "contacts",
 		Fields:     connectors.Fields("id", "first_name", "name"),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testReadSequences(ctx context.Context, conn *ap.Connector) error {
+	params := common.ReadParams{
+		ObjectName: "sequences",
+		Fields:     connectors.Fields("id", "name"),
 	}
 
 	res, err := conn.Read(ctx, params)

--- a/test/apollo/write/write.go
+++ b/test/apollo/write/write.go
@@ -33,6 +33,11 @@ func MainFn() int {
 		return 1
 	}
 
+	err = testUpdatingDeals(ctx)
+	if err != nil {
+		return 1
+	}
+
 	return 0
 }
 
@@ -106,6 +111,36 @@ func testCreatingAccounts(ctx context.Context) error {
 			"domain":       "google.com",
 			"phone_number": "1-866-246-6453",
 			"raw_address":  "1600 Amphitheatre Parkway",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testUpdatingDeals(ctx context.Context) error {
+	conn := apollo.GetApolloConnector(ctx)
+
+	params := common.WriteParams{
+		ObjectName: "Deals",
+		RecordId:   "66d573f1bb530101b230db6f",
+		RecordData: map[string]any{
+			"amount":               "2500",
+			"opportunity_stage_id": "65b1974393794c0300d26dcf",
+			"closed_date":          "2024-12-18",
 		},
 	}
 


### PR DESCRIPTION
Apollo sometimes uses different names in the URL vs in the description of the API documentation:

[Emailer Campaigns are called Sequences](https://docs.apollo.io/reference/search-for-sequences)
[Opportunities are called Deals](https://docs.apollo.io/reference/list-all-deals)
[Opportunity Stages are called Deal Stages](https://docs.apollo.io/reference/list-deal-stages)
[Lists and Tags and called Labels](https://docs.apollo.io/reference/get-a-list-of-all-liststags)

This Adds support for these product names.

Testing(Reading):
<img width="1223" alt="Screenshot 2025-01-03 at 09 15 45" src="https://github.com/user-attachments/assets/d845b285-7b02-4bd5-971c-0c93a9eda851" />

Writing:
<img width="1224" alt="Screenshot 2025-01-04 at 10 17 57" src="https://github.com/user-attachments/assets/4afd61c6-0cef-4207-9d78-77f904239480" />

Reading Metadata:
<img width="1189" alt="Screenshot 2025-01-04 at 10 26 56" src="https://github.com/user-attachments/assets/9cc4d297-7b30-438a-92ae-3bc0a66e1c5b" />

