### PR TITLE
chore(blueshift): update ListMetadata schema and write support

### DIFF
--- a/providers/blueshift.go
+++ b/providers/blueshift.go
@@ -29,9 +29,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		PostAuthInfoNeeded: false,
 	})

--- a/providers/blueshift.go
+++ b/providers/blueshift.go
@@ -29,9 +29,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      true,
+			Read:      false,
 			Subscribe: false,
-			Write:     true,
+			Write:     false,
 		},
 		PostAuthInfoNeeded: false,
 	})

--- a/providers/blueshift/metadata/openapi/api.yaml
+++ b/providers/blueshift/metadata/openapi/api.yaml
@@ -9245,6 +9245,9 @@
             "content": {
               "application/json": {
                 "schema": {
+                   "type": "object",
+                    "properties": {
+                      "results": {
                   "type": "array",
                   "description": "The list of live content slots.",
                   "items": {
@@ -9267,6 +9270,8 @@
                       }
                     }
                   }
+                  }
+                }
                 }
               }
             }

--- a/providers/blueshift/metadata/schemas.json
+++ b/providers/blueshift/metadata/schemas.json
@@ -420,7 +420,7 @@
         "onsite_slots": {
           "displayName": "Onsite Slots",
           "path": "1/onsite_slots.json",
-          "responseKey": "",
+          "responseKey": "results",
           "fields": {
             "format": {
               "displayName": "format",

--- a/providers/blueshift/supports.go
+++ b/providers/blueshift/supports.go
@@ -45,7 +45,7 @@ var writeObjectWithSuffix = datautils.NewSet( //nolint:gochecknoglobals
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
-	writeSupport := []string{objectNameCampaigns, objectNameCustomers, objectNameCustomUserLists, objectNameEvent, objectNameEmailTemplates, objectNamePushTemplates, objectNameSmsTemplates, objectNameExternalFetches} //nolint:lll
+	writeSupport := []string{objectNameCustomers, objectNameCustomUserLists, objectNameEvent, objectNameEmailTemplates, objectNamePushTemplates, objectNameSmsTemplates, objectNameExternalFetches} //nolint:lll
 
 	return components.EndpointRegistryInput{
 		staticschema.RootModuleID: {

--- a/scripts/openapi/blueshift/metadata/main.go
+++ b/scripts/openapi/blueshift/metadata/main.go
@@ -54,6 +54,7 @@ var (
 		"external_fetches": "results",
 		"push_templates":   "results",
 		"sms_templates":    "results",
+		"onsite_slots":     "results",
 	},
 		func(objectName string) (fieldName string) {
 			return objectName

--- a/test/blueshift/read/main.go
+++ b/test/blueshift/read/main.go
@@ -57,5 +57,17 @@ func run() error {
 
 	utils.DumpJSON(res, os.Stdout)
 
+	slog.Info("Reading onsite slots")
+
+	res, err = connector.Read(ctx, common.ReadParams{
+		ObjectName: "onsite_slots",
+		Fields:     datautils.NewStringSet("uuid", "name"),
+	})
+	if err != nil {
+		return err
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
 	return nil
 }


### PR DESCRIPTION
1.  Fix `onsite_slots` response key mapping in Blueshift 

2. Remove unsupported `campaigns` write object  in Blueshift