### PR TITLE
[CON-1666] feat(insightly): Custom objects & fields

### DIFF
--- a/providers/insightly/custom.go
+++ b/providers/insightly/custom.go
@@ -1,0 +1,75 @@
+package insightly
+
+import (
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// Any object returned from READ operation may have a CUSTOMFIELDS array property.
+// This struct is it's schema representation.
+// nolint:tagliatelle
+type readCustomField struct {
+	Name  string `json:"FIELD_NAME"`
+	Value any    `json:"FIELD_VALUE"`
+}
+
+/*
+Provider object response:
+
+	  {
+		"RECORD_ID": 54840682,
+		"RECORD_NAME": "Banana",
+		"CUSTOMFIELDS": [
+		  {
+			"FIELD_NAME": "Color__c",
+			"FIELD_VALUE": null,
+			"CUSTOM_FIELD_ID": "Color__c"
+		  },
+		  {
+			"FIELD_NAME": "Weight__c",
+			"FIELD_VALUE": 3.2,
+			"CUSTOM_FIELD_ID": "Weight__c"
+		  }
+		]
+	  }
+
+Read fields:
+
+	  {
+		"RECORD_ID": 54840682,
+		"RECORD_NAME": "Banana",
+		"Color__c": null,
+		"Weight__c": 3.2
+		"CUSTOMFIELDS": [...]
+	  }
+*/
+func flattenCustomFields(node *ajson.Node) (map[string]any, error) {
+	root, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	customFieldsArray, err := jsonquery.New(node).ArrayOptional("CUSTOMFIELDS")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(customFieldsArray) == 0 {
+		// Nothing to move.
+		return root, nil
+	}
+
+	// Custom fields are converted from the object representing the property to
+	// key:value pair and moved to the top node level.
+	for _, customFieldObject := range customFieldsArray {
+		field, err := jsonquery.ParseNode[readCustomField](customFieldObject)
+		if err != nil {
+			return nil, err
+		}
+
+		root[field.Name] = field.Value
+	}
+
+	// Root level has adopted fields from custom fields.
+	return root, nil
+}

--- a/providers/insightly/test/read/contacts/list.json
+++ b/providers/insightly/test/read/contacts/list.json
@@ -1,0 +1,68 @@
+[
+  {
+    "CONTACT_ID": 366638973,
+    "SALUTATION": "Ms",
+    "FIRST_NAME": "Pamela",
+    "LAST_NAME": "Huber",
+    "IMAGE_URL": null,
+    "BACKGROUND": null,
+    "VISIBLE_TO": "EVERYONE",
+    "OWNER_USER_ID": 2240727,
+    "VISIBLE_TEAM_ID": null,
+    "DATE_CREATED_UTC": "2025-04-19 00:49:32",
+    "DATE_UPDATED_UTC": "2025-04-22 20:03:25",
+    "SOCIAL_LINKEDIN": null,
+    "SOCIAL_FACEBOOK": null,
+    "SOCIAL_TWITTER": null,
+    "DATE_OF_BIRTH": null,
+    "PHONE": null,
+    "PHONE_HOME": null,
+    "PHONE_MOBILE": null,
+    "PHONE_OTHER": null,
+    "PHONE_ASSISTANT": null,
+    "PHONE_FAX": null,
+    "EMAIL_ADDRESS": "pamela@mail.com",
+    "ASSISTANT_NAME": null,
+    "ADDRESS_MAIL_STREET": null,
+    "ADDRESS_MAIL_CITY": null,
+    "ADDRESS_MAIL_STATE": null,
+    "ADDRESS_MAIL_POSTCODE": null,
+    "ADDRESS_MAIL_COUNTRY": null,
+    "ADDRESS_OTHER_STREET": null,
+    "ADDRESS_OTHER_CITY": null,
+    "ADDRESS_OTHER_STATE": null,
+    "ADDRESS_OTHER_POSTCODE": null,
+    "ADDRESS_OTHER_COUNTRY": null,
+    "LAST_ACTIVITY_DATE_UTC": null,
+    "NEXT_ACTIVITY_DATE_UTC": null,
+    "CREATED_USER_ID": 2240727,
+    "ORGANISATION_ID": null,
+    "TITLE": null,
+    "EMAIL_OPTED_OUT": false,
+    "CUSTOMFIELDS": [
+      {
+        "FIELD_NAME": "Hobby__c",
+        "FIELD_VALUE": "Skiing",
+        "CUSTOM_FIELD_ID": "Hobby__c"
+      },
+      {
+        "FIELD_NAME": "Interests__c",
+        "FIELD_VALUE": "Music;Sports;Travel",
+        "CUSTOM_FIELD_ID": "Interests__c"
+      },
+      {
+        "FIELD_NAME": "Newsletter_Subscription__c",
+        "FIELD_VALUE": true,
+        "CUSTOM_FIELD_ID": "Newsletter_Subscription__c"
+      },
+      {
+        "FIELD_NAME": "Preferred_Contact_Method__c",
+        "FIELD_VALUE": "SMS",
+        "CUSTOM_FIELD_ID": "Preferred_Contact_Method__c"
+      }
+    ],
+    "TAGS": [],
+    "DATES": [],
+    "LINKS": []
+  }
+]

--- a/providers/insightly/test/read/fruits-custom-object/list.json
+++ b/providers/insightly/test/read/fruits-custom-object/list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "RECORD_ID": 54840676,
+    "RECORD_NAME": "Apple",
+    "OWNER_USER_ID": 2240727,
+    "DATE_CREATED_UTC": "2025-04-22 19:29:43",
+    "DATE_UPDATED_UTC": "2025-04-22 19:34:12",
+    "CREATED_USER_ID": 2240727,
+    "VISIBLE_TO": "EVERYONE",
+    "VISIBLE_TEAM_ID": null,
+    "CUSTOMFIELDS": [
+      {
+        "FIELD_NAME": "Color__c",
+        "FIELD_VALUE": "Green",
+        "CUSTOM_FIELD_ID": "Color__c"
+      },
+      {
+        "FIELD_NAME": "Weight__c",
+        "FIELD_VALUE": 12,
+        "CUSTOM_FIELD_ID": "Weight__c"
+      }
+    ]
+  },
+  {
+    "RECORD_ID": 54840682,
+    "RECORD_NAME": "Banana",
+    "OWNER_USER_ID": 2240727,
+    "DATE_CREATED_UTC": "2025-04-22 19:29:52",
+    "DATE_UPDATED_UTC": "2025-04-22 19:29:52",
+    "CREATED_USER_ID": 2240727,
+    "VISIBLE_TO": "EVERYONE",
+    "VISIBLE_TEAM_ID": null,
+    "CUSTOMFIELDS": [
+      {
+        "FIELD_NAME": "Color__c",
+        "FIELD_VALUE": null,
+        "CUSTOM_FIELD_ID": "Color__c"
+      },
+      {
+        "FIELD_NAME": "Weight__c",
+        "FIELD_VALUE": 3.2,
+        "CUSTOM_FIELD_ID": "Weight__c"
+      }
+    ]
+  }
+]

--- a/providers/insightly/url.go
+++ b/providers/insightly/url.go
@@ -12,7 +12,9 @@ const apiVersion = "v3.1"
 func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
 	path, err := metadata.Schemas.LookupURLPath(common.ModuleRoot, objectName)
 	if err != nil {
-		return nil, err
+		// It is possible that an object is custom.
+		// Custom objects support Search which allows incremental reading.
+		path = objectName + "/Search"
 	}
 
 	return urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, path)

--- a/test/insightly/read/customObject/main.go
+++ b/test/insightly/read/customObject/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils"
 )
 
-const objectName = "Contacts"
+const objectName = "Fruit__c"
 
 func main() {
 	// Handle Ctrl-C gracefully.
@@ -27,7 +27,7 @@ func main() {
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,
-		Fields:     connectors.Fields("EMAIL_ADDRESS", "CONTACT_ID", "Hobby__c", "Interests__c"),
+		Fields:     connectors.Fields("RECORD_ID", "RECORD_NAME", "Color__c"),
 	})
 	if err != nil {
 		utils.Fail("error reading from provider", "error", err)

--- a/test/utils/mockutils/mockserver/switch.go
+++ b/test/utils/mockutils/mockserver/switch.go
@@ -57,6 +57,8 @@ type Case struct {
 	Then http.HandlerFunc
 }
 
+type Cases []Case
+
 func (p *Case) isOpen(w http.ResponseWriter, r *http.Request) bool {
 	if p.If == nil {
 		return false


### PR DESCRIPTION
# Description
Custom fields on custom object or core object can be requested during the connector read operation.

The fields are flattened and moved to the fields. The raw response is not modified. But custom field querying is treated as equal to the core fields.

# Tests
## Contacts
![image](https://github.com/user-attachments/assets/eba8b1d0-82a6-4bb9-bb2a-3c81fcb15149)

## Fruits the Custom Object
![image](https://github.com/user-attachments/assets/4d3c3512-31c5-458f-b4ad-eeaa1740e8ff)
