### PR TITLE
chore: expose ErrGetRecordNotSupportedForObject

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -116,6 +116,8 @@ var (
 
 	// ErrResolvingCustomFields is returned when custom fields cannot be retrieved for Read or ListObjectMetadata.
 	ErrResolvingCustomFields = errors.New("cannot resolve custom fields")
+
+	ErrGetRecordNotSupportedForObject = errors.New("getRecord is not supported for the object")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -17,8 +17,6 @@ var (
 	getRecordSupportedObjectsSet = datautils.NewStringSet(
 		"company", "contact", "deal", "ticket", "line_item", "product",
 	)
-
-	errGerRecordNotSupportedForObject = errors.New("getRecord is not supproted for the object")
 )
 
 /*
@@ -45,7 +43,7 @@ func (c *Connector) GetRecordsByIds(
 
 	singularObjName := naming.NewSingularString(objectName).String()
 	if !getRecordSupportedObjectsSet.Has(singularObjName) {
-		return nil, fmt.Errorf("%w %s", errGerRecordNotSupportedForObject, objectName)
+		return nil, fmt.Errorf("%w %s", common.ErrGetRecordNotSupportedForObject, objectName)
 	}
 
 	inputs := make([]map[string]any, len(ids))


### PR DESCRIPTION
Exposing this error so that the server can detect it specifically. Also fix typos.