### PR TITLE
[CON-539] feat: Enable proxy: ringCentral

### DIFF
--- a/providers/ringCentral.go
+++ b/providers/ringCentral.go
@@ -26,7 +26,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Checklist
 - [x] Ran Linter
 - [x] Created PR from non-main branch

## Notes
No fishy behaviour was observed. All the requests/responses were parsed correctly.

## Catelog variables
RingCentral Provider = "ringCentral"

## Notes
It supports pagination and batching

## Testing
### GET
URL: https://proxy.withampersand.com/team-messaging/v1/teams
![image](https://github.com/user-attachments/assets/7bd11c71-9b10-4705-8317-8a75a32d71ee)

### POST
URL: https://proxy.withampersand.com/team-messaging/v1/teams
![image](https://github.com/user-attachments/assets/b30532f1-95e0-4019-9bcc-52189407b725)

### PUT
URL: https://proxy.withampersand.com/team-messaging/v1/teams/142731788294
![image](https://github.com/user-attachments/assets/ea617d40-cefa-4e55-abad-a7060bad2c82)

### DELETE
URL: https://proxy.withampersand.com/team-messaging/v1/teams/142731788294
![image](https://github.com/user-attachments/assets/4e757464-8f81-4ae2-adbe-e67b9ad5d755)

## Pagination
Requested a paginated list of teams using the **recordCount** parameter to set the record limit and it will return the **prevPageToken** field with the next page token value.
URL: https://proxy.withampersand.com/team-messaging/v1/teams?recordCount=5
![image](https://github.com/user-attachments/assets/8dcac765-4af6-4ac0-81c7-111b1d0dd5fe)

**a)** Requested the next paginated list of teams by using the **prevPageToken** field value from the previous response and passing it in the **pageToken** parameter
URL: https://proxy.withampersand.com/team-messaging/v1/teams?pageToken=H4sIAAAAAAACAx2LOQqAMBQF7_LqX2gWjf8cdiFF0AgBN0wURLy7SzMMA3PhAJeE_HMEX4j960rUsjSiEVoRDj_u4Y21rIRSUpvGFDch9f-UBjC6Lfgcl7mNUwBh68CaMCSwtcjn-sU4gyza4Cc45-4HmWtygXsAAAA
![image](https://github.com/user-attachments/assets/281da2cf-bd36-415f-8417-611d59c29716)

**b)** Requested the next paginated list of teams by using the **prevPageToken** from the previous response, passing it as the **pageToken** parameter, and limiting the results to 2 records with the **recordCount** parameter
URL: https://proxy.withampersand.com/team-messaging/v1/teams?pageToken=H4sIAAAAAAACAx2LOQqAMBQF7_LqX2gWjf8cdiFF0AgBN0wURLy7SzMMA3PhAJeE_HMEX4j960rUsjSiEVoRDj_u4Y21rIRSUpvGFDch9f-UBjC6Lfgcl7mNUwBh68CaMCSwtcjn-sU4gyza4Cc45-4HmWtygXsAAAA&recordCount=2
![image](https://github.com/user-attachments/assets/59e1e42e-e83e-4fd4-8a8c-ecd7941097d1)

**b1)** Requested the **next** paginated list of teams by using the **prevPageToken** field from the b) response and passing it in the **pageToken** parameter
URL: https://proxy.withampersand.com/team-messaging/v1/teams?pageToken=H4sIAAAAAAACAx2LOQqAMBQF7_Lq35idfw67kCJohIAbJgoi3t2lGYaBuXCAG0L9OYIv5P51JaxsnNJGOsIRxz290UojlJJGW6dvQun_qQxgdFuKNS9zm6cEwtaBBWEoYO9Rz_WLeQZ5tClOCCHcDy6O3SZ7AAAA
![image](https://github.com/user-attachments/assets/6e03c779-7418-4f9e-aef3-cb3bc5c8b0b5)

**b2)** Requested the **previous** paginated list of teams by using the **nextPageToken** field from the b) response and passing it in the **pageToken** parameter
URL: https://proxy.withampersand.com/team-messaging/v1/teams?pageToken=H4sIAAAAAAACAx3LwQqEIBSF4Xc569tCvehwn6OduJAyEKqJtCCid8-Zzfnhg3PjhChChXQtM-RGHhuxdkZ9jGO2hDPOR2rojNXMbaxWD6GM_2-ZIBj2FGv-rn1eEgj7ANGEqUC8R722H-YV5NGnuCCE8LysEthNfAAAAA
![image](https://github.com/user-attachments/assets/e947772d-c70e-482f-9440-4a8fec8664a4)

## Invalid request
### Invalid endpoint
![image](https://github.com/user-attachments/assets/942130ee-2124-44e5-895e-5036b7c82c8b)

### Invalid method
![image](https://github.com/user-attachments/assets/d6dc4378-eace-4df0-8372-ade1461c9e82)

### Success Console Operation
![image](https://github.com/user-attachments/assets/4b703850-3c85-4c5b-b497-f67e6dea1b4e)
![image](https://github.com/user-attachments/assets/fee3c0a9-e99b-4129-bb00-772b9f4eea41)

### Failure Console Operation
![image](https://github.com/user-attachments/assets/8beed6a6-561f-4e80-a863-3be3fcb6179d)