### PR TITLE
[CON-1526]fix(zendesk): Incremental objects diff write URLs

### DIFF
--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -53,13 +53,26 @@ func (c *Connector) String() string {
 	return c.Provider() + ".Connector"
 }
 
-func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
 	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
 	if err != nil {
 		return nil, err
 	}
 
 	return urlbuilder.New(c.BaseURL, path)
+}
+
+func (c *Connector) getWriteURL(objectName string) (*urlbuilder.URL, error) {
+	if objectsUnsupportedWrite[c.Module.ID].Has(objectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	if path, ok := writeURLExceptions[c.Module.ID][objectName]; ok {
+		// URL for write differs from read.
+		return urlbuilder.New(c.BaseURL, path)
+	}
+
+	return c.getReadURL(objectName)
 }
 
 func (c *Connector) setBaseURL(newURL string) {

--- a/providers/zendesksupport/delete.go
+++ b/providers/zendesksupport/delete.go
@@ -11,7 +11,7 @@ func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*co
 		return nil, err
 	}
 
-	url, err := c.getURL(config.ObjectName)
+	url, err := c.getWriteURL(config.ObjectName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/zendesksupport/objectNames.go
+++ b/providers/zendesksupport/objectNames.go
@@ -1,6 +1,30 @@
 package zendesksupport
 
-import "github.com/amp-labs/connectors/providers/zendesksupport/metadata"
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
+)
 
 // Supported object names can be found under schemas.json.
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
+
+var objectsUnsupportedWrite = map[common.ModuleID]datautils.Set[string]{ //nolint:gochecknoglobals
+	ModuleTicketing: datautils.NewSet(
+		"attribute_values",
+		"instance_values",
+		"ticket_events",
+		"ticket_metric_events",
+	),
+	ModuleHelpCenter: datautils.NewStringSet(),
+}
+
+var writeURLExceptions = map[common.ModuleID]datautils.Map[string, string]{ //nolint:gochecknoglobals
+	ModuleTicketing: {
+		"attributes":    "/api/v2/routing/attributes",
+		"organizations": "/api/v2/organizations",
+		"tickets":       "/api/v2/tickets",
+		"users":         "/api/v2/users",
+	},
+	ModuleHelpCenter: {},
+}

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -153,6 +153,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 				If: mockcond.And{
 					mockcond.QueryParam("per_page", "100"),
 					mockcond.QueryParam("start_time", "0"),
+					mockcond.PathSuffix("/api/v2/incremental/tickets/cursor"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseTickets),
 			}.Server(),
@@ -180,6 +181,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 				If: mockcond.And{
 					mockcond.QueryParam("per_page", "100"),
 					mockcond.QueryParam("start_time", "1726674883"),
+					mockcond.PathSuffix("/api/v2/incremental/tickets/cursor"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseTickets),
 			}.Server(),
@@ -197,6 +199,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 				If: mockcond.And{
 					mockcond.QueryParam("per_page", "100"),
 					mockcond.QueryParam("start_time", "0"),
+					mockcond.PathSuffix("/api/v2/incremental/users/cursor"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersFirstPage),
 			}.Server(),
@@ -223,6 +226,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 				If: mockcond.And{
 					mockcond.QueryParam("per_page", "100"),
 					mockcond.QueryParam("start_time", "0"),
+					mockcond.PathSuffix("/api/v2/incremental/users/cursor"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersLastPage),
 			}.Server(),
@@ -249,6 +253,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 				If: mockcond.And{
 					mockcond.QueryParam("per_page", "100"),
 					mockcond.QueryParam("start_time", "0"),
+					mockcond.PathSuffix("/api/v2/incremental/organizations"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseOrganizations),
 			}.Server(),

--- a/providers/zendesksupport/write.go
+++ b/providers/zendesksupport/write.go
@@ -15,7 +15,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	url, err := c.getURL(config.ObjectName)
+	url, err := c.getWriteURL(config.ObjectName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Fix

Issues discovered during integration testing:
* Forgot to update write URL endpoints. Incremental endpoints are unique for Read not Write/Delete.
* `start_time` cannot be less than 1 minute old. If it is then Since parameter is adapted to avoid an error.