### PR TITLE
feat(components): Mock Tests

### DIFF
--- a/internal/components/deleter/deleter.go
+++ b/internal/components/deleter/deleter.go
@@ -30,12 +30,12 @@ func NewHTTPDeleter(
 
 // Delete performs the delete operation.
 func (d *HTTPDeleter) Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error) {
-	if d.operation == nil {
-		return nil, fmt.Errorf("%w: %s", common.ErrNotImplemented, "deleter is not implemented")
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
 	}
 
-	if params.ObjectName == "" {
-		return nil, common.ErrMissingObjects
+	if d.operation == nil {
+		return nil, fmt.Errorf("%w: %s", common.ErrNotImplemented, "deleter is not implemented")
 	}
 
 	if d.registry == nil {

--- a/internal/components/deleter/deleter_test.go
+++ b/internal/components/deleter/deleter_test.go
@@ -1,0 +1,79 @@
+package deleter
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/mocked"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "orders"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.DeleteParams{ObjectName: "someUnknownObject", RecordId: "123"},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+// Connector used to test HTTPDeleter.
+type mockedConnector struct {
+	mocked.Connector
+	*HTTPDeleter
+}
+
+func constructTestConnector(serverURL string) (*mockedConnector, error) {
+	connector := mocked.Connector{
+		BaseURL: serverURL,
+	}
+
+	registry, err := components.NewEndpointRegistry(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mockedConnector{
+		Connector: connector,
+		HTTPDeleter: NewHTTPDeleter(
+			connector.HTTPClient().Client,
+			registry,
+			staticschema.RootModuleID,
+			operations.DeleteHandlers{},
+		),
+	}, nil
+}

--- a/internal/components/mocked/connector.go
+++ b/internal/components/mocked/connector.go
@@ -1,0 +1,38 @@
+package mocked
+
+import (
+	"net/http"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// Connector suitable for building different connector types for mock testing.
+type Connector struct {
+	// BaseURL must be set to the test server URL.
+	BaseURL string
+}
+
+var _ connectors.Connector = &Connector{}
+
+func (c Connector) String() string {
+	return "mock_connector"
+}
+
+func (c Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return &common.JSONHTTPClient{
+		HTTPClient: &common.HTTPClient{
+			Base:   c.BaseURL,
+			Client: http.DefaultClient,
+		},
+	}
+}
+
+func (c Connector) HTTPClient() *common.HTTPClient {
+	return c.JSONHTTPClient().HTTPClient
+}
+
+func (c Connector) Provider() providers.Provider {
+	return "mock_test"
+}

--- a/internal/components/operations/types.go
+++ b/internal/components/operations/types.go
@@ -10,10 +10,10 @@ type (
 	WriteHandlers  = HTTPHandlers[common.WriteParams, *common.WriteResult]
 	DeleteHandlers = HTTPHandlers[common.DeleteParams, *common.DeleteResult]
 
-	// Gets metadata for a list of objects in a single request.
+	// ListObjectMetadataHandlers gets metadata for a list of objects in a single request.
 	ListObjectMetadataHandlers = HTTPHandlers[[]string, *common.ListObjectMetadataResult]
 
-	// Gets metadata for a single object.
+	// SingleObjectMetadataHandlers gets metadata for a single object.
 	SingleObjectMetadataHandlers = HTTPHandlers[string, *common.ObjectMetadata]
 )
 
@@ -23,9 +23,9 @@ type (
 	WriteOperation  = HTTPOperation[common.WriteParams, *common.WriteResult]
 	DeleteOperation = HTTPOperation[common.DeleteParams, *common.DeleteResult]
 
-	// Gets metadata for a list of objects in a single request.
+	// ListObjectMetadataOperation gets metadata for a list of objects in a single request.
 	ListObjectMetadataOperation = HTTPOperation[[]string, *common.ListObjectMetadataResult]
 
-	// Gets metadata for a single object.
+	// SingleObjectMetadataOperation gets metadata for a single object.
 	SingleObjectMetadataOperation = HTTPOperation[string, *common.ObjectMetadata]
 )

--- a/internal/components/reader/reader.go
+++ b/internal/components/reader/reader.go
@@ -31,12 +31,12 @@ func NewHTTPReader(
 }
 
 func (r *HTTPReader) Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
-	if r.operation == nil {
-		return nil, fmt.Errorf("%w: reader is not implemented", common.ErrNotImplemented)
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
 	}
 
-	if params.ObjectName == "" {
-		return nil, common.ErrMissingObjects
+	if r.operation == nil {
+		return nil, fmt.Errorf("%w: reader is not implemented", common.ErrNotImplemented)
 	}
 
 	// If there's no support, we can't validate the operation.

--- a/internal/components/reader/reader_test.go
+++ b/internal/components/reader/reader_test.go
@@ -1,0 +1,80 @@
+package reader
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/mocked"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "orders"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.ReadParams{ObjectName: "someUnknownObject", Fields: connectors.Fields("id")},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+// Connector used to test HTTPReader.
+type mockedConnector struct {
+	mocked.Connector
+	*HTTPReader
+}
+
+func constructTestConnector(serverURL string) (*mockedConnector, error) {
+	connector := mocked.Connector{
+		BaseURL: serverURL,
+	}
+
+	registry, err := components.NewEndpointRegistry(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mockedConnector{
+		Connector: connector,
+		HTTPReader: NewHTTPReader(
+			connector.HTTPClient().Client,
+			registry,
+			staticschema.RootModuleID,
+			operations.ReadHandlers{},
+		),
+	}, nil
+}

--- a/internal/components/schema/openapi_test.go
+++ b/internal/components/schema/openapi_test.go
@@ -1,0 +1,95 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/mocked"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Unknown object requested",
+			Input:        []string{"someUnknownObject"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
+		},
+		{
+			Name:       "Successfully describe one object with metadata",
+			Input:      []string{"orders"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"orders": {
+						DisplayName: "Orders",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Identifier",
+								ValueType:    common.ValueTypeString,
+								ProviderType: "Text",
+							},
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL), nil
+			})
+		})
+	}
+}
+
+// Connector used to test SchemaProvider.
+type mockedConnector struct {
+	mocked.Connector
+	components.SchemaProvider
+}
+
+func constructTestConnector(serverURL string) *mockedConnector {
+	connector := mocked.Connector{
+		BaseURL: serverURL,
+	}
+
+	metadata := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
+	metadata.Add(staticschema.RootModuleID, "orders", "Orders", "/user/orders", "result",
+		map[string]staticschema.FieldMetadata{
+			"id": {
+				DisplayName:  "Identifier",
+				ValueType:    common.ValueTypeString,
+				ProviderType: "Text",
+			},
+		}, nil, nil)
+
+	return &mockedConnector{
+		Connector: connector,
+		SchemaProvider: NewOpenAPISchemaProvider(
+			staticschema.RootModuleID,
+			metadata,
+		),
+	}
+}

--- a/internal/components/writer/writer.go
+++ b/internal/components/writer/writer.go
@@ -30,12 +30,12 @@ func NewHTTPWriter(
 }
 
 func (w *HTTPWriter) Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
-	if w.operation == nil {
-		return nil, fmt.Errorf("%w: %s", common.ErrNotImplemented, "writer is not implemented")
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
 	}
 
-	if params.ObjectName == "" {
-		return nil, common.ErrMissingObjects
+	if w.operation == nil {
+		return nil, fmt.Errorf("%w: %s", common.ErrNotImplemented, "writer is not implemented")
 	}
 
 	// If there's no support, we can't validate the operation.

--- a/internal/components/writer/writer_test.go
+++ b/internal/components/writer/writer_test.go
@@ -1,0 +1,79 @@
+package writer
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/mocked"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs data payload",
+			Input:        common.WriteParams{ObjectName: "orders"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.WriteParams{ObjectName: "someUnknownObject", RecordData: "dummy"},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+// Connector used to test HTTPWriter.
+type mockedConnector struct {
+	mocked.Connector
+	*HTTPWriter
+}
+
+func constructTestConnector(serverURL string) (*mockedConnector, error) {
+	connector := mocked.Connector{
+		BaseURL: serverURL,
+	}
+
+	registry, err := components.NewEndpointRegistry(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mockedConnector{
+		Connector: connector,
+		HTTPWriter: NewHTTPWriter(
+			connector.HTTPClient().Client,
+			registry,
+			staticschema.RootModuleID,
+			operations.WriteHandlers{},
+		),
+	}, nil
+}


### PR DESCRIPTION
# Description

Common test cases no longer need to be repeated, which is a great improvement. Shared test cases now belong to components.

Deep connector mock tests are now more **focused**, covering only **business logic**.

#Changes
* Introduced a mocked package that provides a base connector, which can be extended via struct composition to function as a `ReadConnector`, `WriteConnector`, etc.
* Added tests for Read, Write, Delete, and OpenAPI Metadata.