### PR TITLE
Fix UpdateSubscription method for Salesforce to delete correct objects and return correct ressult

### DIFF
--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -237,6 +237,9 @@ func (c *Connector) UpdateSubscription(
 
 	previousResult.Objects = objectsToDelete
 
+	// this is the delete step, but it looks for only object that were selected to delete
+	// in objectsToDelete array, so we are still preserving some objects
+	// that needs to remain in the subscription
 	if err := c.DeleteSubscription(ctx, *previousResult); err != nil {
 		return nil, fmt.Errorf("failed to delete previous subscription: %w", err)
 	}

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -2,7 +2,6 @@ package salesforce
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -207,16 +206,12 @@ func (c *Connector) UpdateSubscription(
 		}
 	}
 
-	fmt.Println("to exclude from subscription:", prettyFormat(objectsToExcludeFromSubscription))
-
 	// collect objects to exclude from delete
 	for objName := range prevState.EventChannelMembers {
 		if _, ok := params.SubscriptionEvents[objName]; ok {
 			objectsExcludeFromDelete = append(objectsExcludeFromDelete, objName)
 		}
 	}
-
-	fmt.Println("to exclude from delete:", prettyFormat(objectsExcludeFromDelete))
 
 	// remove objects to exclude from subscription and delete
 	for _, objName := range objectsToExcludeFromSubscription {
@@ -240,15 +235,11 @@ func (c *Connector) UpdateSubscription(
 
 	prevState.EventChannelMembers = channelMembersToKeep
 
-	fmt.Println("objects to delete:", prettyFormat(objectsToDelete))
-
 	previousResult.Objects = objectsToDelete
 
 	if err := c.DeleteSubscription(ctx, *previousResult); err != nil {
 		return nil, fmt.Errorf("failed to delete previous subscription: %w", err)
 	}
-
-	fmt.Println("params", prettyFormat(params))
 
 	// create new subscription
 	createRes, err := c.Subscribe(ctx, params)
@@ -258,9 +249,6 @@ func (c *Connector) UpdateSubscription(
 
 	// for clarity, rename the state since we will return the object as the result of update
 	newState := prevState
-
-	fmt.Println("createRes", prettyFormat(createRes))
-	fmt.Println("newState right after", prettyFormat(newState))
 
 	//nolint:forcetypeassert
 	// update the previous result with the new subscription result
@@ -290,10 +278,4 @@ func (c *Connector) UpdateSubscription(
 	}
 
 	return res, nil
-}
-
-func prettyFormat(v any) string {
-	data, _ := json.MarshalIndent(v, "", "  ")
-	return string(data)
-
 }

--- a/test/github/read/main.go
+++ b/test/github/read/main.go
@@ -49,5 +49,4 @@ func main() {
 	}
 
 	utils.DumpJSON(res, os.Stdout)
-
 }


### PR DESCRIPTION
The Update method had bugs that the it was deleting all objects. This PR fixes the issue. 

Test Result
- The lookups are not deleted after update
<img width="1612" alt="Screenshot 2025-03-19 at 11 20 48 PM" src="https://github.com/user-attachments/assets/6cae7892-05b2-4578-a367-d654c40c33e8" />
