### PR TITLE
tidy(Zendesk): Read response key from schemas

### DIFF
--- a/providers/zendesksupport/objectNames.go
+++ b/providers/zendesksupport/objectNames.go
@@ -1,30 +1,6 @@
 package zendesksupport
 
-import (
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
-)
+import "github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 
 // Supported object names can be found under schemas.json.
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
-
-// ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
-var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ //nolint:gochecknoglobals
-	ModuleTicketing: datautils.NewDefaultMap(map[string]string{
-		"ticket_audits":        "audits",
-		"search":               "results", // This is "/api/v2/search"
-		"satisfaction_reasons": "reasons",
-	},
-		func(objectName string) (fieldName string) {
-			return objectName
-		},
-	),
-	ModuleHelpCenter: datautils.NewDefaultMap(map[string]string{
-		"articles":        "results",
-		"article_labels":  "labels",
-		"community_posts": "results",
-	}, func(objectName string) (fieldName string) {
-		return objectName
-	}),
-}

--- a/providers/zendesksupport/read.go
+++ b/providers/zendesksupport/read.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
 
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
@@ -26,7 +27,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	responseFieldName := ObjectNameToResponseField[c.Module.ID].Get(config.ObjectName)
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, config.ObjectName)
 
 	return common.ParseResult(
 		rsp,

--- a/scripts/openapi/zendesksupport/metadata/helpcenter/objects.go
+++ b/scripts/openapi/zendesksupport/metadata/helpcenter/objects.go
@@ -1,9 +1,9 @@
 package helpcenter
 
 import (
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
-	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 )
@@ -18,6 +18,13 @@ var (
 		"/api/v2/help_center/articles/labels":        "article_labels",
 		"/api/v2/help_center/community_posts/search": "community_posts",
 	}
+	objectNameToResponseField = datautils.NewDefaultMap(map[string]string{ // nolint:gochecknoglobals
+		"articles":        "results",
+		"article_labels":  "labels",
+		"community_posts": "results",
+	}, func(objectName string) (fieldName string) {
+		return objectName
+	})
 )
 
 func Objects() []metadatadef.Schema {
@@ -32,7 +39,7 @@ func Objects() []metadatadef.Schema {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewDenyPathStrategy(ignoreEndpoints),
 		objectEndpoints, nil,
-		api3.CustomMappingObjectCheck(zendesksupport.ObjectNameToResponseField[zendesksupport.ModuleHelpCenter]),
+		api3.CustomMappingObjectCheck(objectNameToResponseField),
 	)
 	goutils.MustBeNil(err)
 

--- a/scripts/openapi/zendesksupport/metadata/support/objects.go
+++ b/scripts/openapi/zendesksupport/metadata/support/objects.go
@@ -1,9 +1,9 @@
 package support
 
 import (
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
-	"github.com/amp-labs/connectors/providers/zendesksupport"
 	"github.com/amp-labs/connectors/providers/zendesksupport/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 )
@@ -66,6 +66,13 @@ var (
 		"satisfaction_reasons": "Satisfaction Rating Reasons",
 		"ticket_audits":        "Ticket Audits",
 	}
+	objectNameToResponseField = datautils.NewDefaultMap(map[string]string{ // nolint:gochecknoglobals
+		"ticket_audits":        "audits",
+		"search":               "results", // This is "/api/v2/search"
+		"satisfaction_reasons": "reasons",
+	}, func(objectName string) (fieldName string) {
+		return objectName
+	})
 )
 
 func Objects() []metadatadef.Schema {
@@ -80,7 +87,7 @@ func Objects() []metadatadef.Schema {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewDenyPathStrategy(ignoreEndpoints),
 		nil, displayNameOverride,
-		api3.CustomMappingObjectCheck(zendesksupport.ObjectNameToResponseField[zendesksupport.ModuleTicketing]),
+		api3.CustomMappingObjectCheck(objectNameToResponseField),
 	)
 	goutils.MustBeNil(err)
 


### PR DESCRIPTION
# Background

Zendesk was implemented before schema.json included the responseKey, which stores the array of objects.

Although this mapping always existed, it is hardcoded in the script for other connectors. Simmilarly, to reduce mental load, this PR moves all hardcoded registries into the script, ensuring that `schema.json` is the single source of truth.

# Verification
`schema.json` file includes values as before.