### PR TITLE
[CON-1619] feat(modules): Connectors read moduleInfo

### DIFF
--- a/internal/components/provider.go
+++ b/internal/components/provider.go
@@ -13,7 +13,8 @@ import (
 type ProviderContext struct {
 	provider     providers.Provider
 	providerInfo *providers.ProviderInfo
-	module       common.ModuleID
+	moduleInfo   *providers.ModuleInfo
+	moduleID     common.ModuleID
 }
 
 func NewProviderContext(
@@ -22,7 +23,10 @@ func NewProviderContext(
 	workspace string,
 	metadata map[string]string,
 ) (*ProviderContext, error) {
-	pctx := &ProviderContext{provider: provider}
+	pctx := &ProviderContext{
+		provider: provider,
+		moduleID: module,
+	}
 
 	if metadata == nil {
 		metadata = make(map[string]string)
@@ -30,25 +34,20 @@ func NewProviderContext(
 
 	metadata[catalogreplacer.VariableWorkspace] = workspace
 
-	// TODO: Use module to get provider info
-	providerInfo, err := providers.ReadInfo(provider, paramsbuilder.NewCatalogVariables(metadata)...)
+	var err error
+
+	pctx.providerInfo, err = providers.ReadInfo(provider, paramsbuilder.NewCatalogVariables(metadata)...)
 	if err != nil {
 		return nil, err
 	}
 
-	pctx.providerInfo = providerInfo
-
-	if len(module) == 0 {
-		module = common.ModuleRoot
-	}
-
-	pctx.module = module
+	pctx.moduleInfo = pctx.providerInfo.ReadModuleInfo(module)
 
 	return pctx, nil
 }
 
 func (p *ProviderContext) String() string {
-	return fmt.Sprintf("%v.Connector[%v]", p.provider, p.module)
+	return fmt.Sprintf("%v.Connector[%v]", p.provider, p.moduleID)
 }
 
 func (p *ProviderContext) Provider() providers.Provider {
@@ -60,5 +59,5 @@ func (p *ProviderContext) ProviderInfo() *providers.ProviderInfo {
 }
 
 func (p *ProviderContext) Module() common.ModuleID {
-	return p.module
+	return p.moduleID
 }

--- a/internal/components/transport.go
+++ b/internal/components/transport.go
@@ -45,5 +45,9 @@ func (t *Transport) SetBaseURL(newURL string) {
 	t.json.HTTPClient.Base = newURL
 }
 
+func (t *Transport) SetErrorHandler(handler common.ErrorHandler) {
+	t.HTTPClient().ErrorHandler = handler
+}
+
 func (t *Transport) JSONHTTPClient() *common.JSONHTTPClient { return t.json }
 func (t *Transport) HTTPClient() *common.HTTPClient         { return t.json.HTTPClient }

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -8,9 +8,10 @@ import (
 
 // Connector is a Hubspot connector.
 type Connector struct {
-	BaseURL string
-	Client  *common.JSONHTTPClient
-	Module  common.Module
+	BaseURL    string
+	Client     *common.JSONHTTPClient
+	moduleInfo *providers.ModuleInfo
+	moduleID   common.ModuleID
 }
 
 // NewConnector returns a new Hubspot connector.
@@ -32,11 +33,13 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		Client: &common.JSONHTTPClient{
 			HTTPClient: params.Client.Caller,
 		},
-		Module: params.Module.Selection,
+		moduleID: params.Module.Selection.ID,
 	}
 
 	conn.setBaseURL(providerInfo.BaseURL)
 	conn.Client.HTTPClient.ErrorHandler = conn.interpretError
+
+	conn.moduleInfo = providerInfo.ReadModuleInfo(conn.moduleID)
 
 	return conn, nil
 }

--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -137,12 +137,12 @@ func (c *Connector) getObjectMetadataFromCRMSearch(
 	})
 	if err != nil {
 		// Ignore an error and fallback to static schema.
-		return metadata.Schemas.SelectOne(c.Module.ID, objectName)
+		return metadata.Schemas.SelectOne(c.moduleID, objectName)
 	}
 
 	if len(readResult.Data) == 0 {
 		// Read returned no rows.
-		return metadata.Schemas.SelectOne(c.Module.ID, objectName)
+		return metadata.Schemas.SelectOne(c.moduleID, objectName)
 	}
 
 	fields := make(map[string]common.FieldMetadata)

--- a/providers/hubspot/string.go
+++ b/providers/hubspot/string.go
@@ -4,5 +4,5 @@ import "fmt"
 
 // String returns a string representation of the connector, which is useful for logging / debugging.
 func (c *Connector) String() string {
-	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.Module.Path())
+	return fmt.Sprintf("%s.Connector[%s]", c.Provider(), c.moduleID)
 }

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -15,7 +15,9 @@ var errMissingValue = errors.New("missing value for query parameter")
 // getURL is a helper to return the full URL considering the base URL & module.
 // TODO: replace queryArgs with urlbuilder.New().WithQueryParam().
 func (c *Connector) getURL(arg string, queryArgs ...string) (string, error) {
-	urlBase := c.BaseURL + "/" + path.Join(c.Module.Path(), arg)
+	modulePath := supportedModules[c.moduleID].Path()
+
+	urlBase := c.BaseURL + "/" + path.Join(modulePath, arg)
 
 	if len(queryArgs) > 0 {
 		vals := url.Values{}

--- a/providers/keap/delete.go
+++ b/providers/keap/delete.go
@@ -11,7 +11,7 @@ func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*co
 		return nil, err
 	}
 
-	if !supportedObjectsByDelete[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByDelete[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 

--- a/providers/keap/metadata.go
+++ b/providers/keap/metadata.go
@@ -10,7 +10,7 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
 ) (*common.ListObjectMetadataResult, error) {
-	metadataResult, err := metadata.Schemas.Select(c.Module.ID, objectNames)
+	metadataResult, err := metadata.Schemas.Select(c.moduleID, objectNames)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/keap/write.go
+++ b/providers/keap/write.go
@@ -21,18 +21,18 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	var write common.WriteMethod
 
 	if len(config.RecordId) == 0 {
-		if supportedObjectsByCreate[c.Module.ID].Has(config.ObjectName) {
+		if supportedObjectsByCreate[c.moduleID].Has(config.ObjectName) {
 			write = c.Client.Post
 		}
 	} else {
 		// Update is done either by PUT or PATCH. There is no object present in both sets.
-		if supportedObjectsByUpdatePUT[c.Module.ID].Has(config.ObjectName) {
+		if supportedObjectsByUpdatePUT[c.moduleID].Has(config.ObjectName) {
 			write = c.Client.Put
 
 			url.AddPath(config.RecordId)
 		}
 
-		if supportedObjectsByUpdatePATCH[c.Module.ID].Has(config.ObjectName) {
+		if supportedObjectsByUpdatePATCH[c.moduleID].Has(config.ObjectName) {
 			write = c.Client.Patch
 
 			url.AddPath(config.RecordId)
@@ -57,7 +57,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	}
 
 	// write response was with payload
-	return constructWriteResult(config, c.Module.ID, body)
+	return constructWriteResult(config, c.moduleID, body)
 }
 
 func constructWriteResult(

--- a/providers/klaviyo/connector.go
+++ b/providers/klaviyo/connector.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Connector struct {
-	BaseURL string
-	Client  *common.JSONHTTPClient
-	Module  common.Module
+	BaseURL    string
+	Client     *common.JSONHTTPClient
+	moduleInfo *providers.ModuleInfo
+	moduleID   common.ModuleID
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
@@ -26,7 +27,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		Client: &common.JSONHTTPClient{
 			HTTPClient: httpClient,
 		},
-		Module: params.Module.Selection,
+		moduleID: params.Module.Selection.ID,
 	}
 
 	// Read provider info
@@ -34,6 +35,8 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	if err != nil {
 		return nil, err
 	}
+
+	conn.moduleInfo = providerInfo.ReadModuleInfo(conn.moduleID)
 
 	// connector and its client must mirror base url and provide its own error parser
 	conn.setBaseURL(providerInfo.BaseURL)
@@ -47,7 +50,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 }
 
 func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
-	path, err := metadata.Schemas.LookupURLPath(c.Module.ID, objectName)
+	path, err := metadata.Schemas.LookupURLPath(c.moduleID, objectName)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +71,7 @@ func (c *Connector) getDeleteURL(objectName string) (*urlbuilder.URL, error) {
 func (c *Connector) revisionHeader() common.Header {
 	return common.Header{
 		Key:   "revision",
-		Value: string(c.Module.ID),
+		Value: string(c.moduleID),
 	}
 }
 

--- a/providers/klaviyo/delete.go
+++ b/providers/klaviyo/delete.go
@@ -11,7 +11,7 @@ func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*co
 		return nil, err
 	}
 
-	if !supportedObjectsByDelete[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByDelete[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 

--- a/providers/klaviyo/metadata.go
+++ b/providers/klaviyo/metadata.go
@@ -10,5 +10,5 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
 ) (*common.ListObjectMetadataResult, error) {
-	return metadata.Schemas.Select(c.Module.ID, objectNames)
+	return metadata.Schemas.Select(c.moduleID, objectNames)
 }

--- a/providers/klaviyo/read.go
+++ b/providers/klaviyo/read.go
@@ -14,7 +14,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByRead[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 
@@ -53,7 +53,7 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 	}
 
 	if !config.Since.IsZero() {
-		if sinceField, found := objectsNameToSinceFieldName[c.Module.ID][config.ObjectName]; found {
+		if sinceField, found := objectsNameToSinceFieldName[c.moduleID][config.ObjectName]; found {
 			// Documentation about filtering: https://developers.klaviyo.com/en/docs/filtering_
 			// Ex: ?filter=greater-than(datetime,2023-03-01T01:00:00Z)
 			sinceValue := datautils.Time.FormatRFC3339inUTC(config.Since)

--- a/providers/klaviyo/write.go
+++ b/providers/klaviyo/write.go
@@ -22,11 +22,11 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	var write common.WriteMethod
 
 	if len(config.RecordId) == 0 {
-		if supportedObjectsByCreate[c.Module.ID].Has(config.ObjectName) {
+		if supportedObjectsByCreate[c.moduleID].Has(config.ObjectName) {
 			write = c.Client.Post
 		}
 	} else {
-		if supportedObjectsByUpdate[c.Module.ID].Has(config.ObjectName) {
+		if supportedObjectsByUpdate[c.moduleID].Has(config.ObjectName) {
 			write = c.Client.Patch
 
 			url.AddPath(config.RecordId)

--- a/providers/marketo/connector.go
+++ b/providers/marketo/connector.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Connector struct {
-	BaseURL string
-	Client  *common.JSONHTTPClient
-	Module  common.Module
+	BaseURL    string
+	Client     *common.JSONHTTPClient
+	moduleInfo *providers.ModuleInfo
+	moduleID   common.ModuleID
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
@@ -35,10 +36,12 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 				ResponseHandler: responseHandler,
 			},
 		},
-		Module: params.Module.Selection,
+		moduleID: params.Module.Selection.ID,
 	}
 
 	conn.setBaseURL(providerInfo.BaseURL)
+
+	conn.moduleInfo = providerInfo.ReadModuleInfo(conn.moduleID)
 
 	return conn, nil
 }
@@ -54,9 +57,10 @@ func (c *Connector) Provider() providers.Provider {
 }
 
 func (c *Connector) getAPIURL(objName string) (*urlbuilder.URL, error) {
+	modulePath := supportedModules[c.moduleID].Path()
 	objName = common.AddSuffixIfNotExists(objName, ".json")
 
-	return urlbuilder.New(c.BaseURL, restAPIPrefix, c.Module.Path(), objName)
+	return urlbuilder.New(c.BaseURL, restAPIPrefix, modulePath, objName)
 }
 
 func (c *Connector) String() string {

--- a/providers/marketo/metadata.go
+++ b/providers/marketo/metadata.go
@@ -39,7 +39,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		httpResp, body, err := c.Client.HTTPClient.Get(ctx, url.String())
 		if err != nil {
 			logging.Logger(ctx).Error("failed to get metadata", "object", obj, "body", body, "err", err.Error())
-			runFallback(c.Module.ID, obj, &metadataResult)
+			runFallback(c.moduleID, obj, &metadataResult)
 
 			continue
 		}
@@ -49,13 +49,13 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		resp, err := common.ParseJSONResponse(httpResp, body)
 		if err != nil {
 			logging.Logger(ctx).Error("failed to parse metadata response", "object", obj, "body", body, "err", err.Error())
-			runFallback(c.Module.ID, obj, &metadataResult)
+			runFallback(c.moduleID, obj, &metadataResult)
 
 			continue
 		}
 
 		if _, ok := resp.Body(); !ok {
-			runFallback(c.Module.ID, obj, &metadataResult)
+			runFallback(c.moduleID, obj, &metadataResult)
 
 			continue
 		}
@@ -63,7 +63,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 		data, err := parseMetadataFromResponse(resp, obj)
 		if err != nil {
 			if errors.Is(err, common.ErrMissingExpectedValues) {
-				runFallback(c.Module.ID, obj, &metadataResult)
+				runFallback(c.moduleID, obj, &metadataResult)
 
 				continue
 			} else {

--- a/providers/marketo/url.go
+++ b/providers/marketo/url.go
@@ -54,7 +54,7 @@ func (c *Connector) constructReadURL(ctx context.Context, params common.ReadPara
 	}
 
 	// The only objects in Assets API supporting this are: Emails, Programs, SmartCampaigns,SmartLists
-	if !params.Since.IsZero() && c.Module.ID == providers.ModuleMarketoAssets {
+	if !params.Since.IsZero() && c.moduleID == providers.ModuleMarketoAssets {
 		fmtTime := params.Since.Format(time.RFC3339)
 		url.WithQueryParam(earliestUpdatedQuery, fmtTime)
 		url.WithQueryParam(latestUpdatedAtQuery, time.Now().Format(time.RFC3339))

--- a/providers/zendesksupport/customFields.go
+++ b/providers/zendesksupport/customFields.go
@@ -18,7 +18,7 @@ import (
 func (c *Connector) requestCustomTicketFields(
 	ctx context.Context, objectName string,
 ) (map[int64]ticketField, error) {
-	if !objectsWithCustomFields[c.Module.ID].Has(objectName) {
+	if !objectsWithCustomFields[c.moduleID].Has(objectName) {
 		// This object doesn't have custom fields, we are done.
 		return map[int64]ticketField{}, nil
 	}

--- a/providers/zendesksupport/metadata.go
+++ b/providers/zendesksupport/metadata.go
@@ -11,12 +11,12 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
 ) (*common.ListObjectMetadataResult, error) {
-	metadataResult, err := metadata.Schemas.Select(c.Module.ID, objectNames)
+	metadataResult, err := metadata.Schemas.Select(c.moduleID, objectNames)
 	if err != nil {
 		return nil, err
 	}
 
-	customObjectNames := objectsWithCustomFields[c.Module.ID].Intersection(datautils.NewSetFromList(objectNames))
+	customObjectNames := objectsWithCustomFields[c.moduleID].Intersection(datautils.NewSetFromList(objectNames))
 	if len(customObjectNames) == 0 {
 		return metadataResult, nil
 	}

--- a/providers/zendesksupport/read.go
+++ b/providers/zendesksupport/read.go
@@ -15,7 +15,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByRead[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 
@@ -36,7 +36,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 
 	return common.ParseResult(
 		rsp,
-		getRecords(c.Module.ID, config.ObjectName),
+		getRecords(c.moduleID, config.ObjectName),
 		getNextRecordsURL,
 		common.MakeMarshaledDataFunc(c.attachReadCustomFields(customFields)),
 		config.Fields,
@@ -55,8 +55,8 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	pageSizeStr := metadata.Schemas.PageSize(c.Module.ID, config.ObjectName)
-	isIncremental := metadata.Schemas.IsIncrementalRead(c.Module.ID, config.ObjectName)
+	pageSizeStr := metadata.Schemas.PageSize(c.moduleID, config.ObjectName)
+	isIncremental := metadata.Schemas.IsIncrementalRead(c.moduleID, config.ObjectName)
 
 	if isIncremental {
 		// Incremental endpoints requires start query parameter.
@@ -68,7 +68,7 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 	} else {
 		// Different objects have different pagination types.
 		// https://developer.zendesk.com/api-reference/introduction/pagination/#using-offset-pagination
-		ptype := metadata.Schemas.LookupPaginationType(c.Module.ID, config.ObjectName)
+		ptype := metadata.Schemas.LookupPaginationType(c.moduleID, config.ObjectName)
 		if ptype == "cursor" {
 			url.WithQueryParam("page[size]", pageSizeStr)
 		}

--- a/providers/zoom/metadata.go
+++ b/providers/zoom/metadata.go
@@ -10,5 +10,5 @@ import (
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
 ) (*common.ListObjectMetadataResult, error) {
-	return metadata.Schemas.Select(c.Module.ID, objectNames)
+	return metadata.Schemas.Select(c.moduleID, objectNames)
 }

--- a/providers/zoom/read.go
+++ b/providers/zoom/read.go
@@ -14,7 +14,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	if !supportedObjectsByRead[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByRead[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 
@@ -28,7 +28,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		return nil, err
 	}
 
-	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, config.ObjectName)
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.moduleID, config.ObjectName)
 
 	return common.ParseResult(
 		rsp,

--- a/providers/zoom/write.go
+++ b/providers/zoom/write.go
@@ -14,7 +14,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		return nil, err
 	}
 
-	if !supportedObjectsByWrite[c.Module.ID].Has(config.ObjectName) {
+	if !supportedObjectsByWrite[c.moduleID].Has(config.ObjectName) {
 		return nil, common.ErrOperationNotSupportedForObject
 	}
 
@@ -46,7 +46,7 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 		}, nil
 	}
 
-	recordIdPath := objectNameToWriteResponseIdentifier[c.Module.ID].Get(config.ObjectName)
+	recordIdPath := objectNameToWriteResponseIdentifier[c.moduleID].Get(config.ObjectName)
 
 	// write response with payload
 	return constructWriteResult(body, recordIdPath)


### PR DESCRIPTION
# Background

Connectors built using the components package will automatically load module information into `ProviderContext`, which belongs to `Transport`, a field of the base `components.Connector`.

This PR only introduces the declaration and initialization of this capability — it does not utilize `moduleInfo` yet.

For example, AWS is built using `components.Connector` and will therefore have module info loaded automatically:

![image](https://github.com/user-attachments/assets/97b9a626-941d-4aee-bbb4-b75550d4cff7)
![image](https://github.com/user-attachments/assets/94abab56-5f53-4469-b7c0-b9770bccd584)

# Exceptions

The following connectors manually invoke `ReadModuleInfo` and store the result directly in their `<provider>.Connector` struct:
* Atlassian
* Hubspot
* Keap
* Klaviyo
* Marketo
* Zendesk
* Zoom