### PR TITLE
feat(openapi): Return field enums

### DIFF
--- a/internal/metadatadef/definition.go
+++ b/internal/metadatadef/definition.go
@@ -23,8 +23,9 @@ type Schema struct {
 type Schemas []Schema
 
 type Field struct {
-	Name string
-	Type string
+	Name        string
+	Type        string
+	EnumOptions []string
 }
 
 type Fields = datautils.Map[string, Field]

--- a/scripts/openapi/utils/convert.go
+++ b/scripts/openapi/utils/convert.go
@@ -1,0 +1,53 @@
+package utilsopenapi
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/internal/staticschema"
+)
+
+func ConvertMetadataFieldToFieldMetadataMapV2(field metadatadef.Field) staticschema.FieldMetadataMapV2 {
+	return staticschema.FieldMetadataMapV2{
+		field.Name: staticschema.FieldMetadata{
+			DisplayName:  field.Name,
+			ValueType:    getFieldValueType(field),
+			ProviderType: field.Type,
+			ReadOnly:     false,
+			Values:       getFieldValueOptions(field),
+		},
+	}
+}
+
+func getFieldValueType(field metadatadef.Field) common.ValueType {
+	switch field.Type {
+	case "integer":
+		return common.ValueTypeInt
+	case "boolean":
+		return common.ValueTypeBoolean
+	case "string":
+		if len(field.EnumOptions) != 0 {
+			return common.ValueTypeSingleSelect
+		}
+
+		return common.ValueTypeString
+	default:
+		// object, array
+		return common.ValueTypeOther
+	}
+}
+
+func getFieldValueOptions(field metadatadef.Field) staticschema.FieldValues {
+	if len(field.EnumOptions) == 0 {
+		return nil
+	}
+
+	values := make(staticschema.FieldValues, len(field.EnumOptions))
+	for index, option := range field.EnumOptions {
+		values[index] = staticschema.FieldValue{
+			Value:        option,
+			DisplayValue: option,
+		}
+	}
+
+	return values
+}


### PR DESCRIPTION
# Description
OpenAPI files may contain [enumeration properties](https://swagger.io/docs/specification/v3_0/data-models/enums/).

This PR extends the Field struct to include new properties derived from OpenAPI files:
* Type
* List of enumeration options

# Purpose
Many connectors can benefit from enumeration data present in OpenAPI files. All of them can migrate to `field metadata version 2`.