### PR TITLE
feat: Static schema supports V1 and V2 Fields Metadata

### DIFF
--- a/internal/staticschema/files.go
+++ b/internal/staticschema/files.go
@@ -9,35 +9,35 @@ import (
 const SchemasFile = "schemas.json"
 
 // FileManager operates on schema.json file.
-type FileManager struct {
+type FileManager[F FieldMetadataMap] struct {
 	schemas []byte
 	locator fileconv.FileLocator
 	flush   fileconv.Flusher
 }
 
-func NewFileManager(schemas []byte, locator fileconv.FileLocator) *FileManager {
-	return &FileManager{
+func NewFileManager[F FieldMetadataMap](schemas []byte, locator fileconv.FileLocator) *FileManager[F] {
+	return &FileManager[F]{
 		schemas: schemas,
 		locator: locator,
 	}
 }
 
 // SaveSchemas is useful method when creating or updating static schema file.
-func (m FileManager) SaveSchemas(schemas *Metadata) error {
+func (m FileManager[F]) SaveSchemas(schemas *Metadata[F]) error {
 	schemas.refactorLongestCommonPath()
 
 	return m.flush.ToFile(m.locator.AbsPathTo(SchemasFile), schemas)
 }
 
 // MustLoadSchemas parses static schema file and returns Metadata for deep connector.
-func (m FileManager) MustLoadSchemas() *Metadata {
-	var result *Metadata
+func (m FileManager[F]) MustLoadSchemas() *Metadata[F] {
+	var result *Metadata[F]
 
 	err := json.Unmarshal(m.schemas, &result)
 	if err != nil {
 		// This error should never occur if schemas file is of correct format.
 		// If at least one test exists for the connector this will be caught at development time.
-		return &Metadata{}
+		return &Metadata[F]{}
 	}
 
 	return result

--- a/providers/constantcontact/metadata/schemas.go
+++ b/providers/constantcontact/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/constantcontact/metadata_test.go
+++ b/providers/constantcontact/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/customerapp/metadata/scraping.go
+++ b/providers/customerapp/metadata/scraping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/gong/metadata/schemas.go
+++ b/providers/gong/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",

--- a/providers/instantly/metadata/schemas.go
+++ b/providers/instantly/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/intercom/metadata/schemas.go
+++ b/providers/intercom/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/intercom/metadata_test.go
+++ b/providers/intercom/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/providers/iterable/metadata/metadata.go
+++ b/providers/iterable/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/iterable/metadata_test.go
+++ b/providers/iterable/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/keap/metadata/scraping.go
+++ b/providers/keap/metadata/scraping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -31,7 +30,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:  "Successfully describe multiple objects with metadata",

--- a/providers/kit/metadata/scraping.go
+++ b/providers/kit/metadata/scraping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/klaviyo/metadata/metadata.go
+++ b/providers/klaviyo/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/klaviyo/objectNames.go
+++ b/providers/klaviyo/objectNames.go
@@ -31,7 +31,7 @@ func init() {
 		for objectName, object := range module.Objects {
 		Search:
 			for _, preferredSinceField := range prioritySinceFieldsForRead {
-				for currentField := range object.FieldsMap {
+				for currentField := range object.Fields {
 					if preferredSinceField == currentField {
 						objectsNameToSinceFieldName[moduleID][objectName] = preferredSinceField
 

--- a/providers/marketo/metadata/schemas.go
+++ b/providers/marketo/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -11,7 +12,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/pipedrive/metadata/scraping.go
+++ b/providers/pipedrive/metadata/scraping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/pipeliner/metadata/schemas.go
+++ b/providers/pipeliner/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/pipeliner/metadata_test.go
+++ b/providers/pipeliner/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/providers/salesloft/metadata/schemas.go
+++ b/providers/salesloft/metadata/schemas.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/salesloft/metadata_test.go
+++ b/providers/salesloft/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/providers/smartlead/metadata/scraping.go
+++ b/providers/smartlead/metadata/scraping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -24,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:         "Unknown object requested",
 			Input:        []string{"butterflies"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/zendesksupport/metadata/scrapping.go
+++ b/providers/zendesksupport/metadata/scrapping.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	_ "embed"
 
+	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
@@ -13,7 +14,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager(schemas, fileconv.NewSiblingFileLocator()) // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -26,7 +25,7 @@ func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen
 			Name:         "Object coming from different module is unknown",
 			Input:        []string{"articles"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",
@@ -114,7 +113,7 @@ func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,goc
 			Name:         "Object coming from different module is unknown",
 			Input:        []string{"brands"},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{staticschema.ErrObjectNotFound},
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/scripts/openapi/constantcontact/metadata/main.go
+++ b/scripts/openapi/constantcontact/metadata/main.go
@@ -70,7 +70,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -82,8 +82,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName,
-				field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/customerio/journeysapp/metadata/main.go
+++ b/scripts/openapi/customerio/journeysapp/metadata/main.go
@@ -47,7 +47,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -59,7 +59,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/gong/metadata/main.go
+++ b/scripts/openapi/gong/metadata/main.go
@@ -69,7 +69,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -81,7 +81,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/intercom/metadata/main.go
+++ b/scripts/openapi/intercom/metadata/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	objects := searchObjects.Combine(readObjects)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -81,7 +81,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/iterable/metadata/main.go
+++ b/scripts/openapi/iterable/metadata/main.go
@@ -69,7 +69,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -81,8 +81,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName,
-				field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/keap/metadata/main.go
+++ b/scripts/openapi/keap/metadata/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, api3.Schema]{}
 
@@ -33,8 +33,10 @@ func main() {
 			}
 
 			for _, field := range object.Fields {
-				schemas.Add(module, object.ObjectName, object.DisplayName, field,
-					object.URLPath, object.ResponseKey, nil)
+				schemas.Add(module, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+					staticschema.FieldMetadataMapV1{
+						field: field,
+					}, nil)
 			}
 
 			for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/klaviyo/metadata/main.go
+++ b/scripts/openapi/klaviyo/metadata/main.go
@@ -47,7 +47,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -59,8 +59,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add(klaviyo.Module2024Oct15, object.ObjectName, object.DisplayName,
-				field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add(klaviyo.Module2024Oct15, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/marketo/metadata/metadata.go
+++ b/scripts/openapi/marketo/metadata/metadata.go
@@ -33,7 +33,7 @@ func main() {
 	goutils.MustBeNil(err)
 
 	// Initializes an empty ObjectMetadata variable
-	objectMetadata := make(map[string]staticschema.Object)
+	objectMetadata := make(map[string]staticschema.Object[staticschema.FieldMetadataMapV1])
 
 	// Add Lead metadata details
 	objectMetadata = generateMetadata(ldef, docL, objectMetadata)
@@ -41,8 +41,8 @@ func main() {
 	// Adds Assets Metadata details to the same variable declared above.
 	objectMetadata = generateMetadata(def, docA, objectMetadata)
 
-	goutils.MustBeNil(metadata.FileManager.SaveSchemas(&staticschema.Metadata{
-		Modules: map[common.ModuleID]staticschema.Module{
+	goutils.MustBeNil(metadata.FileManager.SaveSchemas(&staticschema.Metadata[staticschema.FieldMetadataMapV1]{
+		Modules: map[common.ModuleID]staticschema.Module[staticschema.FieldMetadataMapV1]{
 			staticschema.RootModuleID: {
 				Objects: objectMetadata,
 			},
@@ -95,8 +95,8 @@ func cleanDefinitions(def string) string {
 }
 
 func generateMetadata(objDefs map[string]string,
-	doc openapi2.T, objectMetadata map[string]staticschema.Object,
-) map[string]staticschema.Object {
+	doc openapi2.T, objectMetadata map[string]staticschema.Object[staticschema.FieldMetadataMapV1],
+) map[string]staticschema.Object[staticschema.FieldMetadataMapV1] {
 	for obj, dfn := range objDefs {
 		schem := doc.Definitions[dfn].Value.Properties
 
@@ -112,10 +112,10 @@ func generateMetadata(objDefs map[string]string,
 			fields[k] = k
 		}
 
-		om := staticschema.Object{
+		om := staticschema.Object[staticschema.FieldMetadataMapV1]{
 			DisplayName: obj,
 			URLPath:     fmt.Sprintf("/%v", obj),
-			FieldsMap:   fields,
+			Fields:      fields,
 		}
 
 		objectMetadata[obj] = om

--- a/scripts/openapi/pipedrive/metadata/main.go
+++ b/scripts/openapi/pipedrive/metadata/main.go
@@ -75,7 +75,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -87,7 +87,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/pipeliner/metadata/main.go
+++ b/scripts/openapi/pipeliner/metadata/main.go
@@ -45,7 +45,7 @@ func main() {
 	)
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 
 	for _, object := range objects {
@@ -57,7 +57,10 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add("", object.ObjectName, object.DisplayName, field, object.URLPath, object.ResponseKey, nil)
+			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+				staticschema.FieldMetadataMapV1{
+					field: field,
+				}, nil)
 		}
 
 		for _, queryParam := range object.QueryParams {

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, api3.Schema]{}
 
@@ -33,8 +33,10 @@ func main() {
 			}
 
 			for _, field := range object.Fields {
-				schemas.Add(module, object.ObjectName, object.DisplayName,
-					field, object.URLPath, object.ResponseKey, nil)
+				schemas.Add(module, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+					staticschema.FieldMetadataMapV1{
+						field: field,
+					}, nil)
 			}
 
 			for _, queryParam := range object.QueryParams {

--- a/scripts/scrapper/salesloft/metadata/main.go
+++ b/scripts/scrapper/salesloft/metadata/main.go
@@ -69,7 +69,7 @@ func createSchemas() {
 	index, err := metadata.FileManager.LoadIndex()
 	goutils.MustBeNil(err)
 
-	schemas := staticschema.NewMetadata()
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 
 	filteredListDocs := getFilteredListDocs(index)
 	for i := range filteredListDocs { // nolint:varnamelen
@@ -89,7 +89,10 @@ func createSchemas() {
 						newDisplayName, isList := handleDisplayName(model.DisplayName)
 						if isList {
 							schemas.Add("", modelName,
-								newDisplayName, fieldName, fmt.Sprintf("/%v", modelName), "data", &model.URL)
+								newDisplayName, fmt.Sprintf("/%v", modelName), "data",
+								staticschema.FieldMetadataMapV1{
+									fieldName: fieldName,
+								}, &model.URL)
 						}
 					}
 				})

--- a/tools/scrapper/files.go
+++ b/tools/scrapper/files.go
@@ -10,27 +10,29 @@ const (
 	QueryParamStatsFile = "queryParamStats.json"
 )
 
-type MetadataFileManager struct {
-	staticschema.FileManager
+type MetadataFileManager[F staticschema.FieldMetadataMap] struct {
+	staticschema.FileManager[F]
 
 	locator fileconv.FileLocator
 	flush   fileconv.Flusher
 }
 
-func NewMetadataFileManager(schemas []byte, locator fileconv.FileLocator) *MetadataFileManager {
-	return &MetadataFileManager{
-		FileManager: *staticschema.NewFileManager(schemas, locator),
+func NewMetadataFileManager[F staticschema.FieldMetadataMap](
+	schemas []byte, locator fileconv.FileLocator,
+) *MetadataFileManager[F] {
+	return &MetadataFileManager[F]{
+		FileManager: *staticschema.NewFileManager[F](schemas, locator),
 		locator:     locator,
 	}
 }
 
-func (m MetadataFileManager) SaveIndex(index *ModelURLRegistry) error {
+func (m MetadataFileManager[F]) SaveIndex(index *ModelURLRegistry) error {
 	index.Sort()
 
 	return m.flush.ToFile(m.locator.AbsPathTo(IndexFile), index)
 }
 
-func (m MetadataFileManager) LoadIndex() (*ModelURLRegistry, error) {
+func (m MetadataFileManager[F]) LoadIndex() (*ModelURLRegistry, error) {
 	var registry *ModelURLRegistry
 
 	err := LoadFile(m.locator.AbsPathTo(IndexFile), &registry)
@@ -41,6 +43,6 @@ func (m MetadataFileManager) LoadIndex() (*ModelURLRegistry, error) {
 	return registry, nil
 }
 
-func (m MetadataFileManager) SaveQueryParamStats(stats *QueryParamStats) error {
+func (m MetadataFileManager[F]) SaveQueryParamStats(stats *QueryParamStats) error {
 	return m.flush.ToFile(m.locator.AbsPathTo(QueryParamStatsFile), stats)
 }


### PR DESCRIPTION
# Background

There were recent changes to the format of the ObjectMetadata that is returned by ListObjectMetadata.

# Changes
To accommodate these updates, newly created static schema files may need to follow a revised structure. Each reference to the static file structure must now specify a generic type of either `ObjectFieldsV1` or `ObjectFieldsV2`.

* Created new type ObjectFields which is either ObjectFieldsV1(map[string]string) or ObjectFieldsV2 (map[string]common.FieldMetadata)
* Each connector script that parses OpenAPI was affected and now uses the existing `ObjectFieldsV1`.
* Files located under `.../<provider_name>/metadata` were previously named `scrapper.go`. While we are at it, renamed them to be `schemas.go`, because they do not perform scraping but instead reference a constant metadata structure. For context, originally first files were created using scrapping.

# Review
Main code changes are under `internal/staticschema/core.go` file.

# Tests
Ran each OpenAPI script. It produces the same output as before.