### PR TITLE
[CON-957] feat: add monday proxy connector

### DIFF
--- a/providers/monday.go
+++ b/providers/monday.go
@@ -6,17 +6,14 @@ func init() {
 	// Monday Configuration
 	SetInfo(Monday, ProviderInfo{
 		DisplayName: "Monday",
-		AuthType:    Oauth2,
-		BaseURL:     "https://api.monday.com",
-		Oauth2Opts: &Oauth2Opts{
-			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://auth.monday.com/oauth2/authorize",
-			TokenURL:                  "https://auth.monday.com/oauth2/token",
-			ExplicitScopesRequired:    false,
-			ExplicitWorkspaceRequired: false,
-			TokenMetadataFields: TokenMetadataFields{
-				ScopesField: "scope",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.monday.com/",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: "header",
+			Header: &ApiKeyOptsHeader{
+				Name: "Authorization",
 			},
+			DocsURL: "https://developer.monday.com/api-reference/docs/authentication",
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
## Checklist
- [x] Ran Linter

## Catalog variables
no workspace variables used

## Notes
Monday API is a graphql API hence all the calls are POST calls like this: 

```
curl -X POST 'https://api.monday.com/v2' \
-H 'Content-Type: application/json' \
-d '{"query": "query { me { is_guest created_at name id}}"}'
```

## Testing 
### Query 
URL: `localhost:4444/v2`

<img width="852" alt="Screenshot 2025-03-11 at 6 01 23 PM" src="https://github.com/user-attachments/assets/77e2e556-e991-44f1-8dd8-743b06d9f6ec" />



### Mutation
URL: `localhost:4444/v2`

<img width="861" alt="Screenshot 2025-03-11 at 5 57 00 PM" src="https://github.com/user-attachments/assets/a11fd752-4234-4108-a9ff-7ff595d14197" />


## Errors 

### Invalid request 

<img width="855" alt="Screenshot 2025-03-11 at 5 57 45 PM" src="https://github.com/user-attachments/assets/d3e1f630-89d2-437d-9b28-be7e8edf2f23" />

### Pagination

Here pagination works with `limit` & `page` params to the graphQL query

<img width="849" alt="Screenshot 2025-03-11 at 6 11 58 PM" src="https://github.com/user-attachments/assets/cc59dfb7-d322-4e9c-9ea3-8fa5a36ab2e9" />
