### PR TITLE
chore: Remove redundant associations

### DIFF
--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -96,9 +96,5 @@ func makeCRMObjectsQueryValues(config common.ReadParams) []string {
 
 	out = append(out, "limit", DefaultPageSize)
 
-	if len(config.AssociatedObjects) > 0 {
-		out = append(out, "associations", strings.Join(config.AssociatedObjects, ","))
-	}
-
 	return out
 }


### PR DESCRIPTION
This removes associations from the query params, which removes a redundant portion of the response