### PR TITLE
fix: redditAds: Init -> init

### DIFF
--- a/providers/redditAds.go
+++ b/providers/redditAds.go
@@ -2,7 +2,7 @@ package providers
 
 const RedditAds Provider = "redditAds"
 
-func Init() {
+func init() {
 	// RedditAds Configuration
 	SetInfo(RedditAds, ProviderInfo{
 		AuthType: Oauth2,


### PR DESCRIPTION
redditAds uses a function named `Init`, however go won't automatically invoke this, and also we don't really need to export this. I suspect this was a typo. This fixes that.