### PR TITLE
feat: Add support to read all Marketo Lead Activities

### DIFF
--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -95,7 +95,7 @@ func (c *Connector) handleActivitiesAPI(ctx context.Context, url *urlbuilder.URL
 	// For the first call (no NextPage token) with a Since timestamp,
 	// fetch a paging token to ensure pagination starts from the correct time.
 	// Then, append the token to the URL for subsequent pagination.
-	if params.ObjectName == activities && !params.Since.IsZero() {
+	if params.ObjectName == activities {
 		if params.Filter == "" {
 			return ErrFilterInvalid
 		}
@@ -128,6 +128,12 @@ func (c *Connector) addActivityNextParam(ctx context.Context, url *urlbuilder.UR
 		url.WithQueryParam(nextPageQuery, params.NextPage.String())
 
 		return nil
+	}
+
+	// Manually setting the since timestamp to `1970-01-01` for retrieving
+	// all lead activities in the instance.
+	if params.Since.IsZero() {
+		params.Since = time.Unix(0, 0).UTC()
 	}
 
 	// Get initial paging token for first request

--- a/test/marketo/read/read.go
+++ b/test/marketo/read/read.go
@@ -45,6 +45,11 @@ func main() {
 	if err != nil {
 		slog.Error(err.Error())
 	}
+
+	err = testReadAllActivities(ctx)
+	if err != nil {
+		slog.Error(err.Error())
+	}
 }
 
 func testReadChannels(ctx context.Context) error {
@@ -185,6 +190,32 @@ func testReadActivities(ctx context.Context) error {
 		Fields:     connectors.Fields("id", "primaryAttributeValue", "activityDate"),
 		Filter:     "1,2,3,6,7,8,9,10,11,12",
 		NextPage:   "7A4CXBXWDZ7ZTQBOQVIV2VTWDUYUJE7CEG3XLI2FKH6PQYS2LJOQ====",
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testReadAllActivities(ctx context.Context) error {
+	conn := mk.GetMarketoConnectorLeads(ctx)
+
+	params := common.ReadParams{
+		ObjectName: "activities",
+		Fields:     connectors.Fields("id", "primaryAttributeValue", "activityDate"),
+		Filter:     "1,2,3,6,7,8,9,10,11,12",
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
This updates the Read Activity API to use the timestamp `1970-01-01` as the default since parameter when none is provided.
This ensures all historical activities in the instance are retrieved, which is appropriate when backfillHistory is set to true.

Tests:
<img width="1228" alt="Screenshot 2025-05-05 at 07 04 55" src="https://github.com/user-attachments/assets/1e8108c6-435d-4de3-9f88-a32539f843c3" />

<img width="1023" alt="Screenshot 2025-05-05 at 07 04 40" src="https://github.com/user-attachments/assets/7c5d1b59-36cc-4b23-a40f-73eefb5470c7" />

