### PR TITLE
tidy(jsonquery): Explicit querying of required/optional JSON

### DIFF
--- a/common/jsonquery/defaults.go
+++ b/common/jsonquery/defaults.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (q *Query) IntegerWithDefault(key string, defaultValue int64) (int64, error) {
-	result, err := q.Integer(key, true)
+	result, err := q.IntegerOptional(key)
 	if err != nil {
 		return 0, err
 	}
@@ -44,7 +44,7 @@ func (q *Query) TextWithDefault(key string, defaultValue string) (string, error)
 		// Current data under `key` is not a string.
 		// Explore other data types.
 		// NOTE: as of now we check only if it is an integer.
-		number, err := q.Integer(key, true)
+		number, err := q.IntegerOptional(key)
 		if err != nil {
 			return "", err
 		}

--- a/common/jsonquery/defaults.go
+++ b/common/jsonquery/defaults.go
@@ -60,7 +60,7 @@ func (q *Query) TextWithDefault(key string, defaultValue string) (string, error)
 }
 
 func (q *Query) BoolWithDefault(key string, defaultValue bool) (bool, error) {
-	result, err := q.Bool(key, true)
+	result, err := q.BoolOptional(key)
 	if err != nil {
 		return false, err
 	}

--- a/common/jsonquery/defaults.go
+++ b/common/jsonquery/defaults.go
@@ -19,7 +19,7 @@ func (q *Query) IntegerWithDefault(key string, defaultValue int64) (int64, error
 }
 
 func (q *Query) StrWithDefault(key string, defaultValue string) (string, error) {
-	result, err := q.Str(key, true)
+	result, err := q.StringOptional(key)
 	if err != nil {
 		return "", err
 	}

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -98,10 +98,26 @@ func (q *Query) queryInteger(key string, optional bool) (*int64, error) {
 	return &result, nil
 }
 
-// Str returns string.
-// Optional argument set to false will create error in case of missing value.
-// Empty key is interpreter as "this", in other words current node.
-func (q *Query) Str(key string, optional bool) (*string, error) {
+// StringOptional returns string if present.
+// If the entity at the key path is not a string, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) StringOptional(key string) (*string, error) {
+	return q.queryString(key, true)
+}
+
+// StringRequired returns string.
+// If the entity at the key path is not a string or is missing, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) StringRequired(key string) (string, error) {
+	text, err := q.queryString(key, false)
+	if err != nil {
+		return "", err
+	}
+
+	return *text, nil
+}
+
+func (q *Query) queryString(key string, optional bool) (*string, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -51,10 +51,26 @@ func (q *Query) Object(key string, optional bool) (*ajson.Node, error) {
 	return node, nil
 }
 
-// Integer returns integer.
-// Optional argument set to false will create error in case of missing value.
+// IntegerOptional returns integer if present.
+// If the entity at the key path is not an integer, an error is returned.
 // Empty key is interpreter as "this", in other words current node.
-func (q *Query) Integer(key string, optional bool) (*int64, error) {
+func (q *Query) IntegerOptional(key string) (*int64, error) {
+	return q.queryInteger(key, true)
+}
+
+// IntegerRequired returns integer.
+// If the entity at the key path is not an integer or is missing, an error is returned.
+// Empty key is interpreter as "this", in other words current node.
+func (q *Query) IntegerRequired(key string) (int64, error) {
+	integer, err := q.queryInteger(key, false)
+	if err != nil {
+		return 0, err
+	}
+
+	return *integer, nil
+}
+
+func (q *Query) queryInteger(key string, optional bool) (*int64, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -31,20 +31,18 @@ func New(node *ajson.Node, zoom ...string) *Query {
 // If the entity at the key path is not a node object, an error is returned.
 // Empty key is interpreter as "this", in other words current node.
 func (q *Query) ObjectOptional(key string) (*ajson.Node, error) {
-	return q.queryObject(key, true)
+	return q.internalQueryObject(key, true)
 }
 
 // ObjectRequired returns node object.
 // If the entity at the key path is not a node object or is missing, an error is returned.
 // Empty key is interpreter as "this", in other words current node.
+// Missing key returns ErrKeyNotFound. Null value returns ErrNullJSON.
 func (q *Query) ObjectRequired(key string) (*ajson.Node, error) {
-	return q.queryObject(key, false)
+	return q.internalQueryObject(key, false)
 }
 
-// Object returns json object.
-// Optional argument set to false will create error in case of missing value.
-// Empty key is interpreter as "this", in other words current node.
-func (q *Query) queryObject(key string, optional bool) (*ajson.Node, error) {
+func (q *Query) internalQueryObject(key string, optional bool) (*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err
@@ -69,14 +67,15 @@ func (q *Query) queryObject(key string, optional bool) (*ajson.Node, error) {
 // If the entity at the key path is not an integer, an error is returned.
 // Empty key is interpreter as "this", in other words current node.
 func (q *Query) IntegerOptional(key string) (*int64, error) {
-	return q.queryInteger(key, true)
+	return q.internalQueryInteger(key, true)
 }
 
 // IntegerRequired returns integer.
 // If the entity at the key path is not an integer or is missing, an error is returned.
 // Empty key is interpreter as "this", in other words current node.
+// Missing key returns ErrKeyNotFound. Null value returns ErrNullJSON.
 func (q *Query) IntegerRequired(key string) (int64, error) {
-	integer, err := q.queryInteger(key, false)
+	integer, err := q.internalQueryInteger(key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -84,7 +83,7 @@ func (q *Query) IntegerRequired(key string) (int64, error) {
 	return *integer, nil
 }
 
-func (q *Query) queryInteger(key string, optional bool) (*int64, error) {
+func (q *Query) internalQueryInteger(key string, optional bool) (*int64, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err
@@ -116,14 +115,15 @@ func (q *Query) queryInteger(key string, optional bool) (*int64, error) {
 // If the entity at the key path is not a string, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
 func (q *Query) StringOptional(key string) (*string, error) {
-	return q.queryString(key, true)
+	return q.internalQueryString(key, true)
 }
 
 // StringRequired returns string.
 // If the entity at the key path is not a string or is missing, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
+// Missing key returns ErrKeyNotFound. Null value returns ErrNullJSON.
 func (q *Query) StringRequired(key string) (string, error) {
-	text, err := q.queryString(key, false)
+	text, err := q.internalQueryString(key, false)
 	if err != nil {
 		return "", err
 	}
@@ -131,7 +131,7 @@ func (q *Query) StringRequired(key string) (string, error) {
 	return *text, nil
 }
 
-func (q *Query) queryString(key string, optional bool) (*string, error) {
+func (q *Query) internalQueryString(key string, optional bool) (*string, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err
@@ -157,14 +157,15 @@ func (q *Query) queryString(key string, optional bool) (*string, error) {
 // If the entity at the key path is not a boolean, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
 func (q *Query) BoolOptional(key string) (*bool, error) {
-	return q.queryBool(key, true)
+	return q.internalQueryBool(key, true)
 }
 
 // BoolRequired returns boolean.
 // If the entity at the key path is not a boolean or is missing, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
+// Missing key returns ErrKeyNotFound. Null value returns ErrNullJSON.
 func (q *Query) BoolRequired(key string) (bool, error) {
-	flag, err := q.queryBool(key, false)
+	flag, err := q.internalQueryBool(key, false)
 	if err != nil {
 		return false, err
 	}
@@ -172,7 +173,7 @@ func (q *Query) BoolRequired(key string) (bool, error) {
 	return *flag, nil
 }
 
-func (q *Query) queryBool(key string, optional bool) (*bool, error) {
+func (q *Query) internalQueryBool(key string, optional bool) (*bool, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err
@@ -198,20 +199,18 @@ func (q *Query) queryBool(key string, optional bool) (*bool, error) {
 // If the entity at the key path is not an array, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
 func (q *Query) ArrayOptional(key string) ([]*ajson.Node, error) {
-	return q.queryArray(key, true)
+	return q.internalQueryArray(key, true)
 }
 
 // ArrayRequired returns array of nodes.
 // If the entity at the key path is not an array or is missing, an error is returned.
 // Empty key is interpreted as "this", in other words a current node.
+// Missing key returns ErrKeyNotFound. Null value returns ErrNullJSON.
 func (q *Query) ArrayRequired(key string) ([]*ajson.Node, error) {
-	return q.queryArray(key, false)
+	return q.internalQueryArray(key, false)
 }
 
-// Array returns list of nodes.
-// Optional argument set to false will create error in case of missing value.
-// Empty key is interpreter as "this", in other words current node.
-func (q *Query) queryArray(key string, optional bool) ([]*ajson.Node, error) {
+func (q *Query) internalQueryArray(key string, optional bool) ([]*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -180,10 +180,24 @@ func (q *Query) queryBool(key string, optional bool) (*bool, error) {
 	return &flag, nil
 }
 
+// ArrayOptional returns array of nodes if present.
+// If the entity at the key path is not an array, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) ArrayOptional(key string) ([]*ajson.Node, error) {
+	return q.queryArray(key, true)
+}
+
+// ArrayRequired returns array of nodes.
+// If the entity at the key path is not an array or is missing, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) ArrayRequired(key string) ([]*ajson.Node, error) {
+	return q.queryArray(key, false)
+}
+
 // Array returns list of nodes.
 // Optional argument set to false will create error in case of missing value.
 // Empty key is interpreter as "this", in other words current node.
-func (q *Query) Array(key string, optional bool) ([]*ajson.Node, error) {
+func (q *Query) queryArray(key string, optional bool) ([]*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err
@@ -203,16 +217,4 @@ func (q *Query) Array(key string, optional bool) ([]*ajson.Node, error) {
 	}
 
 	return arr, nil
-}
-
-// ArraySize returns the array size located under key.
-// It is assumed that array value must be not null and present.
-// Empty key is interpreter as "this", in other words current node.
-func (q *Query) ArraySize(key string) (int64, error) {
-	arr, err := q.Array(key, false)
-	if err != nil {
-		return 0, err
-	}
-
-	return int64(len(arr)), nil
 }

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -139,10 +139,26 @@ func (q *Query) queryString(key string, optional bool) (*string, error) {
 	return &txt, nil
 }
 
-// Bool returns boolean.
-// Optional argument set to false will create error in case of missing value.
-// Empty key is interpreter as "this", in other words current node.
-func (q *Query) Bool(key string, optional bool) (*bool, error) {
+// BoolOptional returns boolean if present.
+// If the entity at the key path is not a boolean, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) BoolOptional(key string) (*bool, error) {
+	return q.queryBool(key, true)
+}
+
+// BoolRequired returns boolean.
+// If the entity at the key path is not a boolean or is missing, an error is returned.
+// Empty key is interpreted as "this", in other words a current node.
+func (q *Query) BoolRequired(key string) (bool, error) {
+	flag, err := q.queryBool(key, false)
+	if err != nil {
+		return false, err
+	}
+
+	return *flag, nil
+}
+
+func (q *Query) queryBool(key string, optional bool) (*bool, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err

--- a/common/jsonquery/queries.go
+++ b/common/jsonquery/queries.go
@@ -27,10 +27,24 @@ func New(node *ajson.Node, zoom ...string) *Query {
 	}
 }
 
+// ObjectOptional returns node object if present.
+// If the entity at the key path is not a node object, an error is returned.
+// Empty key is interpreter as "this", in other words current node.
+func (q *Query) ObjectOptional(key string) (*ajson.Node, error) {
+	return q.queryObject(key, true)
+}
+
+// ObjectRequired returns node object.
+// If the entity at the key path is not a node object or is missing, an error is returned.
+// Empty key is interpreter as "this", in other words current node.
+func (q *Query) ObjectRequired(key string) (*ajson.Node, error) {
+	return q.queryObject(key, false)
+}
+
 // Object returns json object.
 // Optional argument set to false will create error in case of missing value.
 // Empty key is interpreter as "this", in other words current node.
-func (q *Query) Object(key string, optional bool) (*ajson.Node, error) {
+func (q *Query) queryObject(key string, optional bool) (*ajson.Node, error) {
 	node, err := q.getInnerKey(key, optional)
 	if err != nil {
 		return nil, err

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -496,7 +496,7 @@ func TestQueryObject(t *testing.T) { // nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := New(j, tt.input.zoom...).Object(tt.input.key, tt.input.optional)
+			_, err := New(j, tt.input.zoom...).queryObject(tt.input.key, tt.input.optional)
 
 			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("%s: expected: (%v), got: (%v)", tt.name, tt.expectedErr, err)

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -216,7 +216,7 @@ func TestQueryString(t *testing.T) { // nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output, err := New(j, tt.input.zoom...).Str(tt.input.key, tt.input.optional)
+			output, err := New(j, tt.input.zoom...).queryString(tt.input.key, tt.input.optional)
 			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -410,7 +410,7 @@ func TestQueryArray(t *testing.T) { // nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output, err := New(j, tt.input.zoom...).Array(tt.input.key, tt.input.optional)
+			output, err := New(j, tt.input.zoom...).queryArray(tt.input.key, tt.input.optional)
 
 			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("%s: expected: (%v), got: (%v)", tt.name, tt.expectedErr, err)

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -122,7 +122,7 @@ func TestQueryInteger(t *testing.T) { // nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output, err := New(j, tt.input.zoom...).Integer(tt.input.key, tt.input.optional)
+			output, err := New(j, tt.input.zoom...).queryInteger(tt.input.key, tt.input.optional)
 			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}

--- a/common/jsonquery/queries_test.go
+++ b/common/jsonquery/queries_test.go
@@ -310,7 +310,7 @@ func TestQueryBool(t *testing.T) { // nolint:funlen
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output, err := New(j, tt.input.zoom...).Bool(tt.input.key, tt.input.optional)
+			output, err := New(j, tt.input.zoom...).queryBool(tt.input.key, tt.input.optional)
 			testutils.CheckOutputWithError(t, tt.name, tt.expected, tt.expectedErr, output, err)
 		})
 	}

--- a/common/parse.go
+++ b/common/parse.go
@@ -117,7 +117,17 @@ func GetOptionalRecordsUnderJSONPath(jsonPath string, nestedPath ...string) Reco
 
 func getRecords(optional bool, jsonPath string, nestedPath ...string) RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
-		arr, err := jsonquery.New(node, nestedPath...).Array(jsonPath, optional)
+		var (
+			arr []*ajson.Node
+			err error
+		)
+
+		if optional {
+			arr, err = jsonquery.New(node, nestedPath...).ArrayOptional(jsonPath)
+		} else {
+			arr, err = jsonquery.New(node, nestedPath...).ArrayRequired(jsonPath)
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/providers/apollo/metadata.go
+++ b/providers/apollo/metadata.go
@@ -67,7 +67,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 func parseMetadataFromResponse(body *ajson.Node, objectName string) (*common.ObjectMetadata, error) {
 	objectName = constructSupportedObjectName(objectName)
 
-	arr, err := jsonquery.New(body).Array(objectName, true)
+	arr, err := jsonquery.New(body).ArrayOptional(objectName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -12,7 +12,7 @@ import (
 func getNextRecords(node *ajson.Node) (string, error) {
 	var nextPage string
 
-	pagination, err := jsonquery.New(node).Object("pagination", true)
+	pagination, err := jsonquery.New(node).ObjectOptional("pagination")
 	if err != nil {
 		return "", err
 	}

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -39,7 +39,7 @@ func getNextRecords(node *ajson.Node) (string, error) {
 // recordsWrapperFunc returns the records using the objectName dynamically.
 func recordsWrapperFunc(obj string) common.RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
-		result, err := jsonquery.New(node).Array(obj, true)
+		result, err := jsonquery.New(node).ArrayOptional(obj)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func searchRecords(fld string) common.RecordsFunc {
 	fld = constructSupportedObjectName(fld)
 
 	return func(node *ajson.Node) ([]map[string]any, error) {
-		result, err := jsonquery.New(node).Array(fld, true)
+		result, err := jsonquery.New(node).ArrayOptional(fld)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/apollo/parse.go
+++ b/providers/apollo/parse.go
@@ -23,7 +23,7 @@ func getNextRecords(node *ajson.Node) (string, error) {
 			return "", err
 		}
 
-		totalPages, err := jsonquery.New(pagination).Integer("total_pages", true)
+		totalPages, err := jsonquery.New(pagination).IntegerOptional("total_pages")
 		if err != nil {
 			return "", err
 		}

--- a/providers/apollo/write.go
+++ b/providers/apollo/write.go
@@ -53,7 +53,7 @@ func constructWriteResult(body *ajson.Node, objName string) (*common.WriteResult
 	// created/updated details in it.
 	obj := naming.NewSingularString(objName)
 
-	respObject, err := jsonquery.New(body).Object(obj.String(), false)
+	respObject, err := jsonquery.New(body).ObjectRequired(obj.String())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/asana/parse.go
+++ b/providers/asana/parse.go
@@ -8,7 +8,7 @@ import (
 
 func makeNextRecordsURL() common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		nextPageURL, err := jsonquery.New(node, "next_page").Str("uri", true)
+		nextPageURL, err := jsonquery.New(node, "next_page").StringOptional("uri")
 		if err != nil {
 			return "", err
 		}

--- a/providers/asana/write.go
+++ b/providers/asana/write.go
@@ -51,7 +51,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	nested, err := jsonquery.New(body).Object("data", false)
+	nested, err := jsonquery.New(body).ObjectRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/atlassian/authmetadata.go
+++ b/providers/atlassian/authmetadata.go
@@ -75,19 +75,15 @@ func (c *Connector) retrieveCloudId(ctx context.Context) (string, error) {
 	}
 
 	for _, item := range arr {
-		workspaceName, err := jsonquery.New(item).Str("name", false)
+		workspaceName, err := jsonquery.New(item).StringRequired("name")
 		if err != nil {
 			return "", err
 		}
 
-		if *workspaceName == c.workspace {
-			// names match, select this container.
-			cloudId, err := jsonquery.New(item).Str("id", false)
-			if err != nil {
-				return "", err
-			}
-
-			return *cloudId, nil
+		if workspaceName == c.workspace {
+			// Names match, select this container.
+			// Returns cloudID.
+			return jsonquery.New(item).StringRequired("id")
 		}
 	}
 

--- a/providers/atlassian/metadataFields.go
+++ b/providers/atlassian/metadataFields.go
@@ -26,17 +26,17 @@ func (c *Connector) parseFieldsJiraIssue(node *ajson.Node) (map[string]string, e
 	fieldsMap := make(map[string]string)
 
 	for _, item := range arr {
-		name, err := jsonquery.New(item).Str("id", false)
+		name, err := jsonquery.New(item).StringRequired("id")
 		if err != nil {
 			return nil, err
 		}
 
-		displayName, err := jsonquery.New(item).Str("name", false)
+		displayName, err := jsonquery.New(item).StringRequired("name")
 		if err != nil {
 			return nil, err
 		}
 
-		fieldsMap[*name] = *displayName
+		fieldsMap[name] = displayName
 	}
 
 	return fieldsMap, nil

--- a/providers/atlassian/parse.go
+++ b/providers/atlassian/parse.go
@@ -49,13 +49,13 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 			return nil, errors.Join(common.ErrParseError, err)
 		}
 
-		id, err := jsonquery.New(item).Str("id", false)
+		id, err := jsonquery.New(item).StringRequired("id")
 		if err != nil {
 			return nil, errors.Join(common.ErrParseError, err)
 		}
 
 		// Enhance response with id property.
-		fields["id"] = *id
+		fields["id"] = id
 		list[index] = fields
 	}
 

--- a/providers/atlassian/parse.go
+++ b/providers/atlassian/parse.go
@@ -77,7 +77,7 @@ func getNextRecords(node *ajson.Node) (string, error) {
 		return "", nil
 	}
 
-	startAt, err := jsonquery.New(node).Integer("startAt", true)
+	startAt, err := jsonquery.New(node).IntegerOptional("startAt")
 	if err != nil {
 		return "", err
 	}

--- a/providers/atlassian/parse.go
+++ b/providers/atlassian/parse.go
@@ -39,7 +39,7 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 	list := make([]map[string]any, len(arr))
 
 	for index, item := range arr {
-		fieldsObject, err := jsonquery.New(item).Object("fields", false)
+		fieldsObject, err := jsonquery.New(item).ObjectRequired("fields")
 		if err != nil {
 			return nil, errors.Join(common.ErrParseError, err)
 		}

--- a/providers/atlassian/parse.go
+++ b/providers/atlassian/parse.go
@@ -31,7 +31,7 @@ Visual example of what will happen to each property:
 	}
 */
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("issues", false)
+	arr, err := jsonquery.New(node).ArrayRequired("issues")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/atlassian/write.go
+++ b/providers/atlassian/write.go
@@ -52,14 +52,14 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	recordID, err := jsonquery.New(body).Str("id", false)
+	recordID, err := jsonquery.New(body).StringRequired("id")
 	if err != nil {
 		return nil, err
 	}
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     nil,
 	}, nil

--- a/providers/attio/parse.go
+++ b/providers/attio/parse.go
@@ -14,7 +14,7 @@ func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 		previousStart := 0
 
 		// Extract the data key value from the response.
-		value, err := jsonquery.New(node).Array("data", false)
+		value, err := jsonquery.New(node).ArrayRequired("data")
 		if err != nil {
 			return "", err
 		}

--- a/providers/attio/write.go
+++ b/providers/attio/write.go
@@ -58,7 +58,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 func constructWriteResult(objName string, body *ajson.Node) (*common.WriteResult, error) {
 	obj := naming.NewSingularString(objName)
 
-	objectResponse, err := jsonquery.New(body).Object("data", false)
+	objectResponse, err := jsonquery.New(body).ObjectRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/attio/write.go
+++ b/providers/attio/write.go
@@ -63,7 +63,7 @@ func constructWriteResult(objName string, body *ajson.Node) (*common.WriteResult
 		return nil, err
 	}
 
-	recordID, err := jsonquery.New(objectResponse, "id").Str(obj.String()+"_id", false)
+	recordID, err := jsonquery.New(objectResponse, "id").StringRequired(obj.String() + "_id")
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func constructWriteResult(objName string, body *ajson.Node) (*common.WriteResult
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     response,
 	}, nil

--- a/providers/chilipiper/parse.go
+++ b/providers/chilipiper/parse.go
@@ -24,12 +24,12 @@ func nextRecordsURL(url string) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
 		jsonQuery := jsonquery.New(node)
 
-		page, err := jsonQuery.Integer(pageKey, false)
+		page, err := jsonQuery.IntegerRequired(pageKey)
 		if err != nil {
 			return "", err
 		}
 
-		totalRecords, err := jsonQuery.Integer(totalKey, false)
+		totalRecords, err := jsonQuery.IntegerRequired(totalKey)
 		if err != nil {
 			return "", err
 		}
@@ -39,8 +39,8 @@ func nextRecordsURL(url string) common.NextPageFunc {
 			return "", err
 		}
 
-		if hasMorePages(pagesize, int(*page), int(*totalRecords)) {
-			pg := strconv.Itoa(int(*page + 1))
+		if hasMorePages(pagesize, int(page), int(totalRecords)) {
+			pg := strconv.Itoa(int(page + 1))
 
 			nextURL, err := urlbuilder.New(url)
 			if err != nil {

--- a/providers/closecrm/parse.go
+++ b/providers/closecrm/parse.go
@@ -34,7 +34,7 @@ var ErrSkipFailure = errors.New("error: failed to create next page url")
 func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
 		// check if there is more items in the collection.
-		hasMore, err := jsonquery.New(node).Bool(hasMoreQuery, true)
+		hasMore, err := jsonquery.New(node).BoolOptional(hasMoreQuery)
 		if err != nil {
 			return "", err
 		}

--- a/providers/closecrm/parse.go
+++ b/providers/closecrm/parse.go
@@ -66,7 +66,7 @@ Search Response schema:
 	}
 */
 func getNextRecordCursor(node *ajson.Node) (string, error) {
-	crs, err := jsonquery.New(node).Str("cursor", true)
+	crs, err := jsonquery.New(node).StringOptional("cursor")
 	if err != nil {
 		return "", err
 	}

--- a/providers/closecrm/write.go
+++ b/providers/closecrm/write.go
@@ -48,7 +48,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(node *ajson.Node) (*common.WriteResult, error) {
-	recordID, err := jsonquery.New(node).Str("id", false)
+	recordID, err := jsonquery.New(node).StringRequired("id")
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func constructWriteResult(node *ajson.Node) (*common.WriteResult, error) {
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     data,
 	}, nil

--- a/providers/constantcontact/write.go
+++ b/providers/constantcontact/write.go
@@ -59,7 +59,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.WriteResult, error) {
 	idFieldName := objectNameToWriteResponseIdentifier.Get(config.ObjectName)
 
-	recordID, err := jsonquery.New(body).Str(idFieldName, false)
+	recordID, err := jsonquery.New(body).StringRequired(idFieldName)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     data,
 	}, nil

--- a/providers/customerapp/write.go
+++ b/providers/customerapp/write.go
@@ -62,7 +62,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.WriteResult, error) {
 	fieldName := ObjectNameToWriteResponseField.Get(config.ObjectName)
 
-	nested, err := jsonquery.New(body).Object(fieldName, false)
+	nested, err := jsonquery.New(body).ObjectRequired(fieldName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/dynamicscrm/parse.go
+++ b/providers/dynamicscrm/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("value", false)
+	arr, err := jsonquery.New(node).ArrayRequired("value")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gong/write.go
+++ b/providers/gong/write.go
@@ -41,14 +41,14 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	recordID, err := jsonquery.New(body).Str("callId", false)
+	recordID, err := jsonquery.New(body).StringRequired("callId")
 	if err != nil {
 		return nil, err
 	}
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     nil,
 	}, nil

--- a/providers/instantly/write.go
+++ b/providers/instantly/write.go
@@ -110,14 +110,14 @@ func constructWriteResult(body *ajson.Node, recordIdLocation *string) (*common.W
 	}
 
 	// ID is integer that is always stored under different field name.
-	recordID, err := jsonquery.New(body).Str(*recordIdLocation, false)
+	recordID, err := jsonquery.New(body).StringRequired(*recordIdLocation)
 	if err != nil {
 		return nil, err
 	}
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     nil,
 	}, nil

--- a/providers/intercom/parse.go
+++ b/providers/intercom/parse.go
@@ -59,7 +59,7 @@ func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 		}
 
 		// Probably, we are dealing with an object under `pages.next`
-		startingAfter, err := jsonquery.New(node, "pages", "next").Str("starting_after", true)
+		startingAfter, err := jsonquery.New(node, "pages", "next").StringOptional("starting_after")
 		if err != nil {
 			return "", err
 		}
@@ -95,7 +95,7 @@ func extractListFieldName(node *ajson.Node) (string, error) {
 	// default field at which list is stored
 	defaultFieldName := "data"
 
-	fieldName, err := jsonquery.New(node).Str("type", true)
+	fieldName, err := jsonquery.New(node).StringOptional("type")
 	if err != nil {
 		return "", err
 	}

--- a/providers/intercom/parse.go
+++ b/providers/intercom/parse.go
@@ -38,7 +38,7 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 		return nil, err
 	}
 
-	arr, err := jsonquery.New(node).Array(arrKey, false)
+	arr, err := jsonquery.New(node).ArrayRequired(arrKey)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/iterable/write.go
+++ b/providers/iterable/write.go
@@ -147,7 +147,7 @@ func locateWriteRecordID(body *ajson.Node, objectName string) (string, error) {
 }
 
 func extractTemplateWriteRecordID(body *ajson.Node) (string, error) {
-	message, err := jsonquery.New(body).Str("msg", true)
+	message, err := jsonquery.New(body).StringOptional("msg")
 	if err != nil {
 		return "", err
 	}

--- a/providers/iterable/write.go
+++ b/providers/iterable/write.go
@@ -138,12 +138,12 @@ func locateWriteRecordID(body *ajson.Node, objectName string) (string, error) {
 	}
 
 	// ID is integer that is always stored under different field name.
-	intIdentifier, err := jsonquery.New(body, recordIDLocation.zoom...).Integer(recordIDLocation.id, false)
+	intIdentifier, err := jsonquery.New(body, recordIDLocation.zoom...).IntegerRequired(recordIDLocation.id)
 	if err != nil {
 		return "", err
 	}
 
-	return strconv.FormatInt(*intIdentifier, 10), nil
+	return strconv.FormatInt(intIdentifier, 10), nil
 }
 
 func extractTemplateWriteRecordID(body *ajson.Node) (string, error) {

--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -25,7 +25,7 @@ func (c *Connector) parseReadRecords(
 	ctx context.Context, config common.ReadParams, jsonPath string,
 ) common.RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
-		arr, err := jsonquery.New(node).Array(jsonPath, true)
+		arr, err := jsonquery.New(node).ArrayOptional(jsonPath)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/keap/write.go
+++ b/providers/keap/write.go
@@ -68,7 +68,7 @@ func constructWriteResult(
 	if config.ObjectName == objectNameFiles {
 		var err error
 		// Identifier is nested under "file_descriptor" object.
-		identifierHolder, err = jsonquery.New(body).Object("file_descriptor", false)
+		identifierHolder, err = jsonquery.New(body).ObjectRequired("file_descriptor")
 		if err != nil {
 			return nil, err
 		}

--- a/providers/kit/parse.go
+++ b/providers/kit/parse.go
@@ -24,7 +24,7 @@ func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 				return "", nil
 			}
 
-			endCursorToken, err := jsonquery.New(pagination).Str("end_cursor", true)
+			endCursorToken, err := jsonquery.New(pagination).StringOptional("end_cursor")
 			if err != nil {
 				return "", err
 			}

--- a/providers/kit/parse.go
+++ b/providers/kit/parse.go
@@ -9,7 +9,7 @@ import (
 
 func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		pagination, err := jsonquery.New(node).Object("pagination", true)
+		pagination, err := jsonquery.New(node).ObjectOptional("pagination")
 		if err != nil {
 			return "", err
 		}

--- a/providers/kit/parse.go
+++ b/providers/kit/parse.go
@@ -15,7 +15,7 @@ func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 		}
 
 		if pagination != nil {
-			hasNextPage, err := jsonquery.New(pagination).Bool("has_next_page", true)
+			hasNextPage, err := jsonquery.New(pagination).BoolOptional("has_next_page")
 			if err != nil {
 				return "", err
 			}

--- a/providers/kit/write.go
+++ b/providers/kit/write.go
@@ -56,7 +56,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 func constructWriteResult(objName string, body *ajson.Node) (*common.WriteResult, error) {
 	obj := naming.NewSingularString(objName).String()
 
-	objectResponse, err := jsonquery.New(body).Object(obj, true)
+	objectResponse, err := jsonquery.New(body).ObjectOptional(obj)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/kit/write.go
+++ b/providers/kit/write.go
@@ -61,7 +61,7 @@ func constructWriteResult(objName string, body *ajson.Node) (*common.WriteResult
 		return nil, err
 	}
 
-	recordID, err := jsonquery.New(objectResponse).Integer("id", true)
+	recordID, err := jsonquery.New(objectResponse).IntegerOptional("id")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/klaviyo/parse.go
+++ b/providers/klaviyo/parse.go
@@ -25,7 +25,7 @@ import (
 //
 // The resulting fields for the above will be: type, id, test_account, contact_information, locale, links.
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("data", true)
+	arr, err := jsonquery.New(node).ArrayOptional("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/klaviyo/parse.go
+++ b/providers/klaviyo/parse.go
@@ -39,7 +39,7 @@ func flattenRecords(arr []*ajson.Node) ([]map[string]any, error) {
 	for index, element := range arr {
 		const keyAttributes = "attributes"
 
-		attributes, err := jsonquery.New(element).Object(keyAttributes, true)
+		attributes, err := jsonquery.New(element).ObjectOptional(keyAttributes)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/klaviyo/write.go
+++ b/providers/klaviyo/write.go
@@ -125,7 +125,7 @@ func prepareWritePayload(config common.WriteParams) (any, error) {
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	nested, err := jsonquery.New(body).Object("data", false)
+	nested, err := jsonquery.New(body).ObjectRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/marketo/parse.go
+++ b/providers/marketo/parse.go
@@ -36,12 +36,12 @@ func constructNextPageFilteredURL(node *ajson.Node) (string, error) {
 	// We'd have to check for the next page records, also due deletes the is also a probability of having more records
 	// even if the size do not reach 300.
 	if len(data) > 0 {
-		lastRecordID, err := jsonquery.New(data[len(data)-1]).Integer("id", false)
+		lastRecordID, err := jsonquery.New(data[len(data)-1]).IntegerRequired("id")
 		if err != nil {
 			return "", err
 		}
 
-		return strconv.Itoa(int(*lastRecordID) + 1), nil
+		return strconv.Itoa(int(lastRecordID) + 1), nil
 	}
 
 	return "", nil

--- a/providers/marketo/parse.go
+++ b/providers/marketo/parse.go
@@ -27,7 +27,7 @@ func constructNextRecordsURL(object string) common.NextPageFunc {
 func constructNextPageFilteredURL(node *ajson.Node) (string, error) {
 	jsonParser := jsonquery.New(node)
 
-	data, err := jsonParser.Array("result", false)
+	data, err := jsonParser.ArrayRequired("result")
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +49,7 @@ func constructNextPageFilteredURL(node *ajson.Node) (string, error) {
 
 // getRecords returns the records from the response.
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	result, err := jsonquery.New(node).Array("result", true)
+	result, err := jsonquery.New(node).ArrayOptional("result")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/outreach/parse.go
+++ b/providers/outreach/parse.go
@@ -10,7 +10,7 @@ import (
 // getNextRecords returns the "next" url for the next page of results,
 // If available, else returns an empty string.
 func getNextRecordsURL(node *ajson.Node) (string, error) {
-	nextPageURL, err := jsonquery.New(node, "links").Str("next", true)
+	nextPageURL, err := jsonquery.New(node, "links").StringOptional("next")
 	if err != nil {
 		return "", err
 	}

--- a/providers/pipedrive/parse.go
+++ b/providers/pipedrive/parse.go
@@ -30,7 +30,7 @@ import (
 func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
 		// check if there is more items in the collection.
-		more, err := jsonquery.New(node, "additional_data", "pagination").Bool("more_items_in_collection", true)
+		more, err := jsonquery.New(node, "additional_data", "pagination").BoolOptional("more_items_in_collection")
 		if err != nil {
 			return "", err
 		}

--- a/providers/pipedrive/parse.go
+++ b/providers/pipedrive/parse.go
@@ -35,7 +35,7 @@ func nextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 			return "", err
 		}
 
-		startValue, err := jsonquery.New(node, "additional_data", "pagination").Integer("next_start", true)
+		startValue, err := jsonquery.New(node, "additional_data", "pagination").IntegerOptional("next_start")
 		if err != nil {
 			return "", err
 		}

--- a/providers/pipeliner/parse.go
+++ b/providers/pipeliner/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("data", false)
+	arr, err := jsonquery.New(node).ArrayRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/pipeliner/write.go
+++ b/providers/pipeliner/write.go
@@ -47,7 +47,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	success, err := jsonquery.New(body).Bool("success", false)
+	success, err := jsonquery.New(body).BoolRequired("success")
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
 	}
 
 	return &common.WriteResult{
-		Success:  *success,
+		Success:  success,
 		RecordId: recordID,
 		Errors:   nil,
 		Data:     data,

--- a/providers/pipeliner/write.go
+++ b/providers/pipeliner/write.go
@@ -52,7 +52,7 @@ func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
 		return nil, err
 	}
 
-	nested, err := jsonquery.New(body).Object("data", false)
+	nested, err := jsonquery.New(body).ObjectRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesforce/parse.go
+++ b/providers/salesforce/parse.go
@@ -7,7 +7,7 @@ import (
 
 // getRecords returns the records from the response.
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	records, err := jsonquery.New(node).Array("records", false)
+	records, err := jsonquery.New(node).ArrayRequired("records")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesforce/write.go
+++ b/providers/salesforce/write.go
@@ -42,7 +42,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 		}, nil
 	}
 
-	recordID, err := jsonquery.New(body).Str("id", false)
+	recordID, err := jsonquery.New(body).StringRequired("id")
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 	// Salesforce does not return record data upon successful write so we do not populate
 	// the corresponding result field
 	return &common.WriteResult{
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   errors,
 		Success:  *success,
 	}, nil

--- a/providers/salesforce/write.go
+++ b/providers/salesforce/write.go
@@ -68,7 +68,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 
 // getErrors returns the errors from the response.
 func getErrors(node *ajson.Node) ([]any, error) {
-	arr, err := jsonquery.New(node).Array("errors", true)
+	arr, err := jsonquery.New(node).ArrayOptional("errors")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesforce/write.go
+++ b/providers/salesforce/write.go
@@ -52,7 +52,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 		return nil, err
 	}
 
-	success, err := jsonquery.New(body).Bool("success", false)
+	success, err := jsonquery.New(body).BoolRequired("success")
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func parseWriteResult(rsp *common.JSONHTTPResponse) (*common.WriteResult, error)
 	return &common.WriteResult{
 		RecordId: recordID,
 		Errors:   errors,
-		Success:  *success,
+		Success:  success,
 	}, nil
 }
 

--- a/providers/salesloft/parse.go
+++ b/providers/salesloft/parse.go
@@ -41,7 +41,7 @@ func getRecords(node *ajson.Node) ([]map[string]any, error) {
 
 func makeNextRecordsURL(reqLink *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		nextPageNum, err := jsonquery.New(node, "metadata", "paging").Integer("next_page", true)
+		nextPageNum, err := jsonquery.New(node, "metadata", "paging").IntegerOptional("next_page")
 		if err != nil {
 			if errors.Is(err, jsonquery.ErrKeyNotFound) {
 				// list resource doesn't support pagination, hence no next page

--- a/providers/salesloft/parse.go
+++ b/providers/salesloft/parse.go
@@ -31,7 +31,7 @@ Response example:
 	}
 */
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("data", false)
+	arr, err := jsonquery.New(node).ArrayRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesloft/write.go
+++ b/providers/salesloft/write.go
@@ -49,7 +49,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
-	nested, err := jsonquery.New(body).Object("data", false)
+	nested, err := jsonquery.New(body).ObjectRequired("data")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesloft/write.go
+++ b/providers/salesloft/write.go
@@ -54,7 +54,7 @@ func constructWriteResult(body *ajson.Node) (*common.WriteResult, error) {
 		return nil, err
 	}
 
-	rawID, err := jsonquery.New(nested).Integer("id", true)
+	rawID, err := jsonquery.New(nested).IntegerOptional("id")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/smartlead/parse.go
+++ b/providers/smartlead/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getRecords(node *ajson.Node) ([]map[string]any, error) {
-	arr, err := jsonquery.New(node).Array("", false)
+	arr, err := jsonquery.New(node).ArrayRequired("")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/smartlead/write.go
+++ b/providers/smartlead/write.go
@@ -89,7 +89,7 @@ func constructURLPathUpdate(config common.WriteParams, url *urlbuilder.URL) {
 
 func constructWriteResult(body *ajson.Node, recordIdLocation string) (*common.WriteResult, error) {
 	// ID is integer that is always stored under different field name.
-	rawID, err := jsonquery.New(body).Integer(recordIdLocation, true)
+	rawID, err := jsonquery.New(body).IntegerOptional(recordIdLocation)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/smartleadv2/handlers.go
+++ b/providers/smartleadv2/handlers.go
@@ -99,7 +99,7 @@ func (c *Connector) parseWriteResponse(
 	}
 
 	// ID is integer that is always stored under different field name.
-	rawID, err := jsonquery.New(node).Integer(idPath, true)
+	rawID, err := jsonquery.New(node).IntegerOptional(idPath)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/stripe/parse.go
+++ b/providers/stripe/parse.go
@@ -36,7 +36,7 @@ func makeNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 
 		lastElement := data[len(data)-1]
 
-		lastItemID, err := jsonquery.New(lastElement).Str("id", true)
+		lastItemID, err := jsonquery.New(lastElement).StringOptional("id")
 		if err != nil {
 			return "", err
 		}

--- a/providers/stripe/parse.go
+++ b/providers/stripe/parse.go
@@ -25,7 +25,7 @@ func makeNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 			return "", nil
 		}
 
-		data, err := jsonquery.New(node).Array("data", true)
+		data, err := jsonquery.New(node).ArrayOptional("data")
 		if err != nil {
 			return "", err
 		}

--- a/providers/stripe/write.go
+++ b/providers/stripe/write.go
@@ -54,7 +54,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(node *ajson.Node) (*common.WriteResult, error) {
-	recordID, err := jsonquery.New(node).Str("id", false)
+	recordID, err := jsonquery.New(node).StringRequired("id")
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func constructWriteResult(node *ajson.Node) (*common.WriteResult, error) {
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     data,
 	}, nil

--- a/providers/zendesksupport/write.go
+++ b/providers/zendesksupport/write.go
@@ -50,7 +50,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.WriteResult, error) {
-	nested, err := jsonquery.New(body).Object(config.ObjectName, true)
+	nested, err := jsonquery.New(body).ObjectOptional(config.ObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -58,9 +58,8 @@ func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.
 	if nested == nil {
 		// Field should be in singular form. Either one will be matched.
 		// This one is NOT optional.
-		nested, err = jsonquery.New(body).Object(
+		nested, err = jsonquery.New(body).ObjectOptional(
 			naming.NewSingularString(config.ObjectName).String(),
-			false,
 		)
 		if err != nil {
 			return nil, err

--- a/providers/zendesksupport/write.go
+++ b/providers/zendesksupport/write.go
@@ -68,7 +68,7 @@ func constructWriteResult(config common.WriteParams, body *ajson.Node) (*common.
 	}
 	// nested node now must be not null, carry on
 
-	rawID, err := jsonquery.New(nested).Integer("id", true)
+	rawID, err := jsonquery.New(nested).IntegerOptional("id")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/zohocrm/parse.go
+++ b/providers/zohocrm/parse.go
@@ -29,12 +29,12 @@ import (
 
 func getNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		hasMoreRecords, err := jsonquery.New(node, "info").Bool("more_records", false)
+		hasMoreRecords, err := jsonquery.New(node, "info").BoolRequired("more_records")
 		if err != nil {
 			return "", err
 		}
 
-		if *hasMoreRecords {
+		if hasMoreRecords {
 			pageToken, err := jsonquery.New(node, "info").StringOptional("next_page_token")
 			if err != nil {
 				return "", err

--- a/providers/zohocrm/parse.go
+++ b/providers/zohocrm/parse.go
@@ -35,7 +35,7 @@ func getNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 		}
 
 		if *hasMoreRecords {
-			pageToken, err := jsonquery.New(node, "info").Str("next_page_token", true)
+			pageToken, err := jsonquery.New(node, "info").StringOptional("next_page_token")
 			if err != nil {
 				return "", err
 			}

--- a/providers/zoom/write.go
+++ b/providers/zoom/write.go
@@ -53,7 +53,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 }
 
 func constructWriteResult(body *ajson.Node, recordIdLocation string) (*common.WriteResult, error) {
-	recordID, err := jsonquery.New(body).Str(recordIdLocation, false)
+	recordID, err := jsonquery.New(body).StringRequired(recordIdLocation)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func constructWriteResult(body *ajson.Node, recordIdLocation string) (*common.Wr
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: *recordID,
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     data,
 	}, nil

--- a/test/utils/searcher/search.go
+++ b/test/utils/searcher/search.go
@@ -58,14 +58,14 @@ func Find[T any](res *common.ReadResult, keys []Key, value T) map[string]any {
 					return data.Fields
 				}
 			case Integer:
-				actual, err := jsonquery.New(node).Integer(key.At, false)
+				actual, err := jsonquery.New(node).IntegerRequired(key.At)
 				if err != nil {
 					slog.Warn("integer", "error", err)
 
 					continue
 				}
 
-				if fmt.Sprintf("%v", *actual) == fmt.Sprintf("%v", value) {
+				if fmt.Sprintf("%v", actual) == fmt.Sprintf("%v", value) {
 					return data.Fields
 				}
 			case Array:

--- a/test/utils/searcher/search.go
+++ b/test/utils/searcher/search.go
@@ -47,14 +47,14 @@ func Find[T any](res *common.ReadResult, keys []Key, value T) map[string]any {
 		for _, key := range keys {
 			switch key.Type {
 			case String:
-				actual, err := jsonquery.New(node).Str(key.At, false)
+				actual, err := jsonquery.New(node).StringRequired(key.At)
 				if err != nil {
 					slog.Warn("string", "error", err)
 
 					continue
 				}
 
-				if fmt.Sprintf("%v", *actual) == fmt.Sprintf("%v", value) {
+				if fmt.Sprintf("%v", actual) == fmt.Sprintf("%v", value) {
 					return data.Fields
 				}
 			case Integer:

--- a/test/utils/searcher/search.go
+++ b/test/utils/searcher/search.go
@@ -71,7 +71,7 @@ func Find[T any](res *common.ReadResult, keys []Key, value T) map[string]any {
 			case Array:
 				var nodes []*ajson.Node
 
-				nodes, err = jsonquery.New(node).Array(key.At, false)
+				nodes, err = jsonquery.New(node).ArrayRequired(key.At)
 				if err != nil {
 					slog.Warn("array", "error", err)
 

--- a/test/utils/searcher/search.go
+++ b/test/utils/searcher/search.go
@@ -82,7 +82,7 @@ func Find[T any](res *common.ReadResult, keys []Key, value T) map[string]any {
 			case Object:
 				fallthrough
 			default:
-				node, err = jsonquery.New(node).Object(key.At, false)
+				node, err = jsonquery.New(node).ObjectRequired(key.At)
 				if err != nil {
 					slog.Warn("object", "error", err)
 


### PR DESCRIPTION
# Background
The jsonquery package previously used a boolean flag to indicate whether a value in the JSON response should be optional or required. However, this approach has some issues:
* It is not very intuitive to read and understand.
* Required values should not be pointers, as this forces unnecessary pointer dereferencing despite knowing the value must be non-null.

# Review
The refactoring was performed method by method and split into separate commits for clarity.