### PR TITLE
feat: update Marketo Read Connector to support Leads

### DIFF
--- a/providers/marketo/README.md
+++ b/providers/marketo/README.md
@@ -4,14 +4,14 @@ The connector currently supports Leads API only.
 
 # Supported Objects
 
-| Object | Resource | Method |
-| :-------- | :------- | :-------- |
-| Companies | companies | Write |
-| Leads | leads | Write |
-| Named Account Lists | namedAccountLists | Write |
-| Named Accounts | namedaccounts | Write |
-| Opportunities | opportunities | Write |
-| Sales Person | salespersons | Write |
-| Campaigns | campaigns | Read |
-| Custom Objects | customobjects | Read |
-| Lists | lists | Read |
+| Object              | Resource          | Method      |
+| :------------------ | :---------------- | :---------- |
+| Companies           | companies         | Read, Write |
+| Leads               | leads             | Read, Write |
+| Named Account Lists | namedAccountLists | Write       |
+| Named Accounts      | namedaccounts     | Write       |
+| Opportunities       | opportunities     | Write       |
+| Sales Person        | salespersons      | Read, Write |
+| Campaigns           | campaigns         | Read        |
+| Custom Objects      | customobjects     | Read        |
+| Lists               | lists             | Read        |

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -56,9 +56,9 @@ func (c *Connector) Provider() providers.Provider {
 
 func (c *Connector) getAPIURL(objName string) (*urlbuilder.URL, error) {
 	objName = common.AddSuffixIfNotExists(objName, ".json")
-	bURL := strings.Join([]string{restAPIPrefix, c.Module.Path(), objName}, "/")
+	relativeURL := strings.Join([]string{restAPIPrefix, c.Module.Path(), objName}, "/")
 
-	return urlbuilder.New(c.BaseURL, bURL)
+	return urlbuilder.New(c.BaseURL, relativeURL)
 }
 
 func (c *Connector) String() string {

--- a/providers/marketo/parse.go
+++ b/providers/marketo/parse.go
@@ -1,6 +1,9 @@
 package marketo
 
 import (
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/jsonquery"
 	"github.com/spyzhov/ajson"
 )
@@ -8,6 +11,36 @@ import (
 // getNextRecordsURL returns the URL for the next page of results.
 func getNextRecordsURL(node *ajson.Node) (string, error) {
 	return jsonquery.New(node).StrWithDefault("nextPageToken", "")
+}
+
+func constructNextRecordsURL(object string) common.NextPageFunc {
+	if filtersByIDs(object) {
+		// We use a new func for generating the next page url.
+		return func(node *ajson.Node) (string, error) {
+			jsonParser := jsonquery.New(node)
+
+			data, err := jsonParser.Array("result", false)
+			if err != nil {
+				return "", err
+			}
+
+			// If the records returned matches the maximum batchsize, there is a high probability of having more records.
+			// We'd have to check for the next page records, also due deletes the is also a probability of having more records
+			// even if the size do not reach 300.
+			if len(data) > 0 {
+				id, err := jsonquery.New(data[len(data)-1]).Integer("id", false)
+				if err != nil {
+					return "", err
+				}
+
+				return strconv.Itoa(int(*id) + 1), nil
+			}
+
+			return "", nil
+		}
+	}
+
+	return getNextRecordsURL
 }
 
 // getRecords returns the records from the response.

--- a/providers/marketo/read.go
+++ b/providers/marketo/read.go
@@ -12,7 +12,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	url, err := c.getURL(config)
+	url, err := c.constructURL(config)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(res,
 		getRecords,
-		getNextRecordsURL,
+		constructNextRecordsURL(config.ObjectName),
 		common.GetMarshaledData,
 		config.Fields,
 	)

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -1,6 +1,8 @@
 package marketo
 
 import (
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -9,15 +11,14 @@ import (
 
 const restAPIPrefix = "rest" //nolint:gochecknoglobals
 
-func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
+func (c *Connector) constructURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	url, err := c.getAPIURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	// If NextPage is set, then we're reading the next page of results.
-	if len(params.NextPage) > 0 {
-		url.WithQueryParam("nextPageToken", params.NextPage.String())
+	if err := constructURLQueries(url, params); err != nil {
+		return nil, err
 	}
 
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
@@ -33,4 +34,44 @@ func (c *Connector) getURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	}
 
 	return url, nil
+}
+
+func addFilteringIDQueries(urlbuilder *urlbuilder.URL, startIdx string) error {
+	ids := make([]string, batchSize)
+
+	idx, err := strconv.Atoi(startIdx)
+	if err != nil {
+		return err
+	}
+
+	for i := range ids {
+		ids[i] = strconv.Itoa(idx + i)
+	}
+
+	queryIDs := strings.Join(ids, ",")
+	urlbuilder.WithQueryParam("filterValues", queryIDs)
+	urlbuilder.WithQueryParam("filterType", "id")
+
+	return nil
+}
+
+func constructURLQueries(url *urlbuilder.URL, params common.ReadParams) error {
+	if filtersByIDs(params.ObjectName) && len(params.NextPage) == 0 {
+		if err := addFilteringIDQueries(url, "1"); err != nil {
+			return err
+		}
+	}
+
+	// If NextPage is set, then we're reading the next page of results.
+	if len(params.NextPage) > 0 {
+		if filtersByIDs(params.ObjectName) {
+			if err := addFilteringIDQueries(url, params.NextPage.String()); err != nil {
+				return err
+			}
+		} else {
+			url.WithQueryParam("nextPageToken", params.NextPage.String())
+		}
+	}
+
+	return nil
 }

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -27,7 +27,7 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	return conn
 }
 
-func GetMarketoConnectorW(ctx context.Context) *marketo.Connector {
+func GetMarketoConnectorLeads(ctx context.Context) *marketo.Connector {
 	reader := getMarketoJSONReader()
 
 	conn, err := marketo.NewConnector(

--- a/test/marketo/write/write.go
+++ b/test/marketo/write/write.go
@@ -41,7 +41,7 @@ func MainFn() int {
 }
 
 func testWriteLeads(ctx context.Context) error {
-	conn := marketo.GetMarketoConnectorW(ctx)
+	conn := marketo.GetMarketoConnectorLeads(ctx)
 
 	params := common.WriteParams{
 		ObjectName: "leads",
@@ -76,7 +76,7 @@ func testWriteLeads(ctx context.Context) error {
 }
 
 func testWriteOpportunities(ctx context.Context) error {
-	conn := marketo.GetMarketoConnectorW(ctx)
+	conn := marketo.GetMarketoConnectorLeads(ctx)
 
 	params := common.WriteParams{
 		ObjectName: "opportunities",
@@ -108,7 +108,7 @@ func testWriteOpportunities(ctx context.Context) error {
 }
 
 func testWriteOpportunitiesFail(ctx context.Context) error {
-	conn := marketo.GetMarketoConnectorW(ctx)
+	conn := marketo.GetMarketoConnectorLeads(ctx)
 
 	params := common.WriteParams{
 		ObjectName: "opportunities",


### PR DESCRIPTION
- Marketo Connector requires FilteringValues (Passed as Query Params) to Read `Leads`, `Companies` and  `SalesPersons` Objects. 
- The `Ids` in these objects are numericals starting from 1.
-  I have used the `id` as a filteringType for these Objects and thus we can now provide FilteringValues.

With this Marketo can now support Reading from `Leads` `Companies` and `SalesPersons`. 

Tests:
<img width="1224" alt="Screenshot 2025-02-03 at 13 35 45" src="https://github.com/user-attachments/assets/6dc5ad09-33c8-485c-833f-a4057f01938c" />
