### PR TITLE
chore: Make the mock connector implement all interfaces

### DIFF
--- a/mock/connector.go
+++ b/mock/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 	params *parameters
 }
 
-// We want mock connector to implement all connector interfaces
+// We want the mock connector to implement all connector interfaces.
 type implementsAllConnector interface {
 	connectors.Connector
 	connectors.URLConnector
@@ -30,11 +30,9 @@ type implementsAllConnector interface {
 	connectors.SubscribeConnector
 }
 
-var (
-	_ implementsAllConnector = (*Connector)(nil)
-)
+var _ implementsAllConnector = (*Connector)(nil)
 
-func NewConnector(opts ...Option) (conn *Connector, outErr error) {
+func NewConnector(opts ...Option) (conn *Connector, outErr error) { //nolint:funlen
 	params, err := paramsbuilder.Apply(parameters{}, opts,
 		WithClient(http.DefaultClient),
 		WithRead(func(context.Context, common.ReadParams) (*common.ReadResult, error) {
@@ -55,13 +53,22 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		WithGetPostAuthInfo(func(ctx context.Context) (*common.PostAuthInfo, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "getPostAuthInfo")
 		}),
-		WithGetRecordsByIds(func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error) {
+		WithGetRecordsByIds(func(
+			ctx context.Context,
+			objectName string,
+			recordIds []string,
+			fields []string,
+			associations []string,
+		) ([]common.ReadResultRow, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "getRecordsByIds")
 		}),
 		WithVerifyWebhookMessage(func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error) {
 			return false, fmt.Errorf("%w: %s", ErrNotImplemented, "verifyWebhookMessage")
 		}),
-		WithRegister(func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error) {
+		WithRegister(func(
+			ctx context.Context,
+			params common.SubscriptionRegistrationParams,
+		) (*common.RegistrationResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "register")
 		}),
 		WithDeleteRegistration(func(ctx context.Context, previousResult common.RegistrationResult) error {
@@ -80,7 +87,11 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		WithSubscribe(func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "subscribe")
 		}),
-		WithUpdateSubscription(func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error) {
+		WithUpdateSubscription(func(
+			ctx context.Context,
+			params common.SubscribeParams,
+			previousResult *common.SubscriptionResult,
+		) (*common.SubscriptionResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "updateSubscription")
 		}),
 		WithDeleteSubscription(func(ctx context.Context, previousResult common.SubscriptionResult) error {
@@ -166,15 +177,27 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 	return c.params.getPostAuthInfo(ctx)
 }
 
-func (c *Connector) GetRecordsByIds(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error) {
+func (c *Connector) GetRecordsByIds(
+	ctx context.Context,
+	objectName string,
+	recordIds []string,
+	fields []string,
+	associations []string,
+) ([]common.ReadResultRow, error) {
 	return c.params.getRecordsByIds(ctx, objectName, recordIds, fields, associations)
 }
 
-func (c *Connector) VerifyWebhookMessage(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error) {
+func (c *Connector) VerifyWebhookMessage(
+	ctx context.Context,
+	params *common.WebhookVerificationParameters,
+) (bool, error) {
 	return c.params.verifyWebhookMessage(ctx, params)
 }
 
-func (c *Connector) Register(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error) {
+func (c *Connector) Register(
+	ctx context.Context,
+	params common.SubscriptionRegistrationParams,
+) (*common.RegistrationResult, error) {
 	return c.params.register(ctx, params)
 }
 

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -13,25 +13,7 @@ import (
 
 type Connector struct {
 	client *common.JSONHTTPClient
-
-	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
-	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
-	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
-	getURL             func(resource string, args map[string]any) (string, error)
-	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
-	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
-	getRecordsByIds    func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
-
-	verifyWebhookMessage    func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
-	register                func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error)
-	deleteRegistration      func(ctx context.Context, previousResult common.RegistrationResult) error
-	emptyRegistrationParams func() *common.SubscriptionRegistrationParams
-	emptyRegistrationResult func() *common.RegistrationResult
-	subscribe               func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error)
-	updateSubscription      func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error)
-	deleteSubscription      func(ctx context.Context, previousResult common.SubscriptionResult) error
-	emptySubscriptionParams func() *common.SubscribeParams
-	emptySubscriptionResult func() *common.SubscriptionResult
+	params *parameters
 }
 
 // We want mock connector to implement all connector interfaces
@@ -120,10 +102,8 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	}
 
 	return &Connector{
-		client:             params.client,
-		read:               params.read,
-		write:              params.write,
-		listObjectMetadata: params.listObjectMetadata,
+		client: params.client,
+		params: params,
 	}, nil
 }
 
@@ -148,7 +128,7 @@ func (c *Connector) Read(ctx context.Context, params common.ReadParams) (*common
 		return nil, err
 	}
 
-	return c.read(ctx, params)
+	return c.params.read(ctx, params)
 }
 
 func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
@@ -156,7 +136,7 @@ func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*comm
 		return nil, err
 	}
 
-	return c.write(ctx, params)
+	return c.params.write(ctx, params)
 }
 
 func (c *Connector) ListObjectMetadata(
@@ -167,11 +147,11 @@ func (c *Connector) ListObjectMetadata(
 		return nil, common.ErrMissingObjects
 	}
 
-	return c.listObjectMetadata(ctx, objectNames)
+	return c.params.listObjectMetadata(ctx, objectNames)
 }
 
 func (c *Connector) GetURL(resource string, args map[string]any) (string, error) {
-	return c.getURL(resource, args)
+	return c.params.getURL(resource, args)
 }
 
 func (c *Connector) Delete(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error) {
@@ -179,53 +159,53 @@ func (c *Connector) Delete(ctx context.Context, params connectors.DeleteParams) 
 		return nil, err
 	}
 
-	return c.delete(ctx, params)
+	return c.params.delete(ctx, params)
 }
 
 func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
-	return c.getPostAuthInfo(ctx)
+	return c.params.getPostAuthInfo(ctx)
 }
 
 func (c *Connector) GetRecordsByIds(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error) {
-	return c.getRecordsByIds(ctx, objectName, recordIds, fields, associations)
+	return c.params.getRecordsByIds(ctx, objectName, recordIds, fields, associations)
 }
 
 func (c *Connector) VerifyWebhookMessage(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error) {
-	return c.verifyWebhookMessage(ctx, params)
+	return c.params.verifyWebhookMessage(ctx, params)
 }
 
 func (c *Connector) Register(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error) {
-	return c.register(ctx, params)
+	return c.params.register(ctx, params)
 }
 
 func (c *Connector) DeleteRegistration(ctx context.Context, previousResult common.RegistrationResult) error {
-	return c.deleteRegistration(ctx, previousResult)
+	return c.params.deleteRegistration(ctx, previousResult)
 }
 
 func (c *Connector) EmptyRegistrationParams() *common.SubscriptionRegistrationParams {
-	return c.emptyRegistrationParams()
+	return c.params.emptyRegistrationParams()
 }
 
 func (c *Connector) EmptyRegistrationResult() *common.RegistrationResult {
-	return c.emptyRegistrationResult()
+	return c.params.emptyRegistrationResult()
 }
 
 func (c *Connector) Subscribe(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error) {
-	return c.subscribe(ctx, params)
+	return c.params.subscribe(ctx, params)
 }
 
 func (c *Connector) UpdateSubscription(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error) {
-	return c.updateSubscription(ctx, params, previousResult)
+	return c.params.updateSubscription(ctx, params, previousResult)
 }
 
 func (c *Connector) DeleteSubscription(ctx context.Context, previousResult common.SubscriptionResult) error {
-	return c.deleteSubscription(ctx, previousResult)
+	return c.params.deleteSubscription(ctx, previousResult)
 }
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
-	return c.emptySubscriptionParams()
+	return c.params.emptySubscriptionParams()
 }
 
 func (c *Connector) EmptySubscriptionResult() *common.SubscriptionResult {
-	return c.emptySubscriptionResult()
+	return c.params.emptySubscriptionResult()
 }

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -177,10 +177,10 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 	return c.params.getPostAuthInfo(ctx)
 }
 
-func (c *Connector) GetRecordsByIds(
+func (c *Connector) GetRecordsByIds( //nolint:revive
 	ctx context.Context,
 	objectName string,
-	recordIds []string,
+	recordIds []string, //nolint:revive
 	fields []string,
 	associations []string,
 ) ([]common.ReadResultRow, error) {
@@ -217,7 +217,11 @@ func (c *Connector) Subscribe(ctx context.Context, params common.SubscribeParams
 	return c.params.subscribe(ctx, params)
 }
 
-func (c *Connector) UpdateSubscription(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error) {
+func (c *Connector) UpdateSubscription(
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
 	return c.params.updateSubscription(ctx, params, previousResult)
 }
 

--- a/mock/connector.go
+++ b/mock/connector.go
@@ -3,7 +3,9 @@ package mock
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/providers"
@@ -15,10 +17,44 @@ type Connector struct {
 	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
 	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
 	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
+	getURL             func(resource string, args map[string]any) (string, error)
+	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
+	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
+	getRecordsByIds    func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
+
+	verifyWebhookMessage    func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
+	register                func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error)
+	deleteRegistration      func(ctx context.Context, previousResult common.RegistrationResult) error
+	emptyRegistrationParams func() *common.SubscriptionRegistrationParams
+	emptyRegistrationResult func() *common.RegistrationResult
+	subscribe               func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error)
+	updateSubscription      func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error)
+	deleteSubscription      func(ctx context.Context, previousResult common.SubscriptionResult) error
+	emptySubscriptionParams func() *common.SubscribeParams
+	emptySubscriptionResult func() *common.SubscriptionResult
 }
+
+// We want mock connector to implement all connector interfaces
+type implementsAllConnector interface {
+	connectors.Connector
+	connectors.URLConnector
+	connectors.ReadConnector
+	connectors.WriteConnector
+	connectors.DeleteConnector
+	connectors.ObjectMetadataConnector
+	connectors.AuthMetadataConnector
+	connectors.BatchRecordReaderConnector
+	connectors.WebhookVerifierConnector
+	connectors.SubscribeConnector
+}
+
+var (
+	_ implementsAllConnector = (*Connector)(nil)
+)
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	params, err := paramsbuilder.Apply(parameters{}, opts,
+		WithClient(http.DefaultClient),
 		WithRead(func(context.Context, common.ReadParams) (*common.ReadResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "read")
 		}),
@@ -27,7 +63,58 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		}),
 		WithListObjectMetadata(func(context.Context, []string) (*common.ListObjectMetadataResult, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "listObjectMetadata")
-		}))
+		}),
+		WithGetURL(func(resource string, args map[string]any) (string, error) {
+			return "", fmt.Errorf("%w: %s", ErrNotImplemented, "getURL")
+		}),
+		WithDelete(func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "delete")
+		}),
+		WithGetPostAuthInfo(func(ctx context.Context) (*common.PostAuthInfo, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "getPostAuthInfo")
+		}),
+		WithGetRecordsByIds(func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "getRecordsByIds")
+		}),
+		WithVerifyWebhookMessage(func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error) {
+			return false, fmt.Errorf("%w: %s", ErrNotImplemented, "verifyWebhookMessage")
+		}),
+		WithRegister(func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "register")
+		}),
+		WithDeleteRegistration(func(ctx context.Context, previousResult common.RegistrationResult) error {
+			return fmt.Errorf("%w: %s", ErrNotImplemented, "deleteRegistration")
+		}),
+		WithEmptyRegistrationParams(func() *common.SubscriptionRegistrationParams {
+			return &common.SubscriptionRegistrationParams{
+				Request: make(RegistrationRequest),
+			}
+		}),
+		WithEmptyRegistrationResult(func() *common.RegistrationResult {
+			return &common.RegistrationResult{
+				Result: make(RegistrationResult),
+			}
+		}),
+		WithSubscribe(func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "subscribe")
+		}),
+		WithUpdateSubscription(func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error) {
+			return nil, fmt.Errorf("%w: %s", ErrNotImplemented, "updateSubscription")
+		}),
+		WithDeleteSubscription(func(ctx context.Context, previousResult common.SubscriptionResult) error {
+			return fmt.Errorf("%w: %s", ErrNotImplemented, "deleteSubscription")
+		}),
+		WithEmptySubscriptionParams(func() *common.SubscribeParams {
+			return &common.SubscribeParams{
+				Request: make(SubscriptionRequest),
+			}
+		}),
+		WithEmptySubscriptionResult(func() *common.SubscriptionResult {
+			return &common.SubscriptionResult{
+				Result: make(SubscriptionResult),
+			}
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -81,4 +168,64 @@ func (c *Connector) ListObjectMetadata(
 	}
 
 	return c.listObjectMetadata(ctx, objectNames)
+}
+
+func (c *Connector) GetURL(resource string, args map[string]any) (string, error) {
+	return c.getURL(resource, args)
+}
+
+func (c *Connector) Delete(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	return c.delete(ctx, params)
+}
+
+func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
+	return c.getPostAuthInfo(ctx)
+}
+
+func (c *Connector) GetRecordsByIds(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error) {
+	return c.getRecordsByIds(ctx, objectName, recordIds, fields, associations)
+}
+
+func (c *Connector) VerifyWebhookMessage(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error) {
+	return c.verifyWebhookMessage(ctx, params)
+}
+
+func (c *Connector) Register(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error) {
+	return c.register(ctx, params)
+}
+
+func (c *Connector) DeleteRegistration(ctx context.Context, previousResult common.RegistrationResult) error {
+	return c.deleteRegistration(ctx, previousResult)
+}
+
+func (c *Connector) EmptyRegistrationParams() *common.SubscriptionRegistrationParams {
+	return c.emptyRegistrationParams()
+}
+
+func (c *Connector) EmptyRegistrationResult() *common.RegistrationResult {
+	return c.emptyRegistrationResult()
+}
+
+func (c *Connector) Subscribe(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error) {
+	return c.subscribe(ctx, params)
+}
+
+func (c *Connector) UpdateSubscription(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error) {
+	return c.updateSubscription(ctx, params, previousResult)
+}
+
+func (c *Connector) DeleteSubscription(ctx context.Context, previousResult common.SubscriptionResult) error {
+	return c.deleteSubscription(ctx, previousResult)
+}
+
+func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
+	return c.emptySubscriptionParams()
+}
+
+func (c *Connector) EmptySubscriptionResult() *common.SubscriptionResult {
+	return c.emptySubscriptionResult()
 }

--- a/mock/connector_test.go
+++ b/mock/connector_test.go
@@ -1,0 +1,15 @@
+package mock
+
+import "testing"
+
+func TestDefaultNewConnector(t *testing.T) {
+	// It should be possible to construct a new mock connector without any args.
+	conn, err := NewConnector()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if conn == nil {
+		t.Fatal("expected a connector instance, got nil")
+	}
+}

--- a/mock/connector_test.go
+++ b/mock/connector_test.go
@@ -3,6 +3,8 @@ package mock
 import "testing"
 
 func TestDefaultNewConnector(t *testing.T) {
+	t.Parallel()
+
 	// It should be possible to construct a new mock connector without any args.
 	conn, err := NewConnector()
 	if err != nil {

--- a/mock/params.go
+++ b/mock/params.go
@@ -181,15 +181,14 @@ func WithEmptySubscriptionResult(
 
 // parameters is the internal configuration for the mock connector.
 type parameters struct {
-	client             *common.JSONHTTPClient // required
-	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
-	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
-	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
-	getURL             func(resource string, args map[string]any) (string, error)
-	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
-	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
-	getRecordsByIds    func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
-
+	client                  *common.JSONHTTPClient // required
+	read                    func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
+	write                   func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
+	listObjectMetadata      func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
+	getURL                  func(resource string, args map[string]any) (string, error)
+	delete                  func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
+	getPostAuthInfo         func(ctx context.Context) (*common.PostAuthInfo, error)
+	getRecordsByIds         func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
 	verifyWebhookMessage    func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
 	register                func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error)
 	deleteRegistration      func(ctx context.Context, previousResult common.RegistrationResult) error

--- a/mock/params.go
+++ b/mock/params.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
@@ -52,12 +53,153 @@ func WithListObjectMetadata(
 	}
 }
 
+// WithGetURL sets the getURL function for the connector.
+func WithGetURL(
+	getURL func(resource string, args map[string]any) (string, error),
+) Option {
+	return func(params *parameters) {
+		params.getURL = getURL
+	}
+}
+
+// WithDelete sets the delete function for the connector.
+func WithDelete(
+	deleteFunc func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error),
+) Option {
+	return func(params *parameters) {
+		params.delete = deleteFunc
+	}
+}
+
+// WithGetPostAuthInfo sets the getPostAuthInfo function for the connector.
+func WithGetPostAuthInfo(
+	getPostAuthInfo func(ctx context.Context) (*common.PostAuthInfo, error),
+) Option {
+	return func(params *parameters) {
+		params.getPostAuthInfo = getPostAuthInfo
+	}
+}
+
+// WithGetRecordsByIds sets the getRecordsByIds function for the connector.
+func WithGetRecordsByIds(
+	getRecordsByIds func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error),
+) Option {
+	return func(params *parameters) {
+		params.getRecordsByIds = getRecordsByIds
+	}
+}
+
+// WithVerifyWebhookMessage sets the verifyWebhookMessage function for the connector.
+func WithVerifyWebhookMessage(
+	verifyWebhookMessage func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error),
+) Option {
+	return func(params *parameters) {
+		params.verifyWebhookMessage = verifyWebhookMessage
+	}
+}
+
+// WithRegister sets the register function for the connector.
+func WithRegister(
+	register func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error),
+) Option {
+	return func(params *parameters) {
+		params.register = register
+	}
+}
+
+// WithDeleteRegistration sets the deleteRegistration function for the connector.
+func WithDeleteRegistration(
+	deleteRegistration func(ctx context.Context, previousResult common.RegistrationResult) error,
+) Option {
+	return func(params *parameters) {
+		params.deleteRegistration = deleteRegistration
+	}
+}
+
+// WithEmptyRegistrationParams sets the emptyRegistrationParams function for the connector.
+func WithEmptyRegistrationParams(
+	emptyRegistrationParams func() *common.SubscriptionRegistrationParams,
+) Option {
+	return func(params *parameters) {
+		params.emptyRegistrationParams = emptyRegistrationParams
+	}
+}
+
+// WithEmptyRegistrationResult sets the emptyRegistrationResult function for the connector.
+func WithEmptyRegistrationResult(
+	emptyRegistrationResult func() *common.RegistrationResult,
+) Option {
+	return func(params *parameters) {
+		params.emptyRegistrationResult = emptyRegistrationResult
+	}
+}
+
+// WithSubscribe sets the subscribe function for the connector.
+func WithSubscribe(
+	subscribe func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error),
+) Option {
+	return func(params *parameters) {
+		params.subscribe = subscribe
+	}
+}
+
+// WithUpdateSubscription sets the updateSubscription function for the connector.
+func WithUpdateSubscription(
+	updateSubscription func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error),
+) Option {
+	return func(params *parameters) {
+		params.updateSubscription = updateSubscription
+	}
+}
+
+// WithDeleteSubscription sets the deleteSubscription function for the connector.
+func WithDeleteSubscription(
+	deleteSubscription func(ctx context.Context, previousResult common.SubscriptionResult) error,
+) Option {
+	return func(params *parameters) {
+		params.deleteSubscription = deleteSubscription
+	}
+}
+
+// WithEmptySubscriptionParams sets the emptySubscriptionParams function for the connector.
+func WithEmptySubscriptionParams(
+	emptySubscriptionParams func() *common.SubscribeParams,
+) Option {
+	return func(params *parameters) {
+		params.emptySubscriptionParams = emptySubscriptionParams
+	}
+}
+
+// WithEmptySubscriptionResult sets the emptySubscriptionResult function for the connector.
+func WithEmptySubscriptionResult(
+	emptySubscriptionResult func() *common.SubscriptionResult,
+) Option {
+	return func(params *parameters) {
+		params.emptySubscriptionResult = emptySubscriptionResult
+	}
+}
+
 // parameters is the internal configuration for the mock connector.
 type parameters struct {
 	client             *common.JSONHTTPClient // required
 	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
 	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
 	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
+	getURL             func(resource string, args map[string]any) (string, error)
+	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
+	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
+	getRecordsByIds    func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
+
+	verifyWebhookMessage    func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
+	register                func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error)
+	deleteRegistration      func(ctx context.Context, previousResult common.RegistrationResult) error
+	emptyRegistrationParams func() *common.SubscriptionRegistrationParams
+	emptyRegistrationResult func() *common.RegistrationResult
+	subscribe               func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error)
+	updateSubscription      func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error)
+	deleteSubscription      func(ctx context.Context, previousResult common.SubscriptionResult) error
+	emptySubscriptionParams func() *common.SubscribeParams
+	emptySubscriptionResult func() *common.SubscriptionResult
 }
 
 func (p parameters) ValidateParams() error {
@@ -75,6 +217,62 @@ func (p parameters) ValidateParams() error {
 
 	if p.listObjectMetadata == nil {
 		return fmt.Errorf("%w: %s", ErrMissingParam, "listObjectMetadata")
+	}
+
+	if p.getURL == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "getURL")
+	}
+
+	if p.delete == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "delete")
+	}
+
+	if p.getPostAuthInfo == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "getPostAuthInfo")
+	}
+
+	if p.getRecordsByIds == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "getRecordsByIds")
+	}
+
+	if p.verifyWebhookMessage == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "verifyWebhookMessage")
+	}
+
+	if p.register == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "register")
+	}
+
+	if p.deleteRegistration == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "deleteRegistration")
+	}
+
+	if p.emptyRegistrationParams == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "emptyRegistrationParams")
+	}
+
+	if p.emptyRegistrationResult == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "emptyRegistrationResult")
+	}
+
+	if p.subscribe == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "subscribe")
+	}
+
+	if p.updateSubscription == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "updateSubscription")
+	}
+
+	if p.deleteSubscription == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "deleteSubscription")
+	}
+
+	if p.emptySubscriptionParams == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "emptySubscriptionParams")
+	}
+
+	if p.emptySubscriptionResult == nil {
+		return fmt.Errorf("%w: %s", ErrMissingParam, "emptySubscriptionResult")
 	}
 
 	return nil

--- a/mock/params.go
+++ b/mock/params.go
@@ -81,7 +81,7 @@ func WithGetPostAuthInfo(
 }
 
 // WithGetRecordsByIds sets the getRecordsByIds function for the connector.
-func WithGetRecordsByIds(
+func WithGetRecordsByIds( //nolint:revive
 	getRecordsByIds func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error),
 ) Option {
 	return func(params *parameters) {
@@ -201,7 +201,7 @@ type parameters struct {
 	emptySubscriptionResult func() *common.SubscriptionResult
 }
 
-func (p parameters) ValidateParams() error {
+func (p parameters) ValidateParams() error { //nolint:funlen
 	if p.client == nil {
 		return fmt.Errorf("%w: %s", ErrMissingParam, "client")
 	}

--- a/mock/params.go
+++ b/mock/params.go
@@ -189,27 +189,46 @@ func WithEmptySubscriptionResult(
 
 // parameters is the internal configuration for the mock connector.
 type parameters struct {
-	client                  *common.JSONHTTPClient // required
-	read                    func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
-	write                   func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
-	listObjectMetadata      func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
-	getURL                  func(resource string, args map[string]any) (string, error)
-	delete                  func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
-	getPostAuthInfo         func(ctx context.Context) (*common.PostAuthInfo, error)
-	getRecordsByIds         func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error)
-	verifyWebhookMessage    func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
-	register                func(ctx context.Context, params common.SubscriptionRegistrationParams) (*common.RegistrationResult, error)
+	client             *common.JSONHTTPClient // required
+	read               func(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
+	write              func(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
+	listObjectMetadata func(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
+	getURL             func(resource string, args map[string]any) (string, error)
+	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
+	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
+
+	getRecordsByIds func(
+		ctx context.Context,
+		objectName string,
+		recordIds []string,
+		fields []string,
+		associations []string,
+	) ([]common.ReadResultRow, error)
+
+	verifyWebhookMessage func(ctx context.Context, params *common.WebhookVerificationParameters) (bool, error)
+
+	register func(
+		ctx context.Context,
+		params common.SubscriptionRegistrationParams,
+	) (*common.RegistrationResult, error)
+
 	deleteRegistration      func(ctx context.Context, previousResult common.RegistrationResult) error
 	emptyRegistrationParams func() *common.SubscriptionRegistrationParams
 	emptyRegistrationResult func() *common.RegistrationResult
 	subscribe               func(ctx context.Context, params common.SubscribeParams) (*common.SubscriptionResult, error)
-	updateSubscription      func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error)
+
+	updateSubscription func(
+		ctx context.Context,
+		params common.SubscribeParams,
+		previousResult *common.SubscriptionResult,
+	) (*common.SubscriptionResult, error)
+
 	deleteSubscription      func(ctx context.Context, previousResult common.SubscriptionResult) error
 	emptySubscriptionParams func() *common.SubscribeParams
 	emptySubscriptionResult func() *common.SubscriptionResult
 }
 
-func (p parameters) ValidateParams() error { //nolint:funlen
+func (p parameters) ValidateParams() error { //nolint:funlen,cyclop
 	if p.client == nil {
 		return fmt.Errorf("%w: %s", ErrMissingParam, "client")
 	}

--- a/mock/params.go
+++ b/mock/params.go
@@ -197,7 +197,7 @@ type parameters struct {
 	delete             func(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error)
 	getPostAuthInfo    func(ctx context.Context) (*common.PostAuthInfo, error)
 
-	getRecordsByIds func(
+	getRecordsByIds func( //nolint:revive
 		ctx context.Context,
 		objectName string,
 		recordIds []string,

--- a/mock/params.go
+++ b/mock/params.go
@@ -81,8 +81,13 @@ func WithGetPostAuthInfo(
 }
 
 // WithGetRecordsByIds sets the getRecordsByIds function for the connector.
-func WithGetRecordsByIds( //nolint:revive
-	getRecordsByIds func(ctx context.Context, objectName string, recordIds []string, fields []string, associations []string) ([]common.ReadResultRow, error),
+func WithGetRecordsByIds(getRecordsByIds func( //nolint:revive
+	ctx context.Context,
+	objectName string,
+	recordIds []string,
+	fields []string,
+	associations []string,
+) ([]common.ReadResultRow, error),
 ) Option {
 	return func(params *parameters) {
 		params.getRecordsByIds = getRecordsByIds
@@ -144,8 +149,11 @@ func WithSubscribe(
 }
 
 // WithUpdateSubscription sets the updateSubscription function for the connector.
-func WithUpdateSubscription(
-	updateSubscription func(ctx context.Context, params common.SubscribeParams, previousResult *common.SubscriptionResult) (*common.SubscriptionResult, error),
+func WithUpdateSubscription(updateSubscription func(
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error),
 ) Option {
 	return func(params *parameters) {
 		params.updateSubscription = updateSubscription

--- a/mock/types.go
+++ b/mock/types.go
@@ -1,0 +1,9 @@
+package mock
+
+type RegistrationRequest map[string]any
+
+type RegistrationResult map[string]any
+
+type SubscriptionRequest map[string]any
+
+type SubscriptionResult map[string]any


### PR DESCRIPTION
In unit tests, it would be nice to mock all of the available connector interfaces, not just read and write and listObjectMetadata. This adds the rest.
