### PR TITLE
feat(transport): SetBaseURL

### DIFF
--- a/internal/components/transport.go
+++ b/internal/components/transport.go
@@ -40,5 +40,10 @@ func NewTransport(
 	}, nil
 }
 
-func (c *Transport) JSONHTTPClient() *common.JSONHTTPClient { return c.json }
-func (c *Transport) HTTPClient() *common.HTTPClient         { return c.json.HTTPClient }
+func (t *Transport) SetBaseURL(newURL string) {
+	t.ProviderContext.providerInfo.BaseURL = newURL
+	t.json.HTTPClient.Base = newURL
+}
+
+func (t *Transport) JSONHTTPClient() *common.JSONHTTPClient { return t.json }
+func (t *Transport) HTTPClient() *common.HTTPClient         { return t.json.HTTPClient }

--- a/test/blueshift/metadata/metadata.go
+++ b/test/blueshift/metadata/metadata.go
@@ -19,5 +19,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	utils.DumpJSON(m, os.Stdout)
 }

--- a/test/blueshift/read/main.go
+++ b/test/blueshift/read/main.go
@@ -22,6 +22,7 @@ func run() error {
 	connector := blueshift.GetBlueshiftConnector(ctx)
 
 	slog.Info("Reading campaigns")
+
 	res, err := connector.Read(ctx, common.ReadParams{
 		ObjectName: "campaigns",
 		Fields:     datautils.NewStringSet("uuid", "name"),
@@ -33,6 +34,7 @@ func run() error {
 	utils.DumpJSON(res, os.Stdout)
 
 	slog.Info("Reading email templates")
+
 	res, err = connector.Read(ctx, common.ReadParams{
 		ObjectName: "email_templates",
 		Fields:     datautils.NewStringSet("uuid", "name"),
@@ -44,6 +46,7 @@ func run() error {
 	utils.DumpJSON(res, os.Stdout)
 
 	slog.Info("Reading sms templates")
+
 	res, err = connector.Read(ctx, common.ReadParams{
 		ObjectName: "sms_templates",
 		Fields:     datautils.NewStringSet("uuid", "author"),

--- a/test/front/metadata/main.go
+++ b/test/front/metadata/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 func main() {
-
 	ctx := context.Background()
 
 	conn := front.GetFrontConnector(ctx)

--- a/test/front/read/main.go
+++ b/test/front/read/main.go
@@ -58,6 +58,7 @@ func testRead(ctx context.Context, conn *fr.Connector, objectName string, fields
 	if _, err := os.Stdout.Write(jsonStr); err != nil {
 		return fmt.Errorf("error writing to stdout: %w", err)
 	}
+
 	if _, err := os.Stdout.WriteString("\n"); err != nil {
 		return fmt.Errorf("error writing to stdout: %w", err)
 	}


### PR DESCRIPTION
# Background
Transport should override base URL. This is useful for mock tests, where the base URL is replaced with the test server URL.

# Usage
![image](https://github.com/user-attachments/assets/2c9d6aec-1c92-4fe2-afd4-b0eab83dfc9d)

# Goal
Unblocks mock tests.
