### PR TITLE
feat(httpkit): Link header parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.2
 	github.com/antchfx/xmlquery v1.4.3
 	github.com/brianvoe/gofakeit/v6 v6.28.0
+	github.com/deiu/linkparser v0.0.0-20170608193052-9b6849e15168
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/getkin/kin-openapi v0.129.0
 	github.com/go-playground/validator v9.31.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deiu/linkparser v0.0.0-20170608193052-9b6849e15168 h1:faQ0lJ7RbfOyHSVkVwmWiUk/+HOA648JNBmwIkFHlxI=
+github.com/deiu/linkparser v0.0.0-20170608193052-9b6849e15168/go.mod h1:EPdXetNGTVpWsQ9wn8LQzqNByQOjMeFhYEvNOZNGtwg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/internal/httpkit/response.go
+++ b/internal/httpkit/response.go
@@ -1,0 +1,19 @@
+// nolint:lll
+package httpkit
+
+import (
+	"github.com/amp-labs/connectors/common"
+	lh "github.com/deiu/linkparser"
+)
+
+// HeaderLink extracts and parses Link Header of HTTP response.
+//
+// Example: given the header below we want to return one of the URLs based on the relationship name.
+// <https://api.capsulecrm.com/api/v2/parties?page=3&perPage=1>; rel="next", <https://api.capsulecrm.com/api/v2/parties?page=1&perPage=1>; rel="prev"
+//
+// The implementation is delegated to `linkparser` library.
+func HeaderLink(resp *common.JSONHTTPResponse, relationshipName string) string {
+	link := resp.Headers.Get("Link")
+
+	return lh.ParseHeader(link)[relationshipName]["href"]
+}


### PR DESCRIPTION
# Description

* Created the `httpkit` package.
* The Capsule provider includes the next page URL in the `Link` header. This PR adds utility to parse and extract URL data.
* The implementation delegates to `github.com/deiu/linkparser` library.