### PR TITLE
feat: Batch fetch associations for hubspot

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -13,28 +13,36 @@ import (
 // InterpretError interprets the given HTTP response (in a fairly straightforward
 // way) and returns an error that can be handled by the caller.
 func InterpretError(res *http.Response, body []byte) error {
+	createError := func(err error) error {
+		if len(body) == 0 {
+			return err
+		} else {
+			return fmt.Errorf("%w: %s", err, string(body))
+		}
+	}
+
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
 		// Access token invalid, refresh token and retry
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrAccessToken, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrAccessToken))
 	case http.StatusForbidden:
 		// Forbidden, not retryable
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrForbidden))
 	case http.StatusNotFound:
 		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrRetryable))
 	case http.StatusTooManyRequests:
 		// Too many requests, retryable
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrRetryable, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrRetryable))
 	}
 
 	if res.StatusCode >= 400 && res.StatusCode < 500 {
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrCaller, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrCaller))
 	} else if res.StatusCode >= 500 && res.StatusCode < 600 {
-		return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrServer, string(body)))
+		return NewHTTPStatusError(res.StatusCode, createError(ErrServer))
 	}
 
-	return NewHTTPStatusError(res.StatusCode, fmt.Errorf("%w: %s", ErrUnknown, string(body)))
+	return NewHTTPStatusError(res.StatusCode, createError(ErrUnknown))
 }
 
 type ErrorPostProcessor struct {

--- a/common/types.go
+++ b/common/types.go
@@ -186,10 +186,24 @@ type ReadResultRow struct {
 	// Fields is a map of requested provider field names to values.
 	// All field names are in lowercase (eg: accountid, name, billingcityid)
 	Fields map[string]any `json:"fields"`
+	// Associations is a map of associated objects to the main object.
+	// The key is the associated object name, and the value is an array of associated object ids.
+	Associations map[string][]Association `json:"associations,omitempty"`
 	// Raw is the raw JSON response from the provider.
 	Raw map[string]any `json:"raw"`
 	// RecordId is the ID of the record. Currently only populated for hubspot GetRecord and GetRecordsWithId function
 	Id string `json:"id,omitempty"`
+}
+
+// Association is a struct that represents an association between two objects.
+// If you think of an association as a directed edge between two nodes, then
+// the ObjectID is the target node, and the AssociationType is the type of edge.
+// The source node is represented by ReadResultRow.
+type Association struct {
+	// ObjectID is the ID of the associated object.
+	ObjectID string `json:"objectId"`
+	// AssociationType is the type of association.
+	AssociationType string `json:"associationType,omitempty"`
 }
 
 // WriteResult is what's returned from writing data via the Write call.

--- a/common/types.go
+++ b/common/types.go
@@ -201,7 +201,7 @@ type ReadResultRow struct {
 // The source node is represented by ReadResultRow.
 type Association struct {
 	// ObjectID is the ID of the associated object.
-	ObjectID string `json:"objectId"`
+	ObjectId string `json:"objectId"`
 	// AssociationType is the type of association.
 	AssociationType string `json:"associationType,omitempty"`
 }

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -110,7 +110,7 @@ func (c *Connector) getObjectAssociations(
 		return map[string][]common.Association{}, nil
 	}
 
-	hsUrl, err := c.getURL(fmt.Sprintf("/crm/v4/associations/%s/%s/batch/read", fromObject, toObject))
+	hsURL, err := c.getURL(fmt.Sprintf("/crm/v4/associations/%s/%s/batch/read", fromObject, toObject))
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (c *Connector) getObjectAssociations(
 
 	// Do one big batch request to get all associations.
 	// See https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#retrieve-associated-records
-	rsp, err := c.Client.Post(ctx, hsUrl, &inputs)
+	rsp, err := c.Client.Post(ctx, hsURL, &inputs)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching HubSpot associations: %w", err)
 	}

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -68,6 +68,7 @@ func getUniqueIDs(data *[]common.ReadResultRow) []string {
 }
 
 // fillAssociations fills the associations for the given object names and data.
+// Note that the data is modified in place.
 func (c *Connector) fillAssociations(
 	ctx context.Context,
 	fromObjName string,
@@ -148,7 +149,7 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 		for _, assoc := range result.To {
 			for _, t := range assoc.AssociationTypes {
 				assocs = append(assocs, common.Association{
-					ObjectID:        strconv.FormatInt(assoc.ToObjectId, 10),
+					ObjectId:        strconv.FormatInt(assoc.ToObjectId, 10),
 					AssociationType: t.String(),
 				})
 			}

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -111,10 +111,7 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 		return map[string][]common.Association{}, nil
 	}
 
-	hsURL, err := c.getURL(fmt.Sprintf("/crm/v4/associations/%s/%s/batch/read", fromObject, toObject))
-	if err != nil {
-		return nil, err
-	}
+	hsURL := c.BaseURL + "/" + fmt.Sprintf("crm/v4/associations/%s/%s/batch/read", fromObject, toObject)
 
 	var inputs assocInputs
 

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 )
 
 // Type definitions for HubSpot associations API.
@@ -126,6 +127,8 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 		var httpErr *common.HTTPStatusError
 
 		if errors.As(err, &httpErr) && httpErr.HTTPStatus == 404 {
+			logging.Logger(ctx).Warn("no associations found", "fromObject", fromObject, "toObject", toObject)
+
 			return map[string][]common.Association{}, nil
 		} else {
 			return nil, fmt.Errorf("error fetching HubSpot associations: %w", err)

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -101,7 +101,7 @@ func (c *Connector) fillAssociations(
 
 // getObjectAssociations returns the associations for the given object names and IDs. It returns
 // a mapping of object IDs to their associations.
-func (c *Connector) getObjectAssociations(
+func (c *Connector) getObjectAssociations( //nolint:cyclop
 	ctx context.Context,
 	fromObject string,
 	fromIDs []string,

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -1,0 +1,133 @@
+package hubspot
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+type assocInputs struct {
+	Inputs []assocId `json:"inputs"`
+}
+
+type assocId struct {
+	Id string `json:"id"`
+}
+
+type assocType struct {
+	Category string  `json:"category"`
+	TypeId   int     `json:"typeId"`
+	Label    *string `json:"label"`
+}
+
+type assocObject struct {
+	ToObjectId       int64       `json:"toObjectId"`
+	AssociationTypes []assocType `json:"associationTypes"`
+}
+
+type assocResult struct {
+	From assocId       `json:"from"`
+	To   []assocObject `json:"to"`
+}
+
+type assocOutput struct {
+	Status  string        `json:"status"`
+	Results []assocResult `json:"results"`
+}
+
+func getUniqueIds(data *[]common.ReadResultRow) []string {
+	uniqueIds := make(map[string]struct{})
+
+	for _, row := range *data {
+		uniqueIds[row.Id] = struct{}{}
+	}
+
+	var ids []string
+
+	for id := range uniqueIds {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+func (c *Connector) fillAssociations(ctx context.Context, objName string, data *[]common.ReadResultRow, associatedObjects []string) error {
+	ids := getUniqueIds(data)
+
+	for _, associatedObject := range associatedObjects {
+		associations, err := c.getObjectAssociations(ctx, objName, ids, associatedObject)
+		if err != nil {
+			return err
+		}
+
+		for i, row := range *data {
+			if assocs, ok := associations[row.Id]; ok {
+				if (*data)[i].Associations == nil {
+					(*data)[i].Associations = make(map[string][]common.Association)
+				}
+
+				(*data)[i].Associations[associatedObject] = assocs
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Connector) getObjectAssociations(ctx context.Context, fromObject string, fromIds []string, toObject string) (map[string][]common.Association, error) {
+	if len(fromIds) == 0 {
+		return nil, nil
+	}
+
+	u, err := c.getURL(fmt.Sprintf("/crm/v4/associations/%s/%s/batch/read", fromObject, toObject))
+	if err != nil {
+		return nil, err
+	}
+
+	var inputs assocInputs
+
+	for _, id := range fromIds {
+		inputs.Inputs = append(inputs.Inputs, assocId{Id: id})
+	}
+
+	rsp, err := c.Client.Post(ctx, u, &inputs)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching HubSpot associations: %w", err)
+	}
+
+	output, err := common.UnmarshalJSON[assocOutput](rsp)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string][]common.Association)
+
+	for _, result := range output.Results {
+		var assocs []common.Association
+
+		for _, assoc := range result.To {
+			for _, t := range assoc.AssociationTypes {
+				assocs = append(assocs, common.Association{
+					ObjectID:        strconv.FormatInt(assoc.ToObjectId, 10),
+					AssociationType: getAssociationType(t),
+				})
+			}
+		}
+
+		if len(assocs) > 0 {
+			out[result.From.Id] = assocs
+		}
+	}
+
+	return out, nil
+}
+
+func getAssociationType(t assocType) string {
+	if t.Label != nil && len(*t.Label) > 0 {
+		return fmt.Sprintf("category=%s id=%d label=%s", t.Category, t.TypeId, *t.Label)
+	}
+
+	return fmt.Sprintf("category=%s id=%d", t.Category, t.TypeId)
+}

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -131,7 +131,7 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 		if errors.As(err, &httpErr) && httpErr.HTTPStatus == 404 {
 			return map[string][]common.Association{}, nil
 		} else {
-			return nil, fmt.Errorf("error fetching HubSpot associations: %w", err)
+			return nil, fmt.Errorf("error fetching HubSpot associations: %w (%T)", err, err)
 		}
 	}
 

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -131,7 +131,7 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 		if errors.As(err, &httpErr) && httpErr.HTTPStatus == 404 {
 			return map[string][]common.Association{}, nil
 		} else {
-			return nil, fmt.Errorf("error fetching HubSpot associations: %w (%T)", err, err)
+			return nil, fmt.Errorf("error fetching HubSpot associations: %w", err)
 		}
 	}
 

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -126,7 +126,7 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 	// See https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#retrieve-associated-records
 	rsp, err := c.Client.Post(ctx, hsURL, &inputs)
 	if err != nil {
-		var httpErr common.HTTPStatusError
+		var httpErr *common.HTTPStatusError
 
 		if errors.As(err, &httpErr) && httpErr.HTTPStatus == 404 {
 			return map[string][]common.Association{}, nil

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -117,7 +117,11 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 }
 
 // getMarshalledData accepts a list of records and returns a list of structured data ([]ReadResultRow).
-func (c *Connector) getMarshalledData(ctx context.Context, objName string, associatedObjects []string) func(records []map[string]interface{}, fields []string) ([]common.ReadResultRow, error) {
+func (c *Connector) getMarshalledData(
+	ctx context.Context,
+	objName string,
+	associatedObjects []string,
+) func(records []map[string]interface{}, fields []string) ([]common.ReadResultRow, error) {
 	return func(records []map[string]interface{}, fields []string) ([]common.ReadResultRow, error) {
 		data := make([]common.ReadResultRow, len(records))
 

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -45,8 +45,9 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			SortBy: []SortBy{
 				BuildSort(ObjectFieldHsObjectId, SortDirectionAsc),
 			},
-			NextPage: config.NextPage,
-			Fields:   config.Fields,
+			NextPage:          config.NextPage,
+			Fields:            config.Fields,
+			AssociatedObjects: config.AssociatedObjects,
 		}
 
 		return c.Search(ctx, searchParams)

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -79,7 +79,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		rsp,
 		getRecords,
 		getNextRecordsURL,
-		getMarshalledData,
+		c.getMarshalledData(ctx, config.ObjectName, config.AssociatedObjects),
 		config.Fields,
 	)
 }

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -87,7 +87,7 @@ func (c *Connector) GetRecordsWithIds(
 
 	if len(fields) != 0 {
 		// If fields are specified, extract only those fields from the record.
-		return getMarshalledData(records, fields)
+		return c.getMarshalledData(ctx, objectName, associations)(records, fields)
 	}
 
 	data := make([]common.ReadResultRow, len(records))

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -43,7 +43,7 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 		rsp,
 		getRecords,
 		getNextRecordsAfter,
-		getMarshalledData,
+		c.getMarshalledData(ctx, config.ObjectName, config.AssociatedObjects),
 		config.Fields,
 	)
 }

--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -16,6 +16,8 @@ type SearchParams struct {
 	FilterGroups []FilterGroup // optional
 	// Fields is the list of fields to return in the result.
 	Fields datautils.Set[string] // optional
+	// AssociatedObjects is a list of associated objects to fetch along with the main object.
+	AssociatedObjects []string // optional
 }
 
 func (p SearchParams) ValidateParams() error {

--- a/test/hubspot/read-associations/main.go
+++ b/test/hubspot/read-associations/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	// Turn on logging
+	ctx = logging.WithLoggerEnabled(ctx, true)
+
+	// Get the Hubspot connector.
+	conn := connTest.GetHubspotConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "companies",
+		Fields:     connectors.Fields("name"),
+		NextPage:   "",
+		Since:      time.Now().Add(-24 * 365 * 10 * time.Hour), // 10 years should cover it
+		AssociatedObjects: []string{
+			"contacts",
+		},
+	})
+	if err != nil {
+		utils.Fail("error reading from hubspot", "error", err)
+	}
+
+	fmt.Println("Reading contacts..") //nolint:forbidigo
+
+	// Dump the result.
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
Test run:

```
$> go run ./test/hubspot/read-associations/main.go
time=2025-01-09T14:17:48.910-08:00 level=DEBUG msg="loading credentials file" path=./hubspot-creds.json
time=2025-01-09T14:17:48.911-08:00 level=DEBUG msg="HTTP request" connector=hubspot connector=hubspot method=POST url=https://api.hubapi.com/crm/v3/objects/companies/search headers="[{Key:Accept Value:application/json}]" bodySize=226
time=2025-01-09T14:17:49.271-08:00 level=DEBUG msg="HTTP request" connector=hubspot connector=hubspot method=POST url=https://api.hubapi.com/crm/v4/associations/companies/contacts/batch/read headers="[{Key:Accept Value:application/json}]" bodySize=75
Reading contacts..
{
  "rows": 3,
  "data": [
    {
      "fields": {
        "name": "Airbnb, Inc."
      },
      "associations": {
        "contacts": [
          {
            "objectId": "85902267225",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "85902267225",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86201038441",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86201038441",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86206016394",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86206016394",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86206763063",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86206763063",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86258582579",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86258582579",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86258879556",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86258879556",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86259207711",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86259207711",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86264113173",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86264113173",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86274522916",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86274522916",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86275116726",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86275116726",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86281943922",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86281943922",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          }
        ]
      },
      "raw": {
        "archived": false,
        "createdAt": "2023-12-13T22:20:43.643Z",
        "id": "18417469260",
        "properties": {
          "createdate": "2023-12-13T22:20:43.643Z",
          "hs_lastmodifieddate": "2025-01-08T00:51:24.935Z",
          "hs_object_id": "18417469260",
          "name": "Airbnb, Inc."
        },
        "updatedAt": "2025-01-08T00:51:24.935Z"
      },
      "id": "18417469260"
    },
    {
      "fields": {
        "name": "Test Company"
      },
      "associations": {
        "contacts": [
          {
            "objectId": "82016902681",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "82016902681",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          }
        ]
      },
      "raw": {
        "archived": false,
        "createdAt": "2024-10-16T21:20:53.405Z",
        "id": "23897303830",
        "properties": {
          "createdate": "2024-10-16T21:20:53.405Z",
          "hs_lastmodifieddate": "2025-01-08T00:51:43.512Z",
          "hs_object_id": "23897303830",
          "name": "Test Company"
        },
        "updatedAt": "2025-01-08T00:51:43.512Z"
      },
      "id": "23897303830"
    },
    {
      "fields": {
        "name": "Ampersand new"
      },
      "associations": {
        "contacts": [
          {
            "objectId": "86274522916",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86274676136",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86274676136",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          },
          {
            "objectId": "86281943922",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86292403302",
            "associationType": "category=HUBSPOT_DEFINED id=280"
          },
          {
            "objectId": "86292403302",
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company"
          }
        ]
      },
      "raw": {
        "archived": false,
        "createdAt": "2024-12-06T00:18:51.357Z",
        "id": "26655958117",
        "properties": {
          "createdate": "2024-12-06T00:18:51.357Z",
          "hs_lastmodifieddate": "2025-01-08T00:50:46.108Z",
          "hs_object_id": "26655958117",
          "name": "Ampersand new"
        },
        "updatedAt": "2025-01-08T00:50:46.108Z"
      },
      "id": "26655958117"
    }
  ],
  "done": true
}
```

Sample response (end-to-end, webhook):

```
{
  "action": "read",
  "groupName": "demo-group-name-8",
  "groupRef": "demo-group-id-8",
  "installationId": "2f405d23-4304-4f26-8236-0c1e74ec9761",
  "installationUpdateTime": "2025-01-09T22:15:26.461264Z",
  "objectName": "companies",
  "projectId": "9482e676-4874-43a4-beea-fa8081d13a07",
  "provider": "hubspot",
  "result": [
    {
      "associations": {
        "contacts": [
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "85902267225"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "85902267225"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86201038441"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86201038441"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86206016394"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86206016394"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86206763063"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86206763063"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86258582579"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86258582579"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86258879556"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86258879556"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86259207711"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86259207711"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86264113173"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86264113173"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86274522916"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86274522916"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86275116726"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86275116726"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86281943922"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86281943922"
          }
        ]
      },
      "fields": {
        "about_us": null,
        "address": "888 Brannan Street",
        "address2": null,
        "annualrevenue": "1000000000",
        "city": "San Francisco",
        "closedate": null,
        "country": "United States",
        "createdate": "2023-12-13T22:20:43.643Z",
        "days_to_close": null,
        "description": "Airbnb is the world's largest community-driven hospitality company that offers homes and experiences. It is a trusted online marketplace where people can list, discover, and book unique accommodations and experiences around the world. Whether it's a ca...",
        "domain": "airbnb.com",
        "engagements_last_meeting_booked": null,
        "engagements_last_meeting_booked_campaign": null,
        "engagements_last_meeting_booked_medium": null,
        "engagements_last_meeting_booked_source": null,
        "facebook_company_page": "https://facebook.com/airbnb",
        "facebookfans": null,
        "first_contact_createdate": "2024-12-18T19:21:03.415Z",
        "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
        "first_conversion_date": null,
        "first_conversion_event_name": null,
        "first_deal_created_date": "2024-06-05T21:27:13.091Z",
        "founded_year": "2008",
        "googleplus_page": null,
        "hs_additional_domains": null,
        "hs_all_accessible_team_ids": null,
        "hs_all_assigned_business_unit_ids": null,
        "hs_all_owner_ids": "587722345",
        "hs_all_team_ids": null,
        "hs_analytics_first_timestamp": "2024-12-18T19:21:00Z",
        "hs_analytics_first_touch_converting_campaign": null,
        "hs_analytics_first_visit_timestamp": null,
        "hs_analytics_last_timestamp": null,
        "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
        "hs_analytics_last_touch_converting_campaign": null,
        "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
        "hs_analytics_last_visit_timestamp": null,
        "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
        "hs_analytics_latest_source": "OFFLINE",
        "hs_analytics_latest_source_data_1": "INTEGRATION",
        "hs_analytics_latest_source_data_2": "2317233",
        "hs_analytics_latest_source_timestamp": "2024-12-20T01:31:00Z",
        "hs_analytics_num_page_views": "0",
        "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
        "hs_analytics_num_visits": "0",
        "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
        "hs_analytics_source": "OFFLINE",
        "hs_analytics_source_data_1": "INTEGRATION",
        "hs_analytics_source_data_2": "2317233",
        "hs_annual_revenue_currency_code": null,
        "hs_avatar_filemanager_key": null,
        "hs_country_code": null,
        "hs_created_by_user_id": "61427708",
        "hs_createdate": null,
        "hs_csm_sentiment": null,
        "hs_customer_success_ticket_sentiment": null,
        "hs_date_entered_customer": null,
        "hs_date_entered_evangelist": null,
        "hs_date_entered_lead": "2023-12-13T22:20:43.643Z",
        "hs_date_entered_marketingqualifiedlead": null,
        "hs_date_entered_opportunity": "2025-01-08T00:51:19.402Z",
        "hs_date_entered_other": null,
        "hs_date_entered_salesqualifiedlead": null,
        "hs_date_entered_subscriber": null,
        "hs_date_exited_customer": null,
        "hs_date_exited_evangelist": null,
        "hs_date_exited_lead": "2025-01-08T00:51:19.402Z",
        "hs_date_exited_marketingqualifiedlead": null,
        "hs_date_exited_opportunity": null,
        "hs_date_exited_other": null,
        "hs_date_exited_salesqualifiedlead": null,
        "hs_date_exited_subscriber": null,
        "hs_employee_range": null,
        "hs_ideal_customer_profile": null,
        "hs_industry_group": null,
        "hs_is_enriched": null,
        "hs_is_target_account": null,
        "hs_keywords": null,
        "hs_last_booked_meeting_date": null,
        "hs_last_logged_call_date": null,
        "hs_last_metered_enrichment_timestamp": null,
        "hs_last_open_task_date": null,
        "hs_last_sales_activity_date": null,
        "hs_last_sales_activity_timestamp": null,
        "hs_last_sales_activity_type": null,
        "hs_lastmodifieddate": "2025-01-08T00:51:24.935Z",
        "hs_latest_createdate_of_active_subscriptions": null,
        "hs_latest_meeting_activity": null,
        "hs_lead_status": null,
        "hs_linkedin_handle": null,
        "hs_logo_url": null,
        "hs_merged_object_ids": null,
        "hs_notes_last_activity": null,
        "hs_notes_next_activity": null,
        "hs_notes_next_activity_type": null,
        "hs_num_blockers": "0",
        "hs_num_child_companies": "0",
        "hs_num_contacts_with_buying_roles": "0",
        "hs_num_decision_makers": "0",
        "hs_num_open_deals": "1",
        "hs_object_id": "18417469260",
        "hs_object_source": "CRM_UI",
        "hs_object_source_detail_1": null,
        "hs_object_source_detail_2": null,
        "hs_object_source_detail_3": null,
        "hs_object_source_id": "userId:61427708",
        "hs_object_source_label": "CRM_UI",
        "hs_object_source_user_id": "61427708",
        "hs_parent_company_id": null,
        "hs_pinned_engagement_id": null,
        "hs_pipeline": "companies-lifecycle-pipeline",
        "hs_predictivecontactscore_v2": null,
        "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
        "hs_quick_context": null,
        "hs_read_only": null,
        "hs_revenue_range": null,
        "hs_sales_email_last_replied": null,
        "hs_shared_team_ids": null,
        "hs_shared_user_ids": null,
        "hs_source_object_id": null,
        "hs_target_account": null,
        "hs_target_account_probability": "0.7956095337867737",
        "hs_target_account_recommendation_snooze_time": null,
        "hs_target_account_recommendation_state": null,
        "hs_time_in_customer": null,
        "hs_time_in_evangelist": null,
        "hs_time_in_lead": "33791435759",
        "hs_time_in_marketingqualifiedlead": null,
        "hs_time_in_opportunity": "163447602",
        "hs_time_in_other": null,
        "hs_time_in_salesqualifiedlead": null,
        "hs_time_in_subscriber": null,
        "hs_total_deal_value": null,
        "hs_unique_creation_key": null,
        "hs_updated_by_user_id": "61428794",
        "hs_user_ids_of_all_notification_followers": null,
        "hs_user_ids_of_all_notification_unfollowers": null,
        "hs_user_ids_of_all_owners": "61427708",
        "hs_was_imported": null,
        "hubspot_owner_assigneddate": "2023-12-13T22:20:43.643Z",
        "hubspot_team_id": null,
        "hubspotscore": null,
        "industry": "LEISURE_TRAVEL_TOURISM",
        "is_public": "true",
        "lifecyclestage": "opportunity",
        "linkedin_company_page": "https://www.linkedin.com/company/airbnb",
        "linkedinbio": "Airbnb is the world's largest community-driven hospitality company, offering homes and experiences in 191 countries. It is an online marketplace connecting people to unique accommodations and experiences globally.",
        "name": "Airbnb, Inc.",
        "notes_last_contacted": null,
        "notes_last_updated": null,
        "notes_next_activity_date": null,
        "num_associated_contacts": "11",
        "num_associated_deals": "1",
        "num_contacted_notes": null,
        "num_conversion_events": "0",
        "num_conversion_events_cardinality_sum_d095f14b": null,
        "num_notes": null,
        "numberofemployees": "10000",
        "owneremail": null,
        "ownername": null,
        "phone": "+1 415-800-5958",
        "recent_conversion_date": null,
        "recent_conversion_date_timestamp_latest_value_72856da1": null,
        "recent_conversion_event_name": null,
        "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
        "recent_deal_amount": null,
        "recent_deal_close_date": null,
        "state": "CA",
        "timezone": "America/Los_Angeles",
        "total_money_raised": "4.4B",
        "total_revenue": null,
        "twitterbio": null,
        "twitterfollowers": null,
        "twitterhandle": "airbnb",
        "type": null,
        "web_technologies": "aws_route_53;unbounce;app_nexus;salesforce;stripe;google_apps;amazon_s3;google_analytics;google_tag_manager;braintree",
        "website": "airbnb.com",
        "zip": "94103"
      },
      "mappedFields": {
        "userId": "587722345"
      },
      "raw": {
        "archived": false,
        "associations": {
          "contacts": {
            "results": [
              {
                "id": "85902267225",
                "type": "company_to_contact"
              },
              {
                "id": "86201038441",
                "type": "company_to_contact"
              },
              {
                "id": "86206016394",
                "type": "company_to_contact"
              },
              {
                "id": "86206763063",
                "type": "company_to_contact"
              },
              {
                "id": "86258582579",
                "type": "company_to_contact"
              },
              {
                "id": "86258879556",
                "type": "company_to_contact"
              },
              {
                "id": "86259207711",
                "type": "company_to_contact"
              },
              {
                "id": "86264113173",
                "type": "company_to_contact"
              },
              {
                "id": "86274522916",
                "type": "company_to_contact"
              },
              {
                "id": "86275116726",
                "type": "company_to_contact"
              },
              {
                "id": "86281943922",
                "type": "company_to_contact"
              },
              {
                "id": "85902267225",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86201038441",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86206016394",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86206763063",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86258582579",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86258879556",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86259207711",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86264113173",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86274522916",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86275116726",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86281943922",
                "type": "company_to_contact_unlabeled"
              }
            ]
          }
        },
        "createdAt": "2023-12-13T22:20:43.643Z",
        "id": "18417469260",
        "properties": {
          "about_us": null,
          "address": "888 Brannan Street",
          "address2": null,
          "annualrevenue": "1000000000",
          "city": "San Francisco",
          "closedate": null,
          "country": "United States",
          "createdate": "2023-12-13T22:20:43.643Z",
          "days_to_close": null,
          "description": "Airbnb is the world's largest community-driven hospitality company that offers homes and experiences. It is a trusted online marketplace where people can list, discover, and book unique accommodations and experiences around the world. Whether it's a ca...",
          "domain": "airbnb.com",
          "engagements_last_meeting_booked": null,
          "engagements_last_meeting_booked_campaign": null,
          "engagements_last_meeting_booked_medium": null,
          "engagements_last_meeting_booked_source": null,
          "facebook_company_page": "https://facebook.com/airbnb",
          "facebookfans": null,
          "first_contact_createdate": "2024-12-18T19:21:03.415Z",
          "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
          "first_conversion_date": null,
          "first_conversion_event_name": null,
          "first_deal_created_date": "2024-06-05T21:27:13.091Z",
          "founded_year": "2008",
          "googleplus_page": null,
          "hs_additional_domains": null,
          "hs_all_accessible_team_ids": null,
          "hs_all_assigned_business_unit_ids": null,
          "hs_all_owner_ids": "587722345",
          "hs_all_team_ids": null,
          "hs_analytics_first_timestamp": "2024-12-18T19:21:00Z",
          "hs_analytics_first_touch_converting_campaign": null,
          "hs_analytics_first_visit_timestamp": null,
          "hs_analytics_last_timestamp": null,
          "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
          "hs_analytics_last_touch_converting_campaign": null,
          "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
          "hs_analytics_last_visit_timestamp": null,
          "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
          "hs_analytics_latest_source": "OFFLINE",
          "hs_analytics_latest_source_data_1": "INTEGRATION",
          "hs_analytics_latest_source_data_2": "2317233",
          "hs_analytics_latest_source_timestamp": "2024-12-20T01:31:00Z",
          "hs_analytics_num_page_views": "0",
          "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
          "hs_analytics_num_visits": "0",
          "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
          "hs_analytics_source": "OFFLINE",
          "hs_analytics_source_data_1": "INTEGRATION",
          "hs_analytics_source_data_2": "2317233",
          "hs_annual_revenue_currency_code": null,
          "hs_avatar_filemanager_key": null,
          "hs_country_code": null,
          "hs_created_by_user_id": "61427708",
          "hs_createdate": null,
          "hs_csm_sentiment": null,
          "hs_customer_success_ticket_sentiment": null,
          "hs_date_entered_customer": null,
          "hs_date_entered_evangelist": null,
          "hs_date_entered_lead": "2023-12-13T22:20:43.643Z",
          "hs_date_entered_marketingqualifiedlead": null,
          "hs_date_entered_opportunity": "2025-01-08T00:51:19.402Z",
          "hs_date_entered_other": null,
          "hs_date_entered_salesqualifiedlead": null,
          "hs_date_entered_subscriber": null,
          "hs_date_exited_customer": null,
          "hs_date_exited_evangelist": null,
          "hs_date_exited_lead": "2025-01-08T00:51:19.402Z",
          "hs_date_exited_marketingqualifiedlead": null,
          "hs_date_exited_opportunity": null,
          "hs_date_exited_other": null,
          "hs_date_exited_salesqualifiedlead": null,
          "hs_date_exited_subscriber": null,
          "hs_employee_range": null,
          "hs_ideal_customer_profile": null,
          "hs_industry_group": null,
          "hs_is_enriched": null,
          "hs_is_target_account": null,
          "hs_keywords": null,
          "hs_last_booked_meeting_date": null,
          "hs_last_logged_call_date": null,
          "hs_last_metered_enrichment_timestamp": null,
          "hs_last_open_task_date": null,
          "hs_last_sales_activity_date": null,
          "hs_last_sales_activity_timestamp": null,
          "hs_last_sales_activity_type": null,
          "hs_lastmodifieddate": "2025-01-08T00:51:24.935Z",
          "hs_latest_createdate_of_active_subscriptions": null,
          "hs_latest_meeting_activity": null,
          "hs_lead_status": null,
          "hs_linkedin_handle": null,
          "hs_logo_url": null,
          "hs_merged_object_ids": null,
          "hs_notes_last_activity": null,
          "hs_notes_next_activity": null,
          "hs_notes_next_activity_type": null,
          "hs_num_blockers": "0",
          "hs_num_child_companies": "0",
          "hs_num_contacts_with_buying_roles": "0",
          "hs_num_decision_makers": "0",
          "hs_num_open_deals": "1",
          "hs_object_id": "18417469260",
          "hs_object_source": "CRM_UI",
          "hs_object_source_detail_1": null,
          "hs_object_source_detail_2": null,
          "hs_object_source_detail_3": null,
          "hs_object_source_id": "userId:61427708",
          "hs_object_source_label": "CRM_UI",
          "hs_object_source_user_id": "61427708",
          "hs_parent_company_id": null,
          "hs_pinned_engagement_id": null,
          "hs_pipeline": "companies-lifecycle-pipeline",
          "hs_predictivecontactscore_v2": null,
          "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
          "hs_quick_context": null,
          "hs_read_only": null,
          "hs_revenue_range": null,
          "hs_sales_email_last_replied": null,
          "hs_shared_team_ids": null,
          "hs_shared_user_ids": null,
          "hs_source_object_id": null,
          "hs_target_account": null,
          "hs_target_account_probability": "0.7956095337867737",
          "hs_target_account_recommendation_snooze_time": null,
          "hs_target_account_recommendation_state": null,
          "hs_time_in_customer": null,
          "hs_time_in_evangelist": null,
          "hs_time_in_lead": "33791435759",
          "hs_time_in_marketingqualifiedlead": null,
          "hs_time_in_opportunity": "163447602",
          "hs_time_in_other": null,
          "hs_time_in_salesqualifiedlead": null,
          "hs_time_in_subscriber": null,
          "hs_total_deal_value": null,
          "hs_unique_creation_key": null,
          "hs_updated_by_user_id": "61428794",
          "hs_user_ids_of_all_notification_followers": null,
          "hs_user_ids_of_all_notification_unfollowers": null,
          "hs_user_ids_of_all_owners": "61427708",
          "hs_was_imported": null,
          "hubspot_owner_assigneddate": "2023-12-13T22:20:43.643Z",
          "hubspot_owner_id": "587722345",
          "hubspot_team_id": null,
          "hubspotscore": null,
          "industry": "LEISURE_TRAVEL_TOURISM",
          "is_public": "true",
          "lifecyclestage": "opportunity",
          "linkedin_company_page": "https://www.linkedin.com/company/airbnb",
          "linkedinbio": "Airbnb is the world's largest community-driven hospitality company, offering homes and experiences in 191 countries. It is an online marketplace connecting people to unique accommodations and experiences globally.",
          "name": "Airbnb, Inc.",
          "notes_last_contacted": null,
          "notes_last_updated": null,
          "notes_next_activity_date": null,
          "num_associated_contacts": "11",
          "num_associated_deals": "1",
          "num_contacted_notes": null,
          "num_conversion_events": "0",
          "num_conversion_events_cardinality_sum_d095f14b": null,
          "num_notes": null,
          "numberofemployees": "10000",
          "owneremail": null,
          "ownername": null,
          "phone": "+1 415-800-5958",
          "recent_conversion_date": null,
          "recent_conversion_date_timestamp_latest_value_72856da1": null,
          "recent_conversion_event_name": null,
          "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
          "recent_deal_amount": null,
          "recent_deal_close_date": null,
          "state": "CA",
          "timezone": "America/Los_Angeles",
          "total_money_raised": "4.4B",
          "total_revenue": null,
          "twitterbio": null,
          "twitterfollowers": null,
          "twitterhandle": "airbnb",
          "type": null,
          "web_technologies": "aws_route_53;unbounce;app_nexus;salesforce;stripe;google_apps;amazon_s3;google_analytics;google_tag_manager;braintree",
          "website": "airbnb.com",
          "zip": "94103"
        },
        "updatedAt": "2025-01-08T00:51:24.935Z"
      }
    },
    {
      "associations": {
        "contacts": [
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "82016902681"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "82016902681"
          }
        ]
      },
      "fields": {
        "about_us": null,
        "address": null,
        "address2": null,
        "annualrevenue": null,
        "city": "Test",
        "closedate": null,
        "country": null,
        "createdate": "2024-10-16T21:20:53.405Z",
        "days_to_close": null,
        "description": null,
        "domain": "testcompany.com",
        "engagements_last_meeting_booked": null,
        "engagements_last_meeting_booked_campaign": null,
        "engagements_last_meeting_booked_medium": null,
        "engagements_last_meeting_booked_source": null,
        "facebook_company_page": null,
        "facebookfans": null,
        "first_contact_createdate": "2024-12-04T00:45:40.381Z",
        "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
        "first_conversion_date": null,
        "first_conversion_event_name": null,
        "first_deal_created_date": "2025-01-08T00:51:39.492Z",
        "founded_year": null,
        "googleplus_page": null,
        "hs_additional_domains": null,
        "hs_all_accessible_team_ids": null,
        "hs_all_assigned_business_unit_ids": "0",
        "hs_all_owner_ids": "593937029",
        "hs_all_team_ids": null,
        "hs_analytics_first_timestamp": "2024-12-04T00:45:40.381Z",
        "hs_analytics_first_touch_converting_campaign": null,
        "hs_analytics_first_visit_timestamp": null,
        "hs_analytics_last_timestamp": null,
        "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
        "hs_analytics_last_touch_converting_campaign": null,
        "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
        "hs_analytics_last_visit_timestamp": null,
        "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
        "hs_analytics_latest_source": "OFFLINE",
        "hs_analytics_latest_source_data_1": "CRM_UI",
        "hs_analytics_latest_source_data_2": "userId:61526375",
        "hs_analytics_latest_source_timestamp": "2024-12-04T00:45:40.537Z",
        "hs_analytics_num_page_views": "0",
        "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
        "hs_analytics_num_visits": "0",
        "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
        "hs_analytics_source": "OFFLINE",
        "hs_analytics_source_data_1": "CRM_UI",
        "hs_analytics_source_data_2": "userId:61526375",
        "hs_annual_revenue_currency_code": null,
        "hs_avatar_filemanager_key": null,
        "hs_country_code": null,
        "hs_created_by_user_id": "61526374",
        "hs_createdate": null,
        "hs_csm_sentiment": null,
        "hs_customer_success_ticket_sentiment": null,
        "hs_date_entered_customer": null,
        "hs_date_entered_evangelist": null,
        "hs_date_entered_lead": "2024-10-16T21:20:53.405Z",
        "hs_date_entered_marketingqualifiedlead": null,
        "hs_date_entered_opportunity": "2025-01-08T00:51:40.216Z",
        "hs_date_entered_other": null,
        "hs_date_entered_salesqualifiedlead": null,
        "hs_date_entered_subscriber": null,
        "hs_date_exited_customer": null,
        "hs_date_exited_evangelist": null,
        "hs_date_exited_lead": "2025-01-08T00:51:40.216Z",
        "hs_date_exited_marketingqualifiedlead": null,
        "hs_date_exited_opportunity": null,
        "hs_date_exited_other": null,
        "hs_date_exited_salesqualifiedlead": null,
        "hs_date_exited_subscriber": null,
        "hs_employee_range": null,
        "hs_ideal_customer_profile": null,
        "hs_industry_group": null,
        "hs_is_enriched": null,
        "hs_is_target_account": null,
        "hs_keywords": null,
        "hs_last_booked_meeting_date": null,
        "hs_last_logged_call_date": null,
        "hs_last_metered_enrichment_timestamp": null,
        "hs_last_open_task_date": null,
        "hs_last_sales_activity_date": null,
        "hs_last_sales_activity_timestamp": null,
        "hs_last_sales_activity_type": null,
        "hs_lastmodifieddate": "2025-01-08T00:51:43.512Z",
        "hs_latest_createdate_of_active_subscriptions": null,
        "hs_latest_meeting_activity": null,
        "hs_lead_status": null,
        "hs_linkedin_handle": null,
        "hs_logo_url": null,
        "hs_merged_object_ids": null,
        "hs_notes_last_activity": null,
        "hs_notes_next_activity": null,
        "hs_notes_next_activity_type": null,
        "hs_num_blockers": "0",
        "hs_num_child_companies": "0",
        "hs_num_contacts_with_buying_roles": "0",
        "hs_num_decision_makers": "0",
        "hs_num_open_deals": "1",
        "hs_object_id": "23897303830",
        "hs_object_source": "CRM_UI",
        "hs_object_source_detail_1": null,
        "hs_object_source_detail_2": null,
        "hs_object_source_detail_3": null,
        "hs_object_source_id": "userId:61526374",
        "hs_object_source_label": "CRM_UI",
        "hs_object_source_user_id": "61526374",
        "hs_parent_company_id": null,
        "hs_pinned_engagement_id": null,
        "hs_pipeline": "companies-lifecycle-pipeline",
        "hs_predictivecontactscore_v2": null,
        "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
        "hs_quick_context": null,
        "hs_read_only": null,
        "hs_revenue_range": null,
        "hs_sales_email_last_replied": null,
        "hs_shared_team_ids": null,
        "hs_shared_user_ids": null,
        "hs_source_object_id": null,
        "hs_target_account": null,
        "hs_target_account_probability": "0.46257445216178894",
        "hs_target_account_recommendation_snooze_time": null,
        "hs_target_account_recommendation_state": null,
        "hs_time_in_customer": null,
        "hs_time_in_evangelist": null,
        "hs_time_in_lead": "7183846811",
        "hs_time_in_marketingqualifiedlead": null,
        "hs_time_in_opportunity": "163426788",
        "hs_time_in_other": null,
        "hs_time_in_salesqualifiedlead": null,
        "hs_time_in_subscriber": null,
        "hs_total_deal_value": null,
        "hs_unique_creation_key": null,
        "hs_updated_by_user_id": "61427708",
        "hs_user_ids_of_all_notification_followers": null,
        "hs_user_ids_of_all_notification_unfollowers": null,
        "hs_user_ids_of_all_owners": "61526374",
        "hs_was_imported": null,
        "hubspot_owner_assigneddate": "2024-10-16T21:20:53.405Z",
        "hubspot_team_id": null,
        "hubspotscore": null,
        "industry": "ALTERNATIVE_DISPUTE_RESOLUTION",
        "is_public": null,
        "lifecyclestage": "opportunity",
        "linkedin_company_page": null,
        "linkedinbio": null,
        "name": "Test Company",
        "notes_last_contacted": null,
        "notes_last_updated": null,
        "notes_next_activity_date": null,
        "num_associated_contacts": "1",
        "num_associated_deals": "1",
        "num_contacted_notes": null,
        "num_conversion_events": "0",
        "num_conversion_events_cardinality_sum_d095f14b": null,
        "num_notes": null,
        "numberofemployees": null,
        "owneremail": null,
        "ownername": null,
        "phone": null,
        "recent_conversion_date": null,
        "recent_conversion_date_timestamp_latest_value_72856da1": null,
        "recent_conversion_event_name": null,
        "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
        "recent_deal_amount": null,
        "recent_deal_close_date": null,
        "state": "Abu Dhabi",
        "timezone": null,
        "total_money_raised": null,
        "total_revenue": null,
        "twitterbio": null,
        "twitterfollowers": null,
        "twitterhandle": null,
        "type": "PROSPECT",
        "web_technologies": null,
        "website": "testcompany.com",
        "zip": "12345"
      },
      "mappedFields": {
        "userId": "593937029"
      },
      "raw": {
        "archived": false,
        "associations": {
          "contacts": {
            "results": [
              {
                "id": "82016902681",
                "type": "company_to_contact"
              },
              {
                "id": "82016902681",
                "type": "company_to_contact_unlabeled"
              }
            ]
          }
        },
        "createdAt": "2024-10-16T21:20:53.405Z",
        "id": "23897303830",
        "properties": {
          "about_us": null,
          "address": null,
          "address2": null,
          "annualrevenue": null,
          "city": "Test",
          "closedate": null,
          "country": null,
          "createdate": "2024-10-16T21:20:53.405Z",
          "days_to_close": null,
          "description": null,
          "domain": "testcompany.com",
          "engagements_last_meeting_booked": null,
          "engagements_last_meeting_booked_campaign": null,
          "engagements_last_meeting_booked_medium": null,
          "engagements_last_meeting_booked_source": null,
          "facebook_company_page": null,
          "facebookfans": null,
          "first_contact_createdate": "2024-12-04T00:45:40.381Z",
          "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
          "first_conversion_date": null,
          "first_conversion_event_name": null,
          "first_deal_created_date": "2025-01-08T00:51:39.492Z",
          "founded_year": null,
          "googleplus_page": null,
          "hs_additional_domains": null,
          "hs_all_accessible_team_ids": null,
          "hs_all_assigned_business_unit_ids": "0",
          "hs_all_owner_ids": "593937029",
          "hs_all_team_ids": null,
          "hs_analytics_first_timestamp": "2024-12-04T00:45:40.381Z",
          "hs_analytics_first_touch_converting_campaign": null,
          "hs_analytics_first_visit_timestamp": null,
          "hs_analytics_last_timestamp": null,
          "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
          "hs_analytics_last_touch_converting_campaign": null,
          "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
          "hs_analytics_last_visit_timestamp": null,
          "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
          "hs_analytics_latest_source": "OFFLINE",
          "hs_analytics_latest_source_data_1": "CRM_UI",
          "hs_analytics_latest_source_data_2": "userId:61526375",
          "hs_analytics_latest_source_timestamp": "2024-12-04T00:45:40.537Z",
          "hs_analytics_num_page_views": "0",
          "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
          "hs_analytics_num_visits": "0",
          "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
          "hs_analytics_source": "OFFLINE",
          "hs_analytics_source_data_1": "CRM_UI",
          "hs_analytics_source_data_2": "userId:61526375",
          "hs_annual_revenue_currency_code": null,
          "hs_avatar_filemanager_key": null,
          "hs_country_code": null,
          "hs_created_by_user_id": "61526374",
          "hs_createdate": null,
          "hs_csm_sentiment": null,
          "hs_customer_success_ticket_sentiment": null,
          "hs_date_entered_customer": null,
          "hs_date_entered_evangelist": null,
          "hs_date_entered_lead": "2024-10-16T21:20:53.405Z",
          "hs_date_entered_marketingqualifiedlead": null,
          "hs_date_entered_opportunity": "2025-01-08T00:51:40.216Z",
          "hs_date_entered_other": null,
          "hs_date_entered_salesqualifiedlead": null,
          "hs_date_entered_subscriber": null,
          "hs_date_exited_customer": null,
          "hs_date_exited_evangelist": null,
          "hs_date_exited_lead": "2025-01-08T00:51:40.216Z",
          "hs_date_exited_marketingqualifiedlead": null,
          "hs_date_exited_opportunity": null,
          "hs_date_exited_other": null,
          "hs_date_exited_salesqualifiedlead": null,
          "hs_date_exited_subscriber": null,
          "hs_employee_range": null,
          "hs_ideal_customer_profile": null,
          "hs_industry_group": null,
          "hs_is_enriched": null,
          "hs_is_target_account": null,
          "hs_keywords": null,
          "hs_last_booked_meeting_date": null,
          "hs_last_logged_call_date": null,
          "hs_last_metered_enrichment_timestamp": null,
          "hs_last_open_task_date": null,
          "hs_last_sales_activity_date": null,
          "hs_last_sales_activity_timestamp": null,
          "hs_last_sales_activity_type": null,
          "hs_lastmodifieddate": "2025-01-08T00:51:43.512Z",
          "hs_latest_createdate_of_active_subscriptions": null,
          "hs_latest_meeting_activity": null,
          "hs_lead_status": null,
          "hs_linkedin_handle": null,
          "hs_logo_url": null,
          "hs_merged_object_ids": null,
          "hs_notes_last_activity": null,
          "hs_notes_next_activity": null,
          "hs_notes_next_activity_type": null,
          "hs_num_blockers": "0",
          "hs_num_child_companies": "0",
          "hs_num_contacts_with_buying_roles": "0",
          "hs_num_decision_makers": "0",
          "hs_num_open_deals": "1",
          "hs_object_id": "23897303830",
          "hs_object_source": "CRM_UI",
          "hs_object_source_detail_1": null,
          "hs_object_source_detail_2": null,
          "hs_object_source_detail_3": null,
          "hs_object_source_id": "userId:61526374",
          "hs_object_source_label": "CRM_UI",
          "hs_object_source_user_id": "61526374",
          "hs_parent_company_id": null,
          "hs_pinned_engagement_id": null,
          "hs_pipeline": "companies-lifecycle-pipeline",
          "hs_predictivecontactscore_v2": null,
          "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
          "hs_quick_context": null,
          "hs_read_only": null,
          "hs_revenue_range": null,
          "hs_sales_email_last_replied": null,
          "hs_shared_team_ids": null,
          "hs_shared_user_ids": null,
          "hs_source_object_id": null,
          "hs_target_account": null,
          "hs_target_account_probability": "0.46257445216178894",
          "hs_target_account_recommendation_snooze_time": null,
          "hs_target_account_recommendation_state": null,
          "hs_time_in_customer": null,
          "hs_time_in_evangelist": null,
          "hs_time_in_lead": "7183846811",
          "hs_time_in_marketingqualifiedlead": null,
          "hs_time_in_opportunity": "163426788",
          "hs_time_in_other": null,
          "hs_time_in_salesqualifiedlead": null,
          "hs_time_in_subscriber": null,
          "hs_total_deal_value": null,
          "hs_unique_creation_key": null,
          "hs_updated_by_user_id": "61427708",
          "hs_user_ids_of_all_notification_followers": null,
          "hs_user_ids_of_all_notification_unfollowers": null,
          "hs_user_ids_of_all_owners": "61526374",
          "hs_was_imported": null,
          "hubspot_owner_assigneddate": "2024-10-16T21:20:53.405Z",
          "hubspot_owner_id": "593937029",
          "hubspot_team_id": null,
          "hubspotscore": null,
          "industry": "ALTERNATIVE_DISPUTE_RESOLUTION",
          "is_public": null,
          "lifecyclestage": "opportunity",
          "linkedin_company_page": null,
          "linkedinbio": null,
          "name": "Test Company",
          "notes_last_contacted": null,
          "notes_last_updated": null,
          "notes_next_activity_date": null,
          "num_associated_contacts": "1",
          "num_associated_deals": "1",
          "num_contacted_notes": null,
          "num_conversion_events": "0",
          "num_conversion_events_cardinality_sum_d095f14b": null,
          "num_notes": null,
          "numberofemployees": null,
          "owneremail": null,
          "ownername": null,
          "phone": null,
          "recent_conversion_date": null,
          "recent_conversion_date_timestamp_latest_value_72856da1": null,
          "recent_conversion_event_name": null,
          "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
          "recent_deal_amount": null,
          "recent_deal_close_date": null,
          "state": "Abu Dhabi",
          "timezone": null,
          "total_money_raised": null,
          "total_revenue": null,
          "twitterbio": null,
          "twitterfollowers": null,
          "twitterhandle": null,
          "type": "PROSPECT",
          "web_technologies": null,
          "website": "testcompany.com",
          "zip": "12345"
        },
        "updatedAt": "2025-01-08T00:51:43.512Z"
      }
    },
    {
      "associations": {
        "contacts": [
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86274522916"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86274676136"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86274676136"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86281943922"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=2 label=Contact with Primary Company",
            "objectId": "86292403302"
          },
          {
            "associationType": "category=HUBSPOT_DEFINED id=280",
            "objectId": "86292403302"
          }
        ]
      },
      "fields": {
        "about_us": null,
        "address": null,
        "address2": null,
        "annualrevenue": "1000000000",
        "city": "San Francisco",
        "closedate": null,
        "country": "United States",
        "createdate": "2024-12-06T00:18:51.357Z",
        "days_to_close": null,
        "description": "Ampersand provides a developer platform designed to facilitate the creation of native product integrations with customer relationship management systems and other go-to-market applications, featuring a scalable architecture and a user-friendly framework for extensible and configurable integrations.",
        "domain": "withampersand.com",
        "engagements_last_meeting_booked": null,
        "engagements_last_meeting_booked_campaign": null,
        "engagements_last_meeting_booked_medium": null,
        "engagements_last_meeting_booked_source": null,
        "facebook_company_page": null,
        "facebookfans": null,
        "first_contact_createdate": "2024-12-20T00:05:04.726Z",
        "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
        "first_conversion_date": null,
        "first_conversion_event_name": null,
        "first_deal_created_date": "2025-01-08T00:50:45.030Z",
        "founded_year": "2022",
        "googleplus_page": null,
        "hs_additional_domains": null,
        "hs_all_accessible_team_ids": null,
        "hs_all_assigned_business_unit_ids": "0",
        "hs_all_owner_ids": "593937030",
        "hs_all_team_ids": null,
        "hs_analytics_first_timestamp": "2024-12-20T00:05:00Z",
        "hs_analytics_first_touch_converting_campaign": null,
        "hs_analytics_first_visit_timestamp": null,
        "hs_analytics_last_timestamp": null,
        "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
        "hs_analytics_last_touch_converting_campaign": null,
        "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
        "hs_analytics_last_visit_timestamp": null,
        "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
        "hs_analytics_latest_source": "OFFLINE",
        "hs_analytics_latest_source_data_1": "INTEGRATION",
        "hs_analytics_latest_source_data_2": "2317233",
        "hs_analytics_latest_source_timestamp": "2024-12-20T01:31:00Z",
        "hs_analytics_num_page_views": "0",
        "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
        "hs_analytics_num_visits": "0",
        "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
        "hs_analytics_source": "OFFLINE",
        "hs_analytics_source_data_1": "INTEGRATION",
        "hs_analytics_source_data_2": "2317233",
        "hs_annual_revenue_currency_code": null,
        "hs_avatar_filemanager_key": null,
        "hs_country_code": null,
        "hs_created_by_user_id": "61526375",
        "hs_createdate": null,
        "hs_csm_sentiment": null,
        "hs_customer_success_ticket_sentiment": null,
        "hs_date_entered_customer": null,
        "hs_date_entered_evangelist": null,
        "hs_date_entered_lead": "2024-12-06T00:18:51.357Z",
        "hs_date_entered_marketingqualifiedlead": null,
        "hs_date_entered_opportunity": "2025-01-08T00:50:45.536Z",
        "hs_date_entered_other": null,
        "hs_date_entered_salesqualifiedlead": null,
        "hs_date_entered_subscriber": null,
        "hs_date_exited_customer": null,
        "hs_date_exited_evangelist": null,
        "hs_date_exited_lead": "2025-01-08T00:50:45.536Z",
        "hs_date_exited_marketingqualifiedlead": null,
        "hs_date_exited_opportunity": null,
        "hs_date_exited_other": null,
        "hs_date_exited_salesqualifiedlead": null,
        "hs_date_exited_subscriber": null,
        "hs_employee_range": null,
        "hs_ideal_customer_profile": null,
        "hs_industry_group": null,
        "hs_is_enriched": null,
        "hs_is_target_account": null,
        "hs_keywords": null,
        "hs_last_booked_meeting_date": null,
        "hs_last_logged_call_date": null,
        "hs_last_metered_enrichment_timestamp": null,
        "hs_last_open_task_date": null,
        "hs_last_sales_activity_date": null,
        "hs_last_sales_activity_timestamp": null,
        "hs_last_sales_activity_type": null,
        "hs_lastmodifieddate": "2025-01-08T00:50:46.108Z",
        "hs_latest_createdate_of_active_subscriptions": null,
        "hs_latest_meeting_activity": null,
        "hs_lead_status": null,
        "hs_linkedin_handle": null,
        "hs_logo_url": "https://logo.clearbit.com/withampersand.com",
        "hs_merged_object_ids": null,
        "hs_notes_last_activity": null,
        "hs_notes_next_activity": null,
        "hs_notes_next_activity_type": null,
        "hs_num_blockers": "0",
        "hs_num_child_companies": "0",
        "hs_num_contacts_with_buying_roles": "0",
        "hs_num_decision_makers": "0",
        "hs_num_open_deals": "1",
        "hs_object_id": "26655958117",
        "hs_object_source": "CRM_UI",
        "hs_object_source_detail_1": null,
        "hs_object_source_detail_2": null,
        "hs_object_source_detail_3": null,
        "hs_object_source_id": "userId:61526375",
        "hs_object_source_label": "CRM_UI",
        "hs_object_source_user_id": "61526375",
        "hs_parent_company_id": null,
        "hs_pinned_engagement_id": null,
        "hs_pipeline": "companies-lifecycle-pipeline",
        "hs_predictivecontactscore_v2": null,
        "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
        "hs_quick_context": null,
        "hs_read_only": null,
        "hs_revenue_range": null,
        "hs_sales_email_last_replied": null,
        "hs_shared_team_ids": null,
        "hs_shared_user_ids": null,
        "hs_source_object_id": null,
        "hs_target_account": null,
        "hs_target_account_probability": "0.6707875728607178",
        "hs_target_account_recommendation_snooze_time": null,
        "hs_target_account_recommendation_state": null,
        "hs_time_in_customer": null,
        "hs_time_in_evangelist": null,
        "hs_time_in_lead": "2853114179",
        "hs_time_in_marketingqualifiedlead": null,
        "hs_time_in_opportunity": "163481468",
        "hs_time_in_other": null,
        "hs_time_in_salesqualifiedlead": null,
        "hs_time_in_subscriber": null,
        "hs_total_deal_value": null,
        "hs_unique_creation_key": null,
        "hs_updated_by_user_id": "61526375",
        "hs_user_ids_of_all_notification_followers": null,
        "hs_user_ids_of_all_notification_unfollowers": null,
        "hs_user_ids_of_all_owners": "61526375",
        "hs_was_imported": null,
        "hubspot_owner_assigneddate": "2024-12-06T00:18:51.357Z",
        "hubspot_team_id": null,
        "hubspotscore": null,
        "industry": "COMPUTER_SOFTWARE",
        "is_public": "false",
        "lifecyclestage": "opportunity",
        "linkedin_company_page": "https://www.linkedin.com/company/withampersandmapped",
        "linkedinbio": "Ampersand provides a developer platform designed to facilitate the creation of native product integrations with customer relationship management systems and other go-to-market applications, featuring a scalable architecture and a user-friendly framework for extensible and configurable integrations.",
        "name": "Ampersand new",
        "notes_last_contacted": null,
        "notes_last_updated": null,
        "notes_next_activity_date": null,
        "num_associated_contacts": "4",
        "num_associated_deals": "1",
        "num_contacted_notes": null,
        "num_conversion_events": "0",
        "num_conversion_events_cardinality_sum_d095f14b": null,
        "num_notes": null,
        "numberofemployees": "10",
        "owneremail": null,
        "ownername": null,
        "phone": null,
        "recent_conversion_date": null,
        "recent_conversion_date_timestamp_latest_value_72856da1": null,
        "recent_conversion_event_name": null,
        "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
        "recent_deal_amount": null,
        "recent_deal_close_date": null,
        "state": "CA",
        "timezone": "America/Los_Angeles",
        "total_money_raised": "4700000",
        "total_revenue": null,
        "twitterbio": null,
        "twitterfollowers": null,
        "twitterhandle": null,
        "type": null,
        "web_technologies": "google_tag_manager;google_apps",
        "website": "withampersand.com",
        "zip": "94103"
      },
      "mappedFields": {
        "userId": "593937030"
      },
      "raw": {
        "archived": false,
        "associations": {
          "contacts": {
            "results": [
              {
                "id": "86274676136",
                "type": "company_to_contact"
              },
              {
                "id": "86292403302",
                "type": "company_to_contact"
              },
              {
                "id": "86274522916",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86274676136",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86281943922",
                "type": "company_to_contact_unlabeled"
              },
              {
                "id": "86292403302",
                "type": "company_to_contact_unlabeled"
              }
            ]
          }
        },
        "createdAt": "2024-12-06T00:18:51.357Z",
        "id": "26655958117",
        "properties": {
          "about_us": null,
          "address": null,
          "address2": null,
          "annualrevenue": "1000000000",
          "city": "San Francisco",
          "closedate": null,
          "country": "United States",
          "createdate": "2024-12-06T00:18:51.357Z",
          "days_to_close": null,
          "description": "Ampersand provides a developer platform designed to facilitate the creation of native product integrations with customer relationship management systems and other go-to-market applications, featuring a scalable architecture and a user-friendly framework for extensible and configurable integrations.",
          "domain": "withampersand.com",
          "engagements_last_meeting_booked": null,
          "engagements_last_meeting_booked_campaign": null,
          "engagements_last_meeting_booked_medium": null,
          "engagements_last_meeting_booked_source": null,
          "facebook_company_page": null,
          "facebookfans": null,
          "first_contact_createdate": "2024-12-20T00:05:04.726Z",
          "first_contact_createdate_timestamp_earliest_value_78b50eea": null,
          "first_conversion_date": null,
          "first_conversion_event_name": null,
          "first_deal_created_date": "2025-01-08T00:50:45.030Z",
          "founded_year": "2022",
          "googleplus_page": null,
          "hs_additional_domains": null,
          "hs_all_accessible_team_ids": null,
          "hs_all_assigned_business_unit_ids": "0",
          "hs_all_owner_ids": "593937030",
          "hs_all_team_ids": null,
          "hs_analytics_first_timestamp": "2024-12-20T00:05:00Z",
          "hs_analytics_first_touch_converting_campaign": null,
          "hs_analytics_first_visit_timestamp": null,
          "hs_analytics_last_timestamp": null,
          "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": null,
          "hs_analytics_last_touch_converting_campaign": null,
          "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": null,
          "hs_analytics_last_visit_timestamp": null,
          "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": null,
          "hs_analytics_latest_source": "OFFLINE",
          "hs_analytics_latest_source_data_1": "INTEGRATION",
          "hs_analytics_latest_source_data_2": "2317233",
          "hs_analytics_latest_source_timestamp": "2024-12-20T01:31:00Z",
          "hs_analytics_num_page_views": "0",
          "hs_analytics_num_page_views_cardinality_sum_e46e85b0": null,
          "hs_analytics_num_visits": "0",
          "hs_analytics_num_visits_cardinality_sum_53d952a6": null,
          "hs_analytics_source": "OFFLINE",
          "hs_analytics_source_data_1": "INTEGRATION",
          "hs_analytics_source_data_2": "2317233",
          "hs_annual_revenue_currency_code": null,
          "hs_avatar_filemanager_key": null,
          "hs_country_code": null,
          "hs_created_by_user_id": "61526375",
          "hs_createdate": null,
          "hs_csm_sentiment": null,
          "hs_customer_success_ticket_sentiment": null,
          "hs_date_entered_customer": null,
          "hs_date_entered_evangelist": null,
          "hs_date_entered_lead": "2024-12-06T00:18:51.357Z",
          "hs_date_entered_marketingqualifiedlead": null,
          "hs_date_entered_opportunity": "2025-01-08T00:50:45.536Z",
          "hs_date_entered_other": null,
          "hs_date_entered_salesqualifiedlead": null,
          "hs_date_entered_subscriber": null,
          "hs_date_exited_customer": null,
          "hs_date_exited_evangelist": null,
          "hs_date_exited_lead": "2025-01-08T00:50:45.536Z",
          "hs_date_exited_marketingqualifiedlead": null,
          "hs_date_exited_opportunity": null,
          "hs_date_exited_other": null,
          "hs_date_exited_salesqualifiedlead": null,
          "hs_date_exited_subscriber": null,
          "hs_employee_range": null,
          "hs_ideal_customer_profile": null,
          "hs_industry_group": null,
          "hs_is_enriched": null,
          "hs_is_target_account": null,
          "hs_keywords": null,
          "hs_last_booked_meeting_date": null,
          "hs_last_logged_call_date": null,
          "hs_last_metered_enrichment_timestamp": null,
          "hs_last_open_task_date": null,
          "hs_last_sales_activity_date": null,
          "hs_last_sales_activity_timestamp": null,
          "hs_last_sales_activity_type": null,
          "hs_lastmodifieddate": "2025-01-08T00:50:46.108Z",
          "hs_latest_createdate_of_active_subscriptions": null,
          "hs_latest_meeting_activity": null,
          "hs_lead_status": null,
          "hs_linkedin_handle": null,
          "hs_logo_url": "https://logo.clearbit.com/withampersand.com",
          "hs_merged_object_ids": null,
          "hs_notes_last_activity": null,
          "hs_notes_next_activity": null,
          "hs_notes_next_activity_type": null,
          "hs_num_blockers": "0",
          "hs_num_child_companies": "0",
          "hs_num_contacts_with_buying_roles": "0",
          "hs_num_decision_makers": "0",
          "hs_num_open_deals": "1",
          "hs_object_id": "26655958117",
          "hs_object_source": "CRM_UI",
          "hs_object_source_detail_1": null,
          "hs_object_source_detail_2": null,
          "hs_object_source_detail_3": null,
          "hs_object_source_id": "userId:61526375",
          "hs_object_source_label": "CRM_UI",
          "hs_object_source_user_id": "61526375",
          "hs_parent_company_id": null,
          "hs_pinned_engagement_id": null,
          "hs_pipeline": "companies-lifecycle-pipeline",
          "hs_predictivecontactscore_v2": null,
          "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": null,
          "hs_quick_context": null,
          "hs_read_only": null,
          "hs_revenue_range": null,
          "hs_sales_email_last_replied": null,
          "hs_shared_team_ids": null,
          "hs_shared_user_ids": null,
          "hs_source_object_id": null,
          "hs_target_account": null,
          "hs_target_account_probability": "0.6707875728607178",
          "hs_target_account_recommendation_snooze_time": null,
          "hs_target_account_recommendation_state": null,
          "hs_time_in_customer": null,
          "hs_time_in_evangelist": null,
          "hs_time_in_lead": "2853114179",
          "hs_time_in_marketingqualifiedlead": null,
          "hs_time_in_opportunity": "163481468",
          "hs_time_in_other": null,
          "hs_time_in_salesqualifiedlead": null,
          "hs_time_in_subscriber": null,
          "hs_total_deal_value": null,
          "hs_unique_creation_key": null,
          "hs_updated_by_user_id": "61526375",
          "hs_user_ids_of_all_notification_followers": null,
          "hs_user_ids_of_all_notification_unfollowers": null,
          "hs_user_ids_of_all_owners": "61526375",
          "hs_was_imported": null,
          "hubspot_owner_assigneddate": "2024-12-06T00:18:51.357Z",
          "hubspot_owner_id": "593937030",
          "hubspot_team_id": null,
          "hubspotscore": null,
          "industry": "COMPUTER_SOFTWARE",
          "is_public": "false",
          "lifecyclestage": "opportunity",
          "linkedin_company_page": "https://www.linkedin.com/company/withampersandmapped",
          "linkedinbio": "Ampersand provides a developer platform designed to facilitate the creation of native product integrations with customer relationship management systems and other go-to-market applications, featuring a scalable architecture and a user-friendly framework for extensible and configurable integrations.",
          "name": "Ampersand new",
          "notes_last_contacted": null,
          "notes_last_updated": null,
          "notes_next_activity_date": null,
          "num_associated_contacts": "4",
          "num_associated_deals": "1",
          "num_contacted_notes": null,
          "num_conversion_events": "0",
          "num_conversion_events_cardinality_sum_d095f14b": null,
          "num_notes": null,
          "numberofemployees": "10",
          "owneremail": null,
          "ownername": null,
          "phone": null,
          "recent_conversion_date": null,
          "recent_conversion_date_timestamp_latest_value_72856da1": null,
          "recent_conversion_event_name": null,
          "recent_conversion_event_name_timestamp_latest_value_66c820bf": null,
          "recent_deal_amount": null,
          "recent_deal_close_date": null,
          "state": "CA",
          "timezone": "America/Los_Angeles",
          "total_money_raised": "4700000",
          "total_revenue": null,
          "twitterbio": null,
          "twitterfollowers": null,
          "twitterhandle": null,
          "type": null,
          "web_technologies": "google_tag_manager;google_apps",
          "website": "withampersand.com",
          "zip": "94103"
        },
        "updatedAt": "2025-01-08T00:50:46.108Z"
      }
    }
  ],
  "resultInfo": {
    "numRecords": 3,
    "type": "inline"
  },
  "workspace": "44237313"
}
```