### PR TITLE
Enable user object for Hubspot GetRecordsById

### DIFF
--- a/providers/hubspot/record.go
+++ b/providers/hubspot/record.go
@@ -15,7 +15,7 @@ import (
 //nolint:gochecknoglobals
 var (
 	getRecordSupportedObjectsSet = datautils.NewStringSet(
-		"company", "contact", "deal", "ticket", "line_item", "product",
+		"company", "contact", "deal", "ticket", "line_item", "product", "user",
 	)
 )
 


### PR DESCRIPTION
User is not CRM object, but the API endpoint has the same structure, so we just need to add to the list. 