### PR TITLE
[CON-1039] fix(Hubspot): Separate pipelines and stages

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -104,6 +104,10 @@ var (
 
 	// ErrNextPageInvalid is returned when next page token provided in Read operation cannot be understood.
 	ErrNextPageInvalid = errors.New("next page token is invalid")
+
+	// ErrInvalidImplementation is returned when implementation assumption is broken.
+	// This is not a client issue.
+	ErrInvalidImplementation = errors.New("invalid implementation")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.
@@ -331,6 +335,8 @@ type FieldValue struct {
 	Value        string
 	DisplayValue string
 }
+
+type FieldValues []FieldValue
 
 type PostAuthInfo struct {
 	CatalogVars          *map[string]string

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -207,29 +207,8 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 								ProviderType: "enumeration.select",
 								ReadOnly:     false,
 								Values: []common.FieldValue{{
-									Value:        "subscriber",
-									DisplayValue: "Subscriber",
-								}, {
-									Value:        "lead",
-									DisplayValue: "Lead",
-								}, {
-									Value:        "marketingqualifiedlead",
-									DisplayValue: "Marketing Qualified Lead",
-								}, {
-									Value:        "salesqualifiedlead",
-									DisplayValue: "Sales Qualified Lead",
-								}, {
-									Value:        "opportunity",
-									DisplayValue: "Opportunity",
-								}, {
-									Value:        "customer",
-									DisplayValue: "Customer",
-								}, {
-									Value:        "evangelist",
-									DisplayValue: "Evangelist",
-								}, {
-									Value:        "other",
-									DisplayValue: "Other",
+									Value:        "contacts-lifecycle-pipeline",
+									DisplayValue: "Lifecycle Stage Pipeline",
 								}},
 							},
 						},
@@ -265,25 +244,35 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 								ProviderType: "enumeration.select",
 								ReadOnly:     false,
 								Values: []common.FieldValue{{
-									Value:        "appointmentscheduled",
+									Value:        "default",
+									DisplayValue: "Sales Pipeline",
+								}},
+							},
+							"dealstage": {
+								DisplayName:  "Deal Stage",
+								ValueType:    "singleSelect",
+								ProviderType: "enumeration.radio",
+								ReadOnly:     false,
+								Values: []common.FieldValue{{
+									Value:        "default:appointmentscheduled",
 									DisplayValue: "Appointment Scheduled",
 								}, {
-									Value:        "qualifiedtobuy",
+									Value:        "default:qualifiedtobuy",
 									DisplayValue: "Qualified To Buy",
 								}, {
-									Value:        "presentationscheduled",
+									Value:        "default:presentationscheduled",
 									DisplayValue: "Presentation Scheduled",
 								}, {
-									Value:        "decisionmakerboughtin",
+									Value:        "default:decisionmakerboughtin",
 									DisplayValue: "Decision Maker Bought-In",
 								}, {
-									Value:        "contractsent",
+									Value:        "default:contractsent",
 									DisplayValue: "Contract Sent",
 								}, {
-									Value:        "closedwon",
+									Value:        "default:closedwon",
 									DisplayValue: "Closed Won",
 								}, {
-									Value:        "closedlost",
+									Value:        "default:closedlost",
 									DisplayValue: "Closed Lost",
 								}},
 							},

--- a/providers/hubspot/test/metadata-deals-properties-sampled.json
+++ b/providers/hubspot/test/metadata-deals-properties-sampled.json
@@ -23,6 +23,31 @@
       },
       "formField": false,
       "dataSensitivity": "non_sensitive"
+    },
+    {
+      "updatedAt": "2024-09-05T17:14:04.747Z",
+      "createdAt": "2020-06-30T15:57:38.180Z",
+      "name": "dealstage",
+      "label": "Deal Stage",
+      "type": "enumeration",
+      "fieldType": "radio",
+      "description": "The stage of the deal. Deal stages allow you to categorize and track the progress of the deals that you are working on.",
+      "groupName": "deal_activity",
+      "options": [],
+      "displayOrder": 3,
+      "calculated": false,
+      "externalOptions": true,
+      "hasUniqueValue": false,
+      "hidden": false,
+      "hubspotDefined": true,
+      "modificationMetadata": {
+        "archivable": true,
+        "readOnlyDefinition": true,
+        "readOnlyOptions": false,
+        "readOnlyValue": false
+      },
+      "formField": false,
+      "dataSensitivity": "non_sensitive"
     }
   ]
 }

--- a/test/hubspot/metadata/contacts/main.go
+++ b/test/hubspot/metadata/contacts/main.go
@@ -3,19 +3,14 @@ package main
 import (
 	"context"
 	"log/slog"
+	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/hubspot"
 	"github.com/amp-labs/connectors/test/utils"
 )
 
-var objectName = "contacts"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -27,34 +22,12 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
+		"contacts",
 	})
 	if err != nil {
 		utils.Fail("error listing metadata for Hubspot", "error", err)
 	}
 
-	slog.Info("Read object using all fields from ListObjectMetadata")
-
-	requestFields := datautils.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     requestFields,
-	})
-	if err != nil {
-		utils.Fail("error reading from Hubspot", "error", err)
-	} else {
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
-
-		difference := givenFields.Diff(requestFields)
-		if len(difference) != 0 {
-			utils.Fail("connector read didn't match requested fields", "difference", difference)
-		}
-	}
-
-	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+	slog.Info("Metadata deals..")
+	utils.DumpJSON(metadata, os.Stdout)
 }


### PR DESCRIPTION
# Tests
## Deals
![image](https://github.com/user-attachments/assets/b70aacb1-e221-4038-9ede-2814189d95ee)
![image](https://github.com/user-attachments/assets/76d31f68-d76c-48ae-bb59-6becae12e623)
![image](https://github.com/user-attachments/assets/cb6bb563-c942-444a-9e65-fd8d5d22267b)

## Contacts
![image](https://github.com/user-attachments/assets/fa4fc472-4de2-4e5c-940b-c0d0b36527fb)
![image](https://github.com/user-attachments/assets/8d658332-8158-4398-8fc2-18a9565b9962)
I didn't find a field that would hold stages for contacts. By reading [this documenation](https://knowledge.hubspot.com/object-settings/set-up-and-customize-pipelines#:~:text=The%20default%20pipeline%20has%20seven,(0%25%2C%20Lost).), I have concluded that there are no such field, because there is no mention of contacts in stages paragraph:
![image](https://github.com/user-attachments/assets/aac9e8e3-8f84-4bfd-a605-522300015bf3)

# Notes
Mock tests where updated in accordance to the format specified in the ticket.
![image](https://github.com/user-attachments/assets/22218507-9828-4fe6-8dc9-2cf3f5306405)
![image](https://github.com/user-attachments/assets/d708050a-50e3-408b-bc5b-7d7a0c1eefa8)
