### PR TITLE
[CON-1615] feat(module): Default Root constant

### DIFF
--- a/common/module.go
+++ b/common/module.go
@@ -19,6 +19,8 @@ var (
 	ErrUnsupportedModule = errors.New("provided module is not supported")
 )
 
+const ModuleRoot ModuleID = "root"
+
 type ModuleID string
 
 type Modules = datautils.Map[ModuleID, Module]

--- a/internal/components/connector.go
+++ b/internal/components/connector.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -35,7 +34,7 @@ func Initialize[T any](
 
 	// Default module is always the root module
 	if params.Module == "" {
-		params.Module = staticschema.RootModuleID
+		params.Module = common.ModuleRoot
 	}
 
 	transport, err := NewTransport(provider, params)

--- a/internal/components/deleter/deleter_test.go
+++ b/internal/components/deleter/deleter_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -72,7 +71,7 @@ func constructTestConnector(serverURL string) (*mockedConnector, error) {
 		HTTPDeleter: NewHTTPDeleter(
 			connector.HTTPClient().Client,
 			registry,
-			staticschema.RootModuleID,
+			common.ModuleRoot,
 			operations.DeleteHandlers{},
 		),
 	}, nil

--- a/internal/components/reader/reader_test.go
+++ b/internal/components/reader/reader_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -73,7 +72,7 @@ func constructTestConnector(serverURL string) (*mockedConnector, error) {
 		HTTPReader: NewHTTPReader(
 			connector.HTTPClient().Client,
 			registry,
-			staticschema.RootModuleID,
+			common.ModuleRoot,
 			operations.ReadHandlers{},
 		),
 	}, nil

--- a/internal/components/schema/openapi_test.go
+++ b/internal/components/schema/openapi_test.go
@@ -76,7 +76,7 @@ func constructTestConnector(serverURL string) *mockedConnector {
 	}
 
 	metadata := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
-	metadata.Add(staticschema.RootModuleID, "orders", "Orders", "/user/orders", "result",
+	metadata.Add(common.ModuleRoot, "orders", "Orders", "/user/orders", "result",
 		map[string]staticschema.FieldMetadata{
 			"id": {
 				DisplayName:  "Identifier",
@@ -88,7 +88,7 @@ func constructTestConnector(serverURL string) *mockedConnector {
 	return &mockedConnector{
 		Connector: connector,
 		SchemaProvider: NewOpenAPISchemaProvider(
-			staticschema.RootModuleID,
+			common.ModuleRoot,
 			metadata,
 		),
 	}

--- a/internal/components/writer/writer_test.go
+++ b/internal/components/writer/writer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -72,7 +71,7 @@ func constructTestConnector(serverURL string) (*mockedConnector, error) {
 		HTTPWriter: NewHTTPWriter(
 			connector.HTTPClient().Client,
 			registry,
-			staticschema.RootModuleID,
+			common.ModuleRoot,
 			operations.WriteHandlers{},
 		),
 	}, nil

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -7,8 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
-const RootModuleID common.ModuleID = "root"
-
 // NewMetadata constructs empty Metadata. To populate it with data use Metadata.Add method.
 func NewMetadata[F FieldMetadataMap]() *Metadata[F, any] {
 	return NewExtendedMetadata[F, any]()
@@ -268,7 +266,7 @@ func (m *Metadata[F, C]) ObjectNames() datautils.UniqueLists[common.ModuleID, st
 
 		moduleObjectNames[key] = names
 
-		if key == RootModuleID {
+		if key == common.ModuleRoot {
 			// Empty ModuleID could be passed referring to the same root module.
 			moduleObjectNames[""] = names
 		}
@@ -340,7 +338,7 @@ func (m *Module[F, C]) withPath(path string) {
 // In case an empty ModuleID is provided we fall back to the default root module id.
 func moduleIdentifier(id common.ModuleID) common.ModuleID {
 	if len(id) == 0 {
-		return RootModuleID
+		return common.ModuleRoot
 	}
 
 	return id

--- a/providers/aha/supports.go
+++ b/providers/aha/supports.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/aha/metadata"
 )
 
@@ -45,10 +45,10 @@ var supportWrite = datautils.NewSet( //nolint:gochecknoglobals
 )
 
 func supportedOperations() components.EndpointRegistryInput {
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/ashby/supports.go
+++ b/providers/ashby/supports.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/ashby/metadata"
 )
 
@@ -22,7 +22,7 @@ var (
 )
 
 func supportedOperations() components.EndpointRegistryInput {
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 
 	//nolint:lll
 	writeSupport := []string{
@@ -43,7 +43,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/atlassian/connector.go
+++ b/providers/atlassian/connector.go
@@ -28,7 +28,7 @@ type Connector struct {
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
-		WithModule(ModuleEmpty), // The module is resolved on behalf of the user if the option is missing.
+		WithModule(common.ModuleRoot), // The module is resolved on behalf of the user if the option is missing.
 	)
 	if err != nil {
 		return nil, err

--- a/providers/atlassian/modules.go
+++ b/providers/atlassian/modules.go
@@ -5,8 +5,6 @@ import (
 )
 
 const (
-	// ModuleEmpty is used for proxying requests through.
-	ModuleEmpty common.ModuleID = ""
 	// ModuleJira is the module used for listing Jira issues.
 	ModuleJira common.ModuleID = "jira"
 	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
@@ -16,8 +14,8 @@ const (
 // supportedModules represents currently working and supported modules within the Atlassian connector.
 // Any added module should be appended here.
 var supportedModules = common.Modules{ // nolint: gochecknoglobals
-	ModuleEmpty: {
-		ID:      ModuleEmpty,
+	common.ModuleRoot: {
+		ID:      common.ModuleRoot,
 		Label:   "",
 		Version: "",
 	},

--- a/providers/atlassian/params.go
+++ b/providers/atlassian/params.go
@@ -53,7 +53,7 @@ func WithWorkspace(workspaceRef string) Option {
 // WithModule sets the Atlassian API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, ModuleEmpty)
+		params.WithModule(module, supportedModules, common.ModuleRoot)
 	}
 }
 

--- a/providers/blueshift/supports.go
+++ b/providers/blueshift/supports.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/blueshift/metadata"
 )
 
@@ -44,11 +44,11 @@ var writeObjectWithSuffix = datautils.NewSet( //nolint:gochecknoglobals
 )
 
 func supportedOperations() components.EndpointRegistryInput {
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 	writeSupport := []string{objectNameCustomers, objectNameCustomUserLists, objectNameEvent, objectNameEmailTemplates, objectNamePushTemplates, objectNameSmsTemplates, objectNameExternalFetches} //nolint:lll
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/brevo/support.go
+++ b/providers/brevo/support.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/brevo/metadata"
 )
 
@@ -36,7 +36,7 @@ var supportLimitAndOffset = datautils.NewSet( //nolint:gochecknoglobals
 
 func supportedOperations() components.EndpointRegistryInput {
 	// We support reading everything under schema.json, so we get all the objects and join it into a pattern.
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 
 	writeSupport := []string{
 		"smtp/email", "smtp/templates", "smtp/blockedDomains",
@@ -61,7 +61,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/capsule/metadata_test.go
+++ b/providers/capsule/metadata_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -82,7 +81,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(common.Parameters{
-		Module:              staticschema.RootModuleID,
+		Module:              common.ModuleRoot,
 		AuthenticatedClient: http.DefaultClient,
 	})
 	if err != nil {

--- a/providers/chilipiper/metadata.go
+++ b/providers/chilipiper/metadata.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/chilipiper/metadata"
 )
 
@@ -103,7 +102,7 @@ func metadataFallback(moduleID common.ModuleID, objectName string) (*common.Obje
 func openAPIFallback(obj string, res *common.ListObjectMetadataResult,
 ) *common.ListObjectMetadataResult { //nolint:unparam
 	// Try fallback function
-	data, err := metadataFallback(staticschema.RootModuleID, obj)
+	data, err := metadataFallback(common.ModuleRoot, obj)
 	if err != nil {
 		res.Errors[obj] = err
 

--- a/providers/clickup/supports.go
+++ b/providers/clickup/supports.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/clickup/metadata"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
 	// We support reading everything under schema.json, so we get all the objects and join it into a pattern.
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/dixa/connector.go
+++ b/providers/dixa/connector.go
@@ -64,7 +64,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -76,7 +76,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/dixa/support.go
+++ b/providers/dixa/support.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -23,7 +23,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/front/supports.go
+++ b/providers/front/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -25,7 +25,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/github/supports.go
+++ b/providers/github/supports.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers/github/metadata"
 )
 
@@ -73,7 +73,7 @@ var (
 )
 
 func supportedOperations() components.EndpointRegistryInput {
-	readSupport := metadata.Schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
 
 	// nolint:lll
 	writeSupport := []string{
@@ -88,7 +88,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/gitlab/connector.go
+++ b/providers/gitlab/connector.go
@@ -74,7 +74,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -86,7 +86,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/gitlab/supports.go
+++ b/providers/gitlab/supports.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 var objectResponders = datautils.NewSet( //nolint:gochecknoglobals
@@ -117,7 +117,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/gorgias/connector.go
+++ b/providers/gorgias/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -55,7 +54,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -66,7 +65,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/gorgias/supports.go
+++ b/providers/gorgias/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -24,7 +24,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/groove/connector.go
+++ b/providers/groove/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -52,7 +51,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -64,7 +63,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/groove/supports.go
+++ b/providers/groove/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func responseField(objectName string) string {
@@ -33,7 +33,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/helpscout/supports.go
+++ b/providers/helpscout/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -13,7 +13,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	writeSupport := []string{"conversations", "customers", "customer-properties", "webhooks"}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 // NewConnector returns a new Hubspot connector.
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
-		WithModule(ModuleEmpty), // The module is resolved on behalf of the user if the option is missing.
+		WithModule(common.ModuleRoot), // The module is resolved on behalf of the user if the option is missing.
 	)
 	if err != nil {
 		return nil, err

--- a/providers/hubspot/modules.go
+++ b/providers/hubspot/modules.go
@@ -5,8 +5,6 @@ import (
 )
 
 const (
-	// ModuleEmpty is used for proxying requests through.
-	ModuleEmpty common.ModuleID = ""
 	// ModuleCRM is the module used for accessing standard CRM objects.
 	ModuleCRM common.ModuleID = "CRM"
 )
@@ -14,8 +12,8 @@ const (
 // supportedModules represents currently working and supported modules within the Hubspot connector.
 // Any added module should be appended added here.
 var supportedModules = common.Modules{ // nolint: gochecknoglobals
-	ModuleEmpty: {
-		ID:      ModuleEmpty,
+	common.ModuleRoot: {
+		ID:      common.ModuleRoot,
 		Label:   "",
 		Version: "",
 	},

--- a/providers/hubspot/params.go
+++ b/providers/hubspot/params.go
@@ -51,7 +51,7 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 // WithModule sets the hubspot API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, ModuleEmpty)
+		params.WithModule(module, supportedModules, common.ModuleRoot)
 	}
 }
 

--- a/providers/hunter/connector.go
+++ b/providers/hunter/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -52,7 +51,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -64,7 +63,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/hunter/supports.go
+++ b/providers/hunter/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -18,7 +18,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/lemlist/connector.go
+++ b/providers/lemlist/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -56,7 +55,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -68,7 +67,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/lemlist/supports.go
+++ b/providers/lemlist/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func responseSchema(objectName string) (string, string) {
@@ -42,7 +42,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/marketo/module.go
+++ b/providers/marketo/module.go
@@ -5,8 +5,6 @@ import (
 )
 
 const (
-	// ModuleEmpty is used for proxying requests through.
-	ModuleEmpty common.ModuleID = ""
 	// ModuleAssets is the module/API used for accessing assets objects.
 	ModuleAssets common.ModuleID = "assets"
 	// ModuleLeads is the module/API used for accessing leads objects.
@@ -16,8 +14,8 @@ const (
 // supportedModules represents currently working and supported modules within the Marketo connector.
 // Any added module should be appended here.
 var supportedModules = common.Modules{ // nolint: gochecknoglobals
-	ModuleEmpty: {
-		ID:      ModuleEmpty,
+	common.ModuleRoot: {
+		ID:      common.ModuleRoot,
 		Label:   "",
 		Version: "",
 	},

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -29,7 +29,10 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 			fmtTime := params.Since.Format(time.RFC3339)
 			url.WithQueryParam("earliestUpdatedAt", fmtTime)
 			url.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
-
+		case ModuleLeads:
+			fallthrough
+		case common.ModuleRoot:
+			fallthrough
 		default: // we currently don't support filtering in leads.
 		}
 	}

--- a/providers/mixmax/connector.go
+++ b/providers/mixmax/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -56,7 +55,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -68,7 +67,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/mixmax/supports.go
+++ b/providers/mixmax/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func responseField(objectName string) string {
@@ -36,7 +36,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/monday/utils.go
+++ b/providers/monday/utils.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/spyzhov/ajson"
 )
 
@@ -24,7 +23,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	writeSupport := []string{objectBoard, objectItem, objectUser}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
 				Support:  components.WriteSupport,

--- a/providers/podium/connector.go
+++ b/providers/podium/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -52,7 +51,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -63,7 +62,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/podium/supports.go
+++ b/providers/podium/supports.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func supportsPagination(objectName string) bool {
@@ -44,7 +44,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/smartleadv2/utils.go
+++ b/providers/smartleadv2/utils.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/spyzhov/ajson"
 )
 
@@ -21,11 +21,11 @@ const (
 // How to read & build these patterns: https://github.com/gobwas/glob
 func supportedOperations() components.EndpointRegistryInput {
 	// We support reading everything under schema.json, so we get all the objects and join it into a pattern.
-	readSupport := schemas.ObjectNames().GetList(staticschema.RootModuleID)
+	readSupport := schemas.ObjectNames().GetList(common.ModuleRoot)
 	writeSupport := []string{objectNameCampaign, objectNameEmailAccount, objectNameClient}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
 				Support:  components.WriteSupport,

--- a/providers/zendeskchat/connector.go
+++ b/providers/zendeskchat/connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
-	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -53,7 +52,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
@@ -65,7 +64,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		staticschema.RootModuleID,
+		common.ModuleRoot,
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/zendeskchat/supports.go
+++ b/providers/zendeskchat/supports.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
-	"github.com/amp-labs/connectors/internal/staticschema"
 )
 
 func responseField(objectName string) string {
@@ -46,7 +46,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	return components.EndpointRegistryInput{
-		staticschema.RootModuleID: {
+		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,

--- a/providers/zendesksupport/metadata/metadata.go
+++ b/providers/zendesksupport/metadata/metadata.go
@@ -38,7 +38,7 @@ func (s ZendeskSchemas) LookupPaginationType(
 	moduleID common.ModuleID, objectName string,
 ) string {
 	if len(moduleID) == 0 {
-		moduleID = staticschema.RootModuleID
+		moduleID = common.ModuleRoot
 	}
 
 	ptype := s.Modules[moduleID].Objects[objectName].Custom.Pagination
@@ -54,7 +54,7 @@ func (s ZendeskSchemas) IsIncrementalRead(
 	moduleID common.ModuleID, objectName string,
 ) bool {
 	if len(moduleID) == 0 {
-		moduleID = staticschema.RootModuleID
+		moduleID = common.ModuleRoot
 	}
 
 	return s.Modules[moduleID].Objects[objectName].Custom.Incremental
@@ -116,7 +116,7 @@ func (s ZendeskSchemas) PageSize(
 	moduleID common.ModuleID, objectName string,
 ) string {
 	if len(moduleID) == 0 {
-		moduleID = staticschema.RootModuleID
+		moduleID = common.ModuleRoot
 	}
 
 	// TODO the map should be part of schema.json.

--- a/scripts/docs/salesloft/main.go
+++ b/scripts/docs/salesloft/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"fmt"
 
-	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/salesloft/metadata"
 )
 
 // Prints supported read objects in random order formatted for https://github.com/amp-labs/docs.
 // nolint:forbidigo
 func main() {
-	for objectName, object := range metadata.Schemas.Modules[staticschema.RootModuleID].Objects {
+	for objectName, object := range metadata.Schemas.Modules[common.ModuleRoot].Objects {
 		fmt.Printf("- [%v](%v) (%v)\n", object.DisplayName, *object.DocsURL, objectName)
 	}
 }

--- a/scripts/openapi/chilipiper/openapi/main.go
+++ b/scripts/openapi/chilipiper/openapi/main.go
@@ -147,7 +147,7 @@ func saveSchemas(properties map[string][]string) {
 
 	goutils.MustBeNil(metadata.FileManager.SaveSchemas(&staticschema.Metadata[staticschema.FieldMetadataMapV1, any]{
 		Modules: map[common.ModuleID]staticschema.Module[staticschema.FieldMetadataMapV1, any]{
-			staticschema.RootModuleID: {
+			common.ModuleRoot: {
 				Objects: objectMetadata,
 			},
 		},

--- a/scripts/openapi/dixa/main.go
+++ b/scripts/openapi/dixa/main.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"log/slog"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/staticschema"
@@ -59,7 +60,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add(staticschema.RootModuleID, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+			schemas.Add(common.ModuleRoot, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
 					field.Name: field.Name,
 				}, nil, object.Custom)

--- a/scripts/openapi/marketo/metadata/metadata.go
+++ b/scripts/openapi/marketo/metadata/metadata.go
@@ -43,7 +43,7 @@ func main() {
 
 	goutils.MustBeNil(metadata.FileManager.SaveSchemas(&staticschema.Metadata[staticschema.FieldMetadataMapV1, any]{
 		Modules: map[common.ModuleID]staticschema.Module[staticschema.FieldMetadataMapV1, any]{
-			staticschema.RootModuleID: {
+			common.ModuleRoot: {
 				Objects: objectMetadata,
 			},
 		},

--- a/scripts/scraper/capsule/metadata/schemas.go
+++ b/scripts/scraper/capsule/metadata/schemas.go
@@ -58,7 +58,7 @@ func (s scrappedSchemas) SaveData(model scrapper.ModelDocLink, fieldName, fieldT
 	urlPath := objectNameToURLPath.Get(model.Name)
 
 	s.Metadata.Add(
-		staticschema.RootModuleID, model.Name, modelDisplayName,
+		common.ModuleRoot, model.Name, modelDisplayName,
 		urlPath, responseKey, fields, &model.URL, nil)
 }
 


### PR DESCRIPTION
# Backward Compatibility
* ModuleEmpty is only used by HubSpot. Other connectors declare it but never use it, making removal safe for them.
* Atlassian does not use an empty module. The default (ModuleEmpty) is never invoked because `atlassian.WithModule(module)` is always set.
![image](https://github.com/user-attachments/assets/94aeddf1-bcc1-4805-94f0-b2c1188b9f29)
* HubSpot references ModuleEmpty = "", but its behavior remains unchanged.
  * Either ModuleEmpty or ModuleCRM is selected for read/write.
  * The module is used for path creation or schema.json lookups.
    * Path depends on catalog BaseURL defined by Module. This is to be addressed in future PRs. 
    * `metadata.Schemas.SelectOne` and similar functions already treat both "root" and "" as equivalent.
  * No action required.
![image](https://github.com/user-attachments/assets/5a604d9f-591c-4606-b91e-027be89339ab)

# Summary
`staticschema.RootModuleID` allignes with newly defined `common.ModuleRoot` as planned.

# Review
Changes are grouped by commits.