### PR TITLE
feat(transport): Apply metadata as catalog variables

### DIFF
--- a/internal/components/provider.go
+++ b/internal/components/provider.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -20,23 +19,16 @@ type ProviderContext struct {
 func NewProviderContext(
 	provider providers.Provider,
 	module common.ModuleID,
-	workspace string,
-	metadata map[string]string,
+	catalogVars []catalogreplacer.CatalogVariable,
 ) (*ProviderContext, error) {
 	pctx := &ProviderContext{
 		provider: provider,
 		moduleID: module,
 	}
 
-	if metadata == nil {
-		metadata = make(map[string]string)
-	}
-
-	metadata[catalogreplacer.VariableWorkspace] = workspace
-
 	var err error
 
-	pctx.providerInfo, err = providers.ReadInfo(provider, paramsbuilder.NewCatalogVariables(metadata)...)
+	pctx.providerInfo, err = providers.ReadInfo(provider, catalogVars...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/components/transport.go
+++ b/internal/components/transport.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -18,7 +20,9 @@ func NewTransport(
 	provider providers.Provider,
 	params common.Parameters,
 ) (*Transport, error) {
-	providerContext, err := NewProviderContext(provider, params.Module, params.Workspace, params.Metadata)
+	variables := createCatalogVariables(params)
+
+	providerContext, err := NewProviderContext(provider, params.Module, variables)
 	if err != nil {
 		return nil, err
 	}
@@ -51,3 +55,14 @@ func (t *Transport) SetErrorHandler(handler common.ErrorHandler) {
 
 func (t *Transport) JSONHTTPClient() *common.JSONHTTPClient { return t.json }
 func (t *Transport) HTTPClient() *common.HTTPClient         { return t.json.HTTPClient }
+
+func createCatalogVariables(params common.Parameters) []catalogreplacer.CatalogVariable {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+
+	metadata[catalogreplacer.VariableWorkspace] = params.Workspace
+
+	return paramsbuilder.NewCatalogVariables(metadata)
+}


### PR DESCRIPTION
Workspace is not the only catalog variable. This considers metadata and passes this information when acquiring ProviderInfo instance.