### PR TITLE
feat(opeanapi): Default duplicate path resolver

### DIFF
--- a/internal/goutils/utils.go
+++ b/internal/goutils/utils.go
@@ -1,3 +1,4 @@
+// nolint:ireturn
 package goutils
 
 // Pointer returns a pointer to the given value.
@@ -22,4 +23,10 @@ func PanicRecovery(wrapup func(cause error)) {
 
 		wrapup(err)
 	}
+}
+
+// Identity returns the input value unchanged.
+// It acts as an identity function for any type.
+func Identity[T any](input T) T {
+	return input
 }


### PR DESCRIPTION
# Description

Object names are made up usually for those cases where last URI part collides with other endpoints.

To avoid made up object names the full URL path will be used by default as an object name that collides with others.

This is maybe a better approach then purely reporting the duplicates in the logs. The developer my oversee and forget about addressing those objects. On the contrary `schema.json` will have all objects without exceptions.

`objectEndpoints` still exists as an override as a direct object name control.
`api3.WithDuplicatesResolver` is a procedure to turn any colliding endpoint into an object name.