### PR TITLE
tidy(scripts/oauth): Ignore refresh token if empty

### DIFF
--- a/scripts/utils/credutils/tokenWriter.go
+++ b/scripts/utils/credutils/tokenWriter.go
@@ -53,9 +53,18 @@ func internalCredsFileWrite(filePath string, token *oauth2.Token) (*ordered.Orde
 	}
 
 	orderedMap.Set(credscanning.Fields.AccessToken.PathJSON, token.AccessToken)
-	orderedMap.Set(credscanning.Fields.RefreshToken.PathJSON, token.RefreshToken)
-	orderedMap.Set(credscanning.Fields.ExpiryFormat.PathJSON, "RFC3339Nano")
-	orderedMap.Set(credscanning.Fields.Expiry.PathJSON, token.Expiry.UTC().Format(time.RFC3339Nano))
+
+	if len(token.RefreshToken) == 0 {
+		// Refresh token and data associated with are not relevant for the connector.
+		orderedMap.Delete(credscanning.Fields.RefreshToken.PathJSON)
+		orderedMap.Delete(credscanning.Fields.ExpiryFormat.PathJSON)
+		orderedMap.Delete(credscanning.Fields.Expiry.PathJSON)
+	} else {
+		// Store data related to refresh token.
+		orderedMap.Set(credscanning.Fields.RefreshToken.PathJSON, token.RefreshToken)
+		orderedMap.Set(credscanning.Fields.ExpiryFormat.PathJSON, "RFC3339Nano")
+		orderedMap.Set(credscanning.Fields.Expiry.PathJSON, token.Expiry.UTC().Format(time.RFC3339Nano))
+	}
 
 	outputData, err := json.MarshalIndent(orderedMap, "", "  ")
 	if err != nil {


### PR DESCRIPTION
# Description
Zendesk is such a provider that doesn't return refresh token. Regenereting `accessToken` for this type of provider doesn't make sense to include empty refresh token fields.

## Before
![image](https://github.com/user-attachments/assets/2b36e507-3cd9-405f-9f45-8b646822390a)

## After
![image](https://github.com/user-attachments/assets/54aeea3a-0195-4658-a29b-fb7e60c7bdbc)
