### PR TITLE
feat(components): URL catalog

### DIFF
--- a/internal/components/endpoints/catalog.go
+++ b/internal/components/endpoints/catalog.go
@@ -1,0 +1,141 @@
+package endpoints
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+// Catalog holds registries that map ObjectNames to their respective URLs and REST methods.
+// Registries are divided by Read, Write(Create/Update), Delete connector operations.
+// To create OperationRegistry use NewOperationRegistry.
+type Catalog struct {
+	// Transport is used in URL construction.
+	Transport *components.Transport
+
+	// ReadOperation is used by connector's Read operation.
+	// If reading from a static file, use OperationRegistryFromStaticSchema to populate this field.
+	ReadOperation OperationRegistry
+
+	// CreateOperation is used by connector's Write operation for new records (without a record ID).
+	CreateOperation OperationRegistry
+
+	// UpdateOperation is used by connector's Write operation for existing records (with a record ID).
+	// Use {{.recordID}} in the URL template to be replaced with the actual record ID.
+	// If omitted, the record ID is appended to the URL with a preceding slash.
+	// Example:
+	//   "/orders"					=> "/orders/123"
+	//   "/orders/{{.recordID}}"	=> "/orders/123"
+	//   "/orders({{.recordID}})"	=> "/orders(123)" -- for providers using special syntax.
+	UpdateOperation OperationRegistry
+
+	// DeleteOperation is used by connector's Delete operation.
+	DeleteOperation OperationRegistry
+}
+
+// OperationContext encapsulates the necessary details for executing an API call.
+// It is produced from OperationSpec.
+// TODO: Endpoints may have exceptions in payload construction, headers. This struct needs to be extended to solve this.
+// TODO: Ideally, the OperationContext should be as self-sufficient as possible.
+type OperationContext struct {
+	// URL of the API endpoint.
+	// Note: Query parameters can be appended separately.
+	URL *urlbuilder.URL
+
+	// HTTP Method for the request (e.g., GET, POST, PUT, PATCH, DELETE).
+	Method string
+}
+
+// CreateReadOperation constructs URL matching read operation registry in the catalog.
+func (c *Catalog) CreateReadOperation(
+	config common.ReadParams,
+) (*OperationContext, error) {
+	if c.Transport == nil || c.ReadOperation == nil {
+		return &OperationContext{}, nil
+	}
+
+	// Find operation associated with the object.
+	description := c.ReadOperation[c.Transport.Module()].Get(config.ObjectName)
+	if description.isEmpty() {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	// Build URL according to the defined rules of
+	baseURL := c.Transport.BaseURL()
+
+	url, err := urlbuilder.New(baseURL, description.getURLPath(""))
+	if err != nil {
+		return nil, err
+	}
+
+	return &OperationContext{
+		URL:    url,
+		Method: description.Method,
+	}, nil
+}
+
+// CreateWriteOperation constructs URL matching respective Create/Update operation registry in the catalog.
+func (c *Catalog) CreateWriteOperation(
+	config common.WriteParams,
+) (*OperationContext, error) {
+	registry := c.chooseWriteRegistry(config.RecordId)
+
+	if c.Transport == nil || registry == nil {
+		return &OperationContext{}, nil
+	}
+
+	// Find operation associated with the object.
+	description := registry[c.Transport.Module()].Get(config.ObjectName)
+	if description.isEmpty() {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	// Build URL according to the defined rules of
+	baseURL := c.Transport.BaseURL()
+
+	url, err := urlbuilder.New(baseURL, description.getURLPath(config.RecordId))
+	if err != nil {
+		return nil, err
+	}
+
+	return &OperationContext{
+		URL:    url,
+		Method: description.Method,
+	}, nil
+}
+
+// CreateDeleteOperation constructs URL matching delete operation registry in the catalog.
+func (c *Catalog) CreateDeleteOperation(
+	config common.DeleteParams,
+) (*OperationContext, error) {
+	if c.Transport == nil || c.DeleteOperation == nil {
+		return &OperationContext{}, nil
+	}
+
+	// Find operation associated with the object.
+	description := c.DeleteOperation[c.Transport.Module()].Get(config.ObjectName)
+	if description.isEmpty() {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	// Build URL according to the defined rules of
+	baseURL := c.Transport.BaseURL()
+
+	url, err := urlbuilder.New(baseURL, description.getURLPath(config.RecordId))
+	if err != nil {
+		return nil, err
+	}
+
+	return &OperationContext{
+		URL:    url,
+		Method: description.Method,
+	}, nil
+}
+
+func (c *Catalog) chooseWriteRegistry(recordID string) OperationRegistry {
+	if len(recordID) != 0 {
+		return c.UpdateOperation
+	}
+
+	return c.CreateOperation
+}

--- a/internal/components/endpoints/convertors.go
+++ b/internal/components/endpoints/convertors.go
@@ -1,0 +1,29 @@
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/staticschema"
+)
+
+// OperationRegistryFromStaticSchema creates OperationRegistry suitable for connector's READ operation.
+func OperationRegistryFromStaticSchema[F staticschema.FieldMetadataMap, C any](
+	metadata *staticschema.Metadata[F, C],
+) OperationRegistry {
+	registry := make(map[common.ModuleID]map[string]OperationSpec)
+
+	for moduleID, module := range metadata.Modules {
+		operations := make(map[string]OperationSpec)
+
+		for objectName, object := range module.Objects {
+			operations[objectName] = OperationSpec{
+				Path: module.Path + object.URLPath,
+			}
+		}
+
+		registry[moduleID] = operations
+	}
+
+	return NewOperationRegistry(http.MethodGet, registry, nil)
+}

--- a/internal/components/endpoints/locator.go
+++ b/internal/components/endpoints/locator.go
@@ -1,0 +1,30 @@
+package endpoints
+
+import (
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// ResponseDataLocator uses API specifications to determine how to locate various data in an HTTP response.
+type ResponseDataLocator struct {
+	providerContext    *components.ProviderContext
+	identifierRegistry ResponseIdentifierRegistry
+}
+
+func NewResponseDataLocator(
+	providerContext *components.ProviderContext, identifierRegistry ResponseIdentifierRegistry,
+) *ResponseDataLocator {
+	return &ResponseDataLocator{
+		providerContext:    providerContext,
+		identifierRegistry: identifierRegistry,
+	}
+}
+
+// ExtractRecordID retrieves the record ID from the response node,
+// with the path varying based on the object name.
+func (l ResponseDataLocator) ExtractRecordID(node *ajson.Node, objectName string) (string, error) {
+	path := l.identifierRegistry[l.providerContext.Module()].Get(objectName)
+
+	return jsonquery.New(node, path.nested...).TextWithDefault(path.key, "")
+}

--- a/internal/components/endpoints/models.go
+++ b/internal/components/endpoints/models.go
@@ -1,0 +1,119 @@
+package endpoints
+
+import (
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+const RecordIDKey = "{{.recordID}}"
+
+// OperationRegistry is a comprehensive blueprint that organizes a collection of OperationSpec instances.
+// It is structured by module ID and object name.
+type OperationRegistry map[common.ModuleID]datautils.DefaultMap[string, OperationSpec]
+
+// NewOperationRegistry constructs a new OperationRegistry. It sets the default HTTP method for each operation
+// unless an override is provided in the registry map. This function simplifies the creation of an
+// OperationRegistry by automatically handling default values.
+func NewOperationRegistry(
+	defaultHTTPMethod string,
+	registry map[common.ModuleID]map[string]OperationSpec,
+	fallback func(common.ModuleID, string) OperationSpec,
+) OperationRegistry {
+	result := make(map[common.ModuleID]datautils.DefaultMap[string, OperationSpec])
+
+	for moduleID, mapping := range registry {
+		// OperationSpec should have default value if none is specified.
+		// Usually most write operations have identical operations,
+		// this makes the registry shorter, drawing attention to exceptions.
+		for objectName, spec := range mapping {
+			if len(spec.Method) == 0 {
+				spec.Method = defaultHTTPMethod
+				mapping[objectName] = spec
+			}
+		}
+
+		result[moduleID] = datautils.NewDefaultMap(mapping,
+			createFallback(fallback, moduleID),
+		)
+	}
+
+	return result
+}
+
+func createFallback(
+	fallback func(common.ModuleID, string) OperationSpec,
+	moduleID common.ModuleID,
+) func(objectName string) OperationSpec {
+	if fallback == nil {
+		return func(objectName string) OperationSpec {
+			return OperationSpec{}
+		}
+	}
+
+	return func(objectName string) OperationSpec {
+		return fallback(moduleID, objectName)
+	}
+}
+
+func (r OperationRegistry) ObjectNames() datautils.UniqueLists[common.ModuleID, string] {
+	moduleObjectNames := make(datautils.UniqueLists[common.ModuleID, string])
+
+	for moduleID, module := range r {
+		objects := module.Keys()
+		moduleObjectNames.Add(moduleID, objects...)
+	}
+
+	return moduleObjectNames
+}
+
+// OperationSpec serves as a template for defining API calls.
+// This specification will act as a prototype for constructing an OperationContext at runtime.
+//
+// It includes properties that differentiate endpoints, such as:
+//   - Method: The HTTP method to use for the operation.
+//     For example, most update operations use PUT, while some may use PATCH.
+//   - Path: A required field that defines the relative unique URL path for each object.
+//
+// TODO: Consider expanding this struct to include custom payload construction, headers, and other configurations.
+type OperationSpec struct {
+	Method string
+	Path   string
+}
+
+func (d OperationSpec) isEmpty() bool {
+	return len(d.Method) == 0 && len(d.Path) == 0
+}
+
+func (d OperationSpec) getURLPath(recordID string) string {
+	if len(recordID) == 0 {
+		// Usually this is a create or command endpoint.
+		return d.Path
+	}
+
+	// No template. Usually record identifier is attached at the end of endpoint.
+	if !strings.Contains(d.Path, RecordIDKey) {
+		return d.Path + "/" + recordID
+	}
+
+	// Insert recordID inside URL according to the template format.
+	return strings.ReplaceAll(d.Path, RecordIDKey, recordID)
+}
+
+// ResponseIdentifierRegistry is a collection of JSON paths to locate record identifiers in the response body.
+// It is structured by module ID and object name.
+type ResponseIdentifierRegistry map[common.ModuleID]datautils.DefaultMap[string, JSONPath]
+
+// JSONPath defines a data location using a key and optional nested JSON keys.
+type JSONPath struct {
+	key    string
+	nested []string
+}
+
+func NewJSONPath(key string, nested ...string) JSONPath {
+	return JSONPath{
+		key:    key,
+		nested: nested,
+	}
+}

--- a/internal/components/provider.go
+++ b/internal/components/provider.go
@@ -48,6 +48,10 @@ func (p *ProviderContext) Provider() providers.Provider {
 	return p.provider
 }
 
+func (p *ProviderContext) BaseURL() string {
+	return p.providerInfo.BaseURL
+}
+
 func (p *ProviderContext) ProviderInfo() *providers.ProviderInfo {
 	return p.providerInfo
 }


### PR DESCRIPTION
# Background

While working on Google Contacts and Capsule connectors, I developed a shared utility primarily focused on simplifying the Write operation in newly reformatted deep connectors.

Older connectors achieved similar functionality, but this PR aims to make that intent clearer and more structured.

# Features

1. `endpoints.Catalog` -  defines the context for making API calls.
* Supports template URLs.
* Specifies the default HTTP method.
* Allows HTTP method outliers.
2. `endpoints.ResponseDataLocator` - registry of **object name** to the **JSON path** to locate record identifier inside write response.
https://github.com/amp-labs/connectors/blob/50fc7ceeefe746c5615361d3eacb801109e9e362/providers/iterable/write.go#L98-L101
3. `OperationRegistry.ObjectNames()` returns supported object names, can be used by
`components.EndpointRegistryInput`.

# Use case
Write implementation can entirely be captured by `OperationRegistry`. Read comments below to see how it will be used:
![image](https://github.com/user-attachments/assets/2c77c00f-b9d8-4550-97e5-143376fd691a)


# Goals
* Reduce if..else conditions throughout the code.
* Enable a declarative approach to defining deep connector `write` API calls.

# Future Considerations
* Define default and outlier payload construction (similar to HTTP method handling).
* Support specifying headers or query parameters for outliers.
* Read, Delete connector operations may use POST HTTP method.