### PR TITLE
tidy(Hubspot): Bootstrap Read tests

### DIFF
--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -1,0 +1,86 @@
+package hubspot
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseContacts := testutils.DataFromFile(t, "read-contacts-objects-api.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "contacts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name: "Contacts uses object API endpoint",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("hs_object_id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/crm/v3/objects/contacts"),
+				Then:  mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"hs_object_id": "1",
+					},
+					Raw: map[string]any{
+						"createdAt": "2023-10-26T17:55:48.301Z",
+					},
+				}, {
+					Fields: map[string]any{
+						"hs_object_id": "51",
+					},
+					Raw: map[string]any{
+						"createdAt": "2023-10-26T17:55:48.691Z",
+					},
+				}, {
+					Fields: map[string]any{
+						"hs_object_id": "101",
+					},
+					Raw: map[string]any{
+						"createdAt": "2023-12-13T22:20:02.649Z",
+					},
+				}},
+				NextPage: "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&properties=listId%2Cname&after=394", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -2,7 +2,6 @@ package hubspot
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -22,19 +21,12 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 		return nil, err
 	}
 
-	var (
-		rsp *common.JSONHTTPResponse
-		err error
-	)
-
-	relativeURL := strings.Join([]string{"objects", config.ObjectName, "search"}, "/")
-
-	u, err := c.getURL(relativeURL)
+	url, err := c.getCRMObjectsSearchURL(config)
 	if err != nil {
 		return nil, err
 	}
 
-	rsp, err = c.Client.Post(ctx, u, makeFilterBody(config))
+	rsp, err := c.Client.Post(ctx, url, makeFilterBody(config))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/hubspot/test/read-contacts-objects-api.json
+++ b/providers/hubspot/test/read-contacts-objects-api.json
@@ -1,0 +1,43 @@
+{
+  "results": [
+    {
+      "id": "1",
+      "properties": {
+        "createdate": "2023-10-26T17:55:48.301Z",
+        "hs_object_id": "1",
+        "lastmodifieddate": "2024-12-24T17:31:54.727Z"
+      },
+      "createdAt": "2023-10-26T17:55:48.301Z",
+      "updatedAt": "2024-12-24T17:31:54.727Z",
+      "archived": false
+    },
+    {
+      "id": "51",
+      "properties": {
+        "createdate": "2023-10-26T17:55:48.691Z",
+        "hs_object_id": "51",
+        "lastmodifieddate": "2023-12-13T22:45:30.353Z"
+      },
+      "createdAt": "2023-10-26T17:55:48.691Z",
+      "updatedAt": "2023-12-13T22:45:30.353Z",
+      "archived": false
+    },
+    {
+      "id": "101",
+      "properties": {
+        "createdate": "2023-12-13T22:20:02.649Z",
+        "hs_object_id": "101",
+        "lastmodifieddate": "2023-12-13T22:20:05.498Z"
+      },
+      "createdAt": "2023-12-13T22:20:02.649Z",
+      "updatedAt": "2023-12-13T22:20:05.498Z",
+      "archived": false
+    }
+  ],
+  "paging": {
+    "next": {
+      "after": "394",
+      "link": "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&properties=listId%2Cname&after=394"
+    }
+  }
+}

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
 )
 
 var errMissingValue = errors.New("missing value for query parameter")
 
 // getURL is a helper to return the full URL considering the base URL & module.
+// TODO: replace queryArgs with urlbuilder.New().WithQueryParam().
 func (c *Connector) getURL(arg string, queryArgs ...string) (string, error) {
 	urlBase := c.BaseURL + "/" + path.Join(c.Module.Path(), arg)
 
@@ -32,4 +36,19 @@ func (c *Connector) getURL(arg string, queryArgs ...string) (string, error) {
 	}
 
 	return urlBase, nil
+}
+
+func (c *Connector) getCRMObjectsReadURL(config common.ReadParams) (string, error) {
+	// NB: The final slash is just to emulate prior behavior in earlier versions
+	// of this code. If it turns out to be unnecessary, remove it.
+	relativeURL := "objects/" + config.ObjectName + "/"
+
+	// TODO c.getURL() doesn't make a module assumption. It is not important until Hubspot will have 2+ modules.
+	return c.getURL(relativeURL, makeCRMObjectsQueryValues(config)...)
+}
+
+func (c *Connector) getCRMObjectsSearchURL(config SearchParams) (string, error) {
+	relativeURL := strings.Join([]string{"objects", config.ObjectName, "search"}, "/")
+
+	return c.getURL(relativeURL)
 }

--- a/test/hubspot/read/contacts/main.go
+++ b/test/hubspot/read/contacts/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("email", "phone", "company", "website", "lastname", "firstname"),
+	})
+	if err != nil {
+		utils.Fail("error reading from Hubspot", "error", err)
+	}
+
+	slog.Info("Reading contacts..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Changes

* Given more API endpoints will be called I have seperated building existing API endpoints into dedicated functions and shortening the conditional branching.
* Bootstrap mock read tests.
* Added dedicated hubpost contacts read. See screenshots below.


# Testing
![image](https://github.com/user-attachments/assets/d9ca7dbf-bcd6-491d-b0e5-eed7df957e7d)


