### PR TITLE
feat(openapi): Return field enums

### DIFF
--- a/internal/metadatadef/definition.go
+++ b/internal/metadatadef/definition.go
@@ -27,8 +27,9 @@ type ExtendedSchema[C any] struct {
 type Schemas[C any] []ExtendedSchema[C]
 
 type Field struct {
-	Name string
-	Type string
+	Name         string
+	Type         string
+	ValueOptions []string
 }
 
 type Fields = datautils.Map[string, Field]

--- a/scripts/openapi/utils/convert.go
+++ b/scripts/openapi/utils/convert.go
@@ -1,0 +1,53 @@
+package utilsopenapi
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/internal/staticschema"
+)
+
+func ConvertMetadataFieldToFieldMetadataMapV2(field metadatadef.Field) staticschema.FieldMetadataMapV2 {
+	return staticschema.FieldMetadataMapV2{
+		field.Name: staticschema.FieldMetadata{
+			DisplayName:  field.Name,
+			ValueType:    getFieldValueType(field),
+			ProviderType: field.Type,
+			ReadOnly:     false,
+			Values:       getFieldValueOptions(field),
+		},
+	}
+}
+
+func getFieldValueType(field metadatadef.Field) common.ValueType {
+	switch field.Type {
+	case "integer":
+		return common.ValueTypeInt
+	case "boolean":
+		return common.ValueTypeBoolean
+	case "string":
+		if len(field.ValueOptions) != 0 {
+			return common.ValueTypeSingleSelect
+		}
+
+		return common.ValueTypeString
+	default:
+		// object, array
+		return common.ValueTypeOther
+	}
+}
+
+func getFieldValueOptions(field metadatadef.Field) staticschema.FieldValues {
+	if len(field.ValueOptions) == 0 {
+		return nil
+	}
+
+	values := make(staticschema.FieldValues, len(field.ValueOptions))
+	for index, option := range field.ValueOptions {
+		values[index] = staticschema.FieldValue{
+			Value:        option,
+			DisplayValue: option,
+		}
+	}
+
+	return values
+}

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -107,7 +107,7 @@ func extractObjectFields(
 	propertyFlattener PropertyFlattener,
 	autoSelectArrayItem bool,
 ) (fields metadatadef.Fields, location string, err error) {
-	switch getSchemaType(schema) {
+	switch getSchemaType(objectName, schema) {
 	case schemaTypeObject:
 		return extractFieldsFromArrayHolder(objectName, schema, locator, propertyFlattener, autoSelectArrayItem)
 	case schemaTypeArray:
@@ -289,7 +289,7 @@ func extractFields(
 	objectName string,
 	propertyFlattener PropertyFlattener, source *openapi3.Schema,
 ) (metadatadef.Fields, error) {
-	combined := make(metadatadef.Fields)
+	combinedFields := make(metadatadef.Fields)
 
 	if source.AnyOf != nil {
 		// this object can be represented by various definitions
@@ -301,7 +301,7 @@ func extractFields(
 				return nil, err
 			}
 
-			combined.AddMapValues(fields)
+			combinedFields.AddMapValues(fields)
 		}
 	}
 
@@ -314,7 +314,7 @@ func extractFields(
 				return nil, err
 			}
 
-			combined.AddMapValues(fields)
+			combinedFields.AddMapValues(fields)
 		}
 	}
 
@@ -327,18 +327,20 @@ func extractFields(
 				return nil, err
 			}
 
-			combined.AddMapValues(fields)
+			combinedFields.AddMapValues(fields)
 		} else {
 			// This is just a normal usual case where top level fields are collected as is.
 			propertyType := extractPropertyType(propertySchema)
-			combined[property] = metadatadef.Field{
-				Name: property,
-				Type: propertyType,
+			enumOptions := extractEnumOptions(objectName, propertySchema)
+			combinedFields[property] = metadatadef.Field{
+				Name:         property,
+				Type:         propertyType,
+				ValueOptions: enumOptions,
 			}
 		}
 	}
 
-	return combined, nil
+	return combinedFields, nil
 }
 
 func extractPropertyType(propertySchema *openapi3.SchemaRef) string {
@@ -352,6 +354,22 @@ func extractPropertyType(propertySchema *openapi3.SchemaRef) string {
 	}
 
 	return types[0]
+}
+
+func extractEnumOptions(objectName string, propertySchema *openapi3.SchemaRef) []string {
+	enumOptions := make([]string, 0)
+
+	if propertySchema.Value != nil && propertySchema.Value.Enum != nil {
+		for _, value := range propertySchema.Value.Enum {
+			if option, ok := value.(string); ok {
+				enumOptions = append(enumOptions, option)
+			} else {
+				slog.Warn("Enum option is not a string", "objectName", objectName)
+			}
+		}
+	}
+
+	return enumOptions
 }
 
 type definitionSchemaType int
@@ -371,9 +389,9 @@ const (
 // It is allowed to have an array without it being nested under object.
 //
 // Returns enum marking the type of schema. This can be used to adjust processing.
-func getSchemaType(schema *openapi3.Schema) definitionSchemaType {
+func getSchemaType(objectName string, schema *openapi3.Schema) definitionSchemaType {
 	if schema.Type == nil {
-		slog.Warn("Schema definition has no type")
+		slog.Warn("Schema definition has no type", "objectName", objectName)
 
 		return schemaTypeUnknown
 	}


### PR DESCRIPTION
# Description
OpenAPI files may contain [enumeration properties](https://swagger.io/docs/specification/v3_0/data-models/enums/).

This PR extends the Field struct to include new properties derived from OpenAPI files:
* Type
* List of enumeration options

# Purpose
Many connectors can benefit from enumeration data present in OpenAPI files. All of them can migrate to `field metadata version 2`.