### PR TITLE
fix(openapi): Consistent report on duplicate objectNames

### DIFF
--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -1,3 +1,4 @@
+// nolint:ireturn
 package datautils
 
 import "encoding/json"
@@ -92,7 +93,7 @@ func (m DefaultMap[K, V]) Get(key K) V {
 	return empty
 }
 
-// Convert a struct to a map of string to any.
+// StructToMap convert a struct to a map of string to any.
 func StructToMap(obj any) (map[string]any, error) {
 	var result map[string]any
 


### PR DESCRIPTION
# Problem

When going over each endpoint some of them will have duplicate suffixes and therefore would be associated with the same objectName. Those are duplicates. They were already reported when running OpenAPI extractor to draw attention for action.
However, one endpoint would still be extracted into `shema.json` and others would be considered duplicates. The one that is used was picked at random (not intended).

# Solution
All objectNames that have multiple endpoints will be ignored for consistency.
Each is reported by the DEBUG logs.

# Result
All duplicates are reporeted.
No matter how many times you run the script the output file doesn't change.
