### PR TITLE
feat(tool): Google-Discovery to metadata extractor

### DIFF
--- a/tools/fileconv/explorer.go
+++ b/tools/fileconv/explorer.go
@@ -1,0 +1,1 @@
+package fileconv

--- a/tools/fileconv/googledicsovery/README.md
+++ b/tools/fileconv/googledicsovery/README.md
@@ -1,0 +1,59 @@
+# Package googledicsovery
+
+## Purpose
+This package extracts schemas metadata from `Google Discovery` files.
+
+## Description
+The Google connector does not provide API endpoints for object metadata. 
+Instead, **Google Discovery Files** describe operations and response schemas for each module.
+
+Refer to:
+* [Google API explorer](https://developers.google.com/apis-explorer/)
+* [Google API Go Client](https://github.com/googleapis/google-api-go-client/) (for discovery files)
+
+## Loading File
+
+```go
+var (
+    // Static file containing google discovery file.
+    //
+    //go:embed discovery-file.json
+    apiFile []byte
+
+    FileManager = googledicsovery.NewFileManager(apiFile) // nolint:gochecknoglobals
+)
+```
+
+## Usage
+
+```go
+// Pseudo code, omitting err.
+schemas = packageWithDiscoveryFile.FileManager.GetExplorer().ReadObjectsGet(
+    displayNameOverride,
+)
+```
+
+Argument description:
+
+The Explorer can be configured to process display names after extraction. For example, you can format names to improve readability.
+Edge cases should be handled explicitly using the **displayNameOverride** map.
+
+
+### Configuration
+
+The Google discovery schema explorer can be configured to tailor the handling of edge cases. 
+```go
+packageWithDiscoveryFile.FileManager.GetExplorer(
+    api3.WithDisplayNamePostProcessors(
+        api3.CamelCaseToSpaceSeparated,
+        api3.CapitalizeFirstLetterEveryWord,
+    )
+)
+```
+
+**Display Name.**
+Display names can be transformed using chained formatters.
+For example:
+1. Convert camel case to space-separated words.
+2. Capitalize the first letter of each word.
+While a single formatter is sufficient, chaining allows better composition of built-in utilities.

--- a/tools/fileconv/googledicsovery/discovery.go
+++ b/tools/fileconv/googledicsovery/discovery.go
@@ -1,0 +1,154 @@
+package googledicsovery
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/internal/metadatadef"
+)
+
+type Document struct {
+	Title       string              `json:"title"`
+	Description string              `json:"description"`
+	XResources  map[string]Resource `json:"x-resources"` // nolint:tagliatelle
+	XSchemas    map[string]Schema   `json:"x-schemas"`   // nolint:tagliatelle
+}
+
+func (d Document) ListObjects(httpMethod string) metadatadef.Schemas {
+	objects := make(metadatadef.Schemas, 0)
+
+	for objectName, resource := range d.XResources {
+		for methodName, method := range resource.Methods {
+			if methodName != "list" {
+				continue
+			}
+
+			if !strings.EqualFold(method.HTTPMethod, httpMethod) {
+				continue
+			}
+
+			if strings.Contains(method.Path, "{") {
+				// No path IDs are allowed.
+				continue
+			}
+
+			fields, err := d.schemaFieldsFor(method)
+
+			objects = append(objects, metadatadef.Schema{
+				ObjectName:  objectName,
+				DisplayName: objectName,
+				Fields:      fields,
+				QueryParams: nil,
+				URLPath:     method.Path,
+				ResponseKey: "items",
+				Problem:     err,
+			})
+		}
+	}
+
+	return objects
+}
+
+var (
+	ErrMissingItemsRef = errors.New("missing nested reference to items schema")
+	ErrUnknownRef      = errors.New("unknown schema reference")
+)
+
+func (d Document) schemaFieldsFor(method Method) (metadatadef.Fields, error) {
+	schema, err := d.locateItemsSchema(method)
+	if err != nil {
+		return nil, err
+	}
+
+	return schema.fields(), nil
+}
+
+func (d Document) locateItemsSchema(method Method) (*Schema, error) {
+	schema, err := d.findSchema(method.Response.Ref)
+	if err != nil {
+		return nil, err
+	}
+
+	itemsRef, ok := schema.Properties["items"]
+	if !ok {
+		return nil, fmt.Errorf("%w: problematic method is %v", ErrMissingItemsRef, method.Path)
+	}
+
+	bytes, err := json.Marshal(itemsRef)
+	if err != nil {
+		return nil, err
+	}
+
+	var items ItemsProperty
+	if err = json.Unmarshal(bytes, &items); err != nil {
+		return nil, err
+	}
+
+	return d.findSchema(items.Items.Ref)
+}
+
+func (d Document) findSchema(ref string) (*Schema, error) {
+	schemaName, _ := strings.CutPrefix(ref, "$")
+	for name, schema := range d.XSchemas {
+		if name == schemaName {
+			return &schema, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: reference %v", ErrUnknownRef, ref)
+}
+
+type Resource struct {
+	Methods map[string]Method `json:"methods"`
+}
+
+type Method struct {
+	HTTPMethod  string `json:"httpMethod"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Response    struct {
+		Ref string `json:"$ref"`
+	} `json:"response"`
+}
+
+type Schema struct {
+	Id         string              `json:"id"`
+	Properties map[string]Property `json:"properties"`
+	Type       string              `json:"type"`
+}
+
+type Property struct {
+	Type        string         `json:"type"`
+	Items       map[string]any `json:"items"`
+	Description string         `json:"description"`
+	Ref         string         `json:"$ref"`
+}
+
+func (s *Schema) fields() metadatadef.Fields {
+	fields := make(metadatadef.Fields)
+
+	for propertyName, property := range s.Properties {
+		propertyType := property.Type
+		if len(propertyType) == 0 && len(property.Ref) != 0 {
+			// Embedded object.
+			propertyType = "object"
+		}
+
+		fields[propertyName] = metadatadef.Field{
+			Name: propertyName,
+			Type: propertyType,
+		}
+	}
+
+	return fields
+}
+
+type ItemsProperty struct {
+	Description string `json:"description"`
+	Items       struct {
+		Ref string `json:"$ref"`
+	} `json:"items"`
+	Type string `json:"type"`
+}

--- a/tools/fileconv/googledicsovery/manager.go
+++ b/tools/fileconv/googledicsovery/manager.go
@@ -1,0 +1,30 @@
+package googledicsovery
+
+import (
+	"encoding/json"
+)
+
+// FileManager locates google discovery file.
+// Allows to read data of interest.
+type FileManager struct {
+	file []byte
+}
+
+func NewFileManager(file []byte) *FileManager {
+	return &FileManager{
+		file: file,
+	}
+}
+
+func (m FileManager) GetExplorer(opts ...Option) (*Explorer, error) {
+	discoverFile := Document{}
+
+	if err := json.Unmarshal(m.file, &discoverFile); err != nil {
+		return nil, err
+	}
+
+	return &Explorer{
+		document:   discoverFile,
+		parameters: createParams(opts),
+	}, nil
+}

--- a/tools/fileconv/googledicsovery/parameters.go
+++ b/tools/fileconv/googledicsovery/parameters.go
@@ -1,0 +1,36 @@
+package googledicsovery
+
+import "github.com/amp-labs/connectors/tools/fileconv/api3"
+
+// WithDisplayNamePostProcessors will apply processors in the given order.
+func WithDisplayNamePostProcessors(processors ...api3.DisplayNameProcessor) Option {
+	return func(params *parameters) {
+		params.displayPostProcessing = func(displayName string) string {
+			for _, processor := range processors {
+				displayName = processor(displayName)
+			}
+
+			return displayName
+		}
+	}
+}
+
+type parameters struct {
+	displayPostProcessing api3.DisplayNameProcessor
+}
+
+type Option = func(params *parameters)
+
+func createParams(opts []Option) *parameters {
+	params := parameters{
+		// Default values are setup here.
+		displayPostProcessing: func(displayName string) string {
+			return displayName
+		},
+	}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	return &params
+}

--- a/tools/fileconv/googledicsovery/queries.go
+++ b/tools/fileconv/googledicsovery/queries.go
@@ -1,0 +1,44 @@
+package googledicsovery
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/amp-labs/connectors/internal/metadatadef"
+)
+
+// Explorer allows to traverse schema in most common ways
+// relevant for connectors metadata extraction.
+type Explorer struct {
+	document Document
+	*parameters
+}
+
+func (e Explorer) ReadObjectsGet(
+	displayNameOverride map[string]string,
+) (metadatadef.Schemas, error) {
+	return e.ReadObjects(http.MethodGet, displayNameOverride)
+}
+
+func (e Explorer) ReadObjects(
+	httpMethod string,
+	displayNameOverride map[string]string,
+) (metadatadef.Schemas, error) {
+	schemas := e.document.ListObjects(httpMethod)
+
+	for i, schema := range schemas {
+		displayName, ok := displayNameOverride[schema.ObjectName]
+		if !ok {
+			displayName = e.displayPostProcessing(schema.ObjectName)
+		}
+
+		schema.DisplayName = displayName
+		schemas[i] = schema
+	}
+
+	sort.Slice(schemas, func(i, j int) bool {
+		return schemas[i].Problem == nil && schemas[j].Problem != nil
+	})
+
+	return schemas, nil
+}


### PR DESCRIPTION
# Description

This is a new tool similar to the OpenAPI metadata extractor.
It operates on Google Discovery files. Initially, I considered converting Google Discovery files to OpenAPI format and using the existing script, but I couldn't find such tools online. Since writing a custom extractor is relatively simple, I opted for this approach.

# Purpose
This tool will be useful for adding more Google API modules. Implementing ListObjectMetadata will simply involve downloading the Google Discovery file, making slight script adjustments, and specifying the module ID. This process will generate a schema.json file, mapping each module to its metadata.

# Review

[Next PR ](https://github.com/amp-labs/connectors/pull/1315) in the Graphite stack uses this tool to produce metadata for Calendar Google module.