### PR TITLE
feat(interface): ProxyConnector

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -142,6 +142,9 @@ var (
 	// This can be used when the provider returns a 200 OK status,
 	// but the body of the response indicates an error or is missing expected fields.
 	ErrBadProviderResponse = errors.New("bad response from provider")
+
+	// ErrProxyNotApplicable indicates that a proxy cannot be used in the given context.
+	ErrProxyNotApplicable = errors.New("proxy is not applicable in this context")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/connectors.go
+++ b/connectors.go
@@ -26,6 +26,45 @@ type Connector interface {
 	Provider() providers.Provider
 }
 
+// ProxyConnector defines an interface for connectors that can describe
+// how requests should be proxied to an upstream provider.
+//
+// A connector instance may optionally be associated with a module.
+// Regardless, two proxy modes are exposed:
+//   - general proxy
+//   - module-specific proxy
+//
+// If the instance does not have a module, the module-specific proxy
+// behaves the same as the general proxy.
+type ProxyConnector interface {
+	Connector
+
+	// ProxyConfig returns the general proxy configuration for the provider.
+	//
+	// This represents the base proxy used for the provider.
+	//
+	// Returns common.ErrProxyNotApplicable if proxying is not supported.
+	ProxyConfig() (*ProxyConfig, error)
+
+	// ProxyModuleConfig returns the module-specific proxy configuration.
+	//
+	// If the connector instance is associated with a module, the returned
+	// configuration may include module-specific pathing, host, or routing.
+	//
+	// If the instance is not associated with a module, this MUST return the same
+	// configuration as ProxyConfig().
+	//
+	// Returns common.ErrProxyNotApplicable if proxying is not supported.
+	ProxyModuleConfig() (*ProxyConfig, error)
+}
+
+// ProxyConfig describes all information required to construct a proxy
+// request to an upstream provider.
+type ProxyConfig struct {
+	// URL is used for proxying requests.
+	URL string
+}
+
 // URLConnector is an interface that extends the Connector interface with the ability to
 // retrieve URLs for resources.
 type URLConnector interface {

--- a/internal/components/connector.go
+++ b/internal/components/connector.go
@@ -3,6 +3,7 @@ package components
 import (
 	"errors"
 
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/providers"
@@ -19,7 +20,13 @@ type ConnectorConstructor[T any] func(*Connector) (*T, error)
 // to avoid ambiguity when combined with interfaces that embed fmt.Stringer.
 type Connector struct {
 	*Transport
+	*ProxyResolver
 }
+
+var (
+	_ connectors.Connector      = (*Connector)(nil)
+	_ connectors.ProxyConnector = (*Connector)(nil)
+)
 
 // Initialize initializes a connector with the given provider and parameters
 // by using Connector as a base type. It runs the constructor with the connector
@@ -44,7 +51,10 @@ func Initialize[T any](
 		return nil, err
 	}
 
-	conn, err = constructor(&Connector{Transport: transport})
+	conn, err = constructor(&Connector{
+		Transport:     transport,
+		ProxyResolver: NewProxyResolver(transport.ProviderContext),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/components/proxy.go
+++ b/internal/components/proxy.go
@@ -1,0 +1,56 @@
+package components
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// ProxyResolver derives proxy configurations from provider and module metadata.
+type ProxyResolver struct {
+	defaultURL string
+	moduleURL  string
+}
+
+// NewProxyResolver constructs a ProxyResolver using the given provider context.
+func NewProxyResolver(providerContext ProviderContext) *ProxyResolver {
+	return &ProxyResolver{
+		defaultURL: providerContext.ProviderInfo().BaseURL,
+		moduleURL:  providerContext.ModuleInfo().BaseURL,
+	}
+}
+
+// ProxyConfig returns the general proxy configuration for the provider.
+//
+// It uses the provider-level BaseURL and does not apply any module-specific behavior.
+//
+// Returns common.ErrProxyNotApplicable if the URL cannot be parsed.
+func (r *ProxyResolver) ProxyConfig() (*connectors.ProxyConfig, error) {
+	_, err := url.Parse(r.defaultURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", common.ErrProxyNotApplicable, err)
+	}
+
+	return &connectors.ProxyConfig{
+		URL: r.defaultURL,
+	}, nil
+}
+
+// ProxyModuleConfig returns the module-specific proxy configuration.
+//
+// It uses the module-level BaseURL. If the instance is not associated
+// with a module, this behaves the same as ProxyConfig().
+//
+// Returns common.ErrProxyNotApplicable if the URL cannot be parsed.
+func (r *ProxyResolver) ProxyModuleConfig() (*connectors.ProxyConfig, error) {
+	_, err := url.Parse(r.moduleURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", common.ErrProxyNotApplicable, err)
+	}
+
+	return &connectors.ProxyConfig{
+		URL: r.moduleURL,
+	}, nil
+}

--- a/providers/google/proxy_test.go
+++ b/providers/google/proxy_test.go
@@ -1,0 +1,60 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestProxy(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Proxy{
+		{
+			Name: "Google Calendar Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestCalendarConnector("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://www.googleapis.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://www.googleapis.com/calendar",
+			},
+		},
+		{
+			Name: "Google Contacts Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestContactsConnector("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://www.googleapis.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://people.googleapis.com",
+			},
+		},
+		{
+			Name: "Google Mail Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestMailConnector("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://www.googleapis.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://gmail.googleapis.com/gmail",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t)
+		})
+	}
+}

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/salesforce/internal/crm"
 	crmcore "github.com/amp-labs/connectors/providers/salesforce/internal/crm/core"
@@ -21,6 +22,8 @@ import (
 // while others are delegated to specialized sub-adapters (see below).
 // These sub-adapters will be consolidated as the migration completes under "crm.Adapter".
 type Connector struct {
+	*components.ProxyResolver
+
 	Client *common.JSONHTTPClient
 
 	providerInfo *providers.ProviderInfo
@@ -82,11 +85,15 @@ func NewConnector(opts ...Option) (*Connector, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		conn.ProxyResolver = conn.pardotAdapter.Connector.ProxyResolver
 	} else {
 		conn.crmAdapter, err = crm.NewAdapter(connectorParams, conn.provider)
 		if err != nil {
 			return nil, err
 		}
+
+		conn.ProxyResolver = conn.crmAdapter.Connector.ProxyResolver
 	}
 
 	return conn, nil

--- a/providers/salesforce/proxy_test.go
+++ b/providers/salesforce/proxy_test.go
@@ -1,0 +1,60 @@
+package salesforce
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestProxy(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Proxy{
+		{
+			Name: "Salesforce CRM Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestConnector("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://test-workspace.my.salesforce.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://test-workspace.my.salesforce.com",
+			},
+		},
+		{
+			Name: "Salesforce Account Engagement Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestConnectorAccountEngagement("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://test-workspace.my.salesforce.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://pi.pardot.com",
+			},
+		},
+		{
+			Name: "Salesforce Account Engagement Demo Proxy",
+			Builder: func() (connectors.ProxyConnector, error) {
+				return constructTestConnectorAccountEngagementDemo("")
+			},
+			ExpectedProxy: &connectors.ProxyConfig{
+				URL: "https://test-workspace.my.salesforce.com",
+			},
+			ExpectedModuleProxy: &connectors.ProxyConfig{
+				URL: "https://pi.demo.pardot.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t)
+		})
+	}
+}

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -565,6 +565,10 @@ func constructTestConnectorAccountEngagement(serverURL string) (*Connector, erro
 	return constructTestConnectorGeneral(serverURL, providers.ModuleSalesforceAccountEngagement)
 }
 
+func constructTestConnectorAccountEngagementDemo(serverURL string) (*Connector, error) {
+	return constructTestConnectorGeneral(serverURL, providers.ModuleSalesforceAccountEngagementDemo)
+}
+
 func constructTestConnectorGeneral(serverURL string, module common.ModuleID) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(mockutils.NewClient()),
@@ -580,6 +584,8 @@ func constructTestConnectorGeneral(serverURL string, module common.ModuleID) (*C
 	}
 
 	// for testing we want to redirect calls to our mock server
+	// Some methods still live directly on the connector struct
+	// and not under nested adapter so this should be preserved.
 	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.moduleInfo.BaseURL, serverURL))
 
 	if connector.crmAdapter != nil {

--- a/test/utils/testroutines/proxy.go
+++ b/test/utils/testroutines/proxy.go
@@ -1,0 +1,32 @@
+package testroutines
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+// Proxy is a test suite useful for testing connectors.ProxyConnector interface.
+type Proxy struct {
+	Name                string
+	Builder             ConnectorBuilder[connectors.ProxyConnector]
+	ExpectedProxy       *connectors.ProxyConfig
+	ExpectedModuleProxy *connectors.ProxyConfig
+}
+
+// Run provides a procedure to test connectors.ReadConnector
+func (r Proxy) Run(t *testing.T) {
+	t.Helper()
+
+	conn := r.Builder.Build(t, r.Name)
+	defaultProxy, err1 := conn.ProxyConfig()
+	testutils.CheckOutputWithError(t, r.Name+" ProxyConfig()",
+		r.ExpectedProxy, nil,
+		defaultProxy, err1)
+
+	moduleProxy, err2 := conn.ProxyModuleConfig()
+	testutils.CheckOutputWithError(t, r.Name+" ProxyModuleConfig()",
+		r.ExpectedModuleProxy, nil,
+		moduleProxy, err2)
+}


### PR DESCRIPTION
# Description

Added `ProxyConnector` interface and one implementor `ProxyResolver`.

Every connector which embeds `components.Connector` will automatically inherit the methods of the `ProxyResolver` which are:
* ProxyConfig() (*ProxyConfig, error)
* ProxyModuleConfig() (*ProxyConfig, error)

For other connectors we would need to attach `ProxyResolver` directly.
* Added it to Salesforce as one example.
* Ideally all connectors should use `components.Connector` at its core.
* A connector may override methods provided by `ProxyResolver` for the non-standard cases (see **Future considerations** section below).

# Usage

A server may check if connector is of `ProxyConnector` type. Then it can invoke methods to get the URL and construct proxy.
Server may create proxy to a general URL or the current module. This should be controlled by `amp.yaml` in some way.

# Future considerations
A proxy is not just rerouting to some URL. Often times some headers and other properties can be added as a **decoration**. A connector holds metadata/workspace so it should be able to construct any kind of `ProxyConfig` which then can be consumed by server. This make proxy a feature of a connector just like Read/Write. Of course, in most cases it will continue to be simple as it is now, but it opens a window of opportunity.

cc @eberle1080 since you changed some proxy on server let me know your thoughts about it. This should add support to proxy to modules. I had this idea in mind long time ago ([outdated proposal](https://ampersand.slab.com/posts/better-testing-case-proxy-15zv9rmf)). 
