### PR TITLE
[CON-999] feat: Add ChiliPiper Connector

### DIFF
--- a/providers/chilipiper.go
+++ b/providers/chilipiper.go
@@ -1,0 +1,41 @@
+package providers
+
+const ChiliPiper Provider = "chilipiper"
+
+func init() {
+	SetInfo(ChiliPiper, ProviderInfo{
+		DisplayName: "Chili Piper",
+		AuthType:    ApiKey,
+		BaseURL:     "https://fire.chilipiper.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1737706607/media/chilipiper.com_1737706605.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1737706607/media/chilipiper.com_1737706605.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1737706607/media/chilipiper.com_1737706605.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1737706607/media/chilipiper.com_1737706605.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
## Catalog variables
None. We could choose to use it though.

## Testing
### GET
<img width="1150" alt="Screenshot 2025-01-24 at 12 20 03" src="https://github.com/user-attachments/assets/a999a89c-8dd5-44d3-91e8-328af48589de" />


### POST
<img width="1157" alt="Screenshot 2025-01-24 at 12 24 59" src="https://github.com/user-attachments/assets/1cdd8794-4541-424d-a00b-5620523dcd2f" />

### DELETE
<img width="1153" alt="Screenshot 2025-01-24 at 12 39 15" src="https://github.com/user-attachments/assets/b2c4db90-0ac0-43c5-b607-f28def0757cd" />


## Pagination
Pagination uses the query param `page` and `pageSize`.
<img width="1158" alt="Screenshot 2025-01-24 at 12 29 59" src="https://github.com/user-attachments/assets/fb2a5938-7461-416c-8618-b557e6a166fc" />

You'd have to calculate how much you should go as they give how many records are available.
<img width="1163" alt="Screenshot 2025-01-24 at 12 47 10" src="https://github.com/user-attachments/assets/d26d5638-7c02-46c8-9130-69eb40d4b82e" />

# Logo & Icons
Used the same for logo & icon. It's an svg.
<img width="1271" alt="Screenshot 2025-01-24 at 11 16 20" src="https://github.com/user-attachments/assets/a3987514-2724-44e1-86fa-e74515926961" />
