### PR TITLE
tidy(write): Convert Payload to map

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -163,6 +164,27 @@ type WriteParams struct {
 
 	// Associations contains associations between the object and other objects.
 	Associations any // optional
+}
+
+// RecordDataToMap converts WriteParams.RecordData into a map[string]any.
+// If RecordData is already a map, it is returned directly.
+// Otherwise, it is serialized to JSON and then deserialized back into a map.
+func RecordDataToMap(recordData any) (map[string]any, error) {
+	if object, ok := recordData.(map[string]any); ok {
+		return object, nil
+	}
+
+	bytes, err := json.Marshal(recordData)
+	if err != nil {
+		return nil, err
+	}
+
+	object := make(map[string]any)
+	if err = json.Unmarshal(bytes, &object); err != nil {
+		return nil, err
+	}
+
+	return object, nil
 }
 
 // DeleteParams defines how we are deleting data in SaaS API.

--- a/providers/klaviyo/write.go
+++ b/providers/klaviyo/write.go
@@ -2,7 +2,6 @@ package klaviyo
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"github.com/amp-labs/connectors/common"
@@ -86,7 +85,7 @@ func prepareWritePayload(config common.WriteParams) (any, error) {
 	//
 	// Additionally, update operation must include identifier not only in URL path but in payload,
 	// for convenience this Klaviyo API requirement is automatically satisfied.
-	object, err := convertPayloadToMap(config.RecordData)
+	object, err := common.RecordDataToMap(config.RecordData)
 	if err != nil {
 		return nil, err
 	}
@@ -147,22 +146,4 @@ func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
 		Errors:   nil,
 		Data:     data,
 	}, nil
-}
-
-func convertPayloadToMap(inputPayload any) (map[string]any, error) {
-	if object, ok := inputPayload.(map[string]any); ok {
-		return object, nil
-	}
-
-	bytes, err := json.Marshal(inputPayload)
-	if err != nil {
-		return nil, err
-	}
-
-	object := make(map[string]any)
-	if err = json.Unmarshal(bytes, &object); err != nil {
-		return nil, err
-	}
-
-	return object, nil
 }


### PR DESCRIPTION
# Description

An increasing number of connectors no longer treat WriteParams.RecordData as an opaque object.

This PR introduces a member function that returns RecordData as a map:
* If RecordData is already a map, it is returned as is.
* Otherwise, it is serialized to JSON and deserialized back into a raw map.
