### PR TITLE
fix: Reading Next-Page in Marketo Incremental Leads

### DIFF
--- a/providers/marketo/read.go
+++ b/providers/marketo/read.go
@@ -26,7 +26,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	url, err := c.constructReadURL(ctx, config)
 	if err != nil {
-		// If this is the case, we return an zero records response.
+		// If this is the case, we return a zero records response.
 		if errors.Is(err, ErrZeroRecords) {
 			return &common.ReadResult{
 				Data: []common.ReadResultRow{},

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -322,12 +322,7 @@ func setup() *OAuthApp {
 		slog.Warn("no scopes attached, ensure that the provider doesn't require scopes")
 	}
 
-	var oauthScopes []string
-
-	if len(scopes) != 0 {
-		oauthScopes = strings.Split(scopes, ",")
-	}
-
+	oauthScopes := strings.Split(scopes, ",")
 	var codeVerifier *string
 
 	switch providerInfo.Oauth2Opts.GrantType {

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -322,7 +322,12 @@ func setup() *OAuthApp {
 		slog.Warn("no scopes attached, ensure that the provider doesn't require scopes")
 	}
 
-	oauthScopes := strings.Split(scopes, ",")
+	var oauthScopes []string
+
+	if len(scopes) != 0 {
+		oauthScopes = strings.Split(scopes, ",")
+	}
+
 	var codeVerifier *string
 
 	switch providerInfo.Oauth2Opts.GrantType {

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -155,7 +155,8 @@ func testIncrementalReadLeads(ctx context.Context) error {
 	params := common.ReadParams{
 		ObjectName: "leads",
 		Fields:     connectors.Fields("id", "email"),
-		Since:      time.Now().Add(-24 * time.Hour),
+		Since:      time.Now().Add(-6 * time.Hour),
+		NextPage:   "576",
 	}
 
 	res, err := conn.Read(ctx, params)
@@ -183,6 +184,7 @@ func testReadActivities(ctx context.Context) error {
 		Since:      time.Now().Add(-1800 * time.Hour),
 		Fields:     connectors.Fields("id", "primaryAttributeValue", "activityDate"),
 		Filter:     "1,2,3,6,7,8,9,10,11,12",
+		NextPage:   "7A4CXBXWDZ7ZTQBOQVIV2VTWDUYUJE7CEG3XLI2FKH6PQYS2LJOQ====",
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
Issue:
Reading Leads, using the Incremental read approach, should be treated differently in the first call.  The next-page call should be delegated to the full Lead read, as it takes care of adding subsequent ids, provided the starting Id. 

Reading Next-Page Leads:
<img width="1200" alt="Screenshot 2025-04-25 at 11 59 40" src="https://github.com/user-attachments/assets/9dd98d9c-3ba0-40d8-ac71-b9ab8836336c" />
