### PR TITLE
feat(creds): Custom JSON/ENV fields

### DIFF
--- a/common/scanning/credscanning/fields.go
+++ b/common/scanning/credscanning/fields.go
@@ -129,11 +129,15 @@ func (f Field) GetENVReader(providerName string) *scanning.EnvReader {
 
 // nolint:cyclop
 func getFields(info providers.ProviderInfo,
-	withRequiredAccessToken, withRequiredWorkspace bool,
+	withRequiredAccessToken, withRequiredWorkspace bool, customFields []Field,
 ) (datautils.NamedLists[Field], error) {
 	lists := datautils.NamedLists[Field]{}
 	requiredType := "required"
 	optionalType := "optional"
+
+	for _, customField := range customFields {
+		lists.Add(optionalType, customField)
+	}
 
 	lists.Add(requiredType, Fields.Provider)
 

--- a/common/scanning/credscanning/provider.go
+++ b/common/scanning/credscanning/provider.go
@@ -32,8 +32,11 @@ func NewJSONProviderCredentials(
 	filePath string,
 	withRequiredAccessToken bool,
 	withRequiredWorkspace bool,
+	customFields ...Field,
 ) (*ProviderCredentials, error) {
-	return createProviderCreds(getProviderName(filePath), withRequiredAccessToken, withRequiredWorkspace, filePath)
+	return createProviderCreds(
+		getProviderName(filePath), withRequiredAccessToken, withRequiredWorkspace, filePath, customFields,
+	)
 }
 
 // NewENVProviderCredentials reads ENV variables associated with a provider.
@@ -41,12 +44,15 @@ func NewENVProviderCredentials(
 	providerName string,
 	withRequiredAccessToken bool,
 	withRequiredWorkspace bool,
+	customFields ...Field,
 ) (*ProviderCredentials, error) {
-	return createProviderCreds(providerName, withRequiredAccessToken, withRequiredWorkspace, "")
+	return createProviderCreds(
+		providerName, withRequiredAccessToken, withRequiredWorkspace, "", customFields,
+	)
 }
 
 func createProviderCreds(
-	providerName string, withRequiredAccessToken, withRequiredWorkspace bool, filePath string,
+	providerName string, withRequiredAccessToken, withRequiredWorkspace bool, filePath string, customFields []Field,
 ) (*ProviderCredentials, error) {
 	// load provider from catalog to imply fields in JSON or ENV vars
 	catalog, err := providers.ReadCatalog()
@@ -59,7 +65,7 @@ func createProviderCreds(
 		return nil, ErrProviderNotFound
 	}
 
-	fields, err := getFields(info, withRequiredAccessToken, withRequiredWorkspace)
+	fields, err := getFields(info, withRequiredAccessToken, withRequiredWorkspace, customFields)
 	if err != nil {
 		return nil, err
 	}

--- a/test/utils/creds.go
+++ b/test/utils/creds.go
@@ -12,8 +12,11 @@ import (
 
 func MustCreateProvCredJSON(filePath string,
 	withRequiredAccessToken, withRequiredWorkspace bool,
+	customFields ...credscanning.Field,
 ) *credscanning.ProviderCredentials {
-	reader, err := credscanning.NewJSONProviderCredentials(filePath, withRequiredAccessToken, withRequiredWorkspace)
+	reader, err := credscanning.NewJSONProviderCredentials(
+		filePath, withRequiredAccessToken, withRequiredWorkspace, customFields...,
+	)
 	if err != nil {
 		Fail("json creds file error", "error", err)
 	}


### PR DESCRIPTION
# Background

`credscanning` infers fields in the `<name>-creds.json` file based on the ProviderInfo, no more no less.

# Change

Custom fields can be passed using variadic argument. Then values will be available by calling `reader.Get(someField credscanning.Field)`