### PR TITLE
Salesforce - add RecordId for updates

### DIFF
--- a/providers/salesforce/write.go
+++ b/providers/salesforce/write.go
@@ -30,7 +30,16 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	return parseWriteResult(rsp)
+	rslt, err := parseWriteResult(rsp)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.RecordId != "" && rslt.Success && rslt.RecordId == "" {
+		rslt.RecordId = config.RecordId
+	}
+
+	return rslt, nil
 }
 
 // parseWriteResult parses the response from writing to Salesforce API. A 2xx return type is assumed.

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -66,12 +66,12 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 					mockcond.MethodPOST(),
 					mockcond.QueryParam("_HttpMethod", "PATCH"),
 				},
-				Then: mockserver.Response(http.StatusOK, responseCreateOK),
+				Then: mockserver.Response(http.StatusOK, nil), // real salesforce returns an empty body
 			}.Server(),
 			Expected: &common.WriteResult{
 				Success:  true,
-				RecordId: "001ak00000OQTieAAH",
-				Errors:   []any{},
+				RecordId: "003ak000004dQCUAA2",
+				Errors:   nil,
 				Data:     nil,
 			},
 			ExpectedErrs: nil,


### PR DESCRIPTION
In Salesforce, creates return a recordId, however updates don't. This is due to how their API is written, which returns an empty body as a response for updates. This is confusing for some customers who rely on this field. This change will include the record id in all update responses.