### PR TITLE
[CON-972] feat(Hubspot): Support Lists object by ListObjectMetadata

### DIFF
--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -81,17 +81,17 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 
 // getObjectMetadata returns object metadata for the given object name.
 func (c *Connector) getObjectMetadata(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	if crmObjectsOutsideTheObjectAPI.Has(objectName) {
-		return c.getObjectMetadataCRM(ctx, objectName)
+	if crmObjectsOutsideThePropertiesAPI.Has(objectName) {
+		return c.getObjectMetadataFromObjectAPI(ctx, objectName)
 	}
 
-	return c.getObjectMetadataCRMCoreObjects(ctx, objectName)
+	return c.getObjectMetadataFromPropertyAPI(ctx, objectName)
 }
 
-// This method describes objects that are part of ObjectsAPI.
+// This method describes objects that are part of Objects API using properties endpoint.
 // There is a dedicated API endpoint that is used for discovery of object properties.
 // https://developers.hubspot.com/docs/guides/api/crm/properties
-func (c *Connector) getObjectMetadataCRMCoreObjects(
+func (c *Connector) getObjectMetadataFromPropertyAPI(
 	ctx context.Context, objectName string,
 ) (*common.ObjectMetadata, error) {
 	relativeURL := strings.Join([]string{"properties", objectName}, "/")
@@ -121,10 +121,10 @@ func (c *Connector) getObjectMetadataCRMCoreObjects(
 	), nil
 }
 
-// Method focuses on acquiring object properties for those objects that are not part of CRM ObjectsAPI.
+// Method focuses on acquiring object properties for those objects that are not part of CRM Properties API.
 // https://developers.hubspot.com/docs/guides/api/crm/objects/companies
 // There is no discovery endpoint to acquire object properties, therefore, manual read is used.
-func (c *Connector) getObjectMetadataCRM(
+func (c *Connector) getObjectMetadataFromObjectAPI(
 	ctx context.Context, objectName string,
 ) (*common.ObjectMetadata, error) {
 	readResult, err := c.SearchCRM(ctx, SearchCRMParams{

--- a/providers/hubspot/metadata/metadata.go
+++ b/providers/hubspot/metadata/metadata.go
@@ -1,0 +1,22 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager[staticschema.ObjectFieldsV2]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/hubspot/metadata/metadata.go
+++ b/providers/hubspot/metadata/metadata.go
@@ -14,7 +14,7 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager[staticschema.ObjectFieldsV2]( // nolint:gochecknoglobals
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV2]( // nolint:gochecknoglobals
 		schemas, fileconv.NewSiblingFileLocator())
 
 	// Schemas is cached Object schemas.

--- a/providers/hubspot/metadata/schemas.json
+++ b/providers/hubspot/metadata/schemas.json
@@ -1,0 +1,65 @@
+{
+  "modules": {
+    "CRM": {
+      "id": "CRM",
+      "path": "/crm/v3",
+      "objects": {
+        "lists": {
+          "displayName": "Lists",
+          "path": "/lists/search",
+          "responseKey": "data",
+          "fields": {
+            "additionalProperties": {
+              "displayName": "additionalProperties",
+              "valueType": "other"
+            },
+            "createdAt": {
+              "displayName": "createdAt",
+              "valueType": "other"
+            },
+            "createdById": {
+              "displayName": "createdById",
+              "valueType": "other"
+            },
+            "filtersUpdatedAt": {
+              "displayName": "filtersUpdatedAt",
+              "valueType": "other"
+            },
+            "listId": {
+              "displayName": "listId",
+              "valueType": "other"
+            },
+            "listVersion": {
+              "displayName": "listVersion",
+              "valueType": "other"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "objectTypeId": {
+              "displayName": "objectTypeId",
+              "valueType": "other"
+            },
+            "processingStatus": {
+              "displayName": "processingStatus",
+              "valueType": "other"
+            },
+            "processingType": {
+              "displayName": "processingType",
+              "valueType": "other"
+            },
+            "updatedAt": {
+              "displayName": "updatedAt",
+              "valueType": "other"
+            },
+            "updatedById": {
+              "displayName": "updatedById",
+              "valueType": "other"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -19,6 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	metadataContactsPipelines := testutils.DataFromFile(t, "metadata-contacts-external-pipelines.json")
 	metadataDealsProperties := testutils.DataFromFile(t, "metadata-deals-properties-sampled.json")
 	metadataDealsPipelines := testutils.DataFromFile(t, "metadata-deals-external-pipelines.json")
+	responseLists := testutils.DataFromFile(t, "read-lists-1-first-page.json")
 
 	tests := []testroutines.Metadata{
 		{
@@ -285,6 +286,48 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 									Value:        "closedlost",
 									DisplayValue: "Closed Lost",
 								}},
+							},
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Successfully describe lists, which is outside ObjectsAPI",
+			Input: []string{"lists"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.PathSuffix("/crm/v3/lists/search"),
+				Then:  mockserver.Response(http.StatusOK, responseLists),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"lists": {
+						DisplayName: "lists",
+						Fields: map[string]common.FieldMetadata{
+							"additionalProperties": {
+								DisplayName:  "additionalProperties",
+								ValueType:    "other",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"name": {
+								DisplayName:  "name",
+								ValueType:    "other",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"updatedAt": {
+								DisplayName:  "updatedAt",
+								ValueType:    "other",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
 							},
 						},
 					},

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -295,7 +295,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			ExpectedErrs: nil,
 		},
 		{
-			Name:  "Successfully describe lists, which is outside ObjectsAPI",
+			Name:  "Successfully describe lists, which is outside Properties API",
 			Input: []string{"lists"},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),

--- a/providers/hubspot/objectName.go
+++ b/providers/hubspot/objectName.go
@@ -2,12 +2,12 @@ package hubspot
 
 import "github.com/amp-labs/connectors/internal/datautils"
 
-// This is a list of objectsNames that are part of Hubspot CRM Module but exist outside ObjectAPIs.
+// This is a list of objectsNames that are part of Hubspot CRM Module but exist outside Object Properties APIs.
 //
 // These objects cannot be accessed via `~/crm/v3/objects/{objectTypeId}/...`
 //
-// On the contrary those objects that are part of ObjectAPIs can be found
+// On the contrary those objects that are part of Object Properties APIs can be found
 // in the table here https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
-var crmObjectsOutsideTheObjectAPI = datautils.NewSet( //nolint:gochecknoglobals
+var crmObjectsOutsideThePropertiesAPI = datautils.NewSet( //nolint:gochecknoglobals
 	"lists",
 )

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -21,7 +21,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	if crmObjectsOutsideTheObjectAPI.Has(config.ObjectName) {
+	if crmObjectsOutsideThePropertiesAPI.Has(config.ObjectName) {
 		// Objects outside ObjectAPI have different endpoint while both are part of CRM module.
 		// For instance Lists are fully returned only via Search endpoint.
 		return c.SearchCRM(ctx, SearchCRMParams{

--- a/providers/hubspot/types.go
+++ b/providers/hubspot/types.go
@@ -42,6 +42,7 @@ type SearchCRMParams struct {
 	Fields datautils.Set[string] // optional
 	// NextPage is an opaque token that can be used to get the next page of results.
 	NextPage common.NextPageToken // optional, only set this if you want to read the next page of results
+	PageSize int
 }
 
 func (p SearchCRMParams) ValidateParams() error {
@@ -68,9 +69,14 @@ func (p SearchCRMParams) Payload() (SearchCRMPayload, error) {
 		}
 	}
 
+	pageSize := DefaultPageSizeInt
+	if p.PageSize != 0 {
+		pageSize = p.PageSize
+	}
+
 	return SearchCRMPayload{
 		Offset: offset,
-		Count:  DefaultPageSizeInt,
+		Count:  pageSize,
 	}, nil
 }
 

--- a/test/hubspot/metadata/lists/main.go
+++ b/test/hubspot/metadata/lists/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+var objectName = "lists"
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for Hubspot", "error", err)
+	}
+
+	utils.DumpJSON(metadata, os.Stdout)
+}


### PR DESCRIPTION
# Problem

Lists is an object that lives under CRM module but is outside Objects APIs. Current implementation of `ListObjectMetadata` focusses on CRM Objects API that uses field discovery endpoint. This is not applicable for `Lists`.

# Solution
As with other connectors the approach is to make read request for 1 item and use response fields as metadata fields. As a fallback rely on static schema file for the object metadata. This same approach takes place in this PR. Lists object is added under schema.json for the fallback.

# Tests - ListObjectMetadata
Lists
![image](https://github.com/user-attachments/assets/7bc7ded3-11b7-4c3b-bb49-124803b58016)
![image](https://github.com/user-attachments/assets/eadd6e23-a4c9-46d5-9f76-10df01150112)
Contacts
![image](https://github.com/user-attachments/assets/6c7059f5-740f-44ba-ac66-cb0f60f6b264)
![image](https://github.com/user-attachments/assets/4d8c9829-d6ac-437a-9280-0dc0ea209e72)

