### PR TITLE
fix(Smartlead): Remove unsupported leads

### DIFF
--- a/providers/smartlead/metadata/schemas.json
+++ b/providers/smartlead/metadata/schemas.json
@@ -65,28 +65,6 @@
             "warmup_details": "Warmup Details"
           }
         },
-        "leads": {
-          "displayName": "Leads",
-          "path": "/leads",
-          "docs": "https://api.smartlead.ai/reference/fetch-lead-by-email-address",
-          "fields": {
-            "id": "ID",
-            "first_name": "First name",
-            "last_name": "Last name",
-            "email": "Email",
-            "created_at": "Created at",
-            "phone_number": "Phone number",
-            "company_name": "Company name",
-            "website": "Website",
-            "location": "Location",
-            "custom_fields": "Custom fields",
-            "linkedin_profile": "Linkedin profile",
-            "company_url": "Company URL",
-            "is_unsubscribed": "Is unsubscribed",
-            "unsubscribed_client_id_map": "Unsubscribed client ID map",
-            "lead_campaign_data": "Lead campaign data"
-          }
-        },
         "client": {
           "displayName": "Clients",
           "path": "/client",

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",
-			Input:      []string{"campaigns", "leads"},
+			Input:      []string{"campaigns", "email-accounts"},
 			Server:     mockserver.Dummy(),
 			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
@@ -44,15 +44,14 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							"name":       "Name",
 						},
 					},
-					"leads": {
-						DisplayName: "Leads",
+					"email-accounts": {
+						DisplayName: "Email Accounts",
 						FieldsMap: map[string]string{
-							"first_name":   "First name",
-							"last_name":    "Last name",
-							"email":        "Email",
-							"created_at":   "Created at",
-							"phone_number": "Phone number",
-							"company_name": "Company name",
+							"created_at": "Created at",
+							"updated_at": "Updated at",
+							"user_id":    "User ID",
+							"smtp_host":  "SMTP Host",
+							"smtp_port":  "SMTP Port",
 						},
 					},
 				},


### PR DESCRIPTION
Reading leads requies email as a query parameter.

No place relies on leads object and this PR is to tidy this inconsistency. Its not mentioned up the stack and shouldn't be here either.