### PR TITLE
refactor: Hubspot getMarshalledData -> getDataMarshaller

### DIFF
--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -118,8 +118,9 @@ func getRecords(node *ajson.Node) ([]map[string]interface{}, error) {
 	return out, nil
 }
 
-// getMarshalledData accepts a list of records and returns a list of structured data ([]ReadResultRow).
-func (c *Connector) getMarshalledData(
+// getDataMarshaller returns a function that accepts a list of records and fields
+// and returns a list of structured data ([]ReadResultRow).
+func (c *Connector) getDataMarshaller(
 	ctx context.Context,
 	objName string,
 	associatedObjects []string,
@@ -129,21 +130,26 @@ func (c *Connector) getMarshalledData(
 
 		//nolint:varnamelen
 		for i, record := range records {
-			recordProperties, ok := record["properties"].(map[string]interface{})
-			if !ok {
-				return nil, ErrNotObject
-			}
-
 			id, ok := record["id"].(string)
 			if !ok {
 				return nil, errMissingId
 			}
 
-			data[i] = common.ReadResultRow{
-				Fields: common.ExtractLowercaseFieldsFromRaw(fields, recordProperties),
-				Raw:    record,
-				Id:     id,
+			result := common.ReadResultRow{
+				Raw: record,
+				Id:  id,
 			}
+
+			if len(fields) == 0 {
+				recordProperties, ok := record["properties"].(map[string]interface{})
+				if !ok {
+					return nil, ErrNotObject
+				}
+
+				result.Fields = common.ExtractLowercaseFieldsFromRaw(fields, recordProperties)
+			}
+
+			data[i] = result
 		}
 
 		if len(associatedObjects) > 0 {

--- a/providers/hubspot/parse.go
+++ b/providers/hubspot/parse.go
@@ -140,7 +140,7 @@ func (c *Connector) getDataMarshaller(
 				Id:  id,
 			}
 
-			if len(fields) == 0 {
+			if len(fields) != 0 {
 				recordProperties, ok := record["properties"].(map[string]interface{})
 				if !ok {
 					return nil, ErrNotObject

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -74,7 +74,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		rsp,
 		getRecords,
 		getNextRecordsURL,
-		c.getMarshalledData(ctx, config.ObjectName, config.AssociatedObjects),
+		c.getDataMarshaller(ctx, config.ObjectName, config.AssociatedObjects),
 		config.Fields,
 	)
 }

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -36,7 +36,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name: "Contacts uses object API endpoint",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
-				Fields:     connectors.Fields("hs_object_id"),
+				Fields:     connectors.Fields("email"),
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -46,28 +46,57 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
-				Data: []common.ReadResultRow{{
-					Fields: map[string]any{
-						"hs_object_id": "1",
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"email": "a@example.com",
+						},
+						Id: "1",
+						Raw: map[string]any{
+							"id": "1",
+							"properties": map[string]any{
+								"createdate":       "2023-10-26T17:55:48.301Z",
+								"email":            "a@example.com",
+								"lastmodifieddate": "2024-12-24T17:31:54.727Z",
+							},
+							"createdAt": "2023-10-26T17:55:48.301Z",
+							"updatedAt": "2024-12-24T17:31:54.727Z",
+							"archived":  false,
+						},
+					}, {
+						Fields: map[string]any{
+							"email": "b@example.com",
+						},
+						Id: "51",
+						Raw: map[string]any{
+							"id": "51",
+							"properties": map[string]any{
+								"createdate":       "2023-10-26T17:55:48.691Z",
+								"email":            "b@example.com",
+								"lastmodifieddate": "2023-12-13T22:45:30.353Z",
+							},
+							"createdAt": "2023-10-26T17:55:48.691Z",
+							"updatedAt": "2023-12-13T22:45:30.353Z",
+							"archived":  false,
+						},
+					}, {
+						Fields: map[string]any{
+							"email": "c@example.com",
+						},
+						Id: "101",
+						Raw: map[string]any{
+							"id": "101",
+							"properties": map[string]any{
+								"createdate":       "2023-12-13T22:20:02.649Z",
+								"email":            "c@example.com",
+								"lastmodifieddate": "2023-12-13T22:20:05.498Z",
+							},
+							"createdAt": "2023-12-13T22:20:02.649Z",
+							"updatedAt": "2023-12-13T22:20:05.498Z",
+							"archived":  false,
+						},
 					},
-					Raw: map[string]any{
-						"createdAt": "2023-10-26T17:55:48.301Z",
-					},
-				}, {
-					Fields: map[string]any{
-						"hs_object_id": "51",
-					},
-					Raw: map[string]any{
-						"createdAt": "2023-10-26T17:55:48.691Z",
-					},
-				}, {
-					Fields: map[string]any{
-						"hs_object_id": "101",
-					},
-					Raw: map[string]any{
-						"createdAt": "2023-12-13T22:20:02.649Z",
-					},
-				}},
+				},
 				NextPage: "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&properties=listId%2Cname&after=394", // nolint:lll
 				Done:     false,
 			},

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -43,7 +43,7 @@ func (c *Connector) Search(ctx context.Context, config SearchParams) (*common.Re
 		rsp,
 		getRecords,
 		getNextRecordsAfter,
-		c.getMarshalledData(ctx, config.ObjectName, config.AssociatedObjects),
+		c.getDataMarshaller(ctx, config.ObjectName, config.AssociatedObjects),
 		config.Fields,
 	)
 }

--- a/providers/hubspot/test/read-contacts-objects-api.json
+++ b/providers/hubspot/test/read-contacts-objects-api.json
@@ -4,7 +4,7 @@
       "id": "1",
       "properties": {
         "createdate": "2023-10-26T17:55:48.301Z",
-        "hs_object_id": "1",
+        "email": "a@example.com",
         "lastmodifieddate": "2024-12-24T17:31:54.727Z"
       },
       "createdAt": "2023-10-26T17:55:48.301Z",
@@ -15,7 +15,7 @@
       "id": "51",
       "properties": {
         "createdate": "2023-10-26T17:55:48.691Z",
-        "hs_object_id": "51",
+        "email": "b@example.com",
         "lastmodifieddate": "2023-12-13T22:45:30.353Z"
       },
       "createdAt": "2023-10-26T17:55:48.691Z",
@@ -26,7 +26,7 @@
       "id": "101",
       "properties": {
         "createdate": "2023-12-13T22:20:02.649Z",
-        "hs_object_id": "101",
+        "email": "c@example.com",
         "lastmodifieddate": "2023-12-13T22:20:05.498Z"
       },
       "createdAt": "2023-12-13T22:20:02.649Z",


### PR DESCRIPTION
No functional change, some refactors to make code easier to understand & reduce repetitive code:
- renamed getMarshalledData to getDataMarshaller to make it more obvious it's a higher order function
- revised getDataMarshaller to handle case when len(fields) is 0, so that GetRecordsFromIds doesn't need to implement it that logic
- also modified the test the check that full raw record is returned, I'm surprised it wasn't failing before