### PR TITLE
feat(token): Write access/refresh tokens to creds.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/spyzhov/ajson v0.9.6
 	github.com/stretchr/testify v1.10.0
+	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/text v0.22.0
@@ -63,6 +64,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a h1:DxppxFKRqJ8WD6oJ3+ZXKDY0iMONQDl5UTg2aTyHh8k=
+gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/scripts/utils/credutils/tokenWriter.go
+++ b/scripts/utils/credutils/tokenWriter.go
@@ -1,0 +1,66 @@
+package credutils
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"time"
+
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"gitlab.com/c0b/go-ordered-json"
+	"golang.org/x/oauth2"
+)
+
+func WriteToken(defaultCredsFilePath string, token *oauth2.Token) error {
+	credentials, err := internalCredsFileWrite(defaultCredsFilePath, token)
+	if err != nil {
+		return err
+	}
+
+	// Create/Update provider prefixed file.
+	// Ex: keap-creds.json
+	provider := credentials.Get(credscanning.Fields.Provider.PathJSON)
+
+	providerName, ok := provider.(string)
+	if !ok {
+		return errors.New("cannot infer provider in credentials file") // nolint:err113
+	}
+
+	providerCredsFilePath := credscanning.LoadPath(providerName)
+	_, err = internalCredsFileWrite(providerCredsFilePath, token)
+
+	return err
+}
+
+func internalCredsFileWrite(filePath string, token *oauth2.Token) (*ordered.OrderedMap, error) {
+	jsonFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReader(jsonFile)
+
+	fileData, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	orderedMap := ordered.NewOrderedMap()
+	if err = orderedMap.UnmarshalJSON(fileData); err != nil {
+		return nil, err
+	}
+
+	orderedMap.Set(credscanning.Fields.AccessToken.PathJSON, token.AccessToken)
+	orderedMap.Set(credscanning.Fields.RefreshToken.PathJSON, token.RefreshToken)
+	orderedMap.Set(credscanning.Fields.ExpiryFormat.PathJSON, "RFC3339Nano")
+	orderedMap.Set(credscanning.Fields.Expiry.PathJSON, token.Expiry.UTC().Format(time.RFC3339Nano))
+
+	outputData, err := json.MarshalIndent(orderedMap, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return orderedMap, os.WriteFile(filePath, outputData, os.ModePerm) // nolint:gosec
+}


### PR DESCRIPTION
# Background

Generating a token and repeatedly filling in `accessToken/refreshToken` is a tedious and repetitive task that should be automated.

# Requirements
* The `creds.json` file should be updated when a new access token is acquired.
* The `<provider>-creds.json` file should be updated as well. Ex: `keap-creds.json`.
* `creds.json` and `keap-creds.json` should be updated independently. Ex: if `clientId` is different in both files it should stay that way. We focus only on `accessToken/refreshToken/expiry/expiryFormat`.
* The `expiry` field should be populated to enable proper use of the refresh token (manually it is never updated making it overlooked).
* Other fields should remain unchanged.
* The order of lines should be preserved to allow users to group related fields as desired. 
![image](https://github.com/user-attachments/assets/5387cdf8-78ae-4b4f-9fee-2dcc4a11562e)


# Implementation
To handle file loading, modification, and order preservation efficiently, this implementation uses [gitlab.com/c0b/go-ordered-json](https://gitlab.com/c0b/go-ordered-json). This library provides an ordered map[string]any that works well with the JSON marshaller.

Note: As a side effect, any extra new lines in the file will be removed. However, all other requirements are met.

# Usage
This functionality is NOT applied by default. Credentials files will be updated only if the script will be started using `--writeCreds` flag.
