### PR TITLE
[ENG-2192] feat: update catalog to define required metadata

### DIFF
--- a/providers/activeCampaign.go
+++ b/providers/activeCampaign.go
@@ -36,5 +36,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/aha.go
+++ b/providers/aha.go
@@ -37,5 +37,12 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/amplitude.go
+++ b/providers/amplitude.go
@@ -41,6 +41,5 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 	})
 }

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -68,5 +68,18 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
+		Metadata: &ProviderMetadata{
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "cloudId",
+				},
+			},
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Site URL (Your domain)",
+				},
+			},
+		},
 	})
 }

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -11,6 +11,7 @@ const (
 	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
 )
 
+// nolint:funlen
 func init() {
 	// Atlassian Configuration
 	SetInfo(Atlassian, ProviderInfo{

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -56,6 +56,8 @@ func init() {
 				{
 					Name: "instanceArn",
 				},
+				// IMPORTANT: The 'serviceDomain' variable is figured out in the connector,
+				// at runtime. It is not part of the metadata.
 			},
 		},
 	})

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -45,5 +45,18 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1746046777/media/aws_1746046777.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "region",
+				},
+				{
+					Name: "identityStoreId",
+				},
+				{
+					Name: "instanceArn",
+				},
+			},
+		},
 	})
 }

--- a/providers/basecamp.go
+++ b/providers/basecamp.go
@@ -38,5 +38,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/bitbucket.go
+++ b/providers/bitbucket.go
@@ -14,7 +14,6 @@ func init() {
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
-		PostAuthInfoNeeded: false,
 		//nolint:lll
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/blueshift.go
+++ b/providers/blueshift.go
@@ -33,7 +33,6 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
-		PostAuthInfoNeeded: false,
 	})
 
 	// BlueshiftEU connfiguration
@@ -63,6 +62,5 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 	})
 }

--- a/providers/braintree.go
+++ b/providers/braintree.go
@@ -20,7 +20,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460381/media/braintree_1722460380.png",

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -37,5 +37,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/bynder.go
+++ b/providers/bynder.go
@@ -39,5 +39,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722329821/media/bynder_1722329820.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/chargeOver.go
+++ b/providers/chargeOver.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460983/media/chargeover_1722460983.jpg",
@@ -28,6 +27,13 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722460983/media/chargeover_1722460983.jpg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722461005/media/chargeover_1722461004.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
 			},
 		},
 	})

--- a/providers/chargebee.go
+++ b/providers/chargebee.go
@@ -32,6 +32,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/chartMogul.go
+++ b/providers/chartMogul.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1724223755/media/dofc2atuowphyzyh3x4l.png",

--- a/providers/discourse.go
+++ b/providers/discourse.go
@@ -37,5 +37,13 @@ func init() {
 				LogoURL: " https://res.cloudinary.com/dycvts6vp/image/upload/v1734557138/media/discourse.org_1734557138.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Your domain",
+				},
+			},
+		},
 	})
 }

--- a/providers/docusign.go
+++ b/providers/docusign.go
@@ -42,6 +42,13 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "server",
+				},
+			},
+		},
 		PostAuthInfoNeeded: true,
 	})
 

--- a/providers/dynamics.go
+++ b/providers/dynamics.go
@@ -44,6 +44,14 @@ func init() { // nolint:funlen
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Tenant ID",
+				},
+			},
+		},
 	})
 
 	// Dynamics CRM Configuration
@@ -84,6 +92,14 @@ func init() { // nolint:funlen
 			Read:      true,
 			Subscribe: false,
 			Write:     true,
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Organization ID",
+				},
+			},
 		},
 	})
 }

--- a/providers/emailBison.go
+++ b/providers/emailBison.go
@@ -37,5 +37,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/freshchat.go
+++ b/providers/freshchat.go
@@ -37,5 +37,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321995/media/freshdesk_1722321994.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/freshdesk.go
+++ b/providers/freshdesk.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321939/media/freshdesk_1722321938.svg",
@@ -28,6 +27,13 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321939/media/freshdesk_1722321938.svg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722321995/media/freshdesk_1722321994.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
 			},
 		},
 	})

--- a/providers/freshsales.go
+++ b/providers/freshsales.go
@@ -37,5 +37,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722325347/media/freshsales_1722325345.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/freshservice.go
+++ b/providers/freshservice.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326054/media/freshservice_1722326053.svg",
@@ -28,6 +27,13 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326054/media/freshservice_1722326053.svg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326085/media/freshservice_1722326084.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
 			},
 		},
 	})

--- a/providers/gainsight.go
+++ b/providers/gainsight.go
@@ -38,5 +38,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/geckoboard.go
+++ b/providers/geckoboard.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1724225706/media/zr9qopmgehuupyuabn6k.png",

--- a/providers/gladly.go
+++ b/providers/gladly.go
@@ -33,6 +33,13 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723974024/media/gladly_1723974023.jpg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 	// Gladly qa environment
 	SetInfo(GladlyQA, ProviderInfo{
@@ -59,6 +66,13 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723973960/media/gladly_1723973958.png",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1723974024/media/gladly_1723974023.jpg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
 			},
 		},
 	})

--- a/providers/gladly.go
+++ b/providers/gladly.go
@@ -5,6 +5,7 @@ const (
 	GladlyQA Provider = "gladlyQA"
 )
 
+// nolint:funlen
 func init() {
 	// Gladly production environment
 	SetInfo(Gladly, ProviderInfo{

--- a/providers/gorgias.go
+++ b/providers/gorgias.go
@@ -42,5 +42,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722459319/media/gorgias_1722459317.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/guru.go
+++ b/providers/guru.go
@@ -31,6 +31,5 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 	})
 }

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -56,5 +56,18 @@ func init() {
 			},
 		},
 		PostAuthInfoNeeded: true,
+
+		// IMPORTANT: The fetching of this metadata is added as a special case in the server,
+		// because it requires the access token in the path, which is not really possible to
+		// do with the current set up. If we can find a way to do this with the current interface,
+		// we should remove the special case in the server, and define the GetPostAuthInfo method
+		// as a method on the Connector struct.
+		Metadata: &ProviderMetadata{
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "ownerId",
+				},
+			},
+		},
 	})
 }

--- a/providers/mailgun.go
+++ b/providers/mailgun.go
@@ -22,7 +22,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722071456/media/mailgun_1722071455.svg",

--- a/providers/marketo.go
+++ b/providers/marketo.go
@@ -11,6 +11,7 @@ const (
 	ModuleMarketoLeads common.ModuleID = "leads"
 )
 
+// nolint:funlen
 func init() {
 	// Marketo configuration file
 	// workspace maps to marketo instance

--- a/providers/marketo.go
+++ b/providers/marketo.go
@@ -69,5 +69,12 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/maxio.go
+++ b/providers/maxio.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328568/media/maxio_1722328567.svg",
@@ -28,6 +27,13 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328600/media/maxio_1722328599.svg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722328600/media/maxio_1722328599.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
 			},
 		},
 	})

--- a/providers/netsuite.go
+++ b/providers/netsuite.go
@@ -38,5 +38,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740404009/media/netsuite_1740403997.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/nutshell.go
+++ b/providers/nutshell.go
@@ -31,6 +31,5 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 	})
 }

--- a/providers/outplay.go
+++ b/providers/outplay.go
@@ -29,6 +29,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/recurly.go
+++ b/providers/recurly.go
@@ -19,7 +19,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722066457/media/recurly_1722066456.svg",

--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -42,5 +42,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722470590/media/salesforce_1722470589.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/salesforceMarketing.go
+++ b/providers/salesforceMarketing.go
@@ -17,6 +17,13 @@ func init() {
 				ScopesField: "scope",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
 				Insert: false,

--- a/providers/seismic.go
+++ b/providers/seismic.go
@@ -36,5 +36,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -41,5 +41,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/shopify.go
+++ b/providers/shopify.go
@@ -36,5 +36,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722326881/media/shopify_1722326880.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/solarWindsServiceDesk.go
+++ b/providers/solarWindsServiceDesk.go
@@ -30,7 +30,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1738322100/media/solarwinds.com_1738322099.svg",

--- a/providers/stripe.go
+++ b/providers/stripe.go
@@ -27,7 +27,6 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722456153/media/stripe_1722456152.jpg",

--- a/providers/sugarCRM.go
+++ b/providers/sugarCRM.go
@@ -36,5 +36,13 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Base URL",
+				},
+			},
+		},
 	})
 }

--- a/providers/talkdesk.go
+++ b/providers/talkdesk.go
@@ -39,5 +39,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/teamwork.go
+++ b/providers/teamwork.go
@@ -41,5 +41,12 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/providers/whereby.go
+++ b/providers/whereby.go
@@ -28,7 +28,6 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
-		PostAuthInfoNeeded: false,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1739804309/media/whereby.com_1739804308.png",

--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -71,6 +71,13 @@ func init() { // nolint:funlen
 			Subscribe: false,
 			Write:     true,
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 
 	// BLOCKED: refresh token seems to be one-time use.
@@ -110,6 +117,13 @@ func init() { // nolint:funlen
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
 		},
 	})
 }

--- a/providers/zuora.go
+++ b/providers/zuora.go
@@ -36,5 +36,12 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722063469/media/zuora_1722063468.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name: "workspace",
+				},
+			},
+		},
 	})
 }

--- a/test/ashby/write/main.go
+++ b/test/ashby/write/main.go
@@ -36,8 +36,8 @@ func main() {
 	if err := createApplication(ctx, conn, recordId); err != nil {
 		slog.Error(err.Error())
 	}
-	slog.Info("Done")
 
+	slog.Info("Done")
 }
 
 func createApplication(ctx context.Context, conn *ashby.Connector, candidateId string) error {
@@ -72,6 +72,7 @@ func createCandidate(ctx context.Context, conn *ashby.Connector) (string, error)
 			"name": "Deepu",
 		},
 	}
+
 	result, err := conn.Write(ctx, config)
 	if err != nil {
 		return "", err

--- a/test/dixa/write/main.go
+++ b/test/dixa/write/main.go
@@ -95,7 +95,6 @@ func patchAgent(ctx context.Context, conn *dx.Connector) error {
 	_, _ = os.Stdout.WriteString("\n")
 
 	return nil
-
 }
 
 func testCreatingTeams(ctx context.Context, conn *dx.Connector) error {

--- a/test/monday/read/read.go
+++ b/test/monday/read/read.go
@@ -32,7 +32,6 @@ func main() {
 	if err != nil {
 		slog.Error(err.Error())
 	}
-
 }
 
 func testReadBoards(ctx context.Context) error {

--- a/test/servicenow/read/read.go
+++ b/test/servicenow/read/read.go
@@ -79,7 +79,6 @@ func readEmailServer(ctx context.Context, conn *serviceNow.Connector) error {
 	_, _ = os.Stdout.WriteString("\n")
 
 	return nil
-
 }
 
 func readContacts(ctx context.Context, conn *serviceNow.Connector) error {
@@ -101,5 +100,4 @@ func readContacts(ctx context.Context, conn *serviceNow.Connector) error {
 	_, _ = os.Stdout.WriteString("\n")
 
 	return nil
-
 }

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -23,6 +23,7 @@ func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult)
 	a := mockutils.ReadResultComparator.SubsetFields(actual, expected)
 	b := mockutils.ReadResultComparator.SubsetRaw(actual, expected)
 	c := ComparatorPagination(serverURL, actual, expected)
+
 	return a &&
 		b &&
 		c

--- a/test/zohocrm/subscribe/subscribe.go
+++ b/test/zohocrm/subscribe/subscribe.go
@@ -55,12 +55,11 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("Delete subscription successful")
 
+	fmt.Println("Delete subscription successful")
 }
 
 func prettyPrint(v any) string {
-
 	jsonBytes, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
* Updates all catalogs to state the metadata that the connector needs. Most connectors need a workspace, so this PR adds that in as well.
  * **Exceptions:**
    * Hubspot ownerId: fetched in the server due to some limitations
    * AWS serverDomain: this is a variable that needs to be figured out at runtime based on the kind of request being made. It is not really metadata that is an input to the connector.
* Removes all `PostAuthInfoNeeded: false` because that is assumed
* For all `PostAuthInfoNeeded: true`, defines equivalent `Metadata.PostAuthentication` that we can start using in the server, but does not remove it in this PR.