### PR TITLE
[CON-1572] feat(clickup): enable read support

### DIFF
--- a/providers/clickup.go
+++ b/providers/clickup.go
@@ -23,7 +23,7 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
 			Write:     false,
 		},


### PR DESCRIPTION
>  There is only one object that supports the read operation.


# Installation
<img width="956" alt="image" src="https://github.com/user-attachments/assets/81ecc072-b361-44c1-9531-699a99d02917" />






# Read
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/6031b621-dd47-438c-9e66-5a05331e9a00" />



# Destination webhook object response
<img width="1797" alt="image" src="https://github.com/user-attachments/assets/ea2cc193-d5b8-41a2-b455-6ce7f2ffd5e5" />






# Write
> There are no objects for writing operations. 

