### PR TITLE
feat(openapi): Script to report write endpoints

### DIFF
--- a/scripts/openapi/keap/endpoints/main.go
+++ b/scripts/openapi/keap/endpoints/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/providers/keap/openapi"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+)
+
+func main() {
+	exp1, err := openapi.Version1FileManager.GetExplorer()
+	goutils.MustBeNil(err)
+	exp2, err := openapi.Version2FileManager.GetExplorer()
+	goutils.MustBeNil(err)
+
+	explorers := datautils.Map[string, *api3.Explorer]{"file1": exp1, "file2": exp2}
+	names := explorers.Keys()
+	sort.Strings(names)
+
+	for _, name := range names {
+		fmt.Println("=====================") // nolint:forbidigo
+		fmt.Printf("OpenAPI %v\n", name)     // nolint:forbidigo
+		fmt.Println("=====================") // nolint:forbidigo
+
+		endpoints, err := explorers[name].GetEndpointOperations(
+			api3.DefaultPathMatcher{}, http.MethodPost, http.MethodPatch, http.MethodPut,
+		)
+		goutils.MustBeNil(err)
+
+		displays := make([]string, len(endpoints))
+		for i, endpoint := range endpoints {
+			displays[i] = endpoint.String()
+		}
+
+		sort.Strings(displays)
+
+		for _, display := range displays {
+			fmt.Println(display) // nolint:forbidigo
+		}
+
+		fmt.Printf("\nTotal number of endpoints %v\n\n", len(endpoints)) // nolint:forbidigo
+	}
+
+	slog.Info("Completed.")
+}

--- a/scripts/openapi/stripe/endpoints/main.go
+++ b/scripts/openapi/stripe/endpoints/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/providers/stripe/openapi"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+)
+
+func main() {
+	explorer, err := openapi.FileManager.GetExplorer()
+	goutils.MustBeNil(err)
+
+	endpoints, err := explorer.GetEndpointOperations(
+		api3.DefaultPathMatcher{}, http.MethodPost, http.MethodPatch, http.MethodPut,
+	)
+	goutils.MustBeNil(err)
+
+	for _, endpoint := range endpoints {
+		fmt.Println(endpoint) // nolint:forbidigo
+	}
+
+	fmt.Println("Total number of endpoints", len(endpoints)) // nolint:forbidigo
+
+	slog.Info("Completed.")
+}

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -76,7 +76,7 @@ func (p PathItem) RetrieveSchemaOperation(
 	mime string,
 	autoSelectArrayItem bool,
 ) (*Schema, bool, error) {
-	operation := p.selectOperation(operationName)
+	operation, _ := p.selectOperation(operationName)
 	if operation == nil {
 		return nil, false, nil
 	}
@@ -118,16 +118,21 @@ func (p PathItem) RetrieveSchemaOperation(
 	}, true, nil
 }
 
-func (p PathItem) selectOperation(operationName string) *openapi3.Operation {
+func (p PathItem) selectOperation(operationName string) (*openapi3.Operation, bool) {
 	switch operationName {
-	case "POST":
-		return p.delegate.Post
-	case "PUT":
-		return p.delegate.Put
-	case "PATCH":
-		return p.delegate.Patch
+	case http.MethodGet:
+		return p.delegate.Get, p.delegate.Get != nil
+	case http.MethodPost:
+		return p.delegate.Post, p.delegate.Post != nil
+	case http.MethodPut:
+		return p.delegate.Put, p.delegate.Put != nil
+	case http.MethodPatch:
+		return p.delegate.Patch, p.delegate.Patch != nil
+	case http.MethodDelete:
+		return p.delegate.Delete, p.delegate.Delete != nil
 	default:
-		return p.delegate.Get
+		// Bool will always be false for the default case. This operation is not what we are looking for.
+		return p.delegate.Get, false
 	}
 }
 

--- a/tools/fileconv/api3/strategy.go
+++ b/tools/fileconv/api3/strategy.go
@@ -33,10 +33,20 @@ func NewDenyPathStrategy(paths []string) *StarRulePathResolver {
 	})
 }
 
+// PathMatcher categorizes paths based on specific criteria.
 type PathMatcher interface {
 	IsPathMatching(path string) bool
 }
 
+// DefaultPathMatcher matches any URL path without restrictions.
+type DefaultPathMatcher struct{}
+
+func (DefaultPathMatcher) IsPathMatching(path string) bool {
+	return true
+}
+
+// AndPathMatcher combines multiple path matchers.
+// A path matches only if all matchers in the list agree on the match.
 type AndPathMatcher []PathMatcher
 
 func (m AndPathMatcher) IsPathMatching(path string) bool {
@@ -116,5 +126,17 @@ type IDPathIgnorer struct{}
 func (IDPathIgnorer) IsPathMatching(path string) bool {
 	// There should be no slashes, curly brackets.
 	// If there are we are dealing with nester resources. Those are to be ignored.
+	return !strings.Contains(path, "{")
+}
+
+type NestedIDPathIgnorer struct{}
+
+func (NestedIDPathIgnorer) IsPathMatching(path string) bool {
+	// Remove the last URL part.
+	parts := strings.Split(path, "/")
+	parts = parts[:len(parts)-1]
+	path = strings.Join(parts, "/")
+
+	// We get the large prefix which may have variate parts. It shouldn't.
 	return !strings.Contains(path, "{")
 }


### PR DESCRIPTION
# Description

Added new method to openapi exploerer `GetEndpointOperations`. It gives convinient summary of the OpenAPI file by specified REST operations.

# Purspose

During Write/Delete implementation you can get a list of relevant endpoints.
See output of `scripts/openapi/stripe/endpoints/main.go`:
![image](https://github.com/user-attachments/assets/3064a436-db03-42f0-aa77-727ef5211b29)

For demonstration purpose the same script is added for Keap. It uses 2 files therefore 2 outputs:
![image](https://github.com/user-attachments/assets/bf4cbe4e-bb1f-4478-af7e-f176a6d08a99)
![image](https://github.com/user-attachments/assets/3b395a72-26ff-47d9-b495-f150cdf5dd6b)

# Implementaiton

`GetEndpointOperations` makes a call to `GetPathItems` ignoring paths that has nested IDs. Only one ID at the end is allowed for update operation.