### PR TITLE
[CON-972] feat(Hubspot): Read Lists object

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -101,6 +101,9 @@ var (
 
 	// ErrFailedToUnmarshalBody is returned when response body cannot be marshalled into some type.
 	ErrFailedToUnmarshalBody = errors.New("failed to unmarshal response body")
+
+	// ErrNextPageInvalid is returned when next page token provided in Read operation cannot be understood.
+	ErrNextPageInvalid = errors.New("next page token is invalid")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/providers/hubspot/objectName.go
+++ b/providers/hubspot/objectName.go
@@ -1,0 +1,13 @@
+package hubspot
+
+import "github.com/amp-labs/connectors/internal/datautils"
+
+// This is a list of objectsNames that are part of Hubspot CRM Module but exist outside ObjectAPIs.
+//
+// These objects cannot be accessed via `~/crm/v3/objects/{objectTypeId}/...`
+//
+// On the contrary those objects that are part of ObjectAPIs can be found
+// in the table here https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
+var crmObjectsOutsideTheObjectAPI = datautils.NewSet( //nolint:gochecknoglobals
+	"lists",
+)

--- a/providers/hubspot/params.go
+++ b/providers/hubspot/params.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	// DefaultPageSize is the default page size for paginated requests.
-	DefaultPageSize = "100"
+	DefaultPageSize    = "100"
+	DefaultPageSizeInt = 100
 )
 
 // Option is a function which mutates the hubspot connector configuration.

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -2,8 +2,10 @@ package hubspot
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/spyzhov/ajson"
 )
 
@@ -186,4 +188,23 @@ func GetResultId(row *common.ReadResultRow) string {
 
 	// If everything fails, return an empty string
 	return ""
+}
+
+func getNextRecordsURLCRM(node *ajson.Node) (string, error) {
+	hasMore, err := jsonquery.New(node).BoolWithDefault("hasMore", false)
+	if err != nil {
+		return "", err
+	}
+
+	if !hasMore {
+		// Next page doesn't exist
+		return "", nil
+	}
+
+	offset, err := jsonquery.New(node).IntegerWithDefault("offset", 0)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatInt(offset, 10), nil
 }

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -21,6 +21,16 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
+	if crmObjectsOutsideTheObjectAPI.Has(config.ObjectName) {
+		// Objects outside ObjectAPI have different endpoint while both are part of CRM module.
+		// For instance Lists are fully returned only via Search endpoint.
+		return c.SearchCRM(ctx, SearchCRMParams{
+			ObjectName: config.ObjectName,
+			Fields:     config.Fields,
+			NextPage:   config.NextPage,
+		})
+	}
+
 	// If filtering is required, then we have to use the search endpoint.
 	// The Search endpoint has a 10K record limit. In case this limit is reached,
 	// the sorting allows the caller to continue in another call by offsetting

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -16,6 +16,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
 	responseContacts := testutils.DataFromFile(t, "read-contacts-objects-api.json")
+	responseListsFirst := testutils.DataFromFile(t, "read-lists-1-first-page.json")
+	responseListsLast := testutils.DataFromFile(t, "read-lists-2-second-page.json")
 
 	tests := []testroutines.Read{
 		{
@@ -68,6 +70,69 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				}},
 				NextPage: "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&properties=listId%2Cname&after=394", // nolint:lll
 				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Lists first page is done via search",
+			Input: common.ReadParams{
+				ObjectName: "lists",
+				Fields:     connectors.Fields("processingType"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/crm/v3/lists/search"),
+				Then:  mockserver.Response(http.StatusOK, responseListsFirst),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"processingtype": "DYNAMIC",
+					},
+					Raw: map[string]any{
+						// "listId": "3",
+						"name": "Test List",
+					},
+				}, {
+					Fields: map[string]any{
+						"processingtype": "SNAPSHOT",
+					},
+					Raw: map[string]any{
+						// "listId": "4",
+						"name": "Test static company list",
+					},
+				}},
+				NextPage: "2", // Next page token is in fact an offset.
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Lists next page sends offset in payload",
+			Input: common.ReadParams{
+				ObjectName: "lists",
+				Fields:     connectors.Fields("name"),
+				NextPage:   "2", // Move offset 2 records ahead to get next page.
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.PathSuffix("/crm/v3/lists/search"),
+					mockcond.Body(`{
+						"offset": 2,
+						"count": 100
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseListsLast),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Data:     []common.ReadResultRow{},
+				NextPage: "", // empty next page is inferred from response
+				Done:     true,
 			},
 			ExpectedErrs: nil,
 		},

--- a/providers/hubspot/test/read-lists-1-first-page.json
+++ b/providers/hubspot/test/read-lists-1-first-page.json
@@ -1,0 +1,42 @@
+{
+  "offset": 2,
+  "hasMore": true,
+  "lists": [
+    {
+      "listId": "3",
+      "listVersion": 1,
+      "createdAt": "2025-01-08T20:00:31.738Z",
+      "updatedAt": "2025-01-08T20:00:31.738Z",
+      "filtersUpdatedAt": "2025-01-08T20:00:31.738Z",
+      "processingStatus": "COMPLETE",
+      "createdById": "61526375",
+      "updatedById": "61526375",
+      "processingType": "DYNAMIC",
+      "objectTypeId": "0-1",
+      "name": "Test List",
+      "additionalProperties": {
+        "hs_list_size": "4993",
+        "hs_list_reference_count": "0",
+        "hs_last_record_added_at": "1736775815261"
+      }
+    },
+    {
+      "listId": "4",
+      "listVersion": 1,
+      "createdAt": "2025-01-10T21:09:02.026Z",
+      "updatedAt": "2025-01-10T21:09:02.026Z",
+      "filtersUpdatedAt": "2025-01-10T21:09:02.026Z",
+      "processingStatus": "COMPLETE",
+      "createdById": "61427708",
+      "updatedById": "61427708",
+      "processingType": "SNAPSHOT",
+      "objectTypeId": "0-2",
+      "name": "Test static company list",
+      "additionalProperties": {
+        "hs_list_size": "3",
+        "hs_list_reference_count": "0"
+      }
+    }
+  ],
+  "total": 3
+}

--- a/providers/hubspot/test/read-lists-2-second-page.json
+++ b/providers/hubspot/test/read-lists-2-second-page.json
@@ -1,0 +1,24 @@
+{
+  "offset": 3,
+  "hasMore": false,
+  "lists": [
+    {
+      "listId": "5",
+      "listVersion": 1,
+      "createdAt": "2025-01-13T20:40:43.910Z",
+      "updatedAt": "2025-01-13T20:40:43.910Z",
+      "filtersUpdatedAt": "2025-01-13T20:40:43.910Z",
+      "processingStatus": "COMPLETE",
+      "createdById": "76070032",
+      "updatedById": "76070032",
+      "processingType": "MANUAL",
+      "objectTypeId": "0-1",
+      "name": "My static contacts list",
+      "additionalProperties": {
+        "hs_list_reference_count": "0",
+        "hs_list_size": "0"
+      }
+    }
+  ],
+  "total": 3
+}

--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -1,6 +1,9 @@
 package hubspot
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 )
@@ -30,6 +33,50 @@ func (p SearchParams) ValidateParams() error {
 	}
 
 	return nil
+}
+
+type SearchCRMParams struct {
+	// The name of the object we are reading, e.g. "Lists"
+	ObjectName string // required
+	// Fields is the list of fields to return in the result.
+	Fields datautils.Set[string] // optional
+	// NextPage is an opaque token that can be used to get the next page of results.
+	NextPage common.NextPageToken // optional, only set this if you want to read the next page of results
+}
+
+func (p SearchCRMParams) ValidateParams() error {
+	if len(p.ObjectName) == 0 {
+		return common.ErrMissingObjects
+	}
+
+	if len(p.Fields) == 0 {
+		return common.ErrMissingFields
+	}
+
+	return nil
+}
+
+func (p SearchCRMParams) Payload() (SearchCRMPayload, error) {
+	offset := 0
+
+	if len(p.NextPage) != 0 {
+		var err error
+
+		offset, err = strconv.Atoi(p.NextPage.String())
+		if err != nil {
+			return SearchCRMPayload{}, fmt.Errorf("%w: %w", common.ErrNextPageInvalid, err)
+		}
+	}
+
+	return SearchCRMPayload{
+		Offset: offset,
+		Count:  DefaultPageSizeInt,
+	}, nil
+}
+
+type SearchCRMPayload struct {
+	Offset int `json:"offset"`
+	Count  int `json:"count"`
 }
 
 type SortBy struct {

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -52,3 +52,9 @@ func (c *Connector) getCRMObjectsSearchURL(config SearchParams) (string, error) 
 
 	return c.getURL(relativeURL)
 }
+
+func (c *Connector) getCRMSearchURL(config SearchCRMParams) (string, error) {
+	relativeURL := strings.Join([]string{config.ObjectName, "search"}, "/")
+
+	return c.getURL(relativeURL)
+}

--- a/test/hubspot/read/lists/main.go
+++ b/test/hubspot/read/lists/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "lists",
+		Fields:     connectors.Fields("listId", "name"),
+	})
+	if err != nil {
+		utils.Fail("error reading from Hubspot", "error", err)
+	}
+
+	slog.Info("Reading lists..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Background

Lists object while being part of CRM is not part of Objects API. I put it under `crmObjectsOutsideTheObjectAPI` category.

Lists can be quired using 
* `crm/v3/lists` - relies on query params and knowing ids beforehand, otherwise always returns empty array
* `crm/v3/lists/search` - returns all lists even on empty payload. There is no incremental read. Payload gives control over pagination.

# Changes

Read for `Lists` object defaults to SearchCRM method calling `crm/v3/search`. Next Page token is the offset integer that is used by `Lists` pagination.

# Tests
![image](https://github.com/user-attachments/assets/ee96b9b0-a238-4ea4-8b16-f74b85a06e21)

Modifying page size to 2 and giving NextPage as `2`, meaning offset 2 returns the last page with last third list.
![image](https://github.com/user-attachments/assets/593e6023-56b9-4c40-8927-ce2a1ac28d75)

## Old Tests
Read: Contacts
![image](https://github.com/user-attachments/assets/ff686d89-d753-41d5-8ad6-ee329545019c)
Read+Write Contacts
![image](https://github.com/user-attachments/assets/ed5ca835-e727-4c34-bc04-25227627af0e)
As you can see the reading in read and write doesn't always return contacts, I noticed the same on main. After running the test again I get 
![image](https://github.com/user-attachments/assets/95fc9362-eee4-4fd7-91da-1fdff087436c)



# Docs

Updated docs: https://github.com/amp-labs/docs/pull/147
