### PR TITLE
[CON-1667] feat(aws): Write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-test/deep v1.1.1
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/yaml v0.3.1
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/providers/aws/delete_test.go
+++ b/providers/aws/delete_test.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "Users"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name:  "Successful User removal",
+			Input: common.DeleteParams{ObjectName: "Users", RecordId: "123"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"AWSIdentityStore.DeleteUser"},
+					}),
+					mockcond.Body(`{"IdentityStoreId":"test-identity-store-id","UserId":"123"}`),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Successful Trusted Token Issuer removal",
+			Input: common.DeleteParams{ObjectName: "TrustedTokenIssuers", RecordId: "123"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"SWBExternalService.DeleteTrustedTokenIssuer"},
+					}),
+					mockcond.Body(`{"InstanceArn":"test-instance-arn","TrustedTokenIssuerArn":"123"}`),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/aws/internal/core/commands.go
+++ b/providers/aws/internal/core/commands.go
@@ -1,11 +1,9 @@
 package core
 
-import "github.com/amp-labs/connectors/internal/datautils"
-
 type Command string
 
-func FormatCommand(serviceName string, registry datautils.Map[string, string], objectName string) Command {
-	return Command(serviceName + "." + registry[objectName])
+func FormatCommand(serviceName string, command string) Command {
+	return Command(serviceName + "." + command)
 }
 
 func (c Command) String() string {

--- a/providers/aws/internal/core/object.go
+++ b/providers/aws/internal/core/object.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+type ObjectProperties struct {
+	Commands       ObjectCommands
+	InputRecordID  InputRecordID
+	OutputRecordID OutputRecordID
+}
+
+type ObjectCommands struct {
+	Read   string
+	Create string
+	Update string
+	Delete string
+}
+
+type InputRecordID struct {
+	Update string
+	Delete string
+}
+
+type OutputRecordID struct {
+	Create *RecordLocation
+	Update *RecordLocation
+}
+
+func (p ObjectProperties) CanRead() bool {
+	return len(p.Commands.Read) != 0
+}
+
+func (p ObjectProperties) CanCreate() bool {
+	return len(p.Commands.Create) != 0
+}
+
+func (p ObjectProperties) CanUpdate() bool {
+	return len(p.Commands.Update) != 0
+}
+
+func (p ObjectProperties) CanDelete() bool {
+	return len(p.Commands.Delete) != 0
+}
+
+type Registry datautils.Map[string, ObjectProperties]
+
+func (r Registry) Has(objectName string) bool {
+	return datautils.Map[string, ObjectProperties](r).Has(objectName)
+}
+
+func (r Registry) GetReadObjects() datautils.StringSet {
+	result := datautils.NewStringSet()
+
+	for objectName, props := range r {
+		if props.CanRead() {
+			result.AddOne(objectName)
+		}
+	}
+
+	return result
+}
+
+func (r Registry) GetWriteObjects() datautils.StringSet {
+	result := datautils.NewStringSet()
+
+	for objectName, props := range r {
+		if props.CanCreate() || props.CanUpdate() {
+			result.AddOne(objectName)
+		}
+	}
+
+	return result
+}
+
+func (r Registry) GetDeleteObjects() datautils.StringSet {
+	result := datautils.NewStringSet()
+
+	for objectName, props := range r {
+		if props.CanDelete() {
+			result.AddOne(objectName)
+		}
+	}
+
+	return result
+}
+
+type RecordLocation struct {
+	ID   string
+	Zoom []string
+}
+
+func NewRecordLocation(id string, zoom ...string) *RecordLocation {
+	return &RecordLocation{
+		ID:   id,
+		Zoom: zoom,
+	}
+}
+
+func (l *RecordLocation) Extract(node *ajson.Node, defaultValue string) string {
+	if l == nil {
+		return ""
+	}
+
+	result, err := jsonquery.New(node, l.Zoom...).TextWithDefault(l.ID, defaultValue)
+	if err != nil {
+		return ""
+	}
+
+	return result
+}

--- a/providers/aws/internal/identitystore/delete.go
+++ b/providers/aws/internal/identitystore/delete.go
@@ -1,0 +1,25 @@
+package identitystore
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+)
+
+func DeleteRequest(
+	ctx context.Context, params common.DeleteParams, baseURL, identityStoreID string,
+) (*http.Request, error) {
+	payload := map[string]any{
+		"IdentityStoreId": identityStoreID,
+	}
+
+	objectProps := Registry[params.ObjectName]
+	identifierKey := objectProps.InputRecordID.Delete
+	payload[identifierKey] = params.RecordId
+
+	command := core.FormatCommand(ServiceName, objectProps.Commands.Delete)
+
+	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, payload)
+}

--- a/providers/aws/internal/identitystore/objects.go
+++ b/providers/aws/internal/identitystore/objects.go
@@ -2,7 +2,7 @@
 package identitystore
 
 import (
-	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
 )
 
 const (
@@ -11,7 +11,53 @@ const (
 	ServiceSigningName = "identitystore"
 )
 
-var ReadObjectCommands = datautils.Map[string, string]{
-	"Groups": "ListGroups",
-	"Users":  "ListUsers",
+var Registry = core.Registry{
+	"Users": {
+		Commands: core.ObjectCommands{
+			Read:   "ListUsers",
+			Create: "CreateUser",
+			Update: "UpdateUser",
+			Delete: "DeleteUser",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "UserId",
+			Delete: "UserId",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("UserId"),
+			Update: nil,
+		},
+	},
+	"Groups": {
+		Commands: core.ObjectCommands{
+			Read:   "ListGroups",
+			Create: "CreateGroup",
+			Update: "UpdateGroup",
+			Delete: "DeleteGroup",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "GroupId",
+			Delete: "GroupId",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("GroupId"),
+			Update: nil,
+		},
+	},
+	"GroupMemberships": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "CreateGroupMembership",
+			Update: "",
+			Delete: "DeleteGroupMembership",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "MembershipId",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("MembershipId"),
+			Update: nil,
+		},
+	},
 }

--- a/providers/aws/internal/identitystore/read.go
+++ b/providers/aws/internal/identitystore/read.go
@@ -17,7 +17,9 @@ type readPayload struct {
 func ReadRequest(
 	ctx context.Context, params common.ReadParams, baseURL, identityStoreID string,
 ) (*http.Request, error) {
-	command := core.FormatCommand(ServiceName, ReadObjectCommands, params.ObjectName)
+	objectProps := Registry[params.ObjectName]
+
+	command := core.FormatCommand(ServiceName, objectProps.Commands.Read)
 
 	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, readPayload{
 		ReadPayload:     core.NewReadPayload(params),

--- a/providers/aws/internal/identitystore/write.go
+++ b/providers/aws/internal/identitystore/write.go
@@ -1,0 +1,35 @@
+package identitystore
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+)
+
+func WriteRequest(
+	ctx context.Context, params common.WriteParams, baseURL, identityStoreID string,
+) (*http.Request, error) {
+	recordData, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	recordData["IdentityStoreId"] = identityStoreID
+
+	var command core.Command
+
+	if len(params.RecordId) == 0 {
+		objectProps := Registry[params.ObjectName]
+		command = core.FormatCommand(ServiceName, objectProps.Commands.Create)
+	} else {
+		objectProps := Registry[params.ObjectName]
+		command = core.FormatCommand(ServiceName, objectProps.Commands.Update)
+
+		identifierKey := objectProps.InputRecordID.Update
+		recordData[identifierKey] = params.RecordId
+	}
+
+	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, recordData)
+}

--- a/providers/aws/internal/ssoadmin/delete.go
+++ b/providers/aws/internal/ssoadmin/delete.go
@@ -1,0 +1,25 @@
+package ssoadmin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+)
+
+func DeleteRequest(
+	ctx context.Context, params common.DeleteParams, baseURL, instanceArn string,
+) (*http.Request, error) {
+	payload := map[string]any{
+		"InstanceArn": instanceArn,
+	}
+
+	objectProps := Registry[params.ObjectName]
+	identifierKey := objectProps.InputRecordID.Delete
+	payload[identifierKey] = params.RecordId
+
+	command := core.FormatCommand(ServiceName, objectProps.Commands.Delete)
+
+	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, payload)
+}

--- a/providers/aws/internal/ssoadmin/objects.go
+++ b/providers/aws/internal/ssoadmin/objects.go
@@ -2,7 +2,7 @@
 package ssoadmin
 
 import (
-	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
 )
 
 const (
@@ -11,12 +11,309 @@ const (
 	ServiceSigningName = "sso"
 )
 
-var ReadObjectCommands = datautils.Map[string, string]{
-	"Instances":                       "ListInstances",
-	"Applications":                    "ListApplications",
-	"ApplicationProviders":            "ListApplicationProviders",
-	"AccountAssignmentCreationStatus": "ListAccountAssignmentCreationStatus",
-	"AccountAssignmentDeletionStatus": "ListAccountAssignmentDeletionStatus",
-	"PermissionSetProvisioningStatus": "ListPermissionSetProvisioningStatus",
-	"TrustedTokenIssuers":             "ListTrustedTokenIssuers",
+var Registry = core.Registry{
+	"AccountAssignmentCreationStatus": {
+		Commands: core.ObjectCommands{
+			Read:   "ListAccountAssignmentCreationStatus",
+			Create: "",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"AccountAssignmentDeletionStatus": {
+		Commands: core.ObjectCommands{
+			Read:   "ListAccountAssignmentDeletionStatus",
+			Create: "",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"AccountAssignments": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "CreateAccountAssignment",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationAccessScopes": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutApplicationAccessScope",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "ApplicationArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationAssignmentConfigurations": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutApplicationAssignmentConfiguration",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "ApplicationArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationAssignments": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "CreateApplicationAssignment",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationAuthenticationMethods": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutApplicationAuthenticationMethod",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "ApplicationArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationGrants": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutApplicationGrant",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "ApplicationArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"ApplicationProviders": {
+		Commands: core.ObjectCommands{
+			Read:   "ListApplicationProviders",
+			Create: "",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"Applications": {
+		Commands: core.ObjectCommands{
+			Read:   "ListApplications",
+			Create: "CreateApplication",
+			Update: "UpdateApplication",
+			Delete: "DeleteApplication",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "ApplicationArn",
+			Delete: "ApplicationArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("ApplicationArn"),
+			Update: nil,
+		},
+	},
+	"InlinePolicyFromPermissionSets": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "",
+			Delete: "DeleteInlinePolicyFromPermissionSet",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "PermissionSetArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"InlinePolicyToPermissionSets": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutInlinePolicyToPermissionSet",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "PermissionSetArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"InstanceAccessControlAttributeConfigurations": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "CreateInstanceAccessControlAttributeConfiguration",
+			Update: "", // unclear what record id should be
+			Delete: "DeleteInstanceAccessControlAttributeConfiguration",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "InstanceArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"Instances": {
+		Commands: core.ObjectCommands{
+			Read:   "ListInstances",
+			Create: "CreateInstance",
+			Update: "UpdateInstance",
+			Delete: "DeleteInstance",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "InstanceArn",
+			Delete: "InstanceArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("InstanceArn"),
+			Update: nil,
+		},
+	},
+	"PermissionSetProvisioningStatus": {
+		Commands: core.ObjectCommands{
+			Read:   "ListPermissionSetProvisioningStatus",
+			Create: "",
+			Update: "",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"PermissionSets": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "CreatePermissionSet",
+			Update: "UpdatePermissionSet",
+			Delete: "DeletePermissionSet",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "PermissionSetArn",
+			Delete: "PermissionSetArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("PermissionSetArn", "PermissionSet"),
+			Update: nil,
+		},
+	},
+	"PermissionsBoundaryFromPermissionSets": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "",
+			Delete: "DeletePermissionsBoundaryFromPermissionSet",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "",
+			Delete: "PermissionSetArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"PermissionsBoundaryToPermissionSets": {
+		Commands: core.ObjectCommands{
+			Read:   "",
+			Create: "",
+			Update: "PutPermissionsBoundaryToPermissionSet",
+			Delete: "",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "PermissionSetArn",
+			Delete: "",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: nil,
+			Update: nil,
+		},
+	},
+	"TrustedTokenIssuers": {
+		Commands: core.ObjectCommands{
+			Read:   "ListTrustedTokenIssuers",
+			Create: "CreateTrustedTokenIssuer",
+			Update: "UpdateTrustedTokenIssuer",
+			Delete: "DeleteTrustedTokenIssuer",
+		},
+		InputRecordID: core.InputRecordID{
+			Update: "TrustedTokenIssuerArn",
+			Delete: "TrustedTokenIssuerArn",
+		},
+		OutputRecordID: core.OutputRecordID{
+			Create: core.NewRecordLocation("TrustedTokenIssuerArn"),
+			Update: nil,
+		},
+	},
 }

--- a/providers/aws/internal/ssoadmin/read.go
+++ b/providers/aws/internal/ssoadmin/read.go
@@ -17,7 +17,9 @@ type readPayload struct {
 func ReadRequest(
 	ctx context.Context, params common.ReadParams, baseURL, instanceArn string,
 ) (*http.Request, error) {
-	command := core.FormatCommand(ServiceName, ReadObjectCommands, params.ObjectName)
+	objectProps := Registry[params.ObjectName]
+
+	command := core.FormatCommand(ServiceName, objectProps.Commands.Read)
 
 	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, readPayload{
 		ReadPayload: core.NewReadPayload(params),

--- a/providers/aws/internal/ssoadmin/write.go
+++ b/providers/aws/internal/ssoadmin/write.go
@@ -1,0 +1,35 @@
+package ssoadmin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+)
+
+func WriteRequest(
+	ctx context.Context, params common.WriteParams, baseURL, instanceArn string,
+) (*http.Request, error) {
+	recordData, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	recordData["InstanceArn"] = instanceArn
+
+	var command core.Command
+
+	if len(params.RecordId) == 0 {
+		objectProps := Registry[params.ObjectName]
+		command = core.FormatCommand(ServiceName, objectProps.Commands.Create)
+	} else {
+		objectProps := Registry[params.ObjectName]
+		command = core.FormatCommand(ServiceName, objectProps.Commands.Update)
+
+		identifierKey := objectProps.InputRecordID.Update
+		recordData[identifierKey] = params.RecordId
+	}
+
+	return core.BuildRequest(ctx, baseURL, ServiceDomain, ServiceSigningName, command, recordData)
+}

--- a/providers/aws/requests.go
+++ b/providers/aws/requests.go
@@ -16,10 +16,42 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 	}
 
 	switch {
-	case identitystore.ReadObjectCommands.Has(params.ObjectName):
+	case identitystore.Registry.Has(params.ObjectName):
 		return identitystore.ReadRequest(ctx, params, baseURL, c.identityStoreId)
-	case ssoadmin.ReadObjectCommands.Has(params.ObjectName):
+	case ssoadmin.Registry.Has(params.ObjectName):
 		return ssoadmin.ReadRequest(ctx, params, baseURL, c.instanceARN)
+	default:
+		return nil, common.ErrObjectNotSupported
+	}
+}
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	baseURL, err := c.getModuleURL()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case identitystore.Registry.Has(params.ObjectName):
+		return identitystore.WriteRequest(ctx, params, baseURL, c.identityStoreId)
+	case ssoadmin.Registry.Has(params.ObjectName):
+		return ssoadmin.WriteRequest(ctx, params, baseURL, c.instanceARN)
+	default:
+		return nil, common.ErrObjectNotSupported
+	}
+}
+
+func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	baseURL, err := c.getModuleURL()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case identitystore.Registry.Has(params.ObjectName):
+		return identitystore.DeleteRequest(ctx, params, baseURL, c.identityStoreId)
+	case ssoadmin.Registry.Has(params.ObjectName):
+		return ssoadmin.DeleteRequest(ctx, params, baseURL, c.instanceARN)
 	default:
 		return nil, common.ErrObjectNotSupported
 	}

--- a/providers/aws/responses.go
+++ b/providers/aws/responses.go
@@ -2,11 +2,13 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/providers/aws/internal/identitystore"
 	"github.com/amp-labs/connectors/providers/aws/internal/ssoadmin"
 	"github.com/spyzhov/ajson"
@@ -41,4 +43,55 @@ func getReadRecordsLocation(params common.ReadParams) string {
 	recordsLocation, _ = ssoadmin.Schemas.FindArrayFieldName(providers.ModuleAWSIdentityCenter, params.ObjectName)
 
 	return recordsLocation
+}
+
+func (c *Connector) parseWriteResponse(
+	ctx context.Context, params common.WriteParams, request *http.Request, response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	var outputRecordID core.OutputRecordID
+
+	switch {
+	case identitystore.Registry.Has(params.ObjectName):
+		outputRecordID = identitystore.Registry[params.ObjectName].OutputRecordID
+	case ssoadmin.Registry.Has(params.ObjectName):
+		outputRecordID = ssoadmin.Registry[params.ObjectName].OutputRecordID
+	}
+
+	var recordID string
+	if len(params.RecordId) == 0 {
+		recordID = outputRecordID.Create.Extract(body, params.RecordId)
+	} else {
+		recordID = outputRecordID.Update.Extract(body, params.RecordId)
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     data,
+	}, nil
+}
+
+func (c *Connector) parseDeleteResponse(
+	ctx context.Context, params common.DeleteParams, request *http.Request, response *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	if response.Code != http.StatusOK && response.Code != http.StatusNoContent {
+		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, response.Code)
+	}
+
+	// A successful delete returns 200 OK
+	return &common.DeleteResult{
+		Success: true,
+	}, nil
 }

--- a/providers/aws/supports.go
+++ b/providers/aws/supports.go
@@ -17,10 +17,24 @@ func supportedOperations() components.EndpointRegistryInput {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(
 					datautils.MergeSets(
-						identitystore.ReadObjectCommands.KeySet(),
-						ssoadmin.ReadObjectCommands.KeySet(),
+						identitystore.Registry.GetReadObjects(),
+						ssoadmin.Registry.GetReadObjects(),
 					).List(), ",")),
 				Support: components.ReadSupport,
+			}, {
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(
+					datautils.MergeSets(
+						identitystore.Registry.GetWriteObjects(),
+						ssoadmin.Registry.GetWriteObjects(),
+					).List(), ",")),
+				Support: components.WriteSupport,
+			}, {
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(
+					datautils.MergeSets(
+						identitystore.Registry.GetDeleteObjects(),
+						ssoadmin.Registry.GetDeleteObjects(),
+					).List(), ",")),
+				Support: components.DeleteSupport,
 			},
 		},
 	}

--- a/providers/aws/test/write/issuer/new.json
+++ b/providers/aws/test/write/issuer/new.json
@@ -1,0 +1,3 @@
+{
+  "TrustedTokenIssuerArn": "arn:aws:sso::471112904037:trustedTokenIssuer/ssoins-668432c2a02ced8f/tti-014b2500-f0f0-70b7-ac48-ceddaf77c5fa"
+}

--- a/providers/aws/test/write/user/new.json
+++ b/providers/aws/test/write/user/new.json
@@ -1,0 +1,4 @@
+{
+  "IdentityStoreId": "d-9a670e6550",
+  "UserId": "11cba580-d011-7007-0ab2-963157a0ffd7"
+}

--- a/providers/aws/write_test.go
+++ b/providers/aws/write_test.go
@@ -1,0 +1,152 @@
+package aws
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/aws/internal/core"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseTrustedTokenIssuersCreate := testutils.DataFromFile(t, "write/issuer/new.json")
+	responseUserCreate := testutils.DataFromFile(t, "write/user/new.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs data payload",
+			Input:        common.WriteParams{ObjectName: "TrustedTokenIssuers"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name:     "Unknown object name is not supported",
+			Input:    common.WriteParams{ObjectName: "Orders", RecordData: "dummy"},
+			Server:   mockserver.Dummy(),
+			Expected: nil,
+			ExpectedErrs: []error{
+				common.ErrOperationNotSupportedForObject,
+			},
+		},
+		{
+			Name:  "Create TrustedTokenIssuers",
+			Input: common.WriteParams{ObjectName: "TrustedTokenIssuers", RecordData: map[string]string{}},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"SWBExternalService.CreateTrustedTokenIssuer"},
+					}),
+					mockcond.Body(`{"InstanceArn":"test-instance-arn"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseTrustedTokenIssuersCreate),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "arn:aws:sso::471112904037:trustedTokenIssuer/ssoins-668432c2a02ced8f/tti-014b2500-f0f0-70b7-ac48-ceddaf77c5fa", // nolint:lll
+				Errors:   nil,
+				Data: map[string]any{
+					"TrustedTokenIssuerArn": "arn:aws:sso::471112904037:trustedTokenIssuer/ssoins-668432c2a02ced8f/tti-014b2500-f0f0-70b7-ac48-ceddaf77c5fa", // nolint:lll
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update TrustedTokenIssuers",
+			Input: common.WriteParams{
+				ObjectName: "TrustedTokenIssuers",
+				RecordId:   "123456789",
+				RecordData: map[string]string{},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"SWBExternalService.UpdateTrustedTokenIssuer"},
+					}),
+					mockcond.Body(`{"InstanceArn":"test-instance-arn","TrustedTokenIssuerArn":"123456789"}`),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "",
+				Errors:   nil,
+				Data:     map[string]any{},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Create User",
+			Input: common.WriteParams{ObjectName: "Users", RecordData: map[string]string{}},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"AWSIdentityStore.CreateUser"},
+					}),
+					mockcond.Body(`{"IdentityStoreId":"test-identity-store-id"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseUserCreate),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "11cba580-d011-7007-0ab2-963157a0ffd7",
+				Errors:   nil,
+				Data: map[string]any{
+					"IdentityStoreId": "d-9a670e6550",
+					"UserId":          "11cba580-d011-7007-0ab2-963157a0ffd7",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update User",
+			Input: common.WriteParams{
+				ObjectName: "Users",
+				RecordId:   "123456789",
+				RecordData: map[string]string{},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME(core.Mime),
+				If: mockcond.And{
+					mockcond.Header(http.Header{
+						"X-Amz-Target": []string{"AWSIdentityStore.UpdateUser"},
+					}),
+					mockcond.Body(`{"IdentityStoreId":"test-identity-store-id","UserId":"123456789"}`),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "",
+				Errors:   nil,
+				Data:     map[string]any{},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/aws/write-delete/groups/main.go
+++ b/test/aws/write-delete/groups/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
+	connTest "github.com/amp-labs/connectors/test/aws"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+type CreatePayload struct {
+	DisplayName string `json:"DisplayName"`
+	Description string `json:"Description"`
+}
+
+type UpdatePayload struct {
+	Operations []AttributeOperation `json:"Operations"`
+}
+
+type AttributeOperation struct {
+	AttributePath  string `json:"AttributePath"`
+	AttributeValue any    `json:"AttributeValue"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAWSConnector(ctx, providers.ModuleAWSIdentityCenter)
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"Groups",
+		CreatePayload{
+			DisplayName: "Sales",
+			Description: "Team that knows how to sell",
+		},
+		UpdatePayload{
+			Operations: []AttributeOperation{
+				{
+					AttributePath:  "description",
+					AttributeValue: "Best team ever",
+				},
+			},
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("GroupId", "DisplayName", "Description"),
+			SearchBy: testscenario.Property{
+				Key:   "displayname", // returned fields are in lowercase
+				Value: "Sales",
+			},
+			RecordIdentifierKey: "groupid", // returned fields are in lowercase
+			UpdatedFields: map[string]string{
+				"description": "Best team ever",
+			},
+		},
+	)
+}

--- a/test/aws/write-delete/trust-token-issuer/main.go
+++ b/test/aws/write-delete/trust-token-issuer/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/providers"
+	connTest "github.com/amp-labs/connectors/test/aws"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/google/uuid"
+)
+
+type CreatePayload struct {
+	Name                            string        `json:"Name"`
+	TrustedTokenIssuerConfiguration configuration `json:"TrustedTokenIssuerConfiguration"`
+	TrustedTokenIssuerType          string        `json:"TrustedTokenIssuerType"` // always OIDC_JWT
+	// ClientToken is a string associated with request to ensure Idempotency.
+	ClientToken *string `json:"ClientToken"`
+}
+
+type configuration struct {
+	OidcJwtConfiguration oidcJwtConfiguration `json:"OidcJwtConfiguration"`
+}
+
+// A structure that describes configuration settings for a trusted token issuer
+// that supports OpenID Connect (OIDC) and JSON Web Tokens (JWTs).
+type oidcJwtConfiguration struct {
+	ClaimAttributePath         string `json:"ClaimAttributePath"`
+	IdentityStoreAttributePath string `json:"IdentityStoreAttributePath"`
+	IssuerUrl                  string `json:"IssuerUrl"`
+	JwksRetrievalOption        string `json:"JwksRetrievalOption"` // always OPEN_ID_DISCOVERY
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAWSConnector(ctx, providers.ModuleAWSIdentityCenter)
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"TrustedTokenIssuers",
+		CreatePayload{
+			Name: "OktaTokenIssuer",
+			TrustedTokenIssuerConfiguration: configuration{
+				OidcJwtConfiguration: oidcJwtConfiguration{
+					ClaimAttributePath:         "sub",
+					IdentityStoreAttributePath: "externalId",
+					IssuerUrl:                  "https://www.google.com",
+					JwksRetrievalOption:        "OPEN_ID_DISCOVERY",
+				},
+			},
+			TrustedTokenIssuerType: "OIDC_JWT",
+			ClientToken:            goutils.Pointer(uuid.New().String()),
+		},
+		CreatePayload{
+			Name: "OKTA",
+			TrustedTokenIssuerConfiguration: configuration{
+				OidcJwtConfiguration: oidcJwtConfiguration{
+					ClaimAttributePath:         "sub",
+					IdentityStoreAttributePath: "externalId",
+					IssuerUrl:                  "https://www.google.com",
+					JwksRetrievalOption:        "OPEN_ID_DISCOVERY",
+				},
+			},
+			TrustedTokenIssuerType: "OIDC_JWT",
+			ClientToken:            goutils.Pointer(uuid.New().String()),
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("TrustedTokenIssuerArn", "Name", "TrustedTokenIssuerConfiguration", "TrustedTokenIssuerType"),
+			SearchBy: testscenario.Property{
+				Key:   "name", // returned fields are in lowercase
+				Value: "OktaTokenIssuer",
+			},
+			RecordIdentifierKey: "trustedtokenissuerarn", // returned fields are in lowercase
+			UpdatedFields: map[string]string{
+				"name": "OKTA",
+			},
+		},
+	)
+}

--- a/test/aws/write-delete/users/main.go
+++ b/test/aws/write-delete/users/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers"
+	connTest "github.com/amp-labs/connectors/test/aws"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+type CreatePayload struct {
+	UserName    string   `json:"UserName"`
+	DisplayName string   `json:"DisplayName"`
+	Name        userName `json:"Name"`
+}
+
+type userName struct {
+	FamilyName string `json:"FamilyName"`
+	GivenName  string `json:"GivenName"`
+}
+
+type UpdatePayload struct {
+	Operations []AttributeOperation `json:"Operations"`
+}
+
+type AttributeOperation struct {
+	AttributePath  string `json:"AttributePath"`
+	AttributeValue any    `json:"AttributeValue"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAWSConnector(ctx, providers.ModuleAWSIdentityCenter)
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"Users",
+		CreatePayload{
+			UserName:    "johnDoe",
+			DisplayName: "Johnathan Doe",
+			Name: userName{
+				FamilyName: "Doe",
+				GivenName:  "John",
+			},
+		},
+		UpdatePayload{
+			Operations: []AttributeOperation{
+				{
+					AttributePath:  "userName",
+					AttributeValue: "Johnny",
+				},
+			},
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("UserId", "UserName", "DisplayName", "Name"),
+			SearchBy: testscenario.Property{
+				Key:   "username", // returned fields are in lowercase
+				Value: "johnDoe",
+			},
+			RecordIdentifierKey: "userid", // returned fields are in lowercase
+			UpdatedFields: map[string]string{
+				"username": "Johnny",
+			},
+		},
+	)
+}


### PR DESCRIPTION
# Changes

* AWS Core package defines object registry structs. 
* Each AWS package maps 
  * `object` to AWS commands we support,
  * `object` to `resource identifier` for request payload or id location in response.
![image](https://github.com/user-attachments/assets/8d5a03ab-e941-40b0-96b7-26534773d07c)
* Create/Update injects IdentityStoreId or InstanceARN into payload. This is coming from connector metadata. Each service relies on these identifiers for majority of objects.
* Mock tests capture AWS headers sent and payload which is enhanced using connector-metadata variables and record id in case of update/delete operation.
* Added 2 tests to create/update/delete `User`, `Groups` and `TrustedTokenIssuers`, see testing section below.

# Testing
## IdentityStore
![image](https://github.com/user-attachments/assets/49a31e1c-fe33-48a3-8ade-41d5cf3c59d2)
![image](https://github.com/user-attachments/assets/ee60472e-5378-41c4-94b2-634290baa9c7)
## SSO-Admin
![image](https://github.com/user-attachments/assets/1537ad69-47d0-407d-a23a-80702f86f7b5)

