### PR TITLE
[CON-1125] feat: Add HappyFox Chat connector

### DIFF
--- a/providers/happyFox_Chat.go
+++ b/providers/happyFox_Chat.go
@@ -1,0 +1,43 @@
+package providers
+
+const HappyFoxChat Provider = "happyFoxChat"
+
+func init() {
+	// happyFox Chat Connector Configuration
+	SetInfo(HappyFoxChat, ProviderInfo{
+		DisplayName: "HappyFox Chat",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.happyfoxchat.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://developer.happyfoxchat.com/#authentication",
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739528625/media/happyfoxchat.com_1739528625.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739528579/media/happyfoxchat.com_1739528579.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739528625/media/happyfoxchat.com_1739528625.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739528579/media/happyfoxchat.com_1739528579.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
## Catelog variables
const HappyFoxChat Provider = "happyFoxChat"

## Notes
HappyFox Chat’s REST API provides read-only access to your data for use in your application.
![image](https://github.com/user-attachments/assets/ae9900c8-c83c-4082-af0c-fafe29b058c4)

## Testing
### GET ALL
URL: http://localhost:4444/v1/agents
![image](https://github.com/user-attachments/assets/4343896b-a2f5-4f67-88b6-d8f50a0a6ed6)

### GET by ID
URL: http://localhost:4444/v1/agents/67af15298a8e6a70c0c318f4
![image](https://github.com/user-attachments/assets/fc17ea5e-843d-4e68-a522-577e5a45f7b4)

### Pagination
1. Requesting the paginated list of agents using limit and page parameter with value 1 for both.
URL: http://localhost:4444/v1/agents?page=1&limit=1
![image](https://github.com/user-attachments/assets/7f3a5051-e7ea-42cd-b8df-03ae5f80427a)

2. Requesting the next paginated list of agents giving limit as 1 and page value as 2.
URL: http://localhost:4444/v1/agents?page=2&limit=1
**NOTE**
You can also use the URL from the "next" field in the previous response to retrieve the next set of results.
![image](https://github.com/user-attachments/assets/5e93615a-a736-4fef-9a63-cf21c8c1cb6d)
