### PR TITLE
fix(aws): Mistmatching Read/Metadata object names

### DIFF
--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -315,11 +315,27 @@ func (m *Metadata[F, C]) ModuleRegistry() common.Modules {
 // LookupArrayFieldName will give you the field name which holds the array of objects in provider response.
 // Ex: CustomerSubscriptions is located under field name subscriptions => { "subscriptions": [{},{},{}] }.
 func (m *Metadata[F, C]) LookupArrayFieldName(moduleID common.ModuleID, objectName string) string {
-	moduleID = moduleIdentifier(moduleID)
-
-	fieldName := m.Modules[moduleID].Objects[objectName].ResponseKey
+	fieldName, _ := m.FindArrayFieldName(moduleID, objectName)
 
 	return fieldName
+}
+
+func (m *Metadata[F, C]) FindArrayFieldName(moduleID common.ModuleID, objectName string) (string, bool) {
+	moduleID = moduleIdentifier(moduleID)
+
+	module, ok := m.Modules[moduleID]
+	if !ok {
+		return "", false
+	}
+
+	object, ok := module.Objects[objectName]
+	if !ok {
+		return "", false
+	}
+
+	fieldName := object.ResponseKey
+
+	return fieldName, true
 }
 
 func (m *Module[F, C]) withPath(path string) {

--- a/providers/aws/internal/ssoadmin/schemas.json
+++ b/providers/aws/internal/ssoadmin/schemas.json
@@ -39,7 +39,7 @@
             "ResourceServerConfig": "Resource Server Config"
           }
         },
-        "AccountAssignmentsCreationStatus": {
+        "AccountAssignmentCreationStatus": {
           "displayName": "Account Assignments Creation Status",
           "responseKey": "AccountAssignmentsCreationStatus",
           "fields": {
@@ -48,7 +48,7 @@
             "Status": "Status"
           }
         },
-        "AccountAssignmentsDeletionStatus": {
+        "AccountAssignmentDeletionStatus": {
           "displayName": "Account Assignments Deletion Status",
           "responseKey": "AccountAssignmentsDeletionStatus",
           "fields": {
@@ -57,7 +57,7 @@
             "Status": "Status"
           }
         },
-        "PermissionSetsProvisioningStatus": {
+        "PermissionSetProvisioningStatus": {
           "displayName": "Permission Sets Provisioning Status",
           "responseKey": "PermissionSetsProvisioningStatus",
           "fields": {

--- a/providers/aws/responses.go
+++ b/providers/aws/responses.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/aws/internal/identitystore"
+	"github.com/amp-labs/connectors/providers/aws/internal/ssoadmin"
 	"github.com/spyzhov/ajson"
 )
 
@@ -15,7 +18,7 @@ func (c *Connector) parseReadResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
-	recordsLocation := params.ObjectName
+	recordsLocation := getReadRecordsLocation(params)
 
 	return common.ParseResult(
 		response,
@@ -26,4 +29,16 @@ func (c *Connector) parseReadResponse(
 		common.GetMarshaledData,
 		params.Fields,
 	)
+}
+
+func getReadRecordsLocation(params common.ReadParams) string {
+	recordsLocation, ok := identitystore.Schemas.FindArrayFieldName(providers.ModuleAWSIdentityCenter, params.ObjectName)
+	if ok {
+		return recordsLocation
+	}
+
+	// Object must be coming from this service.
+	recordsLocation, _ = ssoadmin.Schemas.FindArrayFieldName(providers.ModuleAWSIdentityCenter, params.ObjectName)
+
+	return recordsLocation
 }


### PR DESCRIPTION
Some Object names differ among `CLI` and `response JSON key`.

As a standard I use names used in `CLI` because that is documented.

Ex: AccountAssignmentCreationStatus: AWS command header will use `List`AccountAssignmentCreationStatus, while response will be stored at AccountAssignment`s`CreationStatus.