### PR TITLE
feat(urlbuilder): Construct from url.URL

### DIFF
--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -40,6 +40,21 @@ func New(base string, path ...string) (*URL, error) {
 	return u, nil
 }
 
+// FromRawURL converts a core Go `url.URL` into `urlbuilder.URL`,
+// providing better control over query parameters and encoding.
+func FromRawURL(rawURL *url.URL) (*URL, error) {
+	values, err := url.ParseQuery(rawURL.RawQuery)
+	if err != nil {
+		return nil, errors.Join(err, ErrInvalidURL)
+	}
+
+	return &URL{
+		delegate:           rawURL,
+		queryParams:        values,
+		encodingExceptions: nil,
+	}, nil
+}
+
 func (u *URL) WithQueryParamList(name string, values []string) {
 	u.queryParams[name] = values
 }


### PR DESCRIPTION
# Background

With the newly refactored deep connectors, we often work directly with raw `url.URL`. This bypasses the query parameter utilities provided by `urlbuilder`, making simple query parameter modifications cumbersome.

# Change
`urlbuilder.URL` can now be created from a raw `url.URL`.