### PR TITLE
[CON-1038] fix(Keap): ReadResult.Raw

### DIFF
--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -1,12 +1,19 @@
 package keap
 
 import (
-	"context"
-
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/keap/metadata"
 	"github.com/spyzhov/ajson"
 )
+
+func makeGetRecords(moduleID common.ModuleID, objectName string) common.NodeRecordsFunc {
+	return func(node *ajson.Node) ([]*ajson.Node, error) {
+		responseFieldName := metadata.Schemas.LookupArrayFieldName(moduleID, objectName)
+
+		return jsonquery.New(node).ArrayOptional(responseFieldName)
+	}
+}
 
 func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
@@ -21,25 +28,14 @@ func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
 // Before parsing the records, if any custom fields are present (without a human-readable name),
 // this will call the correct API to extend & replace the custom field with human-readable information.
 // Object will then be enhanced using model.
-func (c *Connector) parseReadRecords(
-	ctx context.Context, config common.ReadParams, jsonPath string,
-) common.RecordsFunc {
-	return func(node *ajson.Node) ([]map[string]any, error) {
-		arr, err := jsonquery.New(node).ArrayOptional(jsonPath)
-		if err != nil {
-			return nil, err
-		}
-
-		customFields, err := c.requestCustomFields(ctx, config.ObjectName)
-		if err != nil {
-			return nil, err
-		}
-
+func (c *Connector) attachReadCustomFields(customFields map[int]modelCustomField) common.RawReadRecordFunc {
+	return func(node *ajson.Node) (map[string]any, error) {
 		if len(customFields) == 0 {
-			return jsonquery.Convertor.ArrayToMap(arr)
+			// No custom fields, no-op, return as is.
+			return jsonquery.Convertor.ObjectToMap(node)
 		}
 
-		return enhanceObjectsWithCustomFieldNames(arr, customFields)
+		return enhanceObjectsWithCustomFieldNames(node, customFields)
 	}
 }
 
@@ -49,31 +45,25 @@ func (c *Connector) parseReadRecords(
 // * Replace ids with human-readable names, which is provided as argument.
 // * Place fields at the top level of the object.
 func enhanceObjectsWithCustomFieldNames(
-	arr []*ajson.Node,
+	node *ajson.Node,
 	fields map[int]modelCustomField,
-) ([]map[string]any, error) {
-	result := make([]map[string]any, len(arr))
-
-	for index, node := range arr {
-		object, err := jsonquery.Convertor.ObjectToMap(node)
-		if err != nil {
-			return nil, err
-		}
-
-		customFieldsResponse, err := jsonquery.ParseNode[readCustomFieldsResponse](node)
-		if err != nil {
-			return nil, err
-		}
-
-		// Replace identifiers with human-readable field names which were found by making a call to "/model".
-		for _, field := range customFieldsResponse.CustomFields {
-			if model, ok := fields[field.ID]; ok {
-				object[model.FieldName] = field.Content
-			}
-		}
-
-		result[index] = object
+) (map[string]any, error) {
+	object, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
 	}
 
-	return result, nil
+	customFieldsResponse, err := jsonquery.ParseNode[readCustomFieldsResponse](node)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace identifiers with human-readable field names which were found by making a call to "/model".
+	for _, field := range customFieldsResponse.CustomFields {
+		if model, ok := fields[field.ID]; ok {
+			object[model.FieldName] = field.Content
+		}
+	}
+
+	return object, nil
 }

--- a/providers/keap/read.go
+++ b/providers/keap/read.go
@@ -39,12 +39,15 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, config.ObjectName)
+	customFields, err := c.requestCustomFields(ctx, config.ObjectName)
+	if err != nil {
+		return nil, err
+	}
 
 	return common.ParseResult(res,
-		c.parseReadRecords(ctx, config, responseFieldName),
+		makeGetRecords(c.Module.ID, config.ObjectName),
 		makeNextRecordsURL(c.Module.ID),
-		common.GetMarshaledData,
+		common.MakeMarshaledDataFunc(c.attachReadCustomFields(customFields)),
 		config.Fields,
 	)
 }

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -75,7 +75,11 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name: "Contacts first page has a link to next",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
-				Fields:     connectors.Fields("given_name", "jobtitle"),
+				Fields: connectors.Fields("given_name",
+					// Next fields are custom fields which do NOT exist inside raw.
+					// However, they are surfaced to the user via ListObjectMetadata,
+					// so they will have context to request them.
+					"jobtitle", "jobdescription", "experience", "age"),
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -92,15 +96,15 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Rows: 2,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
-						"given_name": "Erica",
-						"jobtitle":   "Product Owner",
-					},
-					Raw: map[string]any{
-						"id":             float64(22),
-						"family_name":    "Lewis",
+						"given_name":     "Erica",
+						"jobtitle":       "Product Owner",
 						"jobdescription": "AI application in commerce",
 						"experience":     "8 years in 3 companies",
 						"age":            float64(32),
+					},
+					Raw: map[string]any{
+						"id":          float64(22),
+						"family_name": "Lewis",
 						"custom_fields": []any{map[string]any{
 							"id":      float64(12),
 							"content": "8 years in 3 companies",
@@ -117,15 +121,15 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 				}, {
 					Fields: map[string]any{
-						"given_name": "John",
-						"jobtitle":   nil,
-					},
-					Raw: map[string]any{
-						"id":             float64(20),
-						"family_name":    "Doe",
+						"given_name":     "John",
+						"jobtitle":       nil,
 						"jobdescription": nil,
 						"experience":     nil,
 						"age":            nil,
+					},
+					Raw: map[string]any{
+						"id":          float64(20),
+						"family_name": "Doe",
 					},
 				}},
 				NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=2&offset=2&since=2024-06-03T22:17:59.039Z&order=id", // nolint:lll

--- a/test/keap/read/main.go
+++ b/test/keap/read/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "contacts",
-		Fields:     connectors.Fields("id"),
+		Fields:     connectors.Fields("id", "experience"),
 		// Since:      time.Now().Add(-30 * time.Minute),
 		// NextPage: "https://api.infusionsoft.com/crm/rest/v1/contacts/?limit=1&offset=50&since=2024-12-17T21:39:36.099Z&order=id",
 	})
@@ -34,6 +34,6 @@ func main() {
 		utils.Fail("error reading from Keap", "error", err)
 	}
 
-	fmt.Println("Reading emails..")
+	fmt.Println("Reading contacts..")
 	utils.DumpJSON(res, os.Stdout)
 }


### PR DESCRIPTION
# Tests
![image](https://github.com/user-attachments/assets/439233f3-958f-4676-bc1c-c01510c005ed)
![image](https://github.com/user-attachments/assets/9a9ac069-4b2b-4c0d-8085-b7ce8e5f647d)


# Notes
Requested available fields using `ListObjectMetadata`.
![image](https://github.com/user-attachments/assets/480e7b99-bc00-45d3-85a1-2e019cd779cc)
Experience field is one of the custom fields. As you can see this field is not present inside raw response. But requesting such field will include it inside `fields` JSON object.
![image](https://github.com/user-attachments/assets/e48598de-2d74-4372-a2d6-a10f4580441d)
