### PR TITLE
[CON-1201] feat: add Google Meet connector

### DIFF
--- a/providers/googleMeet.go
+++ b/providers/googleMeet.go
@@ -1,0 +1,47 @@
+package providers
+
+const (
+	GoogleMeet Provider = "googleMeet"
+)
+
+//nolint:funlen
+func init() {
+	SetInfo(GoogleMeet, ProviderInfo{
+		DisplayName: "Google Meet",
+		AuthType:    Oauth2,
+		BaseURL:     "https://meet.googleapis.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://accounts.google.com/o/oauth2/v2/auth",
+			AuthURLParams:             map[string]string{"access_type": "offline", "prompt": "consent"},
+			TokenURL:                  "https://oauth2.googleapis.com/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739948447/google-meet-icon-2020-_gngzfu.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739948447/google-meet-icon-2020-_gngzfu.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739948447/google-meet-icon-2020-_gngzfu.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739948447/google-meet-icon-2020-_gngzfu.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
## Checklist
- [x] Ran Linter

## Testing 


### GET
URL: localhost:4444/v2/conferenceRecords
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/cfdbe7d1-59b5-498c-9051-63068a9f446e" />




### GEt
URL: localhost:4444/v2/conferenceRecords/c2416e0b-11ec-40b5-8ec2-ec85fc647d5f
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/44290fce-2f10-4b27-ac68-dfc8134952c8" />





### POST
URL: localhost:4444/api/v2/spaces
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/6b658d77-e818-429b-8378-09ae6d8d8622" />





### PATCH
URL: localhost:4444/v2/spaces/uUHtIF4l-3cB
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/6ec5609d-6824-4228-8b1c-0efa0948858d" />





### Pagination
The list method supports pagination, returning up to 25 files per page by default (max 100 via `pageSize`). Uses `nextPageToken` from the response as `pageToken` in the query to fetch the next page.

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/34999692-7efd-40b3-8ebe-358bacc6cb76" />



Next page:
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/157e86fe-9abf-444d-828d-5f1cb60866cf" />




### Errors



provide invalid data
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/a4c04c5f-bf97-435f-8a66-92e15a82800f" />



provide an incorrect dynamic ID in the URL.
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/5ff6db71-c09e-4ad1-b05c-de812bb7dc1a" />




