### PR TITLE
feat(tests): Metadata.Errors compare with subset of err

### DIFF
--- a/providers/apollo/metadata_test.go
+++ b/providers/apollo/metadata_test.go
@@ -1,12 +1,13 @@
 package apollo
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -94,8 +95,10 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					},
 				},
 				Errors: map[string]error{
-					"Arsenal": common.NewHTTPStatusError(http.StatusBadRequest,
-						fmt.Errorf("%w: %s", common.ErrRetryable, string(unsupportedResponse))),
+					"arsenal": mockutils.ExpectedSubsetErrors{
+						common.ErrCaller,
+						errors.New(string(unsupportedResponse)), // nolint:goerr113
+					},
 				},
 			},
 			ExpectedErrs: nil,

--- a/test/utils/mockutils/errors.go
+++ b/test/utils/mockutils/errors.go
@@ -1,0 +1,30 @@
+package mockutils
+
+import (
+	"errors"
+	"strings"
+)
+
+// ExpectedSubsetErrors represents a collection of errors expected to be found within a target wrapped error.
+// Instead of constructing and comparing a full wrapped error stack, this `error type` focuses on verifying that
+// critical errors are present in the wrapped Go error.
+//
+// By using this type, you dictate to the testing code to perform subset comparison via `errors.Is`.
+type ExpectedSubsetErrors []error
+
+// errorsAre returns true if each expected error is present within the target error object.
+// It is similar to errors.Is() but is applied on list of expected errors.
+func errorsAre(actualError error, expectedErrors ExpectedSubsetErrors) bool {
+	for _, expected := range expectedErrors {
+		if !errors.Is(actualError, expected) &&
+			!strings.Contains(actualError.Error(), expected.Error()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (e ExpectedSubsetErrors) Error() string {
+	return errors.Join(e...).Error()
+}

--- a/test/utils/mockutils/metadataResult.go
+++ b/test/utils/mockutils/metadataResult.go
@@ -56,6 +56,30 @@ func (metadataResultComparator) SubsetFields(actual, expected *common.ListObject
 	return true
 }
 
+func (metadataResultComparator) SubsetErrors(actual, expected *common.ListObjectMetadataResult) bool {
+	for objectName, expectedError := range expected.Errors {
+		actualError, ok := actual.Errors[objectName]
+		if !ok {
+			return false
+		}
+
+		// The tester may specify ExpectedSubsetErrors with a list of errors to be present inside actualError.
+		var expectedErrors ExpectedSubsetErrors
+		if !errors.As(expectedError, &expectedErrors) {
+			// Single expected error.
+			expectedErrors = ExpectedSubsetErrors{expectedError}
+		}
+
+		if !errorsAre(actualError, expectedErrors) {
+			// Subset of errors is not found under actual error for current object name.
+			// No need to check other object names.
+			return false
+		}
+	}
+
+	return true
+}
+
 // ValidateReadConformsMetadata this will check that all the fields that were returned by `Read` method
 // are a subset of ObjectMetadata. It is possible that Read will not return all the possible fields
 // which is fine and not a cause for an error.


### PR DESCRIPTION
# Feature

This mock test utility allows to compare `ListObjectMetadataResult.Errors` map.
As of now tests ignored and never relied on this field.

The utility allows exact match of errors per objectName or convinent subset, this removes the need to construct the full wrapped golang error, which is not the best pracitce in golang in a first place. It is advised to use `errors.Is()`.

By wrapping  errors under `mockutils.ExpectedSubsetErrors` you are telling the test suite comparator to apply `errors.Is()` in a loop with respect to each error. Help me out how to write better documentation to deliever this idea.


# Example on Apollo
```
Errors: map[string]error{
	"arsenal": mockutils.ExpectedSubsetErrors{
		common.ErrCaller,
		errors.New(string(unsupportedResponse)), // nolint:goerr113
	},
},
```
Explanation: The test suite will ask if deep connector returns error under "arsenal" and if `errors.Is(arsenalErr, common.ErrCaller)` && `strings.Contains(arsenalErr.Error(), unsupportedResponse)`.