### PR TITLE
[CON-1591]feat(Salesforce): GetRecordsWithIds

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -91,9 +91,6 @@ var (
 	// ErrRecordDataNotJSON is returned when the record data in WriteParams is not JSON.
 	ErrRecordDataNotJSON = errors.New("record data is not JSON")
 
-	// ErrTooManyRecordIDs is returned when querying by identifiers exceeds the limit.
-	ErrTooManyRecordIDs = errors.New("too many record identifiers to query")
-
 	// ErrOperationNotSupportedForObject is returned when operation is not supported for this object.
 	ErrOperationNotSupportedForObject = errors.New("operation is not supported for this object in this module")
 

--- a/common/types.go
+++ b/common/types.go
@@ -91,6 +91,9 @@ var (
 	// ErrRecordDataNotJSON is returned when the record data in WriteParams is not JSON.
 	ErrRecordDataNotJSON = errors.New("record data is not JSON")
 
+	// ErrTooManyRecordIDs is returned when querying by identifiers exceeds the limit.
+	ErrTooManyRecordIDs = errors.New("too many record identifiers to query")
+
 	// ErrOperationNotSupportedForObject is returned when operation is not supported for this object.
 	ErrOperationNotSupportedForObject = errors.New("operation is not supported for this object in this module")
 

--- a/providers/salesforce/record.go
+++ b/providers/salesforce/record.go
@@ -1,0 +1,78 @@
+package salesforce
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// GetRecordsWithIds returns records matching identifiers.
+func (c *Connector) GetRecordsWithIds( // nolint:revive
+	ctx context.Context,
+	objectName string,
+	ids []string,
+	fields []string,
+	associations []string, // no-op, preserved to match other deep connectors
+) ([]common.ReadResultRow, error) {
+	// Sanitize method arguments.
+	config := recordsByIDsParams{
+		ReadParams: common.ReadParams{
+			ObjectName:        objectName,
+			Fields:            datautils.NewSetFromList(fields),
+			AssociatedObjects: associations,
+		},
+		RecordIdentifiers: datautils.NewSetFromList(ids),
+	}
+
+	if err := config.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	url, err := c.buildReadByIdentifierURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	readResult, err := common.ParseResult(
+		rsp,
+		getRecords,
+		getNextRecordsURL,
+		common.GetMarshaledData,
+		config.Fields,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return readResult.Data, nil
+}
+
+type recordsByIDsParams struct {
+	common.ReadParams
+	RecordIdentifiers datautils.Set[string]
+}
+
+func (c *Connector) buildReadByIdentifierURL(config recordsByIDsParams) (*urlbuilder.URL, error) {
+	// Requesting record identifiers using SOQL query.
+	url, err := c.getRestApiURL("query")
+	if err != nil {
+		return nil, err
+	}
+
+	soql := makeSOQL(config.ReadParams)
+
+	if err = soql.WithIDs(config.RecordIdentifiers.List()); err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("q", soql.String())
+
+	return url, nil
+}

--- a/providers/salesforce/record.go
+++ b/providers/salesforce/record.go
@@ -66,13 +66,11 @@ func (c *Connector) buildReadByIdentifierURL(config recordsByIDsParams) (*urlbui
 		return nil, err
 	}
 
-	soql := makeSOQL(config.ReadParams)
+	query := makeSOQL(config.ReadParams).
+		WithIDs(config.RecordIdentifiers.List()).
+		String()
 
-	if err = soql.WithIDs(config.RecordIdentifiers.List()); err != nil {
-		return nil, err
-	}
-
-	url.WithQueryParam("q", soql.String())
+	url.WithQueryParam("q", query)
 
 	return url, nil
 }

--- a/providers/salesforce/soql.go
+++ b/providers/salesforce/soql.go
@@ -3,15 +3,12 @@ package salesforce
 import (
 	"fmt"
 	"strings"
-
-	"github.com/amp-labs/connectors/common"
 )
 
 // nolint:lll
 const (
 	// See `Limiting Result Rows` section on this webpage:
 	// https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_fields.htm
-	identifiersLimit    = 200
 	identifiersLimitStr = "200"
 )
 
@@ -57,11 +54,7 @@ func (s *soqlBuilder) Where(condition string) *soqlBuilder {
 	return s
 }
 
-func (s *soqlBuilder) WithIDs(identifiers []string) error {
-	if len(identifiers) > identifiersLimit {
-		return common.ErrTooManyRecordIDs
-	}
-
+func (s *soqlBuilder) WithIDs(identifiers []string) *soqlBuilder {
 	// Decorate each id with quotes.
 	for index, id := range identifiers {
 		identifiers[index] = fmt.Sprintf("'%v'", id)
@@ -71,9 +64,7 @@ func (s *soqlBuilder) WithIDs(identifiers []string) error {
 
 	// nolint:lll
 	// https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_fields.htm
-	s.Where(fmt.Sprintf("Id IN (%v)", identifiersList))
-
-	return nil
+	return s.Where(fmt.Sprintf("Id IN (%v)", identifiersList))
 }
 
 func (s *soqlBuilder) String() string {

--- a/providers/salesforce/soql_test.go
+++ b/providers/salesforce/soql_test.go
@@ -1,7 +1,6 @@
 package salesforce
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
@@ -20,21 +19,10 @@ func TestSoqlBuilderWithIDs(t *testing.T) {
 	})
 
 	{
-		// SOQL query has a limit on how many record identifiers can be queried,
-		// exceeding it would produce an error.
-		tooManyIdentifiers := make([]string, 210)
-		for index := range tooManyIdentifiers {
-			tooManyIdentifiers[index] = strconv.Itoa(index)
-		}
-
-		err := soql.WithIDs(tooManyIdentifiers)
-		assert.ErrorIs(t, err, common.ErrTooManyRecordIDs, "expected to get an error for large ids list")
-	}
-	{
 		// SOQL builder must produce query matching documentation.
 		// nolint:lll
 		// https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_fields.htm
-		err := soql.WithIDs(
+		soql.WithIDs(
 			[]string{
 				"001ak00000OQ4RxAAL",
 				"001ak00000OQ4RyAAL",
@@ -43,7 +31,6 @@ func TestSoqlBuilderWithIDs(t *testing.T) {
 				"001ak00000OQ4VBAA1",
 				"001ak00000OQ4VCAA1",
 			})
-		assert.NilError(t, err, "error should be nil")
 
 		output := soql.String()
 		assert.Equal(t, output, "SELECT shippingstreet FROM Account WHERE Id IN ("+

--- a/providers/salesforce/soql_test.go
+++ b/providers/salesforce/soql_test.go
@@ -1,0 +1,57 @@
+package salesforce
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"gotest.tools/v3/assert"
+)
+
+func TestSoqlBuilderWithIDs(t *testing.T) {
+	t.Parallel()
+
+	soql := makeSOQL(common.ReadParams{
+		ObjectName: "Account",
+		// Note: fields doesn't preserve order of elements.
+		// To simplify test only one element is included.
+		Fields: datautils.NewSet("shippingstreet"),
+	})
+
+	{
+		// SOQL query has a limit on how many record identifiers can be queried,
+		// exceeding it would produce an error.
+		tooManyIdentifiers := make([]string, 210)
+		for index := range tooManyIdentifiers {
+			tooManyIdentifiers[index] = strconv.Itoa(index)
+		}
+
+		err := soql.WithIDs(tooManyIdentifiers)
+		assert.ErrorIs(t, err, common.ErrTooManyRecordIDs, "expected to get an error for large ids list")
+	}
+	{
+		// SOQL builder must produce query matching documentation.
+		// nolint:lll
+		// https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_fields.htm
+		err := soql.WithIDs(
+			[]string{
+				"001ak00000OQ4RxAAL",
+				"001ak00000OQ4RyAAL",
+				"001ak00000OQ4TZAA1",
+				"001ak00000OQ4TbAAL",
+				"001ak00000OQ4VBAA1",
+				"001ak00000OQ4VCAA1",
+			})
+		assert.NilError(t, err, "error should be nil")
+
+		output := soql.String()
+		assert.Equal(t, output, "SELECT shippingstreet FROM Account WHERE Id IN ("+
+			"'001ak00000OQ4RxAAL',"+
+			"'001ak00000OQ4RyAAL',"+
+			"'001ak00000OQ4TZAA1',"+
+			"'001ak00000OQ4TbAAL',"+
+			"'001ak00000OQ4VBAA1',"+
+			"'001ak00000OQ4VCAA1')", "mismatching SOQL query string")
+	}
+}

--- a/test/salesforce/record/main.go
+++ b/test/salesforce/record/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceConnector(ctx)
+
+	res, err := conn.GetRecordsWithIds(ctx,
+		"Account",
+		[]string{
+			"001ak00000OQ4RxAAL",
+			"001ak00000OQ4RyAAL",
+			"001ak00000OQ4TZAA1",
+		},
+		[]string{"id", "name", "shippingstreet"},
+		nil)
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Changes

* Extended existing SOQL builder to accept list of identifiers.
  * Added mock test to ensure query is built as expected.
* Added test script to query Accounts (see below).

# Tests
`salesforce/record/main.go`:
![image](https://github.com/user-attachments/assets/77ce3eb2-3ed5-4502-b823-ddeaed9a5307)
![image](https://github.com/user-attachments/assets/9ec66f77-d491-404e-a330-f216420911c5)

# Notes
Associations argument at `GetRecordsWithIds` is preserved to **match method signature** of other deep connectors. However, it is not used by the Salesforce implementation.