### PR TITLE
feat: update Marketo Metadata Connector for Leads Module

### DIFF
--- a/providers/marketo/read.go
+++ b/providers/marketo/read.go
@@ -12,7 +12,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	url, err := c.constructURL(config)
+	url, err := c.constructReadURL(config)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/marketo/types.go
+++ b/providers/marketo/types.go
@@ -24,6 +24,17 @@ var (
 
 	// idFilteringObjects represents objects that uses id as filtering values in read connector.
 	idFilteringObjects = []string{"leads", "salespersons", "companies"}
+
+	// metadataPaths represents a map of a few objects in Marketo that has unique resource for returning metadata fields.
+	metadataPaths = map[string]string{
+		"leads":         "rest/v1/leads/describe2.json",
+		"companies":     "rest/v1/companies/describe.json",
+		"namedaccounts": "rest/v1/namedaccounts/describe.json",
+		"salespersons":  "rest/v1/salespersons/describe.json",
+		"opportunities": "rest/v1/opportunities/describe.json",
+	}
+
+	ErrFailedConvertFields = errors.New("failed to convert the response message to metadata fields")
 )
 
 func constructErrMessage(a any) (string, error) {
@@ -39,4 +50,13 @@ func paginatesByIDs(object string) bool {
 	// Most Marketo APIs requires filtering when reading, Important objects are Leads, Custom Objects, Companies
 	// With this we use the general filter parameter `id` and iterate over the records.
 	return slices.Contains(idFilteringObjects, object)
+}
+
+func hasMetadataResource(object string) (string, bool) {
+	path, ok := metadataPaths[object]
+	if !ok {
+		return "", false
+	}
+
+	return path, true
 }

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -12,7 +12,7 @@ import (
 
 const restAPIPrefix = "rest" //nolint:gochecknoglobals
 
-func (c *Connector) constructURL(params common.ReadParams) (*urlbuilder.URL, error) {
+func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
 	url, err := c.getAPIURL(params.ObjectName)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,6 @@ func (c *Connector) constructURL(params common.ReadParams) (*urlbuilder.URL, err
 	return url, nil
 }
 
-// ref: https://developer.adobe.com/marketo-apis/api/mapi/#operation/getLeadsByFilterUsingGET
 func addFilteringIDQueries(urlbuilder *urlbuilder.URL, startIdx string) error {
 	ids := make([]string, batchSize)
 

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -37,6 +37,15 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 	return url, nil
 }
 
+func (c *Connector) constructMetadataURL(objectName string) (*urlbuilder.URL, error) {
+	path, ok := hasMetadataResource(objectName)
+	if !ok {
+		return c.getAPIURL(objectName)
+	}
+
+	return urlbuilder.New(c.BaseURL, path)
+}
+
 func addFilteringIDQueries(urlbuilder *urlbuilder.URL, startIdx string) error {
 	ids := make([]string, batchSize)
 

--- a/test/marketo/metadata/metadata.go
+++ b/test/marketo/metadata/metadata.go
@@ -13,7 +13,7 @@ func main() {
 
 	conn := marketo.GetMarketoConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"channels", "emailTemplates", "files", "folders", "meandyou"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"channels", "emailTemplates", "files", "folders", "meandyou", "leads"})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Leads API has a few objects that has a dedicated resource for returning Metadata. These objects include
- `Leads`
- `Companies`
- `NamedAccounts`
- `SalesPersons`
-  `Opportunities` (Although this is currently not supporting Read)

This PR Adds support for retrieving Metadata using the `describe` resource.

Tests:
<img width="1227" alt="Screenshot 2025-02-04 at 15 14 55" src="https://github.com/user-attachments/assets/0e02d6b0-c228-482f-b43d-54622a6c1123" />
