### PR TITLE
feat: (zoho) Add support for lowercase fieldnames

### DIFF
--- a/providers/zohocrm/metadata.go
+++ b/providers/zohocrm/metadata.go
@@ -2,6 +2,7 @@ package zohocrm
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/amp-labs/connectors/common"
@@ -105,7 +106,7 @@ func parseMetadataResponse(resp *common.JSONHTTPResponse) (*common.ObjectMetadat
 	for _, f := range response.Fields {
 		apiField, ok := f[apiKeyField].(string)
 		if ok {
-			metadata.FieldsMap[apiField] = apiField
+			metadata.FieldsMap[strings.ToLower(apiField)] = strings.ToLower(apiField)
 		}
 	}
 

--- a/providers/zohocrm/types.go
+++ b/providers/zohocrm/types.go
@@ -1,7 +1,7 @@
 package zohocrm
 
 // uniqueFields maps the fields to the uniquely required fields.
-var uniqueFields = map[string]string{
+var uniqueFields = map[string]string{ // nolint:gochecknoglobals
 	"SIC_Code":                 "SIC_Code",
 	"Skype_ID":                 "Skype_ID",
 	"Num_sent":                 "Num_sent",

--- a/providers/zohocrm/types.go
+++ b/providers/zohocrm/types.go
@@ -2,15 +2,15 @@ package zohocrm
 
 // uniqueFields maps the fields to the uniquely required fields.
 var uniqueFields = map[string]string{ // nolint:gochecknoglobals
-	"SIC_Code":                 "SIC_Code",
-	"Skype_ID":                 "Skype_ID",
-	"Num_sent":                 "Num_sent",
-	"What_Id":                  "What_Id",
-	"Who_Id":                   "Who_Id",
-	"All_day":                  "All_day",
-	"ZIP_Code":                 "ZIP_Code",
-	"CTI_Entry":                "CTI_Entry",
-	"Call_Duration_in_seconds": "Call_Duration_in_seconds",
-	"Caller_ID":                "Caller_ID",
-	"Scheduled_In_CRM":         "Scheduled_In_CRM",
+	"sic_code":                 "SIC_Code",
+	"skype_id":                 "Skype_ID",
+	"num_sent":                 "Num_sent",
+	"what_id":                  "What_Id",
+	"who_id":                   "Who_Id",
+	"all_day":                  "All_day",
+	"zip_code":                 "ZIP_Code",
+	"cti_entry":                "CTI_Entry",
+	"call_duration_in_seconds": "Call_Duration_in_seconds",
+	"caller_id":                "Caller_ID",
+	"scheduled_in_crm":         "Scheduled_In_CRM",
 }

--- a/providers/zohocrm/types.go
+++ b/providers/zohocrm/types.go
@@ -1,0 +1,16 @@
+package zohocrm
+
+// uniqueFields maps the fields to the uniquely required fields.
+var uniqueFields = map[string]string{
+	"SIC_Code":                 "SIC_Code",
+	"Skype_ID":                 "Skype_ID",
+	"Num_sent":                 "Num_sent",
+	"What_Id":                  "What_Id",
+	"Who_Id":                   "Who_Id",
+	"All_day":                  "All_day",
+	"ZIP_Code":                 "ZIP_Code",
+	"CTI_Entry":                "CTI_Entry",
+	"Call_Duration_in_seconds": "Call_Duration_in_seconds",
+	"Caller_ID":                "Caller_ID",
+	"Scheduled_In_CRM":         "Scheduled_In_CRM",
+}

--- a/providers/zohocrm/url.go
+++ b/providers/zohocrm/url.go
@@ -23,9 +23,61 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	// Adds the fields requirement parameter.
-	fields := strings.Join(config.Fields.List(), ",")
+	fields := constructFieldNames(config.Fields.List())
 	url.WithQueryParam("fields", fields)
 
 	return url, nil
+}
+
+// Zoho field names typically start with a capital letter.
+// For fields with multiple words, underscores are used to separate them.
+// This function converts field names into a format that the API can understand.
+func constructFieldNames(flds []string) string {
+	cpdFlds := make([]string, len(flds))
+
+	for idx, fld := range flds {
+		// id is used and attached to the field parameter as is.
+		if fld == "id" {
+			cpdFlds[idx] = fld
+
+			continue
+		}
+
+		// fields ending with __s need to be capitalized the first letter
+		// of every other word only.
+		if strings.HasSuffix(fld, "__s") {
+			fld = capitalizeFields(fld[:len(fld)-3])
+			fld += "__s"
+			cpdFlds[idx] = fld
+
+			continue
+		}
+
+		cpdFld := capitalizeFields(fld)
+		cpdFlds[idx] = cpdFld
+	}
+
+	return strings.Join(cpdFlds, ",")
+}
+
+func capitalizeFields(fld string) string {
+	// Most Fields are in the structure XXX_XXXX (Full_Name).
+	// thus we capitalize first letter of individual substrings.
+	// Split the field by `_` and capitalize the individual segments.
+	segments := strings.Split(fld, "_")
+	for idx, seg := range segments {
+		// A unique case is where the segment is "id" (ie: skype_id)
+		// This should be mapped to (Skype_ID) not (Skype_Id)
+		if seg == "id" {
+			segments[idx] = "ID"
+
+			continue
+		}
+
+		seg = naming.CapitalizeFirstLetterEveryWord(seg)
+		// Update the segment to it's capitalized string.
+		segments[idx] = seg
+	}
+
+	return strings.Join(segments, "_")
 }

--- a/providers/zohocrm/url.go
+++ b/providers/zohocrm/url.go
@@ -58,19 +58,17 @@ func constructFieldNames(flds []string) string {
 }
 
 func capitalizeSegments(fld string) string {
+	// This maps fields to the unique available fields.
+	mappedObject, ok := uniqueFields[strings.ToLower(fld)]
+	if ok {
+		return mappedObject
+	}
+
 	// Most Fields are in the structure XXX_XXXX (Full_Name).
 	// thus we capitalize first letter of individual substrings.
 	// Split the field by `_` and capitalize the individual segments.
 	segments := strings.Split(fld, "_")
 	for idx, seg := range segments {
-		// A unique case is where the segment is "id" (ie: skype_id)
-		// This should be mapped to (Skype_ID) not (Skype_Id)
-		if strings.ToLower(seg) == "id" {
-			segments[idx] = "ID"
-
-			continue
-		}
-
 		seg = naming.CapitalizeFirstLetterEveryWord(seg)
 		// Update the segment to it's capitalized string.
 		segments[idx] = seg

--- a/providers/zohocrm/write.go
+++ b/providers/zohocrm/write.go
@@ -99,15 +99,38 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWritePayload(payload any) (any, error) {
-	v, ok := payload.([]map[string]any)
+	data, ok := payload.([]map[string]any)
 	if !ok {
 		objectData, ok := payload.(map[string]any)
 		if !ok {
 			return nil, common.ErrBadRequest
 		}
 
+		// Capitalize words in the data fields for Creation/Updating
+		for k, data := range objectData {
+			fld := constructFieldNames([]string{k})
+			objectData[fld] = data
+			// Remove the previous field key in the map, as it's no longer required.
+			if fld != k {
+				delete(objectData, k)
+			}
+		}
+
 		return map[string]any{"data": []map[string]any{objectData}}, nil
 	}
 
-	return map[string]any{"data": v}, nil
+	// Range Over the Slice for every map, Capitalize them.
+	for _, v := range data {
+		// Capitalize words in the data fields for Creation/Updating
+		for k, d := range v {
+			fld := constructFieldNames([]string{k})
+			v[fld] = d
+			// Remove the previous field key in the map, as it's no longer required.
+			if fld != k {
+				delete(v, k)
+			}
+		}
+	}
+
+	return map[string]any{"data": data}, nil
 }

--- a/providers/zohocrm/write.go
+++ b/providers/zohocrm/write.go
@@ -106,31 +106,27 @@ func constructWritePayload(payload any) (any, error) {
 			return nil, common.ErrBadRequest
 		}
 
-		// Capitalize words in the data fields for Creation/Updating
-		for k, data := range objectData {
-			fld := constructFieldNames([]string{k})
-			objectData[fld] = data
-			// Remove the previous field key in the map, as it's no longer required.
-			if fld != k {
-				delete(objectData, k)
-			}
-		}
+		capitalizeKeys(objectData)
 
 		return map[string]any{"data": []map[string]any{objectData}}, nil
 	}
 
 	// Range Over the Slice for every map, Capitalize them.
 	for _, v := range data {
-		// Capitalize words in the data fields for Creation/Updating
-		for k, d := range v {
-			fld := constructFieldNames([]string{k})
-			v[fld] = d
-			// Remove the previous field key in the map, as it's no longer required.
-			if fld != k {
-				delete(v, k)
-			}
-		}
+		capitalizeKeys(v)
 	}
 
 	return map[string]any{"data": data}, nil
+}
+
+func capitalizeKeys(data map[string]any) {
+	// Capitalize words in the data fields for Creation/Updating
+	for k, d := range data {
+		fld := constructFieldNames([]string{k})
+		data[fld] = d
+		// Remove the previous field key in the map, as it's no longer required.
+		if fld != k {
+			delete(data, k)
+		}
+	}
 }

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -42,7 +42,7 @@ func readContacts(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "contacts",
 		Since:      time.Now().Add(-3000 * time.Hour),
-		Fields:     connectors.Fields("assistant", "created_by", "full_name", "id", "created_time", "enrich_status__s", "skype_id"),
+		Fields:     connectors.Fields("Assistant", "created_by", "Full_Name", "id", "created_time", "enrich_status__s", "skype_id"),
 		// NextPage:   "https://www.zohoapis.com/crm/v6/Contacts?fields=Assistant%2CCreated_By%2CFull_Name%2Cid%2CCreated_Time\u0026page_token=089df74ef7734aa9f877fa670550bcbafc9c43567bb2f2e2404aa4d2a466a0b2c9432951d4eb3ffe73094c25e18b4c6290eedc53160535ab40b8ed204dd80e7247a90a4d5cd8d69a348dcaeefbccd8087f658d4a72cfa6aaab8ae8e7065246bf6d1fffce6a3eb2a06bab02e3ae935bc3fb63067b3e0da43e421e36b71b7c1bb843d3af99c7679b53100a8f7b8343f012\u0026since=2024-10-22T16%3A15%3A55%2B03%3A00",
 	}
 
@@ -66,7 +66,7 @@ func readDeals(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
 		Since:      time.Now().Add(-720 * time.Hour),
-		Fields:     connectors.Fields("Account_Name", "Closing_Date", "id"),
+		Fields:     connectors.Fields("Deal_Name", "Closing_Date", "id"),
 	}
 
 	result, err := conn.Read(ctx, config)

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -41,8 +41,8 @@ func main() {
 func readContacts(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "contacts",
-		Since:      time.Now().Add(-30 * time.Hour),
-		Fields:     connectors.Fields("Assistant", "Created_By", "Full_Name", "id", "Created_Time"),
+		Since:      time.Now().Add(-3000 * time.Hour),
+		Fields:     connectors.Fields("assistant", "created_by", "full_name", "id", "created_time", "enrich_status__s", "skype_id"),
 		// NextPage:   "https://www.zohoapis.com/crm/v6/Contacts?fields=Assistant%2CCreated_By%2CFull_Name%2Cid%2CCreated_Time\u0026page_token=089df74ef7734aa9f877fa670550bcbafc9c43567bb2f2e2404aa4d2a466a0b2c9432951d4eb3ffe73094c25e18b4c6290eedc53160535ab40b8ed204dd80e7247a90a4d5cd8d69a348dcaeefbccd8087f658d4a72cfa6aaab8ae8e7065246bf6d1fffce6a3eb2a06bab02e3ae935bc3fb63067b3e0da43e421e36b71b7c1bb843d3af99c7679b53100a8f7b8343f012\u0026since=2024-10-22T16%3A15%3A55%2B03%3A00",
 	}
 
@@ -66,7 +66,7 @@ func readDeals(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
 		Since:      time.Now().Add(-720 * time.Hour),
-		Fields:     connectors.Fields("Account_Name", "Closing_Date", "id"),
+		Fields:     connectors.Fields("account_name", "closing_date", "id"),
 	}
 
 	result, err := conn.Read(ctx, config)
@@ -89,7 +89,7 @@ func readLeads(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "leads",
 		Since:      time.Now().Add(-720 * time.Hour),
-		Fields:     connectors.Fields("Converted_Date_Time", "Email", "Record_Status__s", "id"),
+		Fields:     connectors.Fields("converted_date_time", "email", "record_status__s", "id"),
 	}
 
 	result, err := conn.Read(ctx, config)

--- a/test/zohocrm/read/read.go
+++ b/test/zohocrm/read/read.go
@@ -66,7 +66,7 @@ func readDeals(ctx context.Context, conn *zohocrm.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
 		Since:      time.Now().Add(-720 * time.Hour),
-		Fields:     connectors.Fields("account_name", "closing_date", "id"),
+		Fields:     connectors.Fields("Account_Name", "Closing_Date", "id"),
 	}
 
 	result, err := conn.Read(ctx, config)

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -42,9 +42,9 @@ func createDeals(ctx context.Context, conn *zohocrm.Connector) error {
 		ObjectName: "Deals",
 		RecordData: map[string]any{
 			"id":        "3652397000003852095",
-			"Deal_Name": "v6 Update",
-			"Stage":     "Closed Won",
-			"Pipeline":  "Standard (Standard)",
+			"deal_name": "v6 Update",
+			"stage":     "Closed Won",
+			"pipeline":  "Standard (Standard)",
 		},
 	}
 
@@ -65,15 +65,15 @@ func createDeals(ctx context.Context, conn *zohocrm.Connector) error {
 
 func createLeads(ctx context.Context, conn *zohocrm.Connector) error {
 	config := common.WriteParams{
-		ObjectName: "Leads",
+		ObjectName: "leads",
 		RecordData: []map[string]any{
 			{
-				"Lead_Source": "Employee Referral",
-				"Company":     "ABC",
-				"Last_Name":   "Daly",
-				"First_Name":  "Paul",
-				"Email":       "p.daly@zylker.com",
-				"State":       "Texas",
+				"lead_source": "Employee Referral",
+				"company":     "ABC",
+				"last_name":   "Daly",
+				"first_name":  "Paul",
+				"email":       "p.daly@zylker.com",
+				"state":       "Texas",
 			},
 		},
 	}


### PR DESCRIPTION
Currently Reading Field Names are case sensitive. With an exception in `id`. This updates the connector so as it can receiver lower cased field names. 
This also updates the Metadata Connector to return lower case field names.

Testing:
- Read
<img width="1215" alt="Screenshot 2025-01-07 at 15 15 57" src="https://github.com/user-attachments/assets/e5d7acdc-2cc5-4eed-bb15-95eec8f20c1f" />

- Metadata:
<img width="1184" alt="Screenshot 2025-01-07 at 15 07 53" src="https://github.com/user-attachments/assets/1fbf9ae8-a53b-42a0-81ec-de745ff85ab1" />

- Write
<img width="1225" alt="Screenshot 2025-01-08 at 12 47 50" src="https://github.com/user-attachments/assets/a3bd9313-0b07-4716-b3cc-a4ecd977f7a6" />


For more ctx: https://github.com/amp-labs/samples/pull/7
