### PR TITLE
[ENG-1889] Salesforce Subscribe Add EmptyResult method to connector interface

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -510,6 +510,7 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult RegistrationResult,
 	) error
+	GetRegistrationResultUnMarshalFunc() UnmarshalFunc
 
 	Subscribe(
 		ctx context.Context,
@@ -529,3 +530,9 @@ type SubscribeConnector interface {
 }
 
 type UnmarshalFunc func(data []byte) (any, error)
+
+func Unmarshal[T any](data []byte) (T, error) {
+	var v T
+	err := json.Unmarshal(data, &v)
+	return v, err
+}

--- a/common/types.go
+++ b/common/types.go
@@ -531,8 +531,10 @@ type SubscribeConnector interface {
 
 type UnmarshalFunc func(data []byte) (any, error)
 
+//nolint:ireturn
 func Unmarshal[T any](data []byte) (T, error) {
 	var v T
 	err := json.Unmarshal(data, &v)
+
 	return v, err
 }

--- a/common/types.go
+++ b/common/types.go
@@ -510,7 +510,8 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult RegistrationResult,
 	) error
-	GetRegistrationResultUnMarshalFunc() UnmarshalFunc
+	NewRegistrationParams() *SubscriptionRegistrationParams
+	NewRegistrationResult() *RegistrationResult
 
 	Subscribe(
 		ctx context.Context,
@@ -526,17 +527,6 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult SubscriptionResult,
 	) error
-	GetSubscriptionResultUnMarshalFunc() UnmarshalFunc
-}
-
-// The return type any abstraction of provider specific types.
-// see GetSubscriptionResultUnMarshalFunc in salesforce/subscribe.go for an example.
-type UnmarshalFunc func(data []byte) (any, error)
-
-//nolint:ireturn
-func Unmarshal[T any](data []byte) (T, error) {
-	var v T
-	err := json.Unmarshal(data, &v)
-
-	return v, err
+	NewSubscritpionParams() *SubscribeParams
+	NewSubscriptionResult() *SubscriptionResult
 }

--- a/common/types.go
+++ b/common/types.go
@@ -510,12 +510,12 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult RegistrationResult,
 	) error
-	// NewRegistrationParams returns a new instance of SubscriptionRegistrationParams.
+	// EmptyRegistrationParams returns a empty instance of SubscriptionRegistrationParams.
 	// if there is any provider specific initialization required, it should be done here.
-	NewRegistrationParams() *SubscriptionRegistrationParams
-	// NewRegistrationResult returns a new instance of RegistrationResult.
+	EmptyRegistrationParams() *SubscriptionRegistrationParams
+	// EmptyRegistrationResult returns a empty instance of RegistrationResult.
 	// if there is any provider specific initialization required, it should be done here.
-	NewRegistrationResult() *RegistrationResult
+	EmptyRegistrationResult() *RegistrationResult
 
 	Subscribe(
 		ctx context.Context,
@@ -531,10 +531,10 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult SubscriptionResult,
 	) error
-	// NewSubscritpionParams returns a new instance of SubscribeParams.
+	// EmptySubscritpionParams returns a empty instance of SubscribeParams.
 	// if there is any provider specific initialization required, it should be done here.
-	NewSubscritpionParams() *SubscribeParams
-	// NewSubscriptionResult returns a new instance of SubscriptionResult.
+	EmptySubscritpionParams() *SubscribeParams
+	// EmptySubscriptionResult returns a empty instance of SubscriptionResult.
 	// if there is any provider specific initialization required, it should be done here.
-	NewSubscriptionResult() *SubscriptionResult
+	EmptySubscriptionResult() *SubscriptionResult
 }

--- a/common/types.go
+++ b/common/types.go
@@ -529,6 +529,8 @@ type SubscribeConnector interface {
 	GetSubscriptionResultUnMarshalFunc() UnmarshalFunc
 }
 
+// The return type any abstraction of provider specific types.
+// see GetSubscriptionResultUnMarshalFunc in salesforce/subscribe.go for an example.
 type UnmarshalFunc func(data []byte) (any, error)
 
 //nolint:ireturn

--- a/common/types.go
+++ b/common/types.go
@@ -510,7 +510,11 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult RegistrationResult,
 	) error
+	// NewRegistrationParams returns a new instance of SubscriptionRegistrationParams.
+	// if there is any provider specific initialization required, it should be done here.
 	NewRegistrationParams() *SubscriptionRegistrationParams
+	// NewRegistrationResult returns a new instance of RegistrationResult.
+	// if there is any provider specific initialization required, it should be done here.
 	NewRegistrationResult() *RegistrationResult
 
 	Subscribe(
@@ -527,6 +531,10 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult SubscriptionResult,
 	) error
+	// NewSubscritpionParams returns a new instance of SubscribeParams.
+	// if there is any provider specific initialization required, it should be done here.
 	NewSubscritpionParams() *SubscribeParams
+	// NewSubscriptionResult returns a new instance of SubscriptionResult.
+	// if there is any provider specific initialization required, it should be done here.
 	NewSubscriptionResult() *SubscriptionResult
 }

--- a/common/types.go
+++ b/common/types.go
@@ -525,4 +525,7 @@ type SubscribeConnector interface {
 		ctx context.Context,
 		previousResult SubscriptionResult,
 	) error
+	GetSubscriptionResultUnMarshalFunc() UnmarshalFunc
 }
+
+type UnmarshalFunc func(data []byte) (any, error)

--- a/providers/salesforce/connector_test.go
+++ b/providers/salesforce/connector_test.go
@@ -1,0 +1,21 @@
+package salesforce
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestSubscribeConnector(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	conn, err := constructTestConnector("example.com")
+	if err != nil {
+		t.Fatalf("failed to construct test connector: %v", err)
+	}
+
+	_, ok := any(conn).(common.SubscribeConnector)
+	if !ok {
+		t.Fatalf("expected SubscribeConnector, got %T", conn)
+	}
+}

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -30,13 +30,13 @@ type ResultData struct {
 	EventRelayConfig *EventRelayConfig
 }
 
-func (c *Connector) NewRegistrationParams() *common.SubscriptionRegistrationParams {
+func (c *Connector) EmptyRegistrationParams() *common.SubscriptionRegistrationParams {
 	return &common.SubscriptionRegistrationParams{
 		Request: &RegistrationParams{},
 	}
 }
 
-func (c *Connector) NewRegistrationResult() *common.RegistrationResult {
+func (c *Connector) EmptyRegistrationResult() *common.RegistrationResult {
 	return &common.RegistrationResult{
 		Result: &ResultData{},
 	}

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -257,3 +257,10 @@ func GetChangeDataCaptureChannelMembershipName(rawChannelName string, eventName 
 func GetRawPEName(peName string) string {
 	return RemoveSuffix(peName, 3) //nolint:mnd
 }
+
+func (conn *Connector) GetRegistrationResultUnMarshalFunc() common.UnmarshalFunc {
+	return registrationResultUnMarshalFunc
+}
+func registrationResultUnMarshalFunc(data []byte) (any, error) {
+	return common.Unmarshal[ResultData](data)
+}

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -261,6 +261,7 @@ func GetRawPEName(peName string) string {
 func (conn *Connector) GetRegistrationResultUnMarshalFunc() common.UnmarshalFunc {
 	return registrationResultUnMarshalFunc
 }
+
 func registrationResultUnMarshalFunc(data []byte) (any, error) {
 	return common.Unmarshal[ResultData](data)
 }

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -30,6 +30,18 @@ type ResultData struct {
 	EventRelayConfig *EventRelayConfig
 }
 
+func (c *Connector) NewRegistrationParams() *common.SubscriptionRegistrationParams {
+	return &common.SubscriptionRegistrationParams{
+		Request: &RegistrationParams{},
+	}
+}
+
+func (c *Connector) NewRegistrationResult() *common.RegistrationResult {
+	return &common.RegistrationResult{
+		Result: &ResultData{},
+	}
+}
+
 func (c *Connector) rollbackRegister(ctx context.Context, res *ResultData) error {
 	if res.EventRelayConfig != nil {
 		_, err := c.DeleteEventRelayConfig(ctx, res.EventRelayConfig.Id)
@@ -256,12 +268,4 @@ func GetChangeDataCaptureChannelMembershipName(rawChannelName string, eventName 
 
 func GetRawPEName(peName string) string {
 	return RemoveSuffix(peName, 3) //nolint:mnd
-}
-
-func (conn *Connector) GetRegistrationResultUnMarshalFunc() common.UnmarshalFunc {
-	return registrationResultUnMarshalFunc
-}
-
-func registrationResultUnMarshalFunc(data []byte) (any, error) {
-	return common.Unmarshal[ResultData](data)
 }

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -13,6 +13,16 @@ type SubscribeResult struct {
 	EventChannelMembers map[common.ObjectName]*EventChannelMember
 }
 
+func (conn *Connector) NewSubscritpionParams() *common.SubscribeParams {
+	return &common.SubscribeParams{}
+}
+
+func (conn *Connector) NewSubscriptionResult() *common.SubscriptionResult {
+	return &common.SubscriptionResult{
+		Result: &SubscribeResult{},
+	}
+}
+
 // Subscribe subscribes to the events for the given objects.
 // It creates event channel members for each object in the subscription.
 // If any of the event channel members fail to be created, it will rollback the operation.
@@ -158,12 +168,4 @@ func (conn *Connector) DeleteSubscription(ctx context.Context, params common.Sub
 	}
 
 	return nil
-}
-
-func (conn *Connector) GetSubscriptionResultUnMarshalFunc() common.UnmarshalFunc {
-	return subscriptionResultUnMarshalFunc
-}
-
-func subscriptionResultUnMarshalFunc(data []byte) (any, error) {
-	return common.Unmarshal[SubscribeResult](data)
 }

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -2,7 +2,6 @@ package salesforce
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -166,10 +165,5 @@ func (conn *Connector) GetSubscriptionResultUnMarshalFunc() common.UnmarshalFunc
 }
 
 func subscriptionResultUnMarshalFunc(data []byte) (any, error) {
-	res := &SubscribeResult{}
-	if err := json.Unmarshal(data, res); err != nil {
-		return nil, err
-	}
-
-	return res, nil
+	return common.Unmarshal[SubscribeResult](data)
 }

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -2,6 +2,7 @@ package salesforce
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -158,4 +159,17 @@ func (conn *Connector) DeleteSubscription(ctx context.Context, params common.Sub
 	}
 
 	return nil
+}
+
+func (conn *Connector) GetSubscriptionResultUnMarshalFunc() common.UnmarshalFunc {
+	return subscriptionResultUnMarshalFunc
+}
+
+func subscriptionResultUnMarshalFunc(data []byte) (any, error) {
+	res := &SubscribeResult{}
+	if err := json.Unmarshal(data, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -13,11 +13,11 @@ type SubscribeResult struct {
 	EventChannelMembers map[common.ObjectName]*EventChannelMember
 }
 
-func (conn *Connector) NewSubscritpionParams() *common.SubscribeParams {
+func (conn *Connector) EmptySubscritpionParams() *common.SubscribeParams {
 	return &common.SubscribeParams{}
 }
 
-func (conn *Connector) NewSubscriptionResult() *common.SubscriptionResult {
+func (conn *Connector) EmptySubscriptionResult() *common.SubscriptionResult {
 	return &common.SubscriptionResult{
 		Result: &SubscribeResult{},
 	}

--- a/test/front/metadata/main.go
+++ b/test/front/metadata/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 func main() {
-
 	ctx := context.Background()
 
 	conn := front.GetFrontConnector(ctx)

--- a/test/front/read/main.go
+++ b/test/front/read/main.go
@@ -58,6 +58,7 @@ func testRead(ctx context.Context, conn *fr.Connector, objectName string, fields
 	if _, err := os.Stdout.Write(jsonStr); err != nil {
 		return fmt.Errorf("error writing to stdout: %w", err)
 	}
+
 	if _, err := os.Stdout.WriteString("\n"); err != nil {
 		return fmt.Errorf("error writing to stdout: %w", err)
 	}


### PR DESCRIPTION
Problem:
- data is saved in the database as `byte[]`, server needs to convert it to the correct format to pass to the connector for updating a subscription. 

### Updated Solution
When we want to json unmarshal, we basically need the container or shell for the data. 

Instead of the connector interface to have json unmarshal interface methods, we instead have NewSubscribeParams, NewRegistrationParams, NewSubscribeResult NewRegistrationResult methods that will return shells for provider specific data structure we can json unmarshal into. This will make the interface easier to understand and having NewOOO(). 


### Previous Discussion


The RegistrationResult struct is defined as below

```
// in common/types.go
type RegistrationResult struct {
	RegistrationRef string
	Result          any  // this is stored as []byte in database
	Status          RegistrationStatus
}

type Regu


// in salesfoce/subscribe.go
// below struct is stored Result any
type ResultData struct {
	EventChannel     *EventChannel
	NamedCredential  *NamedCredential
	EventRelayConfig *EventRelayConfig
}

// in otherProvider/subscribe.go
type ResultData strunct {
   SomeOtherProviderSpecificField1
   SomeOtherProviderSpecificField2
   ...
}

```

The data stored in the database corresponds to `Request any` field. But at the time of deserializing the Request field from []byte to any, we need to know each one of ResultData structure imported in order to deserialize. Which is a lot of importing and switch mapping that won't scale.

Instead, we have the connector to define deserialization(json unmarshal) for each provider, then the model importing and complications will be abstracted away. 

Open to other suggestions.

A previously explored solution was to make `Result any` field to `Result []byte`. Then server does not need to worry about serialization. But the connector will do serialization and deserialization. 

The other solution could be making it ajson.Node. But this has draw back that we need to mode serialization and deserialization like `[]byte -> ajson.Node -> []byte -> salesforce.ResultData` that loses performance. 