### PR TITLE
feat(common): Extend HTTP POST with form-urlencoded payload

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -108,6 +108,10 @@ var (
 	// ErrInvalidImplementation is returned when implementation assumption is broken.
 	// This is not a client issue.
 	ErrInvalidImplementation = errors.New("invalid implementation")
+
+	// ErrPayloadNotURLForm is returned when payload is not string key-value pair
+	// which could be encoded for POST with content type of application/x-www-form-urlencoded.
+	ErrPayloadNotURLForm = errors.New("payload cannot be url-form encoded")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.
@@ -359,7 +363,7 @@ const (
 	SubscriptionEventTypeOther             SubscriptionEventType = "other"
 )
 
-// SubscribeEvent is an interface for webhook events coming from the provider.
+// SubscriptionEvent is an interface for webhook events coming from the provider.
 // This interface defines methods to extract information from the webhook event.
 type SubscriptionEvent interface {
 	EventType() (SubscriptionEventType, error)


### PR DESCRIPTION
# Problem

The HTTP wrapper methods in the common package do not support making POST requests with the default content type "application/x-www-form-urlencoded".

# Solution

When deep in the HTTP client call stack, the payload is represented as bytes alongside a list of headers. This information is sufficient to decide how to handle the payload:

1. Default Behavior:
* The existing handling remains unchanged for content types other than `"application/x-www-form-urlencoded"`.

2. New Behavior:

* If the caller specifies the header `"application/x-www-form-urlencoded"`, the payload must be string key-value pairs.
* If the payload does not conform, the client will return a new error, `ErrPayloadNotURLForm`, to signal invalid usage.
* Values are URL-encoded, and the content length is calculated respectively.


# Demonstration

Using `localhost` and `netcat` to capture the request, here's an example of a POST request Stripe would receive:
![image](https://github.com/user-attachments/assets/dfc24ba6-8f86-4507-9213-186c03ccf039)

Note: Stripe initially returned a vague 400 error via NGINX. This issue was traced to a mismatch between the content length in the header and the actual payload size. Once corrected, the requests were processed successfully. Netcat to the rescue.