### PR TITLE
feat: Update HTTPHandlers to include request parameter in ParseResponse

### DIFF
--- a/internal/components/operations/operations.go
+++ b/internal/components/operations/operations.go
@@ -23,7 +23,7 @@ type HTTPOperation[RequestType any, ResponseType any] struct {
 // HTTPHandlers contains operation-specific HTTP handlers for building and parsing HTTP requests and responses.
 type HTTPHandlers[RequestType any, ResponseType any] struct {
 	BuildRequest  func(context.Context, RequestType) (*http.Request, error)
-	ParseResponse func(context.Context, RequestType, *common.JSONHTTPResponse) (ResponseType, error)
+	ParseResponse func(context.Context, RequestType, *http.Request, *common.JSONHTTPResponse) (ResponseType, error)
 	ErrorHandler  func(*http.Response, []byte) error
 }
 
@@ -85,5 +85,5 @@ func (op *HTTPOperation[RequestType, ResponseType]) ExecuteRequest(
 		return response, err
 	}
 
-	return op.handlers.ParseResponse(ctx, params, jsonResp)
+	return op.handlers.ParseResponse(ctx, params, req, jsonResp)
 }

--- a/providers/blueshift/handlers.go
+++ b/providers/blueshift/handlers.go
@@ -50,6 +50,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	path, err := metadata.Schemas.LookupURLPath(c.Module(), params.ObjectName)
@@ -102,6 +103,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
 	node, ok := response.Body()

--- a/providers/front/handlers.go
+++ b/providers/front/handlers.go
@@ -37,6 +37,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
@@ -73,6 +74,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
 	body, ok := response.Body()

--- a/providers/gorgias/handlers.go
+++ b/providers/gorgias/handlers.go
@@ -35,6 +35,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 func (c *Connector) parseSingleObjectMetadataResponse(
 	ctx context.Context,
 	objectName string,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
 	objectMetadata := common.ObjectMetadata{

--- a/providers/groove/handlers.go
+++ b/providers/groove/handlers.go
@@ -34,6 +34,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 func (c *Connector) parseSingleObjectMetadataResponse(
 	ctx context.Context,
 	objectName string,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
 	objectMetadata := common.ObjectMetadata{
@@ -106,6 +107,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
@@ -142,6 +144,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
 	body, ok := response.Body()

--- a/providers/helpscout/handlers.go
+++ b/providers/helpscout/handlers.go
@@ -43,6 +43,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 func (c *Connector) parseSingleObjectMetadataResponse(
 	ctx context.Context,
 	objectName string,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
 	objectMetadata := common.ObjectMetadata{
@@ -89,6 +90,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
@@ -125,6 +127,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
+	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
 	// The response is always an empty response body.

--- a/providers/netsuite/handlers.go
+++ b/providers/netsuite/handlers.go
@@ -32,6 +32,7 @@ func (c *Connector) buildObjectMetadataRequest(ctx context.Context, object strin
 func (c *Connector) parseObjectMetadataResponse(
 	ctx context.Context,
 	object string,
+	request *http.Request,
 	resp *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
 	metadata, err := common.UnmarshalJSON[metadataResponse](resp)

--- a/providers/smartleadv2/handlers.go
+++ b/providers/smartleadv2/handlers.go
@@ -25,6 +25,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
+	request *http.Request,
 	resp *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
@@ -74,6 +75,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
+	request *http.Request,
 	resp *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
 	// Get the JSON node from response
@@ -133,6 +135,7 @@ func (c *Connector) buildDeleteRequest(ctx context.Context, params common.Delete
 func (c *Connector) parseDeleteResponse(
 	ctx context.Context,
 	params common.DeleteParams,
+	request *http.Request,
 	resp *common.JSONHTTPResponse,
 ) (*common.DeleteResult, error) {
 	if resp.Code != http.StatusOK && resp.Code != http.StatusNoContent {


### PR DESCRIPTION
This PR modifies the ParseResponse handler signature in HTTPOperation to include the original request, enabling better access to request parameters needed for pagination.

## Changes:
- Updated HTTPHandlers.ParseResponse signature to include *http.Request parameter in `internal/components/operations/operations.go`
- Updated all affected connector implementations to match the new signature

Before:
```go
ParseResponse func(context.Context, RequestType, *common.JSONHTTPResponse) (ResponseType, error)
```

After
``` go
ParseResponse func(context.Context, RequestType, *http.Request, *common.JSONHTTPResponse) (ResponseType, error)
```