### PR TITLE
[CON-1667] feat(aws): Metadata

### DIFF
--- a/providers/aws/internal/core/commands.go
+++ b/providers/aws/internal/core/commands.go
@@ -1,4 +1,4 @@
-package awscore
+package core
 
 import "github.com/amp-labs/connectors/internal/datautils"
 

--- a/providers/aws/internal/core/requests.go
+++ b/providers/aws/internal/core/requests.go
@@ -1,4 +1,4 @@
-package awscore
+package core
 
 import (
 	"bytes"

--- a/providers/aws/internal/identitystore/metadata.go
+++ b/providers/aws/internal/identitystore/metadata.go
@@ -1,0 +1,20 @@
+package identitystore
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/aws/internal/identitystore/schemas.json
+++ b/providers/aws/internal/identitystore/schemas.json
@@ -1,0 +1,51 @@
+{
+  "modules": {
+    "aws-identity-center": {
+      "objects": {
+        "Groups": {
+          "displayName": "Groups",
+          "responseKey": "Groups",
+          "fields": {
+            "GroupId": "Group Id",
+            "IdentityStoreId": "Identity Store Id",
+            "Description": "Description",
+            "DisplayName": "Display Name",
+            "ExternalIds": "External Ids"
+          }
+        },
+        "Users": {
+          "displayName": "Users",
+          "responseKey": "Users",
+          "fields": {
+            "IdentityStoreId": "Identity Store Id",
+            "UserId": "User Id",
+            "Addresses": "Addresses",
+            "DisplayName": "Display Name",
+            "Emails": "Emails",
+            "ExternalIds": "External Ids",
+            "Locale": "Locale",
+            "Name": "Name",
+            "NickName": "NickName",
+            "PhoneNumbers": "Phone Numbers",
+            "PreferredLanguage": "Preferred Language",
+            "ProfileUrl": "Profile URL",
+            "Timezone": "Timezone",
+            "Title": "Title",
+            "UserName": "User Name",
+            "UserType": "User Type"
+          }
+        },
+        "GroupMemberships": {
+          "displayName": "Group Memberships",
+          "responseKey": "GroupMemberships",
+          "fields": {
+            "IdentityStoreId": "Identity Store Id",
+            "GroupId": "Group Id",
+            "MemberId": "Member Id",
+            "MembershipId": "Membership Id"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/aws/internal/ssoadmin/metadata.go
+++ b/providers/aws/internal/ssoadmin/metadata.go
@@ -1,0 +1,20 @@
+package ssoadmin
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV1]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/aws/internal/ssoadmin/schemas.json
+++ b/providers/aws/internal/ssoadmin/schemas.json
@@ -1,0 +1,81 @@
+{
+  "modules": {
+    "aws-identity-center": {
+      "objects": {
+        "Instances": {
+          "displayName": "Instances",
+          "responseKey": "Instances",
+          "fields": {
+            "CreatedDate": "Created Date",
+            "IdentityStoreId": "Identity Store Id",
+            "InstanceArn": "Instance Arn",
+            "Name": "Name",
+            "OwnerAccountId": "Owner Account Id",
+            "Status": "Status"
+          }
+        },
+        "Applications": {
+          "displayName": "Applications",
+          "responseKey": "Applications",
+          "fields": {
+            "ApplicationAccount": "Application Account",
+            "ApplicationArn": "Application Arn",
+            "ApplicationProviderArn": "Application Provider Arn",
+            "CreatedDate": "Created Date",
+            "Description": "Description",
+            "InstanceArn": "Instance Arn",
+            "Name": "Name",
+            "PortalOptions": "Portal Options",
+            "Status": "Status"
+          }
+        },
+        "ApplicationProviders": {
+          "displayName": "Application Providers",
+          "responseKey": "ApplicationProviders",
+          "fields": {
+            "ApplicationProviderArn": "Application Provider Arn",
+            "DisplayData": "Display Data",
+            "FederationProtocol": "Federation Protocol",
+            "ResourceServerConfig": "Resource Server Config"
+          }
+        },
+        "AccountAssignmentsCreationStatus": {
+          "displayName": "Account Assignments Creation Status",
+          "responseKey": "AccountAssignmentsCreationStatus",
+          "fields": {
+            "CreatedDate": "Created Date",
+            "RequestId": "Request Id",
+            "Status": "Status"
+          }
+        },
+        "AccountAssignmentsDeletionStatus": {
+          "displayName": "Account Assignments Deletion Status",
+          "responseKey": "AccountAssignmentsDeletionStatus",
+          "fields": {
+            "CreatedDate": "Created Date",
+            "RequestId": "Request Id",
+            "Status": "Status"
+          }
+        },
+        "PermissionSetsProvisioningStatus": {
+          "displayName": "Permission Sets Provisioning Status",
+          "responseKey": "PermissionSetsProvisioningStatus",
+          "fields": {
+            "CreatedDate": "Created Date",
+            "RequestId": "Request Id",
+            "Status": "Status"
+          }
+        },
+        "TrustedTokenIssuers": {
+          "displayName": "Trusted Token Issuers",
+          "responseKey": "TrustedTokenIssuers",
+          "fields": {
+            "Name": "Name",
+            "TrustedTokenIssuerArn": "Trusted Token Issuer Arn",
+            "TrustedTokenIssuerType": "Trusted Token Issuer Type"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/aws/metadata.go
+++ b/providers/aws/metadata.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/aws/internal/identitystore"
+	"github.com/amp-labs/connectors/providers/aws/internal/ssoadmin"
+)
+
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*connectors.ListObjectMetadataResult, error) {
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	result := common.NewListObjectMetadataResult()
+
+	for _, name := range objectNames {
+		if data, ok := findObjectMetadata(name); ok {
+			result.Result[name] = *data
+		} else {
+			result.Errors[name] = common.ErrObjectNotSupported
+		}
+	}
+
+	return result, nil
+}
+
+// Try locating metadata for an object across AWS services.
+func findObjectMetadata(objectName string) (*common.ObjectMetadata, bool) {
+	data, err := identitystore.Schemas.SelectOne(providers.ModuleAWSIdentityCenter, objectName)
+	if err == nil {
+		return data, true
+	}
+
+	data, err = ssoadmin.Schemas.SelectOne(providers.ModuleAWSIdentityCenter, objectName)
+	if err == nil {
+		return data, true
+	}
+
+	return nil, false
+}

--- a/providers/aws/metadata_test.go
+++ b/providers/aws/metadata_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
+		},
+		{
+			Name:       "Metadata for objects across AWS Services",
+			Input:      []string{"Users", "Applications", "Helicopters"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"Users": {
+						DisplayName: "Users",
+						FieldsMap: map[string]string{
+							"IdentityStoreId":   "Identity Store Id",
+							"UserId":            "User Id",
+							"Addresses":         "Addresses",
+							"DisplayName":       "Display Name",
+							"Emails":            "Emails",
+							"ExternalIds":       "External Ids",
+							"Locale":            "Locale",
+							"Name":              "Name",
+							"NickName":          "NickName",
+							"PhoneNumbers":      "Phone Numbers",
+							"PreferredLanguage": "Preferred Language",
+							"ProfileUrl":        "Profile URL",
+							"Timezone":          "Timezone",
+							"Title":             "Title",
+							"UserName":          "User Name",
+							"UserType":          "User Type",
+						},
+					},
+					"Applications": {
+						DisplayName: "Applications",
+						FieldsMap: map[string]string{
+							"ApplicationAccount":     "Application Account",
+							"ApplicationArn":         "Application Arn",
+							"ApplicationProviderArn": "Application Provider Arn",
+							"CreatedDate":            "Created Date",
+							"Description":            "Description",
+							"InstanceArn":            "Instance Arn",
+							"Name":                   "Name",
+							"PortalOptions":          "Portal Options",
+							"Status":                 "Status",
+						},
+					},
+				},
+				Errors: map[string]error{
+					"Helicopters": common.ErrObjectNotSupported,
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.Parameters{
+		Module:              providers.ModuleAWSIdentityCenter,
+		AuthenticatedClient: http.DefaultClient,
+		Metadata: map[string]string{
+			"region":          "test-region",
+			"identityStoreID": "test-identity-store-id",
+			"instanceArn":     "test-instance-arn",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/test/aws/metadata/main.go
+++ b/test/aws/metadata/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/providers"
+	connTest "github.com/amp-labs/connectors/test/aws"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetAWSConnector(ctx, providers.ModuleAWSIdentityCenter)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"Users", "Applications",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}


### PR DESCRIPTION
# Description

Using [AWS Golang SDK](https://github.com/aws/aws-sdk-go-v2/tree/main) inferred object schema response. Metadata is stored under `schema.json` associated with each AWS service.
Package `awsidentitystore` matches `identitystore` service and `awsssoadmin` matches `sso-admin`.

# Functionality

When object is queried search for metadata service by service.
AWS Identity Center module combines `identitystore` and `sso-admin`. In future other AWS modules may correspond to one or many AWS services.

# Testing
![image](https://github.com/user-attachments/assets/bc05ba05-4369-4e61-bab4-4428664f3725)
