### PR TITLE
convert conn-specific param to common.Parameters

### DIFF
--- a/internal/components/provider.go
+++ b/internal/components/provider.go
@@ -1,6 +1,8 @@
 package components
 
 import (
+	"fmt"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
@@ -35,13 +37,18 @@ func NewProviderContext(
 	}
 
 	pctx.providerInfo = providerInfo
+
+	if len(module) == 0 {
+		module = common.ModuleRoot
+	}
+
 	pctx.module = module
 
 	return pctx, nil
 }
 
 func (p *ProviderContext) String() string {
-	return p.provider + ".Connector"
+	return fmt.Sprintf("%v.Connector[%v]", p.provider, p.module)
 }
 
 func (p *ProviderContext) Provider() providers.Provider {

--- a/providers/apollo/params.go
+++ b/providers/apollo/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/asana/params.go
+++ b/providers/asana/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 const (
 	DefaultPageSize = 100
 )

--- a/providers/atlassian/params.go
+++ b/providers/atlassian/params.go
@@ -21,6 +21,22 @@ type parameters struct {
 	paramsbuilder.Metadata
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(common.ModuleRoot), // The module is resolved on behalf of the user if the option is missing.
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+		Metadata:            oldParams.Metadata.Map,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/attio/params.go
+++ b/providers/attio/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 const (
 	// DefaultPageSize is number of elements per page.
 	// The Page size for standard/custom objects, tasks.

--- a/providers/chilipiper/params.go
+++ b/providers/chilipiper/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/closecrm/params.go
+++ b/providers/closecrm/params.go
@@ -18,6 +18,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(p.Client.ValidateParams())
 }

--- a/providers/constantcontact/params.go
+++ b/providers/constantcontact/params.go
@@ -20,6 +20,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/customerapp/params.go
+++ b/providers/customerapp/params.go
@@ -20,6 +20,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/docusign/params.go
+++ b/providers/docusign/params.go
@@ -17,6 +17,18 @@ type parameters struct {
 	paramsbuilder.Metadata
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Metadata:            oldParams.Metadata.Map,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/dynamicscrm/params.go
+++ b/providers/dynamicscrm/params.go
@@ -24,6 +24,18 @@ type parameters struct {
 	paramsbuilder.Workspace
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/freshdesk/params.go
+++ b/providers/freshdesk/params.go
@@ -16,6 +16,18 @@ type parameters struct {
 	paramsbuilder.Workspace
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -19,6 +19,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/hubspot/params.go
+++ b/providers/hubspot/params.go
@@ -25,6 +25,20 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(common.ModuleRoot),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/instantly/params.go
+++ b/providers/instantly/params.go
@@ -23,6 +23,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/intercom/params.go
+++ b/providers/intercom/params.go
@@ -21,6 +21,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/iterable/params.go
+++ b/providers/iterable/params.go
@@ -20,6 +20,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/keap/params.go
+++ b/providers/keap/params.go
@@ -22,6 +22,20 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ModuleKeapV1),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/kit/params.go
+++ b/providers/kit/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 const (
 	// DefaultPageSize is number of elements per page.
 	DefaultPageSize = 500

--- a/providers/klaviyo/params.go
+++ b/providers/klaviyo/params.go
@@ -19,6 +19,20 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ModuleKlaviyo2024Oct15),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/marketo/params.go
+++ b/providers/marketo/params.go
@@ -19,6 +19,21 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ModuleMarketoLeads),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/outreach/params.go
+++ b/providers/outreach/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/pipedrive/params.go
+++ b/providers/pipedrive/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/pipeliner/params.go
+++ b/providers/pipeliner/params.go
@@ -23,6 +23,18 @@ type parameters struct {
 	paramsbuilder.Workspace
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/salesforce/params.go
+++ b/providers/salesforce/params.go
@@ -19,6 +19,18 @@ type parameters struct {
 	paramsbuilder.Workspace
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/salesloft/params.go
+++ b/providers/salesloft/params.go
@@ -23,6 +23,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/smartlead/params.go
+++ b/providers/smartlead/params.go
@@ -18,6 +18,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/stripe/params.go
+++ b/providers/stripe/params.go
@@ -23,6 +23,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/zendesksupport/params.go
+++ b/providers/zendesksupport/params.go
@@ -21,6 +21,21 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ModuleZendeskTicketing),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+		Workspace:           oldParams.Workspace.Name,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/zohocrm/params.go
+++ b/providers/zohocrm/params.go
@@ -16,6 +16,17 @@ type parameters struct {
 	paramsbuilder.Client
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 func (p parameters) ValidateParams() error {
 	return errors.Join(
 		p.Client.ValidateParams(),

--- a/providers/zoom/params.go
+++ b/providers/zoom/params.go
@@ -18,6 +18,20 @@ type parameters struct {
 	paramsbuilder.Module
 }
 
+func newParams(opts []Option) (*common.Parameters, error) { // nolint:unused
+	oldParams, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ModuleZoomMeeting),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Parameters{
+		Module:              oldParams.Module.Selection.ID,
+		AuthenticatedClient: oldParams.Client.Caller.Client,
+	}, nil
+}
+
 const (
 	DefaultPageSize = 300
 )


### PR DESCRIPTION
# Motiviation
Instead of saving module information directly on the **specific** connector struct we should use base connector which holds this information by naturally implying this from the catalog.

This requires using new parameters. The switch is very simple and will NOT effect the server.

The goal of this PR is to allow 2 kinds of connector constructors:
* with old paramters
* using new parameters


# Follow up
After the server moves to the new connector constructors they can be cleaned up:
1. Remove WithParameters code from every connector.
2. Make each connector constructor V1 point to V2.
3. Go to server and rename NewConnectorV2() into NewConnector
4. Make final cleanup in `connectors`.
Result `NewConnector()` method would use `common.Parameters`.