### PR TITLE
[CON-1617] feat(catalog): Add modules

### DIFF
--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -25,7 +25,7 @@ func init() {
 		PostAuthInfoNeeded: true,
 		Modules: &ModuleInfo{
 			ModuleAtlassianJira: {
-				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloud_id}}/rest/api/3",
+				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api/3",
 				DisplayName: "Jira",
 				Support: ModuleSupport{
 					Read:      true,

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -1,12 +1,14 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Atlassian Provider = "atlassian"
 
 const (
 	// ModuleAtlassianJira is the module used for listing Jira issues.
-	ModuleAtlassianJira string = "jira"
+	ModuleAtlassianJira common.ModuleID = "jira"
 	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
-	ModuleAtlassianJiraConnect string = "atlassian-connect"
+	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
 )
 
 func init() {
@@ -23,11 +25,11 @@ func init() {
 			ExplicitWorkspaceRequired: true, // Needed for GetPostAuthInfo call
 		},
 		PostAuthInfoNeeded: true,
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleAtlassianJira: {
 				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api/3",
-				DisplayName: "Jira",
-				Support: ModuleSupport{
+				DisplayName: "Atlassian Jira",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,
@@ -36,7 +38,7 @@ func init() {
 			ModuleAtlassianJiraConnect: {
 				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api/3",
 				DisplayName: "Atlassian Connect",
-				Support: ModuleSupport{
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -2,6 +2,13 @@ package providers
 
 const Atlassian Provider = "atlassian"
 
+const (
+	// ModuleAtlassianJira is the module used for listing Jira issues.
+	ModuleAtlassianJira string = "jira"
+	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
+	ModuleAtlassianJiraConnect string = "atlassian-connect"
+)
+
 func init() {
 	// Atlassian Configuration
 	SetInfo(Atlassian, ProviderInfo{
@@ -16,6 +23,26 @@ func init() {
 			ExplicitWorkspaceRequired: true, // Needed for GetPostAuthInfo call
 		},
 		PostAuthInfoNeeded: true,
+		Modules: &ModuleInfo{
+			ModuleAtlassianJira: {
+				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloud_id}}/rest/api/3",
+				DisplayName: "Jira",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
+			ModuleAtlassianJiraConnect: {
+				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api/3",
+				DisplayName: "Atlassian Connect",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
+		},
 		//nolint:lll
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/atlassian/authmetadata_test.go
+++ b/providers/atlassian/authmetadata_test.go
@@ -77,7 +77,7 @@ func TestGetPostAuthInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 			connector, err := NewConnector(
 				WithAuthenticatedClient(http.DefaultClient),
 				WithWorkspace("second-proj"),
-				WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+				WithModule(providers.ModuleAtlassianJira),
 			)
 			if err != nil {
 				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)

--- a/providers/atlassian/authmetadata_test.go
+++ b/providers/atlassian/authmetadata_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/go-test/deep"
@@ -76,7 +77,7 @@ func TestGetPostAuthInfo(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 			connector, err := NewConnector(
 				WithAuthenticatedClient(http.DefaultClient),
 				WithWorkspace("second-proj"),
-				WithModule(ModuleJira),
+				WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 			)
 			if err != nil {
 				t.Fatalf("%s: error in test while constructing connector %v", tt.name, err)

--- a/providers/atlassian/connector.go
+++ b/providers/atlassian/connector.go
@@ -72,7 +72,7 @@ func (c *Connector) String() string {
 // https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/#other-integrations
 func (c *Connector) getJiraRestApiURL(arg string) (*urlbuilder.URL, error) {
 	// In the case of JIRA / Atlassian Cloud, we use this path. In other cases, we fall back to the base path.
-	if c.Module.ID == common.ModuleID(providers.ModuleAtlassianJira) {
+	if c.Module.ID == providers.ModuleAtlassianJira {
 		cloudId, err := c.getCloudId()
 		if err != nil {
 			return nil, err
@@ -115,7 +115,7 @@ func (c *Connector) setProviderInfo() error {
 	// When the module is Atlassian Connect, the base URL is different, so we need to override it.
 	// TODO: Replace options with substitution map in the future to avoid having to know
 	// which values need to be substituted.
-	if c.Module.ID == common.ModuleID(providers.ModuleAtlassianJiraConnect) {
+	if c.Module.ID == providers.ModuleAtlassianJiraConnect {
 		vars := []catalogreplacer.CatalogVariable{
 			&paramsbuilder.Workspace{Name: c.workspace},
 		}

--- a/providers/atlassian/connector.go
+++ b/providers/atlassian/connector.go
@@ -72,7 +72,7 @@ func (c *Connector) String() string {
 // https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/#other-integrations
 func (c *Connector) getJiraRestApiURL(arg string) (*urlbuilder.URL, error) {
 	// In the case of JIRA / Atlassian Cloud, we use this path. In other cases, we fall back to the base path.
-	if c.Module.ID == ModuleJira {
+	if c.Module.ID == common.ModuleID(providers.ModuleAtlassianJira) {
 		cloudId, err := c.getCloudId()
 		if err != nil {
 			return nil, err
@@ -115,7 +115,7 @@ func (c *Connector) setProviderInfo() error {
 	// When the module is Atlassian Connect, the base URL is different, so we need to override it.
 	// TODO: Replace options with substitution map in the future to avoid having to know
 	// which values need to be substituted.
-	if c.Module.ID == ModuleAtlassianJiraConnect {
+	if c.Module.ID == common.ModuleID(providers.ModuleAtlassianJiraConnect) {
 		vars := []catalogreplacer.CatalogVariable{
 			&paramsbuilder.Workspace{Name: c.workspace},
 		}

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -75,7 +75,7 @@ func TestDeleteWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		WithModule(providers.ModuleAtlassianJira),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -74,7 +75,7 @@ func TestDeleteWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(ModuleJira),
+		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -113,7 +114,7 @@ func TestListObjectMetadataWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(ModuleJira),
+		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -114,7 +114,7 @@ func TestListObjectMetadataWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		WithModule(providers.ModuleAtlassianJira),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/atlassian/modules.go
+++ b/providers/atlassian/modules.go
@@ -8,10 +8,10 @@ import (
 const (
 	// ModuleJira
 	// Deprecated.
-	ModuleJira = common.ModuleID(providers.ModuleAtlassianJira)
+	ModuleJira = providers.ModuleAtlassianJira
 	// ModuleAtlassianJiraConnect
 	// Deprecated.
-	ModuleAtlassianJiraConnect = common.ModuleID(providers.ModuleAtlassianJiraConnect)
+	ModuleAtlassianJiraConnect = providers.ModuleAtlassianJiraConnect
 )
 
 // supportedModules represents currently working and supported modules within the Atlassian connector.
@@ -22,13 +22,13 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	common.ModuleID(providers.ModuleAtlassianJira): {
-		ID:      common.ModuleID(providers.ModuleAtlassianJira),
+	providers.ModuleAtlassianJira: {
+		ID:      providers.ModuleAtlassianJira,
 		Label:   "rest/api",
 		Version: "3",
 	},
-	common.ModuleID(providers.ModuleAtlassianJiraConnect): {
-		ID:      common.ModuleID(providers.ModuleAtlassianJiraConnect),
+	providers.ModuleAtlassianJiraConnect: {
+		ID:      providers.ModuleAtlassianJiraConnect,
 		Label:   "rest/api",
 		Version: "3",
 	},

--- a/providers/atlassian/modules.go
+++ b/providers/atlassian/modules.go
@@ -2,13 +2,16 @@ package atlassian
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 )
 
 const (
-	// ModuleJira is the module used for listing Jira issues.
-	ModuleJira common.ModuleID = "jira"
-	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
-	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
+	// ModuleJira
+	// Deprecated.
+	ModuleJira = common.ModuleID(providers.ModuleAtlassianJira)
+	// ModuleAtlassianJiraConnect
+	// Deprecated.
+	ModuleAtlassianJiraConnect = common.ModuleID(providers.ModuleAtlassianJiraConnect)
 )
 
 // supportedModules represents currently working and supported modules within the Atlassian connector.
@@ -19,13 +22,13 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	ModuleJira: {
-		ID:      ModuleJira,
+	common.ModuleID(providers.ModuleAtlassianJira): {
+		ID:      common.ModuleID(providers.ModuleAtlassianJira),
 		Label:   "rest/api",
 		Version: "3",
 	},
-	ModuleAtlassianJiraConnect: {
-		ID:      ModuleAtlassianJiraConnect,
+	common.ModuleID(providers.ModuleAtlassianJiraConnect): {
+		ID:      common.ModuleID(providers.ModuleAtlassianJiraConnect),
 		Label:   "rest/api",
 		Version: "3",
 	},

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -267,7 +267,7 @@ func TestReadWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		WithModule(providers.ModuleAtlassianJira),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")
@@ -286,7 +286,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		WithModule(providers.ModuleAtlassianJira),
 		WithMetadata(map[string]string{
 			"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
 		}),

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -266,7 +267,7 @@ func TestReadWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(ModuleJira),
+		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")
@@ -285,7 +286,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(ModuleJira),
+		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 		WithMetadata(map[string]string{
 			"cloudId": "ebc887b2-7e61-4059-ab35-71f15cc16e12", // any value will work for the test
 		}),

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -116,7 +117,7 @@ func TestWriteWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(ModuleJira),
+		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -117,7 +117,7 @@ func TestWriteWithoutMetadata(t *testing.T) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
 		WithWorkspace("test-workspace"),
-		WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		WithModule(providers.ModuleAtlassianJira),
 	)
 	if err != nil {
 		t.Fatal("failed to create connector")

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -1,10 +1,12 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Hubspot Provider = "hubspot"
 
 const (
 	// ModuleHubspotCRM is the module used for accessing standard CRM objects.
-	ModuleHubspotCRM string = "CRM"
+	ModuleHubspotCRM common.ModuleID = "CRM"
 )
 
 func init() {
@@ -32,11 +34,11 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleHubspotCRM: {
 				BaseURL:     "https://api.hubapi.com/crm/v3",
-				DisplayName: "CRM",
-				Support: ModuleSupport{
+				DisplayName: "HubSpot CRM",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -2,6 +2,11 @@ package providers
 
 const Hubspot Provider = "hubspot"
 
+const (
+	// ModuleHubspotCRM is the module used for accessing standard CRM objects.
+	ModuleHubspotCRM string = "CRM"
+)
+
 func init() {
 	// Hubspot configuration
 	SetInfo(Hubspot, ProviderInfo{
@@ -26,6 +31,17 @@ func init() {
 			Read:      true,
 			Subscribe: false,
 			Write:     true,
+		},
+		Modules: &ModuleInfo{
+			ModuleHubspotCRM: {
+				BaseURL:     "https://api.hubapi.com/crm/v3",
+				DisplayName: "CRM",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -343,7 +343,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
-		WithModule(common.ModuleID(providers.ModuleHubspotCRM)),
+		WithModule(providers.ModuleHubspotCRM),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -342,7 +343,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(http.DefaultClient),
-		WithModule(ModuleCRM),
+		WithModule(common.ModuleID(providers.ModuleHubspotCRM)),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/hubspot/modules.go
+++ b/providers/hubspot/modules.go
@@ -8,7 +8,7 @@ import (
 const (
 	// ModuleCRM
 	// Deprecated.
-	ModuleCRM = common.ModuleID(providers.ModuleHubspotCRM)
+	ModuleCRM = providers.ModuleHubspotCRM
 )
 
 // supportedModules represents currently working and supported modules within the Hubspot connector.
@@ -19,8 +19,8 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	common.ModuleID(providers.ModuleHubspotCRM): {
-		ID:      common.ModuleID(providers.ModuleHubspotCRM),
+	providers.ModuleHubspotCRM: {
+		ID:      providers.ModuleHubspotCRM,
 		Label:   "crm",
 		Version: "v3",
 	},

--- a/providers/hubspot/modules.go
+++ b/providers/hubspot/modules.go
@@ -2,11 +2,13 @@ package hubspot
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 )
 
 const (
-	// ModuleCRM is the module used for accessing standard CRM objects.
-	ModuleCRM common.ModuleID = "CRM"
+	// ModuleCRM
+	// Deprecated.
+	ModuleCRM = common.ModuleID(providers.ModuleHubspotCRM)
 )
 
 // supportedModules represents currently working and supported modules within the Hubspot connector.
@@ -17,8 +19,8 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	ModuleCRM: {
-		ID:      ModuleCRM,
+	common.ModuleID(providers.ModuleHubspotCRM): {
+		ID:      common.ModuleID(providers.ModuleHubspotCRM),
 		Label:   "crm",
 		Version: "v3",
 	},

--- a/providers/keap.go
+++ b/providers/keap.go
@@ -1,14 +1,16 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Keap Provider = "keap"
 
 const (
 	// ModuleKeapV1 is a grouping of V1 API endpoints.
 	// https://developer.keap.com/docs/rest/
-	ModuleKeapV1 string = "version1"
+	ModuleKeapV1 common.ModuleID = "version1"
 	// ModuleKeapV2 is a grouping of V2 API endpoints.
 	// https://developer.keap.com/docs/restv2/
-	ModuleKeapV2 string = "version2"
+	ModuleKeapV2 common.ModuleID = "version2"
 )
 
 func init() {
@@ -36,11 +38,11 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleKeapV1: {
 				BaseURL:     "https://api.infusionsoft.com/v1",
-				DisplayName: "Version 1",
-				Support: ModuleSupport{
+				DisplayName: "Keap Version 1",
+				Support: Support{
 					Read:      false,
 					Subscribe: false,
 					Write:     false,
@@ -48,8 +50,8 @@ func init() {
 			},
 			ModuleKeapV2: {
 				BaseURL:     "https://api.infusionsoft.com/v2",
-				DisplayName: "Version 2",
-				Support: ModuleSupport{
+				DisplayName: "Keap Version 2",
+				Support: Support{
 					Read:      false,
 					Subscribe: false,
 					Write:     false,

--- a/providers/keap.go
+++ b/providers/keap.go
@@ -2,6 +2,15 @@ package providers
 
 const Keap Provider = "keap"
 
+const (
+	// ModuleKeapV1 is a grouping of V1 API endpoints.
+	// https://developer.keap.com/docs/rest/
+	ModuleKeapV1 string = "version1"
+	// ModuleKeapV2 is a grouping of V2 API endpoints.
+	// https://developer.keap.com/docs/restv2/
+	ModuleKeapV2 string = "version2"
+)
+
 func init() {
 	// Keap configuration
 	SetInfo(Keap, ProviderInfo{
@@ -26,6 +35,26 @@ func init() {
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Modules: &ModuleInfo{
+			ModuleKeapV1: {
+				BaseURL:     "https://api.infusionsoft.com/v1",
+				DisplayName: "Version 1",
+				Support: ModuleSupport{
+					Read:      false,
+					Subscribe: false,
+					Write:     false,
+				},
+			},
+			ModuleKeapV2: {
+				BaseURL:     "https://api.infusionsoft.com/v2",
+				DisplayName: "Version 2",
+				Support: ModuleSupport{
+					Read:      false,
+					Subscribe: false,
+					Write:     false,
+				},
+			},
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/keap/connector.go
+++ b/providers/keap/connector.go
@@ -18,7 +18,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(ModuleV1))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleKeapV1)))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/keap/connector.go
+++ b/providers/keap/connector.go
@@ -18,7 +18,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleKeapV1)))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(providers.ModuleKeapV1))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/keap/delete_test.go
+++ b/providers/keap/delete_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -73,7 +74,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV1)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
 			})
 		})
 	}

--- a/providers/keap/delete_test.go
+++ b/providers/keap/delete_test.go
@@ -74,7 +74,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV1)
 			})
 		})
 	}

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -141,7 +142,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV1)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
 			})
 		})
 	}
@@ -188,7 +189,7 @@ func TestListObjectMetadataV2(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV2)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV2))
 			})
 		})
 	}

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -142,7 +142,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV1)
 			})
 		})
 	}
@@ -189,7 +189,7 @@ func TestListObjectMetadataV2(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV2))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV2)
 			})
 		})
 	}

--- a/providers/keap/modules.go
+++ b/providers/keap/modules.go
@@ -2,16 +2,17 @@ package keap
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 )
 
 const (
-	// ModuleV1 is a grouping of V1 API endpoints.
-	// https://developer.keap.com/docs/rest/
-	ModuleV1 common.ModuleID = "version1"
-	// ModuleV2 is a grouping of V2 API endpoints.
-	// https://developer.keap.com/docs/restv2/
-	ModuleV2 common.ModuleID = "version2"
+	// ModuleV1
+	// Deprecated.
+	ModuleV1 = common.ModuleID(providers.ModuleKeapV1)
+	// ModuleV2
+	// Deprecated.
+	ModuleV2 = common.ModuleID(providers.ModuleKeapV2)
 )
 
 // SupportedModules represents currently working and supported modules within the Keap connector.

--- a/providers/keap/modules.go
+++ b/providers/keap/modules.go
@@ -1,7 +1,6 @@
 package keap
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 )
@@ -9,10 +8,10 @@ import (
 const (
 	// ModuleV1
 	// Deprecated.
-	ModuleV1 = common.ModuleID(providers.ModuleKeapV1)
+	ModuleV1 = providers.ModuleKeapV1
 	// ModuleV2
 	// Deprecated.
-	ModuleV2 = common.ModuleID(providers.ModuleKeapV2)
+	ModuleV2 = providers.ModuleKeapV2
 )
 
 // SupportedModules represents currently working and supported modules within the Keap connector.

--- a/providers/keap/objectNames.go
+++ b/providers/keap/objectNames.go
@@ -3,6 +3,7 @@ package keap
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 )
 
@@ -31,7 +32,7 @@ const (
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
 
 var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	ModuleV1: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Affiliate/operation/createAffiliateUsingPOST
 		objectNameAffiliates,
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/createAppointmentUsingPOST
@@ -65,7 +66,7 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 		// https://developer.infusionsoft.com/docs/rest/#tag/Users/operation/createUserUsingPOST
 		objectNameUsers,
 	),
-	ModuleV2: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/Affiliate/operation/addAffiliateUsingPOST
 		objectNameAffiliates,
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/createCategoryUsingPOST
@@ -89,7 +90,7 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 
 // Evert update performed using PATCH is not present in the PUT set.
 var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	ModuleV1: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/updatePropertiesOnAppointmentUsingPATCH
 		objectNameAppointments,
 		// https://developer.infusionsoft.com/docs/rest/#tag/Company/operation/updateCompanyUsingPATCH
@@ -105,7 +106,7 @@ var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //n
 		// https://developer.infusionsoft.com/docs/rest/#tag/Task/operation/updatePropertiesOnTaskUsingPATCH
 		objectNameTasks,
 	),
-	ModuleV2: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/Affiliate/operation/updateAffiliateUsingPATCH
 		objectNameAffiliates,
 		// https://developer.keap.com/docs/restv2/#tag/Company/operation/patchCompanyUsingPATCH
@@ -121,20 +122,20 @@ var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //n
 
 // Evert update performed using PUT is not present in the PATCH set.
 var supportedObjectsByUpdatePUT = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	ModuleV1: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/File/operation/updateFileUsingPUT
 		objectNameFiles,
 		// https://developer.infusionsoft.com/docs/rest/#tag/REST-Hooks/operation/update_a_hook_subscription
 		objectNameHooks,
 	),
-	ModuleV2: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/saveCategoryUsingPUT
 		objectNameAutomationCategories,
 	),
 }
 
 var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	ModuleV1: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/deleteAppointmentUsingDELETE
 		objectNameAppointments,
 		// https://developer.keap.com/docs/rest/#tag/Contact/operation/deleteContactUsingDELETE
@@ -154,7 +155,7 @@ var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint
 		// https://developer.infusionsoft.com/docs/rest/#tag/Task/operation/deleteTaskUsingDELETE
 		objectNameTasks,
 	),
-	ModuleV2: datautils.NewSet(
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/deleteCategoriesUsingDELETE
 		objectNameAutomationCategories,
 		// https://developer.keap.com/docs/restv2/#tag/Company/operation/deleteCompanyUsingDELETE
@@ -186,7 +187,7 @@ var objectNameToWritePath = datautils.NewDefaultMap(map[string]string{ //nolint:
 )
 
 var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //nolint:gochecknoglobals
-	ModuleV1: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewDefaultMap(map[string]string{
 		objectNameFiles: "id",
 
 		objectNameHooks: "key",
@@ -195,7 +196,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 			return "id"
 		},
 	),
-	ModuleV2: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewDefaultMap(map[string]string{
 		objectNamePaymentMethodConfigs: "session_key",
 	},
 		func(objectName string) (id string) {
@@ -205,7 +206,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 }
 
 var objectsWithCustomFields = map[common.ModuleID]datautils.StringSet{ // nolint:gochecknoglobals
-	ModuleV1: datautils.NewStringSet(
+	common.ModuleID(providers.ModuleKeapV1): datautils.NewStringSet(
 		objectNameAffiliates,
 		objectNameAppointments,
 		objectNameCompanies,
@@ -216,7 +217,7 @@ var objectsWithCustomFields = map[common.ModuleID]datautils.StringSet{ // nolint
 		objectNameSubscriptions,
 		objectNameTasks,
 	),
-	ModuleV2: datautils.NewStringSet(
+	common.ModuleID(providers.ModuleKeapV2): datautils.NewStringSet(
 		objectNameAffiliates,
 		objectNameContacts,
 		objectNameNotes,

--- a/providers/keap/objectNames.go
+++ b/providers/keap/objectNames.go
@@ -32,7 +32,7 @@ const (
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
 
 var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
+	providers.ModuleKeapV1: datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Affiliate/operation/createAffiliateUsingPOST
 		objectNameAffiliates,
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/createAppointmentUsingPOST
@@ -66,7 +66,7 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 		// https://developer.infusionsoft.com/docs/rest/#tag/Users/operation/createUserUsingPOST
 		objectNameUsers,
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
+	providers.ModuleKeapV2: datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/Affiliate/operation/addAffiliateUsingPOST
 		objectNameAffiliates,
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/createCategoryUsingPOST
@@ -88,9 +88,9 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 	),
 }
 
-// Evert update performed using PATCH is not present in the PUT set.
+// Every update performed using PATCH is not present in the PUT set.
 var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
+	providers.ModuleKeapV1: datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/updatePropertiesOnAppointmentUsingPATCH
 		objectNameAppointments,
 		// https://developer.infusionsoft.com/docs/rest/#tag/Company/operation/updateCompanyUsingPATCH
@@ -106,7 +106,7 @@ var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //n
 		// https://developer.infusionsoft.com/docs/rest/#tag/Task/operation/updatePropertiesOnTaskUsingPATCH
 		objectNameTasks,
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
+	providers.ModuleKeapV2: datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/Affiliate/operation/updateAffiliateUsingPATCH
 		objectNameAffiliates,
 		// https://developer.keap.com/docs/restv2/#tag/Company/operation/patchCompanyUsingPATCH
@@ -120,22 +120,22 @@ var supportedObjectsByUpdatePATCH = map[common.ModuleID]datautils.StringSet{ //n
 	),
 }
 
-// Evert update performed using PUT is not present in the PATCH set.
+// Every update performed using PUT is not present in the PATCH set.
 var supportedObjectsByUpdatePUT = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
+	providers.ModuleKeapV1: datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/File/operation/updateFileUsingPUT
 		objectNameFiles,
 		// https://developer.infusionsoft.com/docs/rest/#tag/REST-Hooks/operation/update_a_hook_subscription
 		objectNameHooks,
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
+	providers.ModuleKeapV2: datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/saveCategoryUsingPUT
 		objectNameAutomationCategories,
 	),
 }
 
 var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewSet(
+	providers.ModuleKeapV1: datautils.NewSet(
 		// https://developer.infusionsoft.com/docs/rest/#tag/Appointment/operation/deleteAppointmentUsingDELETE
 		objectNameAppointments,
 		// https://developer.keap.com/docs/rest/#tag/Contact/operation/deleteContactUsingDELETE
@@ -155,7 +155,7 @@ var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint
 		// https://developer.infusionsoft.com/docs/rest/#tag/Task/operation/deleteTaskUsingDELETE
 		objectNameTasks,
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewSet(
+	providers.ModuleKeapV2: datautils.NewSet(
 		// https://developer.keap.com/docs/restv2/#tag/AutomationCategory/operation/deleteCategoriesUsingDELETE
 		objectNameAutomationCategories,
 		// https://developer.keap.com/docs/restv2/#tag/Company/operation/deleteCompanyUsingDELETE
@@ -187,7 +187,7 @@ var objectNameToWritePath = datautils.NewDefaultMap(map[string]string{ //nolint:
 )
 
 var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleKeapV1: datautils.NewDefaultMap(map[string]string{
 		objectNameFiles: "id",
 
 		objectNameHooks: "key",
@@ -196,7 +196,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 			return "id"
 		},
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleKeapV2: datautils.NewDefaultMap(map[string]string{
 		objectNamePaymentMethodConfigs: "session_key",
 	},
 		func(objectName string) (id string) {
@@ -206,7 +206,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 }
 
 var objectsWithCustomFields = map[common.ModuleID]datautils.StringSet{ // nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKeapV1): datautils.NewStringSet(
+	providers.ModuleKeapV1: datautils.NewStringSet(
 		objectNameAffiliates,
 		objectNameAppointments,
 		objectNameCompanies,
@@ -217,7 +217,7 @@ var objectsWithCustomFields = map[common.ModuleID]datautils.StringSet{ // nolint
 		objectNameSubscriptions,
 		objectNameTasks,
 	),
-	common.ModuleID(providers.ModuleKeapV2): datautils.NewStringSet(
+	providers.ModuleKeapV2: datautils.NewStringSet(
 		objectNameAffiliates,
 		objectNameContacts,
 		objectNameNotes,

--- a/providers/keap/params.go
+++ b/providers/keap/params.go
@@ -45,6 +45,6 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleKeapV1))
+		params.WithModule(module, SupportedModules, providers.ModuleKeapV1)
 	}
 }

--- a/providers/keap/params.go
+++ b/providers/keap/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )
 
@@ -44,6 +45,6 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, ModuleV1)
+		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleKeapV1))
 	}
 }

--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -18,7 +18,7 @@ func makeGetRecords(moduleID common.ModuleID, objectName string) common.NodeReco
 
 func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		if moduleID == common.ModuleID(providers.ModuleKeapV1) {
+		if moduleID == providers.ModuleKeapV1 {
 			return jsonquery.New(node).StrWithDefault("next", "")
 		}
 

--- a/providers/keap/parse.go
+++ b/providers/keap/parse.go
@@ -3,6 +3,7 @@ package keap
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 	"github.com/spyzhov/ajson"
 )
@@ -17,7 +18,7 @@ func makeGetRecords(moduleID common.ModuleID, objectName string) common.NodeReco
 
 func makeNextRecordsURL(moduleID common.ModuleID) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
-		if moduleID == ModuleV1 {
+		if moduleID == common.ModuleID(providers.ModuleKeapV1) {
 			return jsonquery.New(node).StrWithDefault("next", "")
 		}
 

--- a/providers/keap/read.go
+++ b/providers/keap/read.go
@@ -65,13 +65,13 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	if c.Module.ID == common.ModuleID(providers.ModuleKeapV1) {
+	if c.Module.ID == providers.ModuleKeapV1 {
 		url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
 
 		if !config.Since.IsZero() {
 			url.WithQueryParam("since", datautils.Time.FormatRFC3339inUTCWithMilliseconds(config.Since))
 		}
-	} else if c.Module.ID == common.ModuleID(providers.ModuleKeapV2) {
+	} else if c.Module.ID == providers.ModuleKeapV2 {
 		// Since parameter is not applicable to objects in Module V2.
 		if config.ObjectName == "contact_link_types" {
 			url.WithQueryParam("pageSize", strconv.Itoa(DefaultPageSize))

--- a/providers/keap/read.go
+++ b/providers/keap/read.go
@@ -8,6 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 )
 
@@ -64,13 +65,13 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	if c.Module.ID == ModuleV1 {
+	if c.Module.ID == common.ModuleID(providers.ModuleKeapV1) {
 		url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
 
 		if !config.Since.IsZero() {
 			url.WithQueryParam("since", datautils.Time.FormatRFC3339inUTCWithMilliseconds(config.Since))
 		}
-	} else if c.Module.ID == ModuleV2 {
+	} else if c.Module.ID == common.ModuleID(providers.ModuleKeapV2) {
 		// Since parameter is not applicable to objects in Module V2.
 		if config.ObjectName == "contact_link_types" {
 			url.WithQueryParam("pageSize", strconv.Itoa(DefaultPageSize))

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -169,7 +169,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV1)
 			})
 		})
 	}
@@ -220,7 +220,7 @@ func TestReadV2(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV2))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV2)
 			})
 		})
 	}

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -168,7 +169,7 @@ func TestReadV1(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV1)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
 			})
 		})
 	}
@@ -219,7 +220,7 @@ func TestReadV2(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV2)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV2))
 			})
 		})
 	}

--- a/providers/keap/write_test.go
+++ b/providers/keap/write_test.go
@@ -111,7 +111,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
+				return constructTestConnector(tt.Server.URL, providers.ModuleKeapV1)
 			})
 		})
 	}

--- a/providers/keap/write_test.go
+++ b/providers/keap/write_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -110,7 +111,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleV1)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleKeapV1))
 			})
 		})
 	}

--- a/providers/klaviyo.go
+++ b/providers/klaviyo.go
@@ -1,11 +1,13 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Klaviyo Provider = "klaviyo"
 
 const (
 	// ModuleKlaviyo2024Oct15 is the latest stable version of API as of the date of writing.
 	// https://developers.klaviyo.com/en/reference/api_overview
-	ModuleKlaviyo2024Oct15 string = "2024-10-15"
+	ModuleKlaviyo2024Oct15 common.ModuleID = "2024-10-15"
 )
 
 func init() {
@@ -36,11 +38,11 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleKlaviyo2024Oct15: {
 				BaseURL:     "https://a.klaviyo.com",
-				DisplayName: "Version 2024-10-15",
-				Support: ModuleSupport{
+				DisplayName: "Klaviyo (Version 2024-10-15)",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/klaviyo.go
+++ b/providers/klaviyo.go
@@ -2,6 +2,12 @@ package providers
 
 const Klaviyo Provider = "klaviyo"
 
+const (
+	// ModuleKlaviyo2024Oct15 is the latest stable version of API as of the date of writing.
+	// https://developers.klaviyo.com/en/reference/api_overview
+	ModuleKlaviyo2024Oct15 string = "2024-10-15"
+)
+
 func init() {
 	// Klaviyo configuration
 	SetInfo(Klaviyo, ProviderInfo{
@@ -29,6 +35,17 @@ func init() {
 			Read:      true,
 			Subscribe: false,
 			Write:     true,
+		},
+		Modules: &ModuleInfo{
+			ModuleKlaviyo2024Oct15: {
+				BaseURL:     "https://a.klaviyo.com",
+				DisplayName: "Version 2024-10-15",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/klaviyo/connector.go
+++ b/providers/klaviyo/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleKlaviyo2024Oct15)))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(providers.ModuleKlaviyo2024Oct15))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/klaviyo/connector.go
+++ b/providers/klaviyo/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(Module2024Oct15))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleKlaviyo2024Oct15)))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/klaviyo/modules.go
+++ b/providers/klaviyo/modules.go
@@ -1,7 +1,6 @@
 package klaviyo
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
 )
@@ -9,7 +8,7 @@ import (
 const (
 	// Module2024Oct15
 	// Deprecated.
-	Module2024Oct15 = common.ModuleID(providers.ModuleKlaviyo2024Oct15)
+	Module2024Oct15 = providers.ModuleKlaviyo2024Oct15
 )
 
 // SupportedModules represents currently working and supported modules within the Klaviyo connector.

--- a/providers/klaviyo/modules.go
+++ b/providers/klaviyo/modules.go
@@ -2,13 +2,14 @@ package klaviyo
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
 )
 
 const (
-	// Module2024Oct15 is the latest stable version of API as of the date of writing.
-	// https://developers.klaviyo.com/en/reference/api_overview
-	Module2024Oct15 common.ModuleID = "2024-10-15"
+	// Module2024Oct15
+	// Deprecated.
+	Module2024Oct15 = common.ModuleID(providers.ModuleKlaviyo2024Oct15)
 )
 
 // SupportedModules represents currently working and supported modules within the Klaviyo connector.

--- a/providers/klaviyo/objectNames.go
+++ b/providers/klaviyo/objectNames.go
@@ -110,7 +110,7 @@ const (
 )
 
 var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
+	providers.ModuleKlaviyo2024Oct15: datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/create_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/send_campaign
@@ -210,7 +210,7 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 }
 
 var supportedObjectsByUpdate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
+	providers.ModuleKlaviyo2024Oct15: datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/update_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/cancel_campaign_send
@@ -251,7 +251,7 @@ var supportedObjectsByUpdate = map[common.ModuleID]datautils.StringSet{ //nolint
 }
 
 var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
+	providers.ModuleKlaviyo2024Oct15: datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/delete_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/delete_catalog_variant

--- a/providers/klaviyo/objectNames.go
+++ b/providers/klaviyo/objectNames.go
@@ -4,6 +4,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
 )
 
@@ -109,7 +110,7 @@ const (
 )
 
 var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	Module2024Oct15: datautils.NewSet(
+	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/create_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/send_campaign
@@ -209,7 +210,7 @@ var supportedObjectsByCreate = map[common.ModuleID]datautils.StringSet{ //nolint
 }
 
 var supportedObjectsByUpdate = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	Module2024Oct15: datautils.NewSet(
+	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/update_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/cancel_campaign_send
@@ -250,7 +251,7 @@ var supportedObjectsByUpdate = map[common.ModuleID]datautils.StringSet{ //nolint
 }
 
 var supportedObjectsByDelete = map[common.ModuleID]datautils.StringSet{ //nolint:gochecknoglobals
-	Module2024Oct15: datautils.NewSet(
+	common.ModuleID(providers.ModuleKlaviyo2024Oct15): datautils.NewSet(
 		// https://developers.klaviyo.com/en/reference/delete_campaign
 		objectNameCampaigns,
 		// https://developers.klaviyo.com/en/reference/delete_catalog_variant

--- a/providers/klaviyo/params.go
+++ b/providers/klaviyo/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )
 
@@ -41,6 +42,6 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 // WithModule sets the Atlassian API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, Module2024Oct15)
+		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleKlaviyo2024Oct15))
 	}
 }

--- a/providers/klaviyo/params.go
+++ b/providers/klaviyo/params.go
@@ -39,9 +39,9 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 	}
 }
 
-// WithModule sets the Atlassian API module to use for the connector. It's required.
+// WithModule sets the Klaviyo API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleKlaviyo2024Oct15))
+		params.WithModule(module, SupportedModules, providers.ModuleKlaviyo2024Oct15)
 	}
 }

--- a/providers/marketo.go
+++ b/providers/marketo.go
@@ -2,6 +2,13 @@ package providers
 
 const Marketo Provider = "marketo"
 
+const (
+	// ModuleMarketoAssets is the module/API used for accessing assets objects.
+	ModuleMarketoAssets string = "assets"
+	// ModuleMarketoLeads is the module/API used for accessing leads objects.
+	ModuleMarketoLeads string = "leads"
+)
+
 func init() {
 	// Marketo configuration file
 	// workspace maps to marketo instance
@@ -26,6 +33,26 @@ func init() {
 			GrantType:                 ClientCredentials,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
+			},
+		},
+		Modules: &ModuleInfo{
+			ModuleMarketoAssets: {
+				BaseURL:     "https://{{.workspace}}.mktorest.com/asset/v1",
+				DisplayName: "Assets",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
+			ModuleMarketoLeads: {
+				BaseURL:     "https://{{.workspace}}.mktorest.com/v1",
+				DisplayName: "Leads",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
 			},
 		},
 		Support: Support{

--- a/providers/marketo.go
+++ b/providers/marketo.go
@@ -1,12 +1,14 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Marketo Provider = "marketo"
 
 const (
 	// ModuleMarketoAssets is the module/API used for accessing assets objects.
-	ModuleMarketoAssets string = "assets"
+	ModuleMarketoAssets common.ModuleID = "assets"
 	// ModuleMarketoLeads is the module/API used for accessing leads objects.
-	ModuleMarketoLeads string = "leads"
+	ModuleMarketoLeads common.ModuleID = "leads"
 )
 
 func init() {
@@ -35,11 +37,11 @@ func init() {
 				ScopesField: "scope",
 			},
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleMarketoAssets: {
 				BaseURL:     "https://{{.workspace}}.mktorest.com/asset/v1",
-				DisplayName: "Assets",
-				Support: ModuleSupport{
+				DisplayName: "Marketo (Assets)",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,
@@ -47,8 +49,8 @@ func init() {
 			},
 			ModuleMarketoLeads: {
 				BaseURL:     "https://{{.workspace}}.mktorest.com/v1",
-				DisplayName: "Leads",
-				Support: ModuleSupport{
+				DisplayName: "Marketo (Leads)",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		// The module is resolved on behalf of the user if the option is missing.
-		WithModule(common.ModuleID(providers.ModuleMarketoLeads)),
+		WithModule(providers.ModuleMarketoLeads),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -15,7 +15,8 @@ type Connector struct {
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
-		WithModule(ModuleLeads), // The module is resolved on behalf of the user if the option is missing.
+		// The module is resolved on behalf of the user if the option is missing.
+		WithModule(common.ModuleID(providers.ModuleMarketoLeads)),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/marketo/module.go
+++ b/providers/marketo/module.go
@@ -8,10 +8,10 @@ import (
 const (
 	// ModuleAssets
 	// Deprecated.
-	ModuleAssets = common.ModuleID(providers.ModuleMarketoAssets)
+	ModuleAssets = providers.ModuleMarketoAssets
 	// ModuleLeads
 	// Deprecated.
-	ModuleLeads = common.ModuleID(providers.ModuleMarketoLeads)
+	ModuleLeads = providers.ModuleMarketoLeads
 )
 
 // supportedModules represents currently working and supported modules within the Marketo connector.
@@ -22,13 +22,13 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	common.ModuleID(providers.ModuleMarketoAssets): {
-		ID:      common.ModuleID(providers.ModuleMarketoAssets),
+	providers.ModuleMarketoAssets: {
+		ID:      providers.ModuleMarketoAssets,
 		Label:   "asset",
 		Version: "v1",
 	},
-	common.ModuleID(providers.ModuleMarketoLeads): {
-		ID:      common.ModuleID(providers.ModuleMarketoLeads),
+	providers.ModuleMarketoLeads: {
+		ID:      providers.ModuleMarketoLeads,
 		Label:   "",
 		Version: "v1",
 	},

--- a/providers/marketo/module.go
+++ b/providers/marketo/module.go
@@ -2,13 +2,16 @@ package marketo
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 )
 
 const (
-	// ModuleAssets is the module/API used for accessing assets objects.
-	ModuleAssets common.ModuleID = "assets"
-	// ModuleLeads is the module/API used for accessing leads objects.
-	ModuleLeads common.ModuleID = "leads"
+	// ModuleAssets
+	// Deprecated.
+	ModuleAssets = common.ModuleID(providers.ModuleMarketoAssets)
+	// ModuleLeads
+	// Deprecated.
+	ModuleLeads = common.ModuleID(providers.ModuleMarketoLeads)
 )
 
 // supportedModules represents currently working and supported modules within the Marketo connector.
@@ -19,13 +22,13 @@ var supportedModules = common.Modules{ // nolint: gochecknoglobals
 		Label:   "",
 		Version: "",
 	},
-	ModuleAssets: {
-		ID:      ModuleAssets,
+	common.ModuleID(providers.ModuleMarketoAssets): {
+		ID:      common.ModuleID(providers.ModuleMarketoAssets),
 		Label:   "asset",
 		Version: "v1",
 	},
-	ModuleLeads: {
-		ID:      ModuleLeads,
+	common.ModuleID(providers.ModuleMarketoLeads): {
+		ID:      common.ModuleID(providers.ModuleMarketoLeads),
 		Label:   "",
 		Version: "v1",
 	},

--- a/providers/marketo/params.go
+++ b/providers/marketo/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -39,7 +40,7 @@ func WithClient(ctx context.Context, client *http.Client,
 // WithModule sets the marketo API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, ModuleLeads)
+		params.WithModule(module, supportedModules, common.ModuleID(providers.ModuleMarketoLeads))
 	}
 }
 

--- a/providers/marketo/params.go
+++ b/providers/marketo/params.go
@@ -40,7 +40,7 @@ func WithClient(ctx context.Context, client *http.Client,
 // WithModule sets the marketo API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, supportedModules, common.ModuleID(providers.ModuleMarketoLeads))
+		params.WithModule(module, supportedModules, providers.ModuleMarketoLeads)
 	}
 }
 

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -26,11 +26,11 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
 	if !params.Since.IsZero() {
 		switch c.Module.ID {
-		case common.ModuleID(providers.ModuleMarketoAssets):
+		case providers.ModuleMarketoAssets:
 			fmtTime := params.Since.Format(time.RFC3339)
 			url.WithQueryParam("earliestUpdatedAt", fmtTime)
 			url.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
-		case common.ModuleID(providers.ModuleMarketoLeads):
+		case providers.ModuleMarketoLeads:
 			fallthrough
 		case common.ModuleRoot:
 			fallthrough

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
 )
 
 const restAPIPrefix = "rest" //nolint:gochecknoglobals
@@ -25,11 +26,11 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
 	if !params.Since.IsZero() {
 		switch c.Module.ID {
-		case ModuleAssets:
+		case common.ModuleID(providers.ModuleMarketoAssets):
 			fmtTime := params.Since.Format(time.RFC3339)
 			url.WithQueryParam("earliestUpdatedAt", fmtTime)
 			url.WithQueryParam("latestUpdatedAt", time.Now().Format(time.RFC3339))
-		case ModuleLeads:
+		case common.ModuleID(providers.ModuleMarketoLeads):
 			fallthrough
 		case common.ModuleRoot:
 			fallthrough

--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -1,5 +1,7 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const (
 	ZendeskChat    Provider = "zendeskChat"
 	ZendeskSupport Provider = "zendeskSupport"
@@ -8,10 +10,10 @@ const (
 const (
 	// ModuleZendeskTicketing is used for proxying requests through.
 	// https://developer.zendesk.com/api-reference/ticketing/introduction/
-	ModuleZendeskTicketing string = "ticketing"
+	ModuleZendeskTicketing common.ModuleID = "ticketing"
 	// ModuleZendeskHelpCenter is Zendesk Help Center.
 	// https://developer.zendesk.com/api-reference/help_center/help-center-api/introduction/
-	ModuleZendeskHelpCenter string = "help-center"
+	ModuleZendeskHelpCenter common.ModuleID = "help-center"
 )
 
 func init() { // nolint:funlen
@@ -27,11 +29,11 @@ func init() { // nolint:funlen
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleZendeskTicketing: {
 				BaseURL:     "https://{{.workspace}}.zendesk.com/api/v2",
-				DisplayName: "Ticketing",
-				Support: ModuleSupport{
+				DisplayName: "Zendesk Ticketing",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,
@@ -39,8 +41,8 @@ func init() { // nolint:funlen
 			},
 			ModuleZendeskHelpCenter: {
 				BaseURL:     "https://{{.workspace}}.zendesk.com/api/v2",
-				DisplayName: "Help Center",
-				Support: ModuleSupport{
+				DisplayName: "Zendesk Help Center",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -5,6 +5,15 @@ const (
 	ZendeskSupport Provider = "zendeskSupport"
 )
 
+const (
+	// ModuleZendeskTicketing is used for proxying requests through.
+	// https://developer.zendesk.com/api-reference/ticketing/introduction/
+	ModuleZendeskTicketing string = "ticketing"
+	// ModuleZendeskHelpCenter is Zendesk Help Center.
+	// https://developer.zendesk.com/api-reference/help_center/help-center-api/introduction/
+	ModuleZendeskHelpCenter string = "help-center"
+)
+
 func init() { // nolint:funlen
 	// Zendesk Support configuration
 	SetInfo(ZendeskSupport, ProviderInfo{
@@ -17,6 +26,26 @@ func init() { // nolint:funlen
 			TokenURL:                  "https://{{.workspace}}.zendesk.com/oauth/tokens",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: true,
+		},
+		Modules: &ModuleInfo{
+			ModuleZendeskTicketing: {
+				BaseURL:     "https://{{.workspace}}.zendesk.com/api/v2",
+				DisplayName: "Ticketing",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
+			ModuleZendeskHelpCenter: {
+				BaseURL:     "https://{{.workspace}}.zendesk.com/api/v2",
+				DisplayName: "Help Center",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -18,7 +18,7 @@ type Connector struct {
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		// The module is resolved on behalf of the user if the option is missing.
-		WithModule(common.ModuleID(providers.ModuleZendeskTicketing)),
+		WithModule(providers.ModuleZendeskTicketing),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/zendesksupport/connector.go
+++ b/providers/zendesksupport/connector.go
@@ -17,7 +17,8 @@ type Connector struct {
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
-		WithModule(ModuleTicketing), // The module is resolved on behalf of the user if the option is missing.
+		// The module is resolved on behalf of the user if the option is missing.
+		WithModule(common.ModuleID(providers.ModuleZendeskTicketing)),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -65,7 +65,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskTicketing)
 			})
 		})
 	}

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -64,7 +65,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
 			})
 		})
 	}

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -101,7 +102,7 @@ func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
 			})
 		})
 	}
@@ -147,7 +148,7 @@ func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,goc
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleHelpCenter)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
 			})
 		})
 	}

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -102,7 +102,7 @@ func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskTicketing)
 			})
 		})
 	}
@@ -148,7 +148,7 @@ func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,goc
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskHelpCenter)
 			})
 		})
 	}

--- a/providers/zendesksupport/modules.go
+++ b/providers/zendesksupport/modules.go
@@ -2,16 +2,17 @@ package zendesksupport
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
 
 const (
-	// ModuleTicketing is used for proxying requests through.
-	// https://developer.zendesk.com/api-reference/ticketing/introduction/
-	ModuleTicketing common.ModuleID = "ticketing"
-	// ModuleHelpCenter is Zendesk Help Center.
-	// https://developer.zendesk.com/api-reference/help_center/help-center-api/introduction/
-	ModuleHelpCenter common.ModuleID = "help-center"
+	// ModuleTicketing
+	// Deprecated.
+	ModuleTicketing = common.ModuleID(providers.ModuleZendeskTicketing)
+	// ModuleHelpCenter
+	// Deprecated.
+	ModuleHelpCenter = common.ModuleID(providers.ModuleZendeskHelpCenter)
 )
 
 // SupportedModules represents currently working and supported modules within the Zendesk connector.

--- a/providers/zendesksupport/modules.go
+++ b/providers/zendesksupport/modules.go
@@ -1,7 +1,6 @@
 package zendesksupport
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
@@ -9,10 +8,10 @@ import (
 const (
 	// ModuleTicketing
 	// Deprecated.
-	ModuleTicketing = common.ModuleID(providers.ModuleZendeskTicketing)
+	ModuleTicketing = providers.ModuleZendeskTicketing
 	// ModuleHelpCenter
 	// Deprecated.
-	ModuleHelpCenter = common.ModuleID(providers.ModuleZendeskHelpCenter)
+	ModuleHelpCenter = providers.ModuleZendeskHelpCenter
 )
 
 // SupportedModules represents currently working and supported modules within the Zendesk connector.

--- a/providers/zendesksupport/objectNames.go
+++ b/providers/zendesksupport/objectNames.go
@@ -11,21 +11,21 @@ import (
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
 
 var objectsUnsupportedWrite = map[common.ModuleID]datautils.Set[string]{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleZendeskTicketing): datautils.NewSet(
+	providers.ModuleZendeskTicketing: datautils.NewSet(
 		"attribute_values",
 		"instance_values",
 		"ticket_events",
 		"ticket_metric_events",
 	),
-	common.ModuleID(providers.ModuleZendeskHelpCenter): datautils.NewStringSet(),
+	providers.ModuleZendeskHelpCenter: datautils.NewStringSet(),
 }
 
 var writeURLExceptions = map[common.ModuleID]datautils.Map[string, string]{ //nolint:gochecknoglobals
-	common.ModuleID(providers.ModuleZendeskTicketing): {
+	providers.ModuleZendeskTicketing: {
 		"attributes":    "/api/v2/routing/attributes",
 		"organizations": "/api/v2/organizations",
 		"tickets":       "/api/v2/tickets",
 		"users":         "/api/v2/users",
 	},
-	common.ModuleID(providers.ModuleZendeskHelpCenter): {},
+	providers.ModuleZendeskHelpCenter: {},
 }

--- a/providers/zendesksupport/objectNames.go
+++ b/providers/zendesksupport/objectNames.go
@@ -3,6 +3,7 @@ package zendesksupport
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
 
@@ -10,21 +11,21 @@ import (
 var supportedObjectsByRead = metadata.Schemas.ObjectNames() //nolint:gochecknoglobals
 
 var objectsUnsupportedWrite = map[common.ModuleID]datautils.Set[string]{ //nolint:gochecknoglobals
-	ModuleTicketing: datautils.NewSet(
+	common.ModuleID(providers.ModuleZendeskTicketing): datautils.NewSet(
 		"attribute_values",
 		"instance_values",
 		"ticket_events",
 		"ticket_metric_events",
 	),
-	ModuleHelpCenter: datautils.NewStringSet(),
+	common.ModuleID(providers.ModuleZendeskHelpCenter): datautils.NewStringSet(),
 }
 
 var writeURLExceptions = map[common.ModuleID]datautils.Map[string, string]{ //nolint:gochecknoglobals
-	ModuleTicketing: {
+	common.ModuleID(providers.ModuleZendeskTicketing): {
 		"attributes":    "/api/v2/routing/attributes",
 		"organizations": "/api/v2/organizations",
 		"tickets":       "/api/v2/tickets",
 		"users":         "/api/v2/users",
 	},
-	ModuleHelpCenter: {},
+	common.ModuleID(providers.ModuleZendeskHelpCenter): {},
 }

--- a/providers/zendesksupport/params.go
+++ b/providers/zendesksupport/params.go
@@ -52,6 +52,6 @@ func WithWorkspace(workspaceRef string) Option {
 // WithModule sets the zendesk API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleZendeskTicketing))
+		params.WithModule(module, SupportedModules, providers.ModuleZendeskTicketing)
 	}
 }

--- a/providers/zendesksupport/params.go
+++ b/providers/zendesksupport/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )
 
@@ -51,6 +52,6 @@ func WithWorkspace(workspaceRef string) Option {
 // WithModule sets the zendesk API module to use for the connector. It's required.
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, ModuleTicketing)
+		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleZendeskTicketing))
 	}
 }

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -127,7 +128,7 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
 			})
 		})
 	}
@@ -273,7 +274,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
 			})
 		})
 	}
@@ -331,7 +332,7 @@ func TestReadHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,ma
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleHelpCenter)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
 			})
 		})
 	}

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -128,7 +128,7 @@ func TestReadZendeskSupportModule(t *testing.T) { //nolint:funlen,gocognit,cyclo
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskTicketing)
 			})
 		})
 	}
@@ -274,7 +274,7 @@ func TestIncrementalReadZendeskSupportModule(t *testing.T) { //nolint:funlen,goc
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskTicketing)
 			})
 		})
 	}
@@ -332,7 +332,7 @@ func TestReadHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,ma
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskHelpCenter)
 			})
 		})
 	}

--- a/providers/zendesksupport/schema_test.go
+++ b/providers/zendesksupport/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 )
 
@@ -16,27 +17,27 @@ func TestLookupPaginationType(t *testing.T) {
 		want   string
 	}{
 		{
-			module: ModuleTicketing,
+			module: common.ModuleID(providers.ModuleZendeskTicketing),
 			object: "tickets",
 			want:   "cursor",
 		},
 		{
-			module: ModuleTicketing,
+			module: common.ModuleID(providers.ModuleZendeskTicketing),
 			object: "workspaces",
 			want:   "offset",
 		},
 		{
-			module: ModuleHelpCenter,
+			module: common.ModuleID(providers.ModuleZendeskHelpCenter),
 			object: "articles",
 			want:   "offset",
 		},
 		{
-			module: ModuleTicketing,
+			module: common.ModuleID(providers.ModuleZendeskTicketing),
 			object: "macros",
 			want:   "cursor",
 		},
 		{
-			module: ModuleHelpCenter,
+			module: common.ModuleID(providers.ModuleZendeskHelpCenter),
 			object: "community_posts",
 			want:   "offset",
 		},

--- a/providers/zendesksupport/schema_test.go
+++ b/providers/zendesksupport/schema_test.go
@@ -17,27 +17,27 @@ func TestLookupPaginationType(t *testing.T) {
 		want   string
 	}{
 		{
-			module: common.ModuleID(providers.ModuleZendeskTicketing),
+			module: providers.ModuleZendeskTicketing,
 			object: "tickets",
 			want:   "cursor",
 		},
 		{
-			module: common.ModuleID(providers.ModuleZendeskTicketing),
+			module: providers.ModuleZendeskTicketing,
 			object: "workspaces",
 			want:   "offset",
 		},
 		{
-			module: common.ModuleID(providers.ModuleZendeskHelpCenter),
+			module: providers.ModuleZendeskHelpCenter,
 			object: "articles",
 			want:   "offset",
 		},
 		{
-			module: common.ModuleID(providers.ModuleZendeskTicketing),
+			module: providers.ModuleZendeskTicketing,
 			object: "macros",
 			want:   "cursor",
 		},
 		{
-			module: common.ModuleID(providers.ModuleZendeskHelpCenter),
+			module: providers.ModuleZendeskHelpCenter,
 			object: "community_posts",
 			want:   "offset",
 		},

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -167,7 +167,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskTicketing)
 			})
 		})
 	}
@@ -211,7 +211,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZendeskHelpCenter)
 			})
 		})
 	}

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -166,7 +167,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleTicketing)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskTicketing))
 			})
 		})
 	}
@@ -210,7 +211,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleHelpCenter)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZendeskHelpCenter))
 			})
 		})
 	}

--- a/providers/zoom.go
+++ b/providers/zoom.go
@@ -2,6 +2,11 @@ package providers
 
 const Zoom Provider = "zoom"
 
+const (
+	ModuleZoomUser    string = "user"
+	ModuleZoomMeeting string = "meeting"
+)
+
 func init() {
 	// Zoom configuration
 	SetInfo(Zoom, ProviderInfo{
@@ -16,6 +21,26 @@ func init() {
 			GrantType:                 AuthorizationCode,
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField: "scope",
+			},
+		},
+		Modules: &ModuleInfo{
+			ModuleZoomUser: {
+				BaseURL:     "https://api.zoom.us/v2",
+				DisplayName: "User",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
+			},
+			ModuleZoomMeeting: {
+				BaseURL:     "https://api.zoom.us/v2",
+				DisplayName: "Meeting",
+				Support: ModuleSupport{
+					Read:      true,
+					Subscribe: false,
+					Write:     true,
+				},
 			},
 		},
 		//nolint:lll

--- a/providers/zoom.go
+++ b/providers/zoom.go
@@ -1,10 +1,12 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const Zoom Provider = "zoom"
 
 const (
-	ModuleZoomUser    string = "user"
-	ModuleZoomMeeting string = "meeting"
+	ModuleZoomUser    common.ModuleID = "user"
+	ModuleZoomMeeting common.ModuleID = "meeting"
 )
 
 func init() {
@@ -23,11 +25,11 @@ func init() {
 				ScopesField: "scope",
 			},
 		},
-		Modules: &ModuleInfo{
+		Modules: &Modules{
 			ModuleZoomUser: {
 				BaseURL:     "https://api.zoom.us/v2",
-				DisplayName: "User",
-				Support: ModuleSupport{
+				DisplayName: "Zoom (User)",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,
@@ -35,8 +37,8 @@ func init() {
 			},
 			ModuleZoomMeeting: {
 				BaseURL:     "https://api.zoom.us/v2",
-				DisplayName: "Meeting",
-				Support: ModuleSupport{
+				DisplayName: "Zoom (Meeting)",
+				Support: Support{
 					Read:      true,
 					Subscribe: false,
 					Write:     true,

--- a/providers/zoom/connector.go
+++ b/providers/zoom/connector.go
@@ -17,7 +17,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleZoomMeeting)))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(providers.ModuleZoomMeeting))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/zoom/connector.go
+++ b/providers/zoom/connector.go
@@ -17,7 +17,7 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(ModuleMeeting))
+	params, err := paramsbuilder.Apply(parameters{}, opts, WithModule(common.ModuleID(providers.ModuleZoomMeeting)))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/zoom/metadata_test.go
+++ b/providers/zoom/metadata_test.go
@@ -62,7 +62,7 @@ func TestListObjectMetaUserModule(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomUser)
 			})
 		})
 	}
@@ -107,7 +107,7 @@ func TestListObjectMetaMeetingModule(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomMeeting)
 			})
 		})
 	}

--- a/providers/zoom/metadata_test.go
+++ b/providers/zoom/metadata_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -61,7 +62,7 @@ func TestListObjectMetaUserModule(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleUser)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
 			})
 		})
 	}
@@ -106,7 +107,7 @@ func TestListObjectMetaMeetingModule(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleMeeting)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
 			})
 		})
 	}

--- a/providers/zoom/modules.go
+++ b/providers/zoom/modules.go
@@ -1,7 +1,6 @@
 package zoom
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom/metadata"
 )
@@ -9,10 +8,10 @@ import (
 const (
 	// ModuleUser
 	// Deprecated.
-	ModuleUser = common.ModuleID(providers.ModuleZoomUser)
+	ModuleUser = providers.ModuleZoomUser
 	// ModuleMeeting
 	// Deprecated.
-	ModuleMeeting = common.ModuleID(providers.ModuleZoomMeeting)
+	ModuleMeeting = providers.ModuleZoomMeeting
 )
 
 var SupportedModules = metadata.Schemas.ModuleRegistry() // nolint: gochecknoglobals

--- a/providers/zoom/modules.go
+++ b/providers/zoom/modules.go
@@ -2,13 +2,17 @@ package zoom
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom/metadata"
 )
 
 const (
-	ModuleUser common.ModuleID = "user"
-
-	ModuleMeeting common.ModuleID = "meeting"
+	// ModuleUser
+	// Deprecated.
+	ModuleUser = common.ModuleID(providers.ModuleZoomUser)
+	// ModuleMeeting
+	// Deprecated.
+	ModuleMeeting = common.ModuleID(providers.ModuleZoomMeeting)
 )
 
 var SupportedModules = metadata.Schemas.ModuleRegistry() // nolint: gochecknoglobals

--- a/providers/zoom/objectNames.go
+++ b/providers/zoom/objectNames.go
@@ -3,6 +3,7 @@ package zoom
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom/metadata"
 )
 
@@ -19,7 +20,7 @@ var (
 // ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
 var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: gochecknoglobals
 
-	ModuleMeeting: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewDefaultMap(map[string]string{
 		"device_groups":     "groups",
 		"archive_files":     "meetings",
 		"meeting_summaries": "summaries",
@@ -31,7 +32,7 @@ var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: g
 			return objectName
 		},
 	),
-	ModuleUser: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleZoomUser): datautils.NewDefaultMap(map[string]string{
 		"contacts_groups": "groups",
 	},
 		func(objectName string) (fieldName string) {
@@ -41,13 +42,13 @@ var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: g
 }
 
 var supportedObjectsByWrite = map[common.ModuleID]datautils.StringSet{ // nolint: gochecknoglobals
-	ModuleUser: datautils.NewSet(
+	common.ModuleID(providers.ModuleZoomUser): datautils.NewSet(
 		ObjectNameContactGroup,
 		ObjectNameUser,
 		ObjectNameGroup,
 	),
 
-	ModuleMeeting: datautils.NewSet(
+	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewSet(
 		objectNameTrackingField,
 		objectNameDevice,
 		objectNameH322Device,
@@ -70,7 +71,7 @@ var objectNameToWritePath = datautils.NewDefaultMap(map[string]string{ // nolint
 // This map is used to get the record id field for each object.
 var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ // nolint: gochecknoglobals
 
-	ModuleMeeting: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewDefaultMap(map[string]string{
 		objectNameTrackingField: "id",
 		objectNameDevice:        "",
 		objectNameH322Device:    "id",
@@ -80,7 +81,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 		},
 	),
 
-	ModuleUser: datautils.NewDefaultMap(map[string]string{
+	common.ModuleID(providers.ModuleZoomUser): datautils.NewDefaultMap(map[string]string{
 		ObjectNameContactGroup: "group_id",
 		ObjectNameUser:         "id",
 		ObjectNameGroup:        "",

--- a/providers/zoom/objectNames.go
+++ b/providers/zoom/objectNames.go
@@ -20,7 +20,7 @@ var (
 // ObjectNameToResponseField maps ObjectName to the response field name which contains that object.
 var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: gochecknoglobals
 
-	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleZoomMeeting: datautils.NewDefaultMap(map[string]string{
 		"device_groups":     "groups",
 		"archive_files":     "meetings",
 		"meeting_summaries": "summaries",
@@ -32,7 +32,7 @@ var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: g
 			return objectName
 		},
 	),
-	common.ModuleID(providers.ModuleZoomUser): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleZoomUser: datautils.NewDefaultMap(map[string]string{
 		"contacts_groups": "groups",
 	},
 		func(objectName string) (fieldName string) {
@@ -42,13 +42,13 @@ var ObjectNameToResponseField = common.ModuleObjectNameToFieldName{ // nolint: g
 }
 
 var supportedObjectsByWrite = map[common.ModuleID]datautils.StringSet{ // nolint: gochecknoglobals
-	common.ModuleID(providers.ModuleZoomUser): datautils.NewSet(
+	providers.ModuleZoomUser: datautils.NewSet(
 		ObjectNameContactGroup,
 		ObjectNameUser,
 		ObjectNameGroup,
 	),
 
-	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewSet(
+	providers.ModuleZoomMeeting: datautils.NewSet(
 		objectNameTrackingField,
 		objectNameDevice,
 		objectNameH322Device,
@@ -71,7 +71,7 @@ var objectNameToWritePath = datautils.NewDefaultMap(map[string]string{ // nolint
 // This map is used to get the record id field for each object.
 var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ // nolint: gochecknoglobals
 
-	common.ModuleID(providers.ModuleZoomMeeting): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleZoomMeeting: datautils.NewDefaultMap(map[string]string{
 		objectNameTrackingField: "id",
 		objectNameDevice:        "",
 		objectNameH322Device:    "id",
@@ -81,7 +81,7 @@ var objectNameToWriteResponseIdentifier = common.ModuleObjectNameToFieldName{ //
 		},
 	),
 
-	common.ModuleID(providers.ModuleZoomUser): datautils.NewDefaultMap(map[string]string{
+	providers.ModuleZoomUser: datautils.NewDefaultMap(map[string]string{
 		ObjectNameContactGroup: "group_id",
 		ObjectNameUser:         "id",
 		ObjectNameGroup:        "",

--- a/providers/zoom/params.go
+++ b/providers/zoom/params.go
@@ -45,6 +45,6 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleZoomUser))
+		params.WithModule(module, SupportedModules, providers.ModuleZoomUser)
 	}
 }

--- a/providers/zoom/params.go
+++ b/providers/zoom/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )
 
@@ -44,6 +45,6 @@ func WithAuthenticatedClient(client common.AuthenticatedHTTPClient) Option {
 
 func WithModule(module common.ModuleID) Option {
 	return func(params *parameters) {
-		params.WithModule(module, SupportedModules, ModuleUser)
+		params.WithModule(module, SupportedModules, common.ModuleID(providers.ModuleZoomUser))
 	}
 }

--- a/providers/zoom/read_test.go
+++ b/providers/zoom/read_test.go
@@ -99,7 +99,7 @@ func TestReadModuleUser(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomUser)
 			})
 		})
 	}
@@ -177,7 +177,7 @@ func TestReadModuleMeeting(t *testing.T) { //nolint:funlen,gocognit,cyclop,maint
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomMeeting)
 			})
 		})
 	}

--- a/providers/zoom/read_test.go
+++ b/providers/zoom/read_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -98,7 +99,7 @@ func TestReadModuleUser(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleUser)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
 			})
 		})
 	}
@@ -176,7 +177,7 @@ func TestReadModuleMeeting(t *testing.T) { //nolint:funlen,gocognit,cyclop,maint
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleMeeting)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
 			})
 		})
 	}

--- a/providers/zoom/write_test.go
+++ b/providers/zoom/write_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -92,7 +93,7 @@ func TestWriteModuleMeeting(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleMeeting)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
 			})
 		})
 	}
@@ -155,7 +156,7 @@ func TestWriteModuleUser(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, ModuleUser)
+				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
 			})
 		})
 	}

--- a/providers/zoom/write_test.go
+++ b/providers/zoom/write_test.go
@@ -93,7 +93,7 @@ func TestWriteModuleMeeting(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomMeeting))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomMeeting)
 			})
 		})
 	}
@@ -156,7 +156,7 @@ func TestWriteModuleUser(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL, common.ModuleID(providers.ModuleZoomUser))
+				return constructTestConnector(tt.Server.URL, providers.ModuleZoomUser)
 			})
 		})
 	}

--- a/scripts/openapi/keap/metadata/main.go
+++ b/scripts/openapi/keap/metadata/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/providers/keap"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/keap/metadata"
 	keapv1 "github.com/amp-labs/connectors/scripts/openapi/keap/metadata/v1"
 	keapv2 "github.com/amp-labs/connectors/scripts/openapi/keap/metadata/v2"
@@ -20,8 +20,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
-	lists.Add(keap.ModuleV1, keapv1.Objects()...)
-	lists.Add(keap.ModuleV2, keapv2.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleKeapV1), keapv1.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleKeapV2), keapv2.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/keap/metadata/main.go
+++ b/scripts/openapi/keap/metadata/main.go
@@ -20,8 +20,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
-	lists.Add(common.ModuleID(providers.ModuleKeapV1), keapv1.Objects()...)
-	lists.Add(common.ModuleID(providers.ModuleKeapV2), keapv2.Objects()...)
+	lists.Add(providers.ModuleKeapV1, keapv1.Objects()...)
+	lists.Add(providers.ModuleKeapV2, keapv2.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/klaviyo/metadata/main.go
+++ b/scripts/openapi/klaviyo/metadata/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"log/slog"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/staticschema"
@@ -60,7 +59,7 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add(common.ModuleID(providers.ModuleKlaviyo2024Oct15),
+			schemas.Add(providers.ModuleKlaviyo2024Oct15,
 				object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
 					field.Name: field.Name,

--- a/scripts/openapi/klaviyo/metadata/main.go
+++ b/scripts/openapi/klaviyo/metadata/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"log/slog"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/providers/klaviyo"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/klaviyo/metadata"
 	"github.com/amp-labs/connectors/providers/klaviyo/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -59,7 +60,8 @@ func main() {
 		}
 
 		for _, field := range object.Fields {
-			schemas.Add(klaviyo.Module2024Oct15, object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
+			schemas.Add(common.ModuleID(providers.ModuleKlaviyo2024Oct15),
+				object.ObjectName, object.DisplayName, object.URLPath, object.ResponseKey,
 				staticschema.FieldMetadataMapV1{
 					field.Name: field.Name,
 				}, nil, object.Custom)

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/providers/zendesksupport"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport/metadata"
 	utilsopenapi "github.com/amp-labs/connectors/scripts/openapi/utils"
 	"github.com/amp-labs/connectors/scripts/openapi/zendesksupport/metadata/helpcenter"
@@ -21,8 +21,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.ExtendedSchema[metadata.CustomProperties]]{}
 
-	lists.Add(zendesksupport.ModuleTicketing, support.Objects()...)
-	lists.Add(zendesksupport.ModuleHelpCenter, helpcenter.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleZendeskTicketing), support.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleZendeskHelpCenter), helpcenter.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/zendesksupport/metadata/main.go
+++ b/scripts/openapi/zendesksupport/metadata/main.go
@@ -21,8 +21,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.ExtendedSchema[metadata.CustomProperties]]{}
 
-	lists.Add(common.ModuleID(providers.ModuleZendeskTicketing), support.Objects()...)
-	lists.Add(common.ModuleID(providers.ModuleZendeskHelpCenter), helpcenter.Objects()...)
+	lists.Add(providers.ModuleZendeskTicketing, support.Objects()...)
+	lists.Add(providers.ModuleZendeskHelpCenter, helpcenter.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/zoom/metadata/main.go
+++ b/scripts/openapi/zoom/metadata/main.go
@@ -20,8 +20,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
-	lists.Add(common.ModuleID(providers.ModuleZoomUser), user.Objects()...)
-	lists.Add(common.ModuleID(providers.ModuleZoomMeeting), meeting.Objects()...)
+	lists.Add(providers.ModuleZoomUser, user.Objects()...)
+	lists.Add(providers.ModuleZoomMeeting, meeting.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/zoom/metadata/main.go
+++ b/scripts/openapi/zoom/metadata/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/providers/zoom"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom/metadata"
 	"github.com/amp-labs/connectors/scripts/openapi/zoom/metadata/meeting"
 	"github.com/amp-labs/connectors/scripts/openapi/zoom/metadata/user"
@@ -20,8 +20,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 	lists := datautils.IndexedLists[common.ModuleID, metadatadef.Schema]{}
 
-	lists.Add(zoom.ModuleUser, user.Objects()...)
-	lists.Add(zoom.ModuleMeeting, meeting.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleZoomUser), user.Objects()...)
+	lists.Add(common.ModuleID(providers.ModuleZoomMeeting), meeting.Objects()...)
 
 	for module, objects := range lists {
 		for _, object := range objects {

--- a/scripts/openapi/zoom/metadata/meeting/object.go
+++ b/scripts/openapi/zoom/metadata/meeting/object.go
@@ -1,8 +1,10 @@
 package meeting
 
 import (
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom"
 	"github.com/amp-labs/connectors/providers/zoom/metadata/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -43,7 +45,7 @@ func Objects() []metadatadef.Schema {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewAllowPathStrategy(allowedEndpoints),
 		objectEndpoints, nil,
-		api3.CustomMappingObjectCheck(zoom.ObjectNameToResponseField[zoom.ModuleMeeting]),
+		api3.CustomMappingObjectCheck(zoom.ObjectNameToResponseField[common.ModuleID(providers.ModuleZoomMeeting)]),
 	)
 
 	goutils.MustBeNil(err)

--- a/scripts/openapi/zoom/metadata/meeting/object.go
+++ b/scripts/openapi/zoom/metadata/meeting/object.go
@@ -1,7 +1,6 @@
 package meeting
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers"
@@ -45,7 +44,7 @@ func Objects() []metadatadef.Schema {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewAllowPathStrategy(allowedEndpoints),
 		objectEndpoints, nil,
-		api3.CustomMappingObjectCheck(zoom.ObjectNameToResponseField[common.ModuleID(providers.ModuleZoomMeeting)]),
+		api3.CustomMappingObjectCheck(zoom.ObjectNameToResponseField[providers.ModuleZoomMeeting]),
 	)
 
 	goutils.MustBeNil(err)

--- a/scripts/openapi/zoom/metadata/user/object.go
+++ b/scripts/openapi/zoom/metadata/user/object.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
 	"github.com/amp-labs/connectors/providers"
@@ -34,7 +33,7 @@ func Objects() []metadatadef.Schema {
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewAllowPathStrategy(allowedEndpoints),
 		objectEndpoints, nil, api3.CustomMappingObjectCheck(
-			zoom.ObjectNameToResponseField[common.ModuleID(providers.ModuleZoomUser)],
+			zoom.ObjectNameToResponseField[providers.ModuleZoomUser],
 		),
 	)
 

--- a/scripts/openapi/zoom/metadata/user/object.go
+++ b/scripts/openapi/zoom/metadata/user/object.go
@@ -1,8 +1,10 @@
 package user
 
 import (
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom"
 	"github.com/amp-labs/connectors/providers/zoom/metadata/openapi"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
@@ -31,7 +33,9 @@ func Objects() []metadatadef.Schema {
 
 	objects, err := explorer.ReadObjectsGet(
 		api3.NewAllowPathStrategy(allowedEndpoints),
-		objectEndpoints, nil, api3.CustomMappingObjectCheck(zoom.ObjectNameToResponseField[zoom.ModuleUser]),
+		objectEndpoints, nil, api3.CustomMappingObjectCheck(
+			zoom.ObjectNameToResponseField[common.ModuleID(providers.ModuleZoomUser)],
+		),
 	)
 
 	goutils.MustBeNil(err)

--- a/test/atlassian/connector.go
+++ b/test/atlassian/connector.go
@@ -21,7 +21,7 @@ func GetAtlassianConnector(ctx context.Context) *atlassian.Connector {
 	conn, err := atlassian.NewConnector(
 		atlassian.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
 		atlassian.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		atlassian.WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
+		atlassian.WithModule(providers.ModuleAtlassianJira),
 		atlassian.WithMetadata(map[string]string{
 			// This value can be obtained by following this API reference.
 			// https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/#3-1-get-the-cloudid-for-your-site
@@ -53,7 +53,7 @@ func GetAtlassianConnectConnector(ctx context.Context, claims map[string]any) *a
 	conn, err := atlassian.NewConnector(
 		atlassian.WithAuthenticatedClient(client),
 		atlassian.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		atlassian.WithModule(common.ModuleID(providers.ModuleAtlassianJiraConnect)),
+		atlassian.WithModule(providers.ModuleAtlassianJiraConnect),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/atlassian/connector.go
+++ b/test/atlassian/connector.go
@@ -21,7 +21,7 @@ func GetAtlassianConnector(ctx context.Context) *atlassian.Connector {
 	conn, err := atlassian.NewConnector(
 		atlassian.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
 		atlassian.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		atlassian.WithModule(atlassian.ModuleJira),
+		atlassian.WithModule(common.ModuleID(providers.ModuleAtlassianJira)),
 		atlassian.WithMetadata(map[string]string{
 			// This value can be obtained by following this API reference.
 			// https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/#3-1-get-the-cloudid-for-your-site
@@ -53,7 +53,7 @@ func GetAtlassianConnectConnector(ctx context.Context, claims map[string]any) *a
 	conn, err := atlassian.NewConnector(
 		atlassian.WithAuthenticatedClient(client),
 		atlassian.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		atlassian.WithModule(atlassian.ModuleAtlassianJiraConnect),
+		atlassian.WithModule(common.ModuleID(providers.ModuleAtlassianJiraConnect)),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/hubspot/connector.go
+++ b/test/hubspot/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/hubspot"
@@ -17,7 +18,7 @@ func GetHubspotConnector(ctx context.Context) *hubspot.Connector {
 
 	conn, err := hubspot.NewConnector(
 		hubspot.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
-		hubspot.WithModule(hubspot.ModuleCRM))
+		hubspot.WithModule(common.ModuleID(providers.ModuleHubspotCRM)))
 	if err != nil {
 		utils.Fail("error creating hubspot connector", "error", err)
 	}

--- a/test/hubspot/connector.go
+++ b/test/hubspot/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/hubspot"
@@ -18,7 +17,7 @@ func GetHubspotConnector(ctx context.Context) *hubspot.Connector {
 
 	conn, err := hubspot.NewConnector(
 		hubspot.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
-		hubspot.WithModule(common.ModuleID(providers.ModuleHubspotCRM)))
+		hubspot.WithModule(providers.ModuleHubspotCRM))
 	if err != nil {
 		utils.Fail("error creating hubspot connector", "error", err)
 	}

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/marketo"
@@ -18,7 +19,7 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	conn, err := marketo.NewConnector(
 		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		marketo.WithModule(marketo.ModuleAssets),
+		marketo.WithModule(common.ModuleID(providers.ModuleMarketoAssets)),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)
@@ -33,7 +34,7 @@ func GetMarketoConnectorLeads(ctx context.Context) *marketo.Connector {
 	conn, err := marketo.NewConnector(
 		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		marketo.WithModule(marketo.ModuleLeads),
+		marketo.WithModule(common.ModuleID(providers.ModuleMarketoLeads)),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/marketo"
@@ -19,7 +18,7 @@ func GetMarketoConnector(ctx context.Context) *marketo.Connector {
 	conn, err := marketo.NewConnector(
 		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		marketo.WithModule(common.ModuleID(providers.ModuleMarketoAssets)),
+		marketo.WithModule(providers.ModuleMarketoAssets),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)
@@ -34,7 +33,7 @@ func GetMarketoConnectorLeads(ctx context.Context) *marketo.Connector {
 	conn, err := marketo.NewConnector(
 		marketo.WithClient(ctx, http.DefaultClient, getConfig(reader)),
 		marketo.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		marketo.WithModule(common.ModuleID(providers.ModuleMarketoLeads)),
+		marketo.WithModule(providers.ModuleMarketoLeads),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/zendesksupport/connector.go
+++ b/test/zendesksupport/connector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport"
@@ -19,7 +20,7 @@ func GetZendeskSupportConnector(ctx context.Context) *zendesksupport.Connector {
 	conn, err := zendesksupport.NewConnector(
 		zendesksupport.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
 		zendesksupport.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		zendesksupport.WithModule(zendesksupport.ModuleTicketing),
+		zendesksupport.WithModule(common.ModuleID(providers.ModuleZendeskTicketing)),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/zendesksupport/connector.go
+++ b/test/zendesksupport/connector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zendesksupport"
@@ -20,7 +19,7 @@ func GetZendeskSupportConnector(ctx context.Context) *zendesksupport.Connector {
 	conn, err := zendesksupport.NewConnector(
 		zendesksupport.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
 		zendesksupport.WithWorkspace(reader.Get(credscanning.Fields.Workspace)),
-		zendesksupport.WithModule(common.ModuleID(providers.ModuleZendeskTicketing)),
+		zendesksupport.WithModule(providers.ModuleZendeskTicketing),
 	)
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/zoom/metadata/metadata.go
+++ b/test/zoom/metadata/metadata.go
@@ -7,7 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/providers/zoom"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils"
 	connTest "github.com/amp-labs/connectors/test/zoom"
 )
@@ -19,7 +20,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, zoom.ModuleUser)
+	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
 	defer utils.Close(conn)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "groups"})

--- a/test/zoom/metadata/metadata.go
+++ b/test/zoom/metadata/metadata.go
@@ -7,7 +7,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils"
 	connTest "github.com/amp-labs/connectors/test/zoom"
@@ -20,7 +19,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
+	conn := connTest.GetZoomConnector(ctx, providers.ModuleZoomUser)
 	defer utils.Close(conn)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "groups"})

--- a/test/zoom/read/main.go
+++ b/test/zoom/read/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/providers/zoom"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils"
 	connTest "github.com/amp-labs/connectors/test/zoom"
 )
@@ -22,7 +22,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, zoom.ModuleUser)
+	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/zoom/read/main.go
+++ b/test/zoom/read/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
+	conn := connTest.GetZoomConnector(ctx, providers.ModuleZoomUser)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,

--- a/test/zoom/write/main.go
+++ b/test/zoom/write/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/zoom"
 	"github.com/amp-labs/connectors/test/utils"
 	connTest "github.com/amp-labs/connectors/test/zoom"
@@ -37,7 +38,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, zoom.ModuleUser)
+	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
 
 	slog.Info("> TEST Create User")
 	slog.Info("Creating a user...")

--- a/test/zoom/write/main.go
+++ b/test/zoom/write/main.go
@@ -38,7 +38,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetZoomConnector(ctx, common.ModuleID(providers.ModuleZoomUser))
+	conn := connTest.GetZoomConnector(ctx, providers.ModuleZoomUser)
 
 	slog.Info("> TEST Create User")
 	slog.Info("Creating a user...")


### PR DESCRIPTION
# Server

Old references to specific module IDs are preserved for backward compatability.
Once this is merged the server should use modules located at `providers` package.
Only then those references can be fully removed.