### PR TITLE
feat: update grant type helpScout connector

### DIFF
--- a/providers/helpScoutMailbox.go
+++ b/providers/helpScoutMailbox.go
@@ -9,8 +9,7 @@ func init() {
 		AuthType:    Oauth2,
 		BaseURL:     "https://api.helpscout.net",
 		Oauth2Opts: &Oauth2Opts{
-			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://secure.helpscout.net/authentication/authorizeClientApplication",
+			GrantType:                 ClientCredentials,
 			TokenURL:                  "https://api.helpscout.net/v2/oauth2/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,

--- a/providers/helpScoutMailbox.go
+++ b/providers/helpScoutMailbox.go
@@ -13,6 +13,7 @@ func init() {
 			TokenURL:                  "https://api.helpscout.net/v2/oauth2/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
+			DocsURL:                   "https://developer.helpscout.com/mailbox-api/overview/authentication/",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
With Authorization Code Grant,  The refresh token can only be used once(found this by testing).  Updating this to use client credentials grant for simplicity.