### PR TITLE
[ENG-2051] feat(docs): Print Salesloft objects

### DIFF
--- a/scripts/docs/salesloft/main.go
+++ b/scripts/docs/salesloft/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/providers/salesloft/metadata"
+)
+
+// Prints supported read objects in random order formatted for https://github.com/amp-labs/docs.
+// nolint:forbidigo
+func main() {
+	for objectName, object := range metadata.Schemas.Modules[staticschema.RootModuleID].Objects {
+		fmt.Printf("- [%v](%v) (%v)\n", object.DisplayName, *object.DocsURL, objectName)
+	}
+}


### PR DESCRIPTION
# Description
Prints lines that can be copy pasted into the docs repo.

![image](https://github.com/user-attachments/assets/ac6868c4-9c47-4695-bdba-377868b387e1)
