### PR TITLE
[CON-1642] feat: Add incremental read support for Marketo Leads API

### DIFF
--- a/providers/marketo/read.go
+++ b/providers/marketo/read.go
@@ -2,9 +2,21 @@ package marketo
 
 import (
 	"context"
+	"errors"
 
 	"github.com/amp-labs/connectors/common"
 )
+
+type readResponse struct {
+	Result        []leadActivity `json:"result"`
+	MoreResult    bool           `json:"moreResult"`
+	NextPageToken string         `json:"nextPageToken"`
+}
+
+type leadActivity struct {
+	LeadID int `json:"leadId"`
+	// Other fields
+}
 
 // Read retrieves data based on the provided common.ReadParams configuration parameters.
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
@@ -14,6 +26,14 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	url, err := c.constructReadURL(ctx, config)
 	if err != nil {
+		// If this is the case, we return an zero records response.
+		if errors.Is(err, ErrZeroRecords) {
+			return &common.ReadResult{
+				Data: []common.ReadResultRow{},
+				Done: true,
+			}, nil
+		}
+
 		return nil, err
 	}
 

--- a/providers/marketo/types.go
+++ b/providers/marketo/types.go
@@ -38,6 +38,9 @@ var (
 
 	// ErrFilterInvalid indicates missing activityTypeIds when reading Marketo lead activities.
 	ErrFilterInvalid = errors.New("reading lead activities require Filter parameter with comma-separated activityTypeIds")
+
+	// ErrZeroRecords indicates missing records for the provided timestamp range, using the Since Field.
+	ErrZeroRecords = errors.New("returned zero records for the provided timestamp range")
 )
 
 func constructErrMessage(a any) (string, error) {

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -36,6 +36,11 @@ func main() {
 		slog.Error(err.Error())
 	}
 
+	err = testIncrementalReadLeads(ctx)
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
 	err = testReadActivities(ctx)
 	if err != nil {
 		slog.Error(err.Error())
@@ -125,7 +130,32 @@ func testReadLeads(ctx context.Context) error {
 	params := common.ReadParams{
 		ObjectName: "leads",
 		Fields:     connectors.Fields("id", "email"),
-		// NextPage:   "301",
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testIncrementalReadLeads(ctx context.Context) error {
+	conn := mk.GetMarketoConnectorLeads(ctx)
+
+	params := common.ReadParams{
+		ObjectName: "leads",
+		Fields:     connectors.Fields("id", "email"),
+		Since:      time.Now().Add(-24 * time.Hour),
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
Tests:
<img width="1224" alt="Screenshot 2025-04-22 at 11 45 37" src="https://github.com/user-attachments/assets/c0ebd5b7-2003-4367-a363-4d418a375cb1" />
<img width="1020" alt="Screenshot 2025-04-22 at 11 46 53" src="https://github.com/user-attachments/assets/226fe7cd-2b39-44ef-95cc-52fbbfd2ef79" />

Added some comment on the task [here](https://linear.app/ampersand/issue/CON-1642/support-incremental-read-for-leads#comment-c2532a5d)

Closes CON-1641 as well.