### PR TITLE
[CON-1253] feat: Add Instantly(V2) connector

### DIFF
--- a/providers/instantly.go
+++ b/providers/instantly.go
@@ -1,7 +1,9 @@
 package providers
 
-const Instantly Provider = "instantly"
-const InstantlyAI Provider = "instantlyAI"
+const (
+	Instantly   Provider = "instantly"
+	InstantlyAI Provider = "instantlyAI"
+)
 
 //nolint:funlen
 func init() {

--- a/providers/instantly.go
+++ b/providers/instantly.go
@@ -47,7 +47,7 @@ func init() {
 	SetInfo(InstantlyAI, ProviderInfo{
 		DisplayName: "Instantly",
 		AuthType:    ApiKey,
-		BaseURL:     "https://api.instantly.ai/api",
+		BaseURL:     "https://developer.instantly.ai/getting-started/getting-started#generate-a-new-api-key",
 		ApiKeyOpts: &ApiKeyOpts{
 			AttachmentType: Header,
 			Header: &ApiKeyOptsHeader{

--- a/providers/instantly.go
+++ b/providers/instantly.go
@@ -1,10 +1,13 @@
 package providers
 
 const Instantly Provider = "instantly"
+const InstantlyAI Provider = "instantlyAI"
 
+//nolint:funlen
 func init() {
+	// Instantly v1 configuration
 	SetInfo(Instantly, ProviderInfo{
-		DisplayName: "Instantly",
+		DisplayName: "Instantly (Legacy V1)",
 		AuthType:    ApiKey,
 		BaseURL:     "https://api.instantly.ai/api",
 		ApiKeyOpts: &ApiKeyOpts{
@@ -35,6 +38,43 @@ func init() {
 			Read:      true,
 			Subscribe: false,
 			Write:     true,
+		},
+	})
+
+	// Instantly v2 configuration
+	SetInfo(InstantlyAI, ProviderInfo{
+		DisplayName: "Instantly",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.instantly.ai/api",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://developer.instantly.ai/",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723645909/media/instantly_1723645909.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723645924/media/instantly_1723645924.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723645909/media/instantly_1723645909.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723645924/media/instantly_1723645924.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
 		},
 	})
 }


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Created PR from non-main branch

## Notes
**Expanded Endpoints:** V2 offers twice the number of endpoints compared to V1.
**Granular API Scopes:** Allows precise control over API keys and their usage.
**Multiple API Keys:** Supports creating multiple keys with different privileges. API keys can also be created via an endpoint.
**Pagination:** Now uses limit and starting_after parameters.

## Catelog variables
InstantlyAI Provider = "instantlyAI"

## Testing
### POST
URL: http://localhost:4444/v2/campaigns
![image](https://github.com/user-attachments/assets/a9d38469-09cf-4969-8fb3-76948c3fb06d)

### GET
URL: http://localhost:4444/v2/campaigns
![image](https://github.com/user-attachments/assets/0d4b8e33-342a-4e37-ba71-3a1c98d574b3)

### GET by ID
URL: http://localhost:4444/v2/campaigns/5dd3c8b5-52ba-4679-866a-c7c2cad699a2
![image](https://github.com/user-attachments/assets/ee9f3340-9b71-431e-ad3b-ef101b6f3c2d)

### PATCH
URL: http://localhost:4444/v2/campaigns/5dd3c8b5-52ba-4679-866a-c7c2cad699a2
![image](https://github.com/user-attachments/assets/6e7c486c-a8c1-495e-967c-fa80747a06eb)

### DELETE
URL: http://localhost:4444/v2/campaigns/5dd3c8b5-52ba-4679-866a-c7c2cad699a2
![image](https://github.com/user-attachments/assets/ca696aaf-41d3-4789-ac19-8266cd413322)

### PAGINATION
Requesting a paginated list of campaigns using limit:
URL: http://localhost:4444/v2/campaigns?limit=2
![image](https://github.com/user-attachments/assets/d9d288c3-cff4-4a25-b144-827bf54c7820)

Requesting the next paginated list of campaigns using the limit and starting_after parameters, where the value of starting_after is taken from the next_starting_after field in the previous paginated response:
URL: http://localhost:4444/v2/campaigns?limit=2&starting_after=65d890fe-ae4d-43d0-b014-af0e89b6281f
![image](https://github.com/user-attachments/assets/077f70b0-0344-4ec3-8a37-9b6550853afc)
