### PR TITLE
feat(test): Soft equals NextPage URLs

### DIFF
--- a/common/urlbuilder/url_test.go
+++ b/common/urlbuilder/url_test.go
@@ -254,3 +254,113 @@ func TestFromRawURL(t *testing.T) { // nolint:funlen
 		})
 	}
 }
+
+func TestEquality(t *testing.T) { // nolint:funlen
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		a     string
+		b     string
+		equal bool
+	}{
+		{
+			name:  "Query params in different order",
+			a:     "https://example.com/path?a=1&b=2",
+			b:     "https://example.com/path?b=2&a=1",
+			equal: true,
+		},
+		{
+			name:  "Repeated query params, same values different order",
+			a:     "https://example.com/path?a=1&a=2",
+			b:     "https://example.com/path?a=2&a=1",
+			equal: true,
+		},
+		{
+			name:  "Encoded vs unencoded space in query",
+			a:     "https://example.com/path?q=hello+world",
+			b:     "https://example.com/path?q=hello%20world",
+			equal: true,
+		},
+		{
+			name:  "Empty query vs missing query",
+			a:     "https://example.com/path?",
+			b:     "https://example.com/path",
+			equal: true,
+		},
+		{
+			name:  "Mixed order and encoding",
+			a:     "https://example.com/path?x=1&y=a%2Fb",
+			b:     "https://example.com/path?y=a%2Fb&x=1",
+			equal: true,
+		},
+		{
+			name:  "Case-insensitive host",
+			a:     "https://EXAMPLE.com/path?a=1",
+			b:     "https://example.com/path?a=1",
+			equal: true,
+		},
+		{
+			name:  "No query vs query with just question mark",
+			a:     "https://example.com/path",
+			b:     "https://example.com/path?",
+			equal: true,
+		},
+		{
+			name:  "Same key repeated multiple times in different order",
+			a:     "https://example.com/path?x=1&x=2",
+			b:     "https://example.com/path?x=2&x=1",
+			equal: true,
+		},
+		{
+			name:  "Same URL, different query param order, same fragment",
+			a:     "https://example.com/path?a=1&b=2#section1",
+			b:     "https://example.com/path?b=2&a=1#section1",
+			equal: true,
+		},
+		{
+			name:  "Symbol encoding",
+			a:     "https://example.com/reset?email=user@example.com",
+			b:     "https://example.com/reset?email=user%40example.com",
+			equal: true,
+		},
+		{
+			name:  "Different origin",
+			a:     "https://example.com",
+			b:     "https://canada.gov",
+			equal: false,
+		},
+		{
+			name:  "Different paths",
+			a:     "https://example.com/customers",
+			b:     "https://example.com/orders",
+			equal: false,
+		},
+		{
+			name:  "Different query param values",
+			a:     "https://example.com/orders?customer=Bob",
+			b:     "https://example.com/orders?customer=Alice",
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests { // nolint:varnamelen
+		// nolint:varnamelen
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			firstURL, err := New(tt.a)
+			if err != nil {
+				t.Fatalf("%s: is an invalid test, check urls", tt.name)
+			}
+
+			secondURL, err := New(tt.b)
+			if err != nil {
+				t.Fatalf("%s: is an invalid test, check urls", tt.name)
+			}
+
+			output := firstURL.Equals(secondURL)
+			testutils.CheckOutput(t, tt.name, tt.equal, output)
+		})
+	}
+}

--- a/internal/datautils/slice.go
+++ b/internal/datautils/slice.go
@@ -1,0 +1,21 @@
+package datautils
+
+func EqualUnordered[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	count := make(map[T]int)
+	for _, v := range a {
+		count[v]++
+	}
+
+	for _, v := range b {
+		count[v]--
+		if count[v] < 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 )
 
@@ -33,12 +34,40 @@ func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult)
 //	 }
 //
 // At runtime this may look as follows: http://127.0.0.1:38653/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=.
+// The query parameters in URL can be in different order, encoding could differ as soon as the URL content matches
+// the check will conclude that pagination matches.
 func ComparatorPagination(serverURL string, actual *common.ReadResult, expected *common.ReadResult) bool {
 	expectedNextPage := resolveTestServerURL(expected.NextPage.String(), serverURL)
 
-	return actual.NextPage.String() == expectedNextPage &&
+	return compareNextPageToken(actual.NextPage.String(), expectedNextPage) &&
 		actual.Rows == expected.Rows &&
 		actual.Done == expected.Done
+}
+
+func compareNextPageToken(actual, expected string) bool {
+	if len(actual) == 0 && len(expected) == 0 {
+		return true
+	}
+
+	if !strings.HasPrefix(actual, "http") {
+		// Next page token is not a URL, compare raw text.
+		return actual == expected
+	}
+
+	// We are dealing with URLs.
+	// Compare URLs ignoring the query parameter order or encoding.
+	// However, the "data content" must match.
+	actualURL, err := urlbuilder.New(actual)
+	if err != nil {
+		return false
+	}
+
+	expectedURL, err := urlbuilder.New(expected)
+	if err != nil {
+		return false
+	}
+
+	return actualURL.Equals(expectedURL)
 }
 
 // ComparatorSubsetWrite ensures that only the specified metadata objects are present,


### PR DESCRIPTION
# Problem
Strict string comparison of `NextPage` tokens in mock tests isn't reliable:
```
actual.NextPage.String() == expectedNextPage
```
Query parameters can appear in different orders, making equivalent URLs fail the comparison.

# Fix
Introduced a `compareNextPageToken` method used by all read test suites. It delegates to the `urlbuilder.URL` equality check.
Added test cases with semantically equivalent but differently ordered URLs to validate the implementation.