### PR TITLE
feat: Add a generic UnauthorizedHandler to HTTP client

### DIFF
--- a/examples/utils/api_key.go
+++ b/examples/utils/api_key.go
@@ -12,7 +12,12 @@ type ApiKeyOptions struct {
 	ApiKey string
 }
 
-func CreateApiKeyClient(ctx context.Context, info *providers.ProviderInfo, opts ApiKeyOptions) common.AuthenticatedHTTPClient {
+//nolint:ireturn
+func CreateApiKeyClient(
+	ctx context.Context,
+	info *providers.ProviderInfo,
+	opts ApiKeyOptions,
+) common.AuthenticatedHTTPClient {
 	// Create the authenticated HTTP client.
 	httpClient, err := info.NewClient(ctx, &providers.NewClientParams{
 		// If you set this to true, the client will log all requests and responses.
@@ -20,7 +25,11 @@ func CreateApiKeyClient(ctx context.Context, info *providers.ProviderInfo, opts 
 		Debug: *debug,
 		// If you have your own HTTP client, you can use it here.
 		Client: http.DefaultClient,
-		ApiKey: opts.ApiKey,
+
+		// ApiKeyCreds represents the API key authentication credentials.
+		ApiKeyCreds: &providers.ApiKeyParams{
+			Key: opts.ApiKey,
+		},
 	})
 	if err != nil {
 		panic(err)

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -171,6 +171,13 @@ func (i *ProviderInfo) GetOption(key string) (string, bool) {
 // The handler can be used to refresh the token or to perform other actions. The client is
 // included so you can make additional requests if needed, but be careful not to create an
 // infinite loop (hint, use the request's context to attach a counter to avoid this possibility).
+//
+// The proper semantics of this function can be read as: "I received an unauthorized response,
+// and I want to do something about it, and then I want to return a modified response to the
+// original caller."
+//
+// The most common planned use case is to refresh the token and then retry the request and return
+// the non-401 response to the original caller.
 type UnauthorizedHandler func(client common.AuthenticatedHTTPClient, event *UnauthorizedEvent) (*http.Response, error)
 
 // UnauthorizedEvent is the event that is triggered when an unauthorized response (http 401) is received.

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -169,7 +169,7 @@ func (i *ProviderInfo) GetOption(key string) (string, bool) {
 
 // UnauthorizedHandler is a function that is called when an unauthorized response is received.
 // The handler can be used to refresh the token or to perform other actions. The client is
-// included so you can make additionaadditionall requests if needed, but be careful not to create an
+// included so you can make additional requests if needed, but be careful not to create an
 // infinite loop (hint, use the request's context to attach a counter to avoid this possibility).
 type UnauthorizedHandler func(client common.AuthenticatedHTTPClient, event *UnauthorizedEvent) (*http.Response, error)
 

--- a/scripts/utils/proxyserv/oauthApiKey.go
+++ b/scripts/utils/proxyserv/oauthApiKey.go
@@ -26,8 +26,10 @@ func setupAPIKeyHTTPClient(
 	ctx context.Context, prov *providers.ProviderInfo, apiKey string, debug bool,
 ) common.AuthenticatedHTTPClient {
 	client, err := prov.NewClient(ctx, &providers.NewClientParams{
-		Debug:  debug,
-		ApiKey: apiKey,
+		Debug: debug,
+		ApiKeyCreds: &providers.ApiKeyParams{
+			Key: apiKey,
+		},
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
We have a provider (Asana) which penalizes us when we refresh the token too early (well, penalizes is a strong word, it just doesn't follow typical refresh logic rules). As a result we need to refresh those tokens reactively (wait for a 401) rather than proactively (wait for some timestamp). This PR lets us do the plumbing to support this, by adding a generic Unauthorized handler.