### PR TITLE
tidy(metadata): Separate Schema definition from tools

### DIFF
--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -60,6 +60,12 @@ func (m Map[K, V]) Values() []V {
 	return values
 }
 
+func (m Map[K, V]) AddMapValues(source Map[K, V]) {
+	for k, v := range source {
+		m[k] = v
+	}
+}
+
 // DefaultMap wrapper of the map that allows setting default return value on missing keys.
 type DefaultMap[K comparable, V any] struct {
 	// Map is a delegate.

--- a/internal/metadatadef/definition.go
+++ b/internal/metadatadef/definition.go
@@ -1,0 +1,51 @@
+package metadatadef
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// Schema is a model that describes a REST API object.
+// This is usually created when metadata is coming not from API but alternative sources, example: OpenAPI.
+// This model holds more information than common.ObjectMetadata.
+type Schema struct {
+	ObjectName  string
+	DisplayName string
+	Fields      Fields
+	QueryParams []string
+	URLPath     string
+	ResponseKey string
+	Problem     error
+}
+
+type Schemas []Schema
+
+type Field struct {
+	Name string
+	Type string
+}
+
+type Fields = datautils.Map[string, Field]
+
+func (s Schemas) Combine(others Schemas) Schemas {
+	registry := datautils.Map[string, Schema]{}
+	for _, schema := range append(s, others...) {
+		_, found := registry[schema.ObjectName]
+
+		if !found || len(schema.Fields) != 0 {
+			registry[schema.ObjectName] = schema
+		}
+	}
+
+	return registry.Values()
+}
+
+func (s Schema) String() string {
+	if s.Problem != nil {
+		return fmt.Sprintf("    {%v}    ", s.ObjectName)
+	}
+
+	return fmt.Sprintf("%v=[%v]", s.ObjectName, strings.Join(s.Fields.Keys(), ","))
+}

--- a/scripts/openapi/asana/metadata/main.go
+++ b/scripts/openapi/asana/metadata/main.go
@@ -75,7 +75,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/constantcontact/metadata/main.go
+++ b/scripts/openapi/constantcontact/metadata/main.go
@@ -84,7 +84,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/customerio/journeysapp/metadata/main.go
+++ b/scripts/openapi/customerio/journeysapp/metadata/main.go
@@ -61,7 +61,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/gong/metadata/main.go
+++ b/scripts/openapi/gong/metadata/main.go
@@ -83,7 +83,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/intercom/metadata/main.go
+++ b/scripts/openapi/intercom/metadata/main.go
@@ -83,7 +83,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/iterable/metadata/main.go
+++ b/scripts/openapi/iterable/metadata/main.go
@@ -83,7 +83,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/keap/metadata/main.go
+++ b/scripts/openapi/keap/metadata/main.go
@@ -6,19 +6,19 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/keap"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 	keapv1 "github.com/amp-labs/connectors/scripts/openapi/keap/metadata/v1"
 	keapv2 "github.com/amp-labs/connectors/scripts/openapi/keap/metadata/v2"
-	"github.com/amp-labs/connectors/tools/fileconv/api3"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
 func main() {
 	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
-	lists := datautils.IndexedLists[common.ModuleID, api3.Schema]{}
+	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
 	lists.Add(keap.ModuleV1, keapv1.Objects()...)
 	lists.Add(keap.ModuleV2, keapv2.Objects()...)
@@ -35,7 +35,7 @@ func main() {
 			for _, field := range object.Fields {
 				schemas.Add(module, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 					staticschema.FieldMetadataMapV1{
-						field: field,
+						field.Name: field.Name,
 					}, nil)
 			}
 

--- a/scripts/openapi/keap/metadata/v1/objects.go
+++ b/scripts/openapi/keap/metadata/v1/objects.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers/keap/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 )
@@ -61,7 +62,7 @@ var (
 	)
 )
 
-func Objects() []api3.Schema {
+func Objects() []metadatadef.Schema {
 	explorer, err := openapi.Version1FileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
 			func(displayName string) string {

--- a/scripts/openapi/keap/metadata/v2/objects.go
+++ b/scripts/openapi/keap/metadata/v2/objects.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers/keap/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 )
@@ -40,7 +41,7 @@ var (
 	)
 )
 
-func Objects() []api3.Schema {
+func Objects() []metadatadef.Schema {
 	explorer, err := openapi.Version2FileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
 			func(displayName string) string {

--- a/scripts/openapi/klaviyo/metadata/main.go
+++ b/scripts/openapi/klaviyo/metadata/main.go
@@ -61,7 +61,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add(klaviyo.Module2024Oct15, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/pipedrive/metadata/main.go
+++ b/scripts/openapi/pipedrive/metadata/main.go
@@ -89,7 +89,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/pipeliner/metadata/main.go
+++ b/scripts/openapi/pipeliner/metadata/main.go
@@ -59,7 +59,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/stripe/metadata/main.go
+++ b/scripts/openapi/stripe/metadata/main.go
@@ -126,7 +126,7 @@ func main() {
 		for _, field := range object.Fields {
 			schemas.Add("", object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
-					field: field,
+					field.Name: field.Name,
 				}, nil)
 		}
 

--- a/scripts/openapi/zendesksupport/metadata/helpcenter/objects.go
+++ b/scripts/openapi/zendesksupport/metadata/helpcenter/objects.go
@@ -2,6 +2,7 @@ package helpcenter
 
 import (
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -19,7 +20,7 @@ var (
 	}
 )
 
-func Objects() []api3.Schema {
+func Objects() []metadatadef.Schema {
 	explorer, err := openapi.HelpCenterFileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
 			api3.CamelCaseToSpaceSeparated,

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -6,19 +6,19 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 	"github.com/amp-labs/connectors/scripts/openapi/zendesksupport/metadata/helpcenter"
 	"github.com/amp-labs/connectors/scripts/openapi/zendesksupport/metadata/support"
-	"github.com/amp-labs/connectors/tools/fileconv/api3"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
 func main() {
 	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV1]()
 	registry := datautils.NamedLists[string]{}
-	lists := datautils.IndexedLists[common.ModuleID, api3.Schema]{}
+	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
 	lists.Add(zendesksupport.ModuleTicketing, support.Objects()...)
 	lists.Add(zendesksupport.ModuleHelpCenter, helpcenter.Objects()...)
@@ -35,7 +35,7 @@ func main() {
 			for _, field := range object.Fields {
 				schemas.Add(module, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 					staticschema.FieldMetadataMapV1{
-						field: field,
+						field.Name: field.Name,
 					}, nil)
 			}
 

--- a/scripts/openapi/zendesksupport/metadata/support/objects.go
+++ b/scripts/openapi/zendesksupport/metadata/support/objects.go
@@ -2,6 +2,7 @@ package support
 
 import (
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -67,7 +68,7 @@ var (
 	}
 )
 
-func Objects() []api3.Schema {
+func Objects() []metadatadef.Schema {
 	explorer, err := openapi.SupportFileManager.GetExplorer(
 		api3.WithDisplayNamePostProcessors(
 			api3.CamelCaseToSpaceSeparated,

--- a/tools/fileconv/api3/queries.go
+++ b/tools/fileconv/api3/queries.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -37,7 +38,7 @@ func (e Explorer) ReadObjectsGet(
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
 	locator ObjectArrayLocator,
-) (Schemas, error) {
+) (metadatadef.Schemas, error) {
 	return e.ReadObjects("GET", pathMatcher, objectEndpoints, displayNameOverride, locator)
 }
 
@@ -48,7 +49,7 @@ func (e Explorer) ReadObjectsPost(
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
 	locator ObjectArrayLocator,
-) (Schemas, error) {
+) (metadatadef.Schemas, error) {
 	return e.ReadObjects("POST", pathMatcher, objectEndpoints, displayNameOverride, locator)
 }
 
@@ -74,8 +75,8 @@ func (e Explorer) ReadObjects(
 	objectEndpoints map[string]string,
 	displayNameOverride map[string]string,
 	locator ObjectArrayLocator,
-) (Schemas, error) {
-	schemas := make(Schemas, 0)
+) (metadatadef.Schemas, error) {
+	schemas := make(metadatadef.Schemas, 0)
 
 	pathItems, _ := e.GetPathItems(AndPathMatcher{
 		pathMatcher,


### PR DESCRIPTION
# Description

Schema struct is a model that is used by `OpenAPI` scripts and one `Scrapper`.
With the upcoming introduction of the GoogleDiscovery extractor, the following considerations are clear:
* Metadata can originate from multiple sources (OpenAPI/GoogleDiscovery/Scrapper).
* A single model should be sufficient to represent all sources. (`metadatadef.Schema`)
* The model should exist within its own package, separate from the tools. (`metadatadef`)

This PR restructures the code to separate data models from tools.

Additonally, fields extractor does not just return the field names as array of strings but array of `metadatadef.Field{}`.