### PR TITLE
tidy(proxy): Split file, utils package

### DIFF
--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -3,28 +3,17 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"log/slog"
-	"net"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"os/signal"
-	"strings"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/scanning"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
-	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
-	"github.com/amp-labs/connectors/connector"
 	"github.com/amp-labs/connectors/providers"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
+	"github.com/amp-labs/connectors/scripts/utils/proxyserv"
 )
 
 // ================================
@@ -112,370 +101,46 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
+	proxy := createProviderProxy(ctx, info, proxyserv.Factory{
+		Provider:         provider,
+		CatalogVariables: catalogVariables,
+		Debug:            *debug,
+		Registry:         registry,
+		CredsFilePath:    DefaultCredsFile,
+	})
+
+	proxy.Start(ctx, DefaultPort)
+}
+
+func createProviderProxy(
+	ctx context.Context, info *providers.ProviderInfo, factory proxyserv.Factory,
+) *proxyserv.Proxy {
 	switch info.AuthType {
 	case providers.Oauth2:
 		if info.Oauth2Opts == nil {
-			log.Fatalf("Missing OAuth options for provider %s", provider)
+			log.Fatalf("Missing OAuth options for provider %s", factory.Provider)
 		}
 
 		switch info.Oauth2Opts.GrantType {
 		case providers.ClientCredentials:
-			mainOAuth2ClientCreds(ctx, provider, catalogVariables)
+			return factory.CreateProxyOAuth2ClientCreds(ctx)
 		case providers.AuthorizationCodePKCE:
 			fallthrough
 		case providers.AuthorizationCode:
-			mainOAuth2AuthCode(ctx, provider, catalogVariables)
+			return factory.CreateProxyOAuth2AuthCode(ctx)
 		case providers.Password:
-			// de facto, password grant acts as client credentials,
-			// even so access and refresh tokens were acquired differently.
-			mainOAuth2ClientCreds(ctx, provider, catalogVariables)
+			return factory.CreateProxyOAuth2Password(ctx)
 		default:
 			log.Fatalf("Unsupported OAuth2 grant type: %s", info.Oauth2Opts.GrantType)
 		}
 	case providers.ApiKey:
-		mainApiKey(ctx, provider, catalogVariables)
+		return factory.CreateProxyAPIKey(ctx)
 	case providers.Basic:
-		mainBasic(ctx, provider, catalogVariables)
+		return factory.CreateProxyBasic(ctx)
 	default:
 		log.Fatalf("Unsupported auth type: %s", info.AuthType)
 	}
-}
 
-func mainOAuth2ClientCreds(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable) {
-	params := createClientAuthParams(provider)
-	proxy := buildOAuth2ClientCredentialsProxy(ctx, provider, params.Scopes, params.ID, params.Secret, catalogVariables)
-	startProxy(ctx, proxy, DefaultPort)
-}
-
-func mainOAuth2AuthCode(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable) {
-	params := createClientAuthParams(provider)
-	tokens := getTokensFromRegistry()
-	proxy := buildOAuth2AuthCodeProxy(ctx, provider, params.Scopes, params.ID, params.Secret, catalogVariables, tokens)
-	startProxy(ctx, proxy, DefaultPort)
-}
-
-func mainApiKey(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable) {
-	apiKey := registry.MustString(credscanning.Fields.ApiKey.Name)
-	if apiKey == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "api key from registry is empty")
-		os.Exit(1)
-	}
-
-	proxy := buildApiKeyProxy(ctx, provider, catalogVariables, apiKey)
-	startProxy(ctx, proxy, DefaultPort)
-}
-
-func mainBasic(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable) {
-	params := createBasicParams()
-
-	proxy := buildBasicAuthProxy(ctx, provider, catalogVariables, params.User, params.Pass)
-	startProxy(ctx, proxy, DefaultPort)
-}
-
-func createBasicParams() *providers.BasicParams {
-	user := registry.MustString(credscanning.Fields.Username.Name)
-	pass := registry.MustString(credscanning.Fields.Password.Name)
-
-	if len(user)+len(pass) == 0 {
-		log.Fatalf("Missing username or password")
-	}
-
-	if len(user) == 0 {
-		slog.Warn("no username for basic authentication, ensure that it is not required")
-	}
-
-	if len(pass) == 0 {
-		slog.Warn("no password for basic authentication, ensure that it is not required")
-	}
-
-	return &providers.BasicParams{
-		User: user,
-		Pass: pass,
-	}
-}
-
-func createClientAuthParams(provider string) *ClientAuthParams {
-	clientId := registry.MustString(credscanning.Fields.ClientId.Name)
-	clientSecret := registry.MustString(credscanning.Fields.ClientSecret.Name)
-
-	scopes, err := registry.GetString(credscanning.Fields.Scopes.Name)
-	if err != nil {
-		slog.Warn("no scopes attached, ensure that the provider doesn't require scopes")
-	}
-
-	validateRequiredOAuth2Flags(provider, clientId, clientSecret)
-
-	return &ClientAuthParams{
-		ID:     clientId,
-		Secret: clientSecret,
-		Scopes: strings.Split(scopes, ","),
-	}
-}
-
-func getTokensFromRegistry() *oauth2.Token {
-	reader, err := credscanning.NewJSONProviderCredentials(DefaultCredsFile, true, false)
-	if err != nil {
-		panic(err)
-	}
-
-	return reader.GetOauthToken()
-}
-
-func validateRequiredOAuth2Flags(provider, clientId, clientSecret string) {
-	if provider == "" || clientId == "" || clientSecret == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "Missing required flags: -provider, -client-id, -client-secret")
-
-		flag.Usage()
-		os.Exit(1)
-	}
-}
-
-// listen will start a server on the given port and block until it is closed.
-// This is used as opposed to http.ListenAndServe because it respects the context
-// and has a cleaner shutdown sequence.
-func listen(ctx context.Context, port int) error {
-	var lc net.ListenConfig
-
-	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		return err
-	}
-
-	server := &http.Server{
-		Addr: fmt.Sprintf(":%d", port),
-	}
-
-	go func() {
-		<-ctx.Done()
-
-		_ = server.Shutdown(context.Background())
-	}()
-
-	if err := server.Serve(listener); err != nil {
-		if errors.Is(err, http.ErrServerClosed) {
-			fmt.Println("HTTP server stopped")
-
-			return nil
-		}
-
-		return err
-	}
-
+	// unreachable
 	return nil
-}
-
-func startProxy(ctx context.Context, proxy *Proxy, port int) {
-	http.Handle("/", proxy)
-
-	fmt.Printf("\nProxy server listening on :%d\n", port)
-
-	if err := listen(ctx, port); err != nil {
-		panic(err)
-	}
-}
-
-func buildOAuth2ClientCredentialsProxy(ctx context.Context, provider string, scopes []string, clientId, clientSecret string, catalogVariables []catalogreplacer.CatalogVariable) *Proxy {
-	providerInfo := getProviderConfig(provider, catalogVariables)
-	cfg := configureOAuthClientCredentials(clientId, clientSecret, scopes, providerInfo)
-	httpClient := setupOAuth2ClientCredentialsHttpClient(ctx, providerInfo, cfg)
-
-	target, err := url.Parse(providerInfo.BaseURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return newProxy(target, httpClient)
-}
-
-func buildApiKeyProxy(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable, apiKey string) *Proxy {
-	providerInfo := getProviderConfig(provider, catalogVariables)
-	httpClient := setupApiKeyHttpClient(ctx, providerInfo, apiKey)
-
-	target, err := url.Parse(providerInfo.BaseURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return newProxy(target, httpClient)
-}
-
-func buildBasicAuthProxy(ctx context.Context, provider string, catalogVariables []catalogreplacer.CatalogVariable, user, pass string) *Proxy {
-	providerInfo := getProviderConfig(provider, catalogVariables)
-	httpClient := setupBasicAuthHttpClient(ctx, providerInfo, user, pass)
-
-	target, err := url.Parse(providerInfo.BaseURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return newProxy(target, httpClient)
-}
-
-func buildOAuth2AuthCodeProxy(ctx context.Context, provider string, scopes []string, clientId, clientSecret string, catalogVariables []catalogreplacer.CatalogVariable, tokens *oauth2.Token) *Proxy {
-	providerInfo := getProviderConfig(provider, catalogVariables)
-	cfg := configureOAuthAuthCode(clientId, clientSecret, scopes, providerInfo)
-	httpClient := setupOAuth2AuthCodeHttpClient(ctx, providerInfo, cfg, tokens)
-
-	target, err := url.Parse(providerInfo.BaseURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return newProxy(target, httpClient)
-}
-
-func getProviderConfig(provider string, catalogVariables []catalogreplacer.CatalogVariable) *providers.ProviderInfo {
-	config, err := providers.ReadInfo(provider, catalogVariables...)
-	if err != nil {
-		panic(fmt.Errorf("%w: %s", err, provider))
-	}
-
-	return config
-}
-
-func configureOAuthClientCredentials(clientId, clientSecret string, scopes []string, providerInfo *providers.ProviderInfo) *clientcredentials.Config {
-	cfg := &clientcredentials.Config{
-		ClientID:     clientId,
-		ClientSecret: clientSecret,
-		TokenURL:     providerInfo.Oauth2Opts.TokenURL,
-	}
-
-	if providerInfo.Oauth2Opts.ExplicitScopesRequired {
-		cfg.Scopes = scopes
-	}
-
-	if providerInfo.Oauth2Opts.Audience != nil {
-		aud := providerInfo.Oauth2Opts.Audience
-		cfg.EndpointParams = url.Values{"audience": aud}
-	}
-
-	return cfg
-}
-
-type ClientAuthParams struct {
-	ID     string
-	Secret string
-	Scopes []string
-}
-
-func configureOAuthAuthCode(clientId, clientSecret string, scopes []string, providerInfo *providers.ProviderInfo) *oauth2.Config {
-	return &oauth2.Config{
-		ClientID:     clientId,
-		ClientSecret: clientSecret,
-		Scopes:       scopes,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:   providerInfo.Oauth2Opts.AuthURL,
-			TokenURL:  providerInfo.Oauth2Opts.TokenURL,
-			AuthStyle: oauth2.AuthStyleAutoDetect,
-		},
-	}
-}
-
-func setupOAuth2ClientCredentialsHttpClient(ctx context.Context, prov *providers.ProviderInfo, cfg *clientcredentials.Config) common.AuthenticatedHTTPClient {
-	c, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug: *debug,
-		OAuth2ClientCreds: &providers.OAuth2ClientCredentialsParams{
-			Config: cfg,
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(c))
-	if err != nil {
-		panic(err)
-	}
-
-	return cc.HTTPClient().Client
-}
-
-// This helps with refreshing tokens automatically.
-func setupOAuth2AuthCodeHttpClient(ctx context.Context, prov *providers.ProviderInfo, cfg *oauth2.Config, tokens *oauth2.Token) common.AuthenticatedHTTPClient {
-	c, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug: *debug,
-		OAuth2AuthCodeCreds: &providers.OAuth2AuthCodeParams{
-			Config: cfg,
-			Token:  tokens,
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(c))
-	if err != nil {
-		panic(err)
-	}
-
-	return cc.HTTPClient().Client
-}
-
-func setupBasicAuthHttpClient(ctx context.Context, prov *providers.ProviderInfo, user, pass string) common.AuthenticatedHTTPClient {
-	c, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug: *debug,
-		BasicCreds: &providers.BasicParams{
-			User: user,
-			Pass: pass,
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(c))
-	if err != nil {
-		panic(err)
-	}
-
-	return cc.HTTPClient().Client
-}
-
-func setupApiKeyHttpClient(ctx context.Context, prov *providers.ProviderInfo, apiKey string) common.AuthenticatedHTTPClient {
-	c, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug:  *debug,
-		ApiKey: apiKey,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(c))
-	if err != nil {
-		panic(err)
-	}
-
-	return cc.HTTPClient().Client
-}
-
-type Proxy struct {
-	*httputil.ReverseProxy
-	target *url.URL
-}
-
-func newProxy(target *url.URL, httpClient common.AuthenticatedHTTPClient) *Proxy {
-	reverseProxy := httputil.NewSingleHostReverseProxy(target)
-	reverseProxy.Transport = &customTransport{httpClient}
-
-	return &Proxy{
-		ReverseProxy: reverseProxy,
-		target:       target,
-	}
-}
-
-func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	r.URL.Host = p.target.Host
-	r.Host = p.target.Host
-	r.RequestURI = "" // Must be cleared
-
-	fmt.Printf("Proxying request: %s %s%s\n", r.Method, r.URL.Host, r.URL.Path)
-	p.ReverseProxy.ServeHTTP(w, r)
-}
-
-type customTransport struct {
-	httpClient common.AuthenticatedHTTPClient
-}
-
-func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return t.httpClient.Do(req)
 }

--- a/scripts/utils/proxyserv/common.go
+++ b/scripts/utils/proxyserv/common.go
@@ -1,0 +1,85 @@
+package proxyserv
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/amp-labs/connectors/common/scanning"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
+	"github.com/amp-labs/connectors/providers"
+	"golang.org/x/oauth2"
+)
+
+// Factory holds arguments used to create Proxy of any type.
+type Factory struct {
+	Provider         string
+	CatalogVariables []catalogreplacer.CatalogVariable
+	Debug            bool
+	Registry         scanning.Registry
+	CredsFilePath    string
+}
+
+type ClientAuthParams struct {
+	ID     string
+	Secret string
+	Scopes []string
+}
+
+func createClientAuthParams(provider string, registry scanning.Registry) *ClientAuthParams {
+	clientId := registry.MustString(credscanning.Fields.ClientId.Name)
+	clientSecret := registry.MustString(credscanning.Fields.ClientSecret.Name)
+
+	scopes, err := registry.GetString(credscanning.Fields.Scopes.Name)
+	if err != nil {
+		slog.Warn("no scopes attached, ensure that the provider doesn't require scopes")
+	}
+
+	validateRequiredOAuth2Flags(provider, clientId, clientSecret)
+
+	return &ClientAuthParams{
+		ID:     clientId,
+		Secret: clientSecret,
+		Scopes: strings.Split(scopes, ","),
+	}
+}
+
+func validateRequiredOAuth2Flags(provider, clientId, clientSecret string) {
+	if provider == "" || clientId == "" || clientSecret == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Missing required flags: -provider, -client-id, -client-secret")
+
+		flag.Usage()
+		os.Exit(1)
+	}
+}
+
+func getTokensFromRegistry(credsFile string) *oauth2.Token {
+	reader, err := credscanning.NewJSONProviderCredentials(credsFile, true, false)
+	if err != nil {
+		panic(err)
+	}
+
+	return reader.GetOauthToken()
+}
+
+func getProviderConfig(provider string, catalogVariables []catalogreplacer.CatalogVariable) *providers.ProviderInfo {
+	config, err := providers.ReadInfo(provider, catalogVariables...)
+	if err != nil {
+		panic(fmt.Errorf("%w: %s", err, provider))
+	}
+
+	return config
+}
+
+func getBaseURL(providerInfo *providers.ProviderInfo) *url.URL {
+	target, err := url.Parse(providerInfo.BaseURL)
+	if err != nil {
+		panic(err)
+	}
+
+	return target
+}

--- a/scripts/utils/proxyserv/oauthApiKey.go
+++ b/scripts/utils/proxyserv/oauthApiKey.go
@@ -1,0 +1,52 @@
+// nolint:ireturn
+package proxyserv
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/connector"
+	"github.com/amp-labs/connectors/providers"
+)
+
+func (f Factory) CreateProxyAPIKey(ctx context.Context) *Proxy {
+	apiKey := getAPIKey(f.Registry)
+	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
+	httpClient := setupAPIKeyHTTPClient(ctx, providerInfo, apiKey, f.Debug)
+	baseURL := getBaseURL(providerInfo)
+
+	return newProxy(baseURL, httpClient)
+}
+
+func setupAPIKeyHTTPClient(
+	ctx context.Context, prov *providers.ProviderInfo, apiKey string, debug bool,
+) common.AuthenticatedHTTPClient {
+	client, err := prov.NewClient(ctx, &providers.NewClientParams{
+		Debug:  debug,
+		ApiKey: apiKey,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(client))
+	if err != nil {
+		panic(err)
+	}
+
+	return cc.HTTPClient().Client
+}
+
+func getAPIKey(registry scanning.Registry) string {
+	apiKey := registry.MustString(credscanning.Fields.ApiKey.Name)
+	if apiKey == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "api key from registry is empty")
+		os.Exit(1)
+	}
+
+	return apiKey
+}

--- a/scripts/utils/proxyserv/oauthAuthCode.go
+++ b/scripts/utils/proxyserv/oauthAuthCode.go
@@ -1,0 +1,60 @@
+// nolint:ireturn
+package proxyserv
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/connector"
+	"github.com/amp-labs/connectors/providers"
+	"golang.org/x/oauth2"
+)
+
+func (f Factory) CreateProxyOAuth2AuthCode(ctx context.Context) *Proxy {
+	params := createClientAuthParams(f.Provider, f.Registry)
+	tokens := getTokensFromRegistry(f.CredsFilePath)
+	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
+	cfg := configureOAuthAuthCode(params.ID, params.Secret, params.Scopes, providerInfo)
+	httpClient := setupOAuth2AuthCodeHTTPClient(ctx, providerInfo, cfg, tokens, f.Debug)
+	baseURL := getBaseURL(providerInfo)
+
+	return newProxy(baseURL, httpClient)
+}
+
+func configureOAuthAuthCode(
+	clientId, clientSecret string, scopes []string, providerInfo *providers.ProviderInfo,
+) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		Scopes:       scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   providerInfo.Oauth2Opts.AuthURL,
+			TokenURL:  providerInfo.Oauth2Opts.TokenURL,
+			AuthStyle: oauth2.AuthStyleAutoDetect,
+		},
+	}
+}
+
+// This helps with refreshing tokens automatically.
+func setupOAuth2AuthCodeHTTPClient(
+	ctx context.Context, prov *providers.ProviderInfo, cfg *oauth2.Config, tokens *oauth2.Token, debug bool,
+) common.AuthenticatedHTTPClient {
+	client, err := prov.NewClient(ctx, &providers.NewClientParams{
+		Debug: debug,
+		OAuth2AuthCodeCreds: &providers.OAuth2AuthCodeParams{
+			Config: cfg,
+			Token:  tokens,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(client))
+	if err != nil {
+		panic(err)
+	}
+
+	return cc.HTTPClient().Client
+}

--- a/scripts/utils/proxyserv/oauthBasic.go
+++ b/scripts/utils/proxyserv/oauthBasic.go
@@ -1,0 +1,67 @@
+// nolint:ireturn
+package proxyserv
+
+import (
+	"context"
+	"log"
+	"log/slog"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/connector"
+	"github.com/amp-labs/connectors/providers"
+)
+
+func (f Factory) CreateProxyBasic(ctx context.Context) *Proxy {
+	params := createBasicParams(f.Registry)
+	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
+	httpClient := setupBasicAuthHTTPClient(ctx, providerInfo, params.User, params.Pass, f.Debug)
+	baseURL := getBaseURL(providerInfo)
+
+	return newProxy(baseURL, httpClient)
+}
+
+func createBasicParams(registry scanning.Registry) *providers.BasicParams {
+	user := registry.MustString(credscanning.Fields.Username.Name)
+	pass := registry.MustString(credscanning.Fields.Password.Name)
+
+	if len(user)+len(pass) == 0 {
+		log.Fatalf("Missing username or password")
+	}
+
+	if len(user) == 0 {
+		slog.Warn("no username for basic authentication, ensure that it is not required")
+	}
+
+	if len(pass) == 0 {
+		slog.Warn("no password for basic authentication, ensure that it is not required")
+	}
+
+	return &providers.BasicParams{
+		User: user,
+		Pass: pass,
+	}
+}
+
+func setupBasicAuthHTTPClient(
+	ctx context.Context, prov *providers.ProviderInfo, user, pass string, debug bool,
+) common.AuthenticatedHTTPClient {
+	client, err := prov.NewClient(ctx, &providers.NewClientParams{
+		Debug: debug,
+		BasicCreds: &providers.BasicParams{
+			User: user,
+			Pass: pass,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(client))
+	if err != nil {
+		panic(err)
+	}
+
+	return cc.HTTPClient().Client
+}

--- a/scripts/utils/proxyserv/oauthClientCred.go
+++ b/scripts/utils/proxyserv/oauthClientCred.go
@@ -1,0 +1,64 @@
+// nolint:ireturn
+package proxyserv
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/connector"
+	"github.com/amp-labs/connectors/providers"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+func (f Factory) CreateProxyOAuth2ClientCreds(ctx context.Context) *Proxy {
+	params := createClientAuthParams(f.Provider, f.Registry)
+	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
+	cfg := configureOAuthClientCredentials(params.ID, params.Secret, params.Scopes, providerInfo)
+	httpClient := setupOAuth2ClientCredentialsHTTPClient(ctx, providerInfo, cfg, f.Debug)
+	baseURL := getBaseURL(providerInfo)
+
+	return newProxy(baseURL, httpClient)
+}
+
+func configureOAuthClientCredentials(
+	clientId, clientSecret string, scopes []string, providerInfo *providers.ProviderInfo,
+) *clientcredentials.Config {
+	cfg := &clientcredentials.Config{
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		TokenURL:     providerInfo.Oauth2Opts.TokenURL,
+	}
+
+	if providerInfo.Oauth2Opts.ExplicitScopesRequired {
+		cfg.Scopes = scopes
+	}
+
+	if providerInfo.Oauth2Opts.Audience != nil {
+		aud := providerInfo.Oauth2Opts.Audience
+		cfg.EndpointParams = url.Values{"audience": aud}
+	}
+
+	return cfg
+}
+
+func setupOAuth2ClientCredentialsHTTPClient(
+	ctx context.Context, prov *providers.ProviderInfo, cfg *clientcredentials.Config, debug bool,
+) common.AuthenticatedHTTPClient {
+	client, err := prov.NewClient(ctx, &providers.NewClientParams{
+		Debug: debug,
+		OAuth2ClientCreds: &providers.OAuth2ClientCredentialsParams{
+			Config: cfg,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cc, err := connector.NewConnector(prov.Name, connector.WithAuthenticatedClient(client))
+	if err != nil {
+		panic(err)
+	}
+
+	return cc.HTTPClient().Client
+}

--- a/scripts/utils/proxyserv/oauthPassword.go
+++ b/scripts/utils/proxyserv/oauthPassword.go
@@ -1,0 +1,11 @@
+// nolint:ireturn
+package proxyserv
+
+import "context"
+
+// CreateProxyOAuth2Password creates Oauth2 Proxy with password grant.
+//
+// De facto, password grant acts as auth code grant type.
+func (f Factory) CreateProxyOAuth2Password(ctx context.Context) *Proxy {
+	return f.CreateProxyOAuth2AuthCode(ctx)
+}

--- a/scripts/utils/proxyserv/proxy.go
+++ b/scripts/utils/proxyserv/proxy.go
@@ -1,0 +1,92 @@
+// nolint:forbidigo,ireturn
+package proxyserv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+type Proxy struct {
+	*httputil.ReverseProxy
+	target *url.URL
+}
+
+func newProxy(target *url.URL, httpClient common.AuthenticatedHTTPClient) *Proxy {
+	reverseProxy := httputil.NewSingleHostReverseProxy(target)
+	reverseProxy.Transport = &customTransport{httpClient}
+
+	return &Proxy{
+		ReverseProxy: reverseProxy,
+		target:       target,
+	}
+}
+
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.URL.Host = p.target.Host
+	r.Host = p.target.Host
+	r.RequestURI = "" // Must be cleared
+
+	fmt.Printf("Proxying request: %s %s%s\n", r.Method, r.URL.Host, r.URL.Path)
+	p.ReverseProxy.ServeHTTP(w, r)
+}
+
+func (p *Proxy) Start(ctx context.Context, port int) {
+	http.Handle("/", p)
+
+	fmt.Printf("\nProxy server listening on :%d\n", port)
+
+	if err := listen(ctx, port); err != nil {
+		panic(err)
+	}
+}
+
+type customTransport struct {
+	httpClient common.AuthenticatedHTTPClient
+}
+
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.httpClient.Do(req)
+}
+
+// listen will start a server on the given port and block until it is closed.
+// This is used as opposed to http.ListenAndServe because it respects the context
+// and has a cleaner shutdown sequence.
+func listen(ctx context.Context, port int) error {
+	var lc net.ListenConfig
+
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		ReadHeaderTimeout: 5 * time.Second, // nolint:mnd
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		_ = server.Shutdown(context.Background()) // nolint:contextcheck
+	}()
+
+	if err := server.Serve(listener); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			fmt.Println("HTTP server stopped")
+
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Background

The proxy for the OAuth2 password grant type no longer works. However, reverting to an earlier commit when it was introduced confirms that it previously functioned.
The solution is straightforward (one liner): the password grant type should delegate and construct a proxy identical to the authorization code grant type (not client credentials).

While I am at it, refactored the script.

# Motivation
The file is quite large, and while it didn’t take long to locate the issue, it was slightly longer than expected. Splitting the file into multiple smaller files helps to isolate similar-looking functions. There is no point to refactor more than that for little return.

# Changes
1. All proxies are now created using the same set of arguments. To avoid excessively long function signatures, these values are encapsulated in a struct `proxyserv.Factory{}`.
2. The `Proxy` struct and its methods were already well-organized, so moving them to a separate file was straightforward. The `Start` method is now a member function of the `Proxy` struct.
3. Other files are now grouped by **authentication type**, with each extracting values from registry and creating the corresponding proxy using `factory` struct.