### PR TITLE
 feat(tests): Improve failure diagnostics

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -231,10 +231,10 @@ func (c *Connector) RunScheduledMaintenance(
 // Re-exports of Gmail history.list types so external callers can use them
 // without importing the internal mail package.
 type (
-	HistoryListParams  = mail.HistoryListParams
-	HistoryListResult  = mail.HistoryListResult
-	HistoryRecord      = mail.HistoryRecord
-	HistoryMessage     = mail.HistoryMessage
+	HistoryListParams    = mail.HistoryListParams
+	HistoryListResult    = mail.HistoryListResult
+	HistoryRecord        = mail.HistoryRecord
+	HistoryMessage       = mail.HistoryMessage
 	HistoryMessageChange = mail.HistoryMessageChange
 )
 

--- a/providers/hubspot/internal/crm/associations/create_test.go
+++ b/providers/hubspot/internal/crm/associations/create_test.go
@@ -211,12 +211,13 @@ func (c batchCreateTestCase) Run(t *testing.T, builder testroutines.ConnectorBui
 	testCaseTypeBatchCreate(c).Validate(t, err, output)
 }
 
-func batchCreateComparator(_ string, actual, expected *BatchCreateResult) bool {
-	different := actual.Success != expected.Success ||
-		!mockutils.ErrorNormalizedComparator.EachErrorEquals(
-			goutils.ToAnySlice(expected.Errors),
-			goutils.ToAnySlice(actual.Errors),
-		)
+func batchCreateComparator(_ string, actual, expected *BatchCreateResult) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+	result.Assert("Success", expected.Success, actual.Success)
+	result.Merge(mockutils.ErrorNormalizedComparator.EachErrorEquals(
+		goutils.ToAnySlice(expected.Errors),
+		goutils.ToAnySlice(actual.Errors),
+	))
 
-	return !different
+	return result
 }

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -345,7 +346,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	}
 }
 
-func comparatorSubsetReadOrderByFolderID(serverURL string, actual, expected *common.ReadResult) bool {
+func comparatorSubsetReadOrderByFolderID(
+	serverURL string, actual, expected *common.ReadResult,
+) *mockutils.CompareResult {
 	sort.Slice(actual.Data, func(i, j int) bool {
 		ai, _ := actual.Data[i].Fields["folder_id"].(string)
 		aj, _ := actual.Data[j].Fields["folder_id"].(string)

--- a/providers/salesforce/bulk-info_test.go
+++ b/providers/salesforce/bulk-info_test.go
@@ -2,10 +2,10 @@ package salesforce
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -248,21 +248,35 @@ func TestGetBulkQueryResults(t *testing.T) { // nolint:dupl
 	}
 }
 
-func statusCodeComparator(serverURL string, actual, expected *http.Response) bool {
-	return actual.StatusCode == expected.StatusCode
+func statusCodeComparator(serverURL string, actual, expected *http.Response) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+
+	result.Assert("StatusCode", expected.StatusCode, actual.StatusCode)
+
+	return result
 }
 
-func testJobResultsComparator(serverURL string, actual, expected *JobResults) bool {
+func testJobResultsComparator(serverURL string, actual, expected *JobResults) *mockutils.CompareResult {
 	actual.JobInfo = nil // ignore JobInfo when comparing
 
-	return reflect.DeepEqual(actual, expected)
+	result := mockutils.NewCompareResult()
+
+	result.Assert("JobResults", expected, actual)
+
+	return result
 }
 
-func testConciseJobInfoComparator(serverURL string, actual *GetJobInfoResult, expected *GetJobInfoResult) bool {
-	return actual.Id == expected.Id &&
-		actual.Object == expected.Object &&
-		actual.State == expected.State &&
-		actual.CreatedDate == expected.CreatedDate
+func testConciseJobInfoComparator(
+	serverURL string, actual *GetJobInfoResult, expected *GetJobInfoResult,
+) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+
+	result.Assert("Id", expected.Id, actual.Id)
+	result.Assert("Object", expected.Object, actual.Object)
+	result.Assert("State", expected.State, actual.State)
+	result.Assert("CreatedDate", expected.CreatedDate, actual.CreatedDate)
+
+	return result
 }
 
 type (

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -3,7 +3,6 @@ package salesforce
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -161,7 +160,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithAccount),
 			}.Server(),
-			Comparator: comparatorSubsetReadWithAssociations,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -231,7 +230,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithContacts),
 			}.Server(),
-			Comparator: comparatorSubsetReadWithAssociations,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -304,160 +303,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
 				return constructTestConnector(tt.Server.URL)
-			})
-		})
-	}
-}
-
-// comparatorSubsetReadWithAssociations extends ComparatorSubsetRead to also validate associations.
-func comparatorSubsetReadWithAssociations(serverURL string, actual, expected *common.ReadResult) bool {
-	// First check fields, raw, and pagination using the standard comparator
-	if !testroutines.ComparatorSubsetRead(serverURL, actual, expected) {
-		return false
-	}
-
-	// Then check associations
-	if len(actual.Data) < len(expected.Data) {
-		return false
-	}
-
-	for i := range expected.Data {
-		if !validateAssociationsForRow(actual.Data[i].Associations, expected.Data[i].Associations) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// validateAssociationsForRow validates associations for a single row.
-func validateAssociationsForRow(actualAssoc, expectedAssoc map[string][]common.Association) bool {
-	// If expected has no associations, actual can have none or some (we don't care)
-	if len(expectedAssoc) == 0 {
-		return true
-	}
-
-	// If expected has associations but actual doesn't, that's a failure
-	if len(actualAssoc) == 0 {
-		return false
-	}
-
-	// Check each expected association type
-	for assocType, expectedAssociations := range expectedAssoc {
-		actualAssociations, ok := actualAssoc[assocType]
-		if !ok {
-			return false
-		}
-
-		if !validateAssociationsList(actualAssociations, expectedAssociations) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// validateAssociationsList validates a list of associations.
-func validateAssociationsList(actualAssociations, expectedAssociations []common.Association) bool {
-	// Check that we have at least as many associations as expected
-	if len(actualAssociations) < len(expectedAssociations) {
-		return false
-	}
-
-	// Check each expected association
-	for j, expectedAssoc := range expectedAssociations {
-		actualAssoc := actualAssociations[j]
-
-		if !validateSingleAssociation(actualAssoc, expectedAssoc) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// validateSingleAssociation validates a single association.
-func validateSingleAssociation(actualAssoc, expectedAssoc common.Association) bool {
-	// Check ObjectId
-	if expectedAssoc.ObjectId != "" && actualAssoc.ObjectId != expectedAssoc.ObjectId {
-		return false
-	}
-
-	// Check Raw - if expected is nil, actual should be nil
-	if expectedAssoc.Raw == nil && actualAssoc.Raw != nil {
-		return false
-	}
-
-	// If expected has Raw data, check it matches
-	if expectedAssoc.Raw != nil {
-		if !reflect.DeepEqual(actualAssoc.Raw, expectedAssoc.Raw) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func TestReadWithCustomTimestampColumn(t *testing.T) {
-	t.Parallel()
-
-	responseListContacts := testutils.DataFromFile(t, "read-list-contacts.json")
-
-	since := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
-
-	tests := []testroutines.Read{
-		{
-			Name: "Incremental read uses custom timestamp column in SOQL",
-			Input: common.ReadParams{
-				ObjectName: "contacts",
-				Fields:     connectors.Fields("Department"),
-				Since:      since,
-			},
-			Server: mockserver.Conditional{
-				Setup: mockserver.ContentJSON(),
-				If: mockcond.And{
-					mockcond.Path("/services/data/v60.0/query"),
-					mockcond.QueryParam("q",
-						"SELECT Id,Department FROM contacts WHERE LastModifiedDate > 2024-01-15T00:00:00Z"),
-				},
-				Then: mockserver.Response(http.StatusOK, responseListContacts),
-			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
-			Expected: &common.ReadResult{
-				Rows: 20,
-				Done: true,
-			},
-			ExpectedErrs: nil,
-		},
-		{
-			Name: "Backfill read unaffected by custom timestamp column",
-			Input: common.ReadParams{
-				ObjectName: "contacts",
-				Fields:     connectors.Fields("Department"),
-			},
-			Server: mockserver.Conditional{
-				Setup: mockserver.ContentJSON(),
-				If: mockcond.And{
-					mockcond.Path("/services/data/v60.0/query"),
-					mockcond.QueryParam("q", "SELECT Id,Department FROM contacts"),
-				},
-				Then: mockserver.Response(http.StatusOK, responseListContacts),
-			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
-			Expected: &common.ReadResult{
-				Rows: 20,
-				Done: true,
-			},
-			ExpectedErrs: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
-
-			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnectorWithTimestampColumn(tt.Server.URL, "LastModifiedDate")
 			})
 		})
 	}

--- a/providers/salesforce/search_test.go
+++ b/providers/salesforce/search_test.go
@@ -146,7 +146,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithAccount),
 			}.Server(),
-			Comparator: comparatorSubsetReadWithAssociations,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -217,7 +217,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithContacts),
 			}.Server(),
-			Comparator: comparatorSubsetReadWithAssociations,
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{

--- a/test/utils/mockutils/batchWriteResult.go
+++ b/test/utils/mockutils/batchWriteResult.go
@@ -1,6 +1,8 @@
 package mockutils
 
 import (
+	"fmt"
+
 	"github.com/amp-labs/connectors/common"
 )
 
@@ -12,16 +14,18 @@ var BatchWriteResultComparator = batchWriteResultComparator{}
 
 type batchWriteResultComparator struct{}
 
-// SubsetWriteResults compares two BatchWriteResult objects and returns true
+// SubsetWriteResults compares two BatchWriteResult objects and returns a CompareResult
 // if each WriteResult in `expected` matches its corresponding entry in `actual`.
 //
 // A match is defined as follows:
 //   - Subset equality for the Data field of each WriteResult (only expected keys/values are checked).
 //   - Normalized equality for Errors, supporting struct/JSON, string, or golang error comparison.
 //   - Exact equality for the Success and RecordId fields.
-func (batchWriteResultComparator) SubsetWriteResults(actual, expected *common.BatchWriteResult) bool {
+func (batchWriteResultComparator) SubsetWriteResults(actual, expected *common.BatchWriteResult) *CompareResult {
+	result := NewCompareResult()
 	if len(actual.Results) != len(expected.Results) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected %d batch results, got %d", len(expected.Results), len(actual.Results)))
+		return result
 	}
 
 	// Compare each result using existing comparator
@@ -29,15 +33,21 @@ func (batchWriteResultComparator) SubsetWriteResults(actual, expected *common.Ba
 		actualResult := &actual.Results[i]
 		expectedResult := &expected.Results[i]
 
-		a := WriteResultComparator.SubsetData(actualResult, expectedResult)
-		b := ErrorNormalizedComparator.EachErrorEquals(actualResult.Errors, expectedResult.Errors)
-		c := actualResult.Success == expectedResult.Success &&
-			actualResult.RecordId == expectedResult.RecordId
+		dataComparison := WriteResultComparator.SubsetData(actualResult, expectedResult)
+		errorComparison := ErrorNormalizedComparator.EachErrorEquals(actualResult.Errors, expectedResult.Errors)
 
-		if !(a && b && c) {
-			return false
+		for _, diff := range dataComparison.Diff {
+			result.AddDiff(fmt.Sprintf("Result[%d] %s", i, diff))
 		}
+
+		for _, diff := range errorComparison.Diff {
+			result.AddDiff(fmt.Sprintf("Result[%d] %s", i, diff))
+		}
+
+		result.Assert(fmt.Sprintf("Result[%d].Success", i), expectedResult.Success, actualResult.Success)
+		result.Assert(fmt.Sprintf("Result[%d].RecordId", i), expectedResult.RecordId, actualResult.RecordId)
+
 	}
 
-	return true
+	return result
 }

--- a/test/utils/mockutils/checks.go
+++ b/test/utils/mockutils/checks.go
@@ -3,8 +3,81 @@ package mockutils
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/go-test/deep"
 )
+
+// CompareResult holds the result of a comparison operation between actual and expected values.
+// It tracks whether the comparison passed (OK) and collects detailed failure messages (Diff)
+// for precise test failure diagnostics.
+type CompareResult struct {
+	OK   bool     // True if comparison passed completely, false otherwise
+	Diff []string // List of human-readable failure descriptions, empty if OK
+}
+
+// NewCompareResult creates a successful comparison result instance.
+func NewCompareResult() *CompareResult {
+	return &CompareResult{OK: true}
+}
+
+// AddDiff marks the comparison as failed and appends a custom failure message.
+//
+// This is the primary way to report simple failures like row count mismatches
+// or pagination URL differences.
+func (r *CompareResult) AddDiff(diff string) {
+	r.OK = false
+	r.Diff = append(r.Diff, diff)
+}
+
+// Assert compares two data structures using github.com/go-test/deep.Equal
+// and records a formatted mismatch report for the specified data name.
+// Returns true if mismatch found (and recorded), false if exact match.
+//
+// Example output:
+//
+//	Data[0].Fields[stagename] mismatch:
+//	❌ Prospecting != PROSPECTING
+//
+//	Data[0].Raw[OpportunityContactRoles] mismatch:
+//	❌ map[totalSize]: 2 != 3
+//
+// No-op (returns false) if structures match exactly.
+func (r *CompareResult) Assert(dataName string, expectedData, gotData any) bool {
+	diff := deep.Equal(gotData, expectedData)
+	if len(diff) == 0 {
+		return false
+	}
+
+	list := make([]string, len(diff))
+	for index, text := range diff {
+		// Tabulated list of mismatches.
+		list[index] = fmt.Sprintf("\t❌ %v", text)
+	}
+
+	message := fmt.Sprintf("%v mismatch:\n%v", dataName, strings.Join(list, "\n"))
+
+	r.Diff = append(r.Diff, message)
+	r.OK = false
+
+	return true
+}
+
+// Merge combines another CompareResult into the receiver.
+//
+// Updates OK status (true only if both were true) and concatenates all Diff messages.
+// Ignores nil other results. Used for chaining multiple sub-comparisons.
+func (r *CompareResult) Merge(other *CompareResult) {
+	if other == nil {
+		return
+	}
+
+	// Success requires both to succeed.
+	// Fail if either failed.
+	r.OK = r.OK && other.OK
+	r.Diff = append(r.Diff, other.Diff...)
+}
 
 func DoesObjectCorrespondToString(object any, correspondent string) bool {
 	if object == nil && len(correspondent) == 0 {

--- a/test/utils/mockutils/metadataResult.go
+++ b/test/utils/mockutils/metadataResult.go
@@ -2,7 +2,7 @@ package mockutils
 
 import (
 	"errors"
-	"reflect"
+	"fmt"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -12,49 +12,52 @@ var MetadataResultComparator = metadataResultComparator{}
 type metadataResultComparator struct{}
 
 // SubsetFields checks that expected ListObjectMetadataResult fields are a subset of actual metadata result.
-func (metadataResultComparator) SubsetFields(actual, expected *common.ListObjectMetadataResult) bool {
+func (metadataResultComparator) SubsetFields(actual, expected *common.ListObjectMetadataResult) *CompareResult {
+	result := NewCompareResult()
 	for objectName, expectedMetadata := range expected.Result {
 		actualMetadata, ok := actual.Result[objectName]
 		if !ok {
-			return false
+			result.AddDiff(fmt.Sprintf("Result[%s] missing", objectName))
+			continue
 		}
 
-		if actualMetadata.DisplayName != expectedMetadata.DisplayName {
-			return false
-		}
+		result.Assert(fmt.Sprintf("Result[%s].DisplayName", objectName),
+			expectedMetadata.DisplayName, actualMetadata.DisplayName)
 
-		for k, v := range expectedMetadata.Fields {
-			value, ok := actualMetadata.Fields[k]
+		for k, expectedValue := range expectedMetadata.Fields {
+			actualValue, ok := actualMetadata.Fields[k]
 			if !ok {
-				return false
+				result.AddDiff(fmt.Sprintf("Result[%s].Fields[%s] missing", objectName, k))
+				continue
 			}
 
-			if !reflect.DeepEqual(value, v) {
-				return false
-			}
+			result.Assert(fmt.Sprintf("Result[%s].Fields[%s]", objectName, k),
+				expectedValue, actualValue)
 		}
 
 		// For backwards compatibility the FieldsMap is checked alongside
-		for k, v := range expectedMetadata.FieldsMap {
-			value, ok := actualMetadata.FieldsMap[k]
+		for k, expectedValue := range expectedMetadata.FieldsMap {
+			actualValue, ok := actualMetadata.FieldsMap[k]
 			if !ok {
-				return false
+				result.AddDiff(fmt.Sprintf("Result[%s].FieldsMap[%s] missing", objectName, k))
+				continue
 			}
 
-			if value != v {
-				return false
-			}
+			result.Assert(fmt.Sprintf("Result[%s].FieldsMap[%s]", objectName, k),
+				expectedValue, actualValue)
 		}
 	}
 
-	return true
+	return result
 }
 
-func (metadataResultComparator) SubsetErrors(actual, expected *common.ListObjectMetadataResult) bool {
+func (metadataResultComparator) SubsetErrors(actual, expected *common.ListObjectMetadataResult) *CompareResult {
+	result := NewCompareResult()
 	for objectName, expectedError := range expected.Errors {
 		actualError, ok := actual.Errors[objectName]
 		if !ok {
-			return false
+			result.AddDiff(fmt.Sprintf("Errors[%s] missing", objectName))
+			continue
 		}
 
 		// The tester may specify ExpectedSubsetErrors with a list of errors to be present inside actualError.
@@ -66,10 +69,9 @@ func (metadataResultComparator) SubsetErrors(actual, expected *common.ListObject
 
 		if !errorsAre(actualError, expectedErrors) {
 			// Subset of errors is not found under actual error for current object name.
-			// No need to check other object names.
-			return false
+			result.Assert(fmt.Sprintf("Errors[%s]", objectName), expectedErrors, actualError)
 		}
 	}
 
-	return true
+	return result
 }

--- a/test/utils/mockutils/normalizedErrors.go
+++ b/test/utils/mockutils/normalizedErrors.go
@@ -27,10 +27,11 @@ type errorNormalizedComparator struct{}
 //  4. Fallback: string comparison via fmt.Sprintf("%v").
 //
 // It returns true if the two values are considered equivalent under these rules.
-func (errorNormalizedComparator) ErrorEquals(actualErr, expectedErr any) bool {
+func (errorNormalizedComparator) ErrorEquals(actualErr, expectedErr any) *CompareResult {
+	result := NewCompareResult()
 	// 1. Direct equality first.
 	if reflect.DeepEqual(actualErr, expectedErr) {
-		return true
+		return result // good
 	}
 
 	// 2. If both implement error, compare semantically.
@@ -39,35 +40,36 @@ func (errorNormalizedComparator) ErrorEquals(actualErr, expectedErr any) bool {
 
 	if aOK && eOL {
 		if errors.Is(aErr, eErr) || strings.Contains(aErr.Error(), eErr.Error()) {
-			return true
+			return result // good
 		}
 
-		return false
+		result.Assert("error", eErr, aErr)
+		return result
 	}
 
 	// 3. Handle JSON case if expected is a JSON string.
 	if expectedJSON, ok := expectedErr.(JSONErrorWrapper); ok {
 		aJSON, err := json.Marshal(actualErr)
 		if err != nil {
-			return false
+			result.AddDiff(fmt.Sprintf("failed to marshal actual error to JSON: %v", err))
+			return result
 		}
 
 		if jsonBodyMatch(aJSON, string(expectedJSON)) {
-			return true
+			return result // good
 		}
 
-		return false
+		result.Assert("JSON error", string(expectedJSON), string(aJSON))
+		return result
 	}
 
 	// 4. Fallback string-based comparison.
 	aStr := fmt.Sprintf("%v", actualErr)
 	eStr := fmt.Sprintf("%v", expectedErr)
 
-	if aStr == eStr {
-		return true
-	}
+	result.Assert("error string", eStr, aStr)
 
-	return false
+	return result
 }
 
 // EachErrorEquals compares two slices of heterogeneous error values.
@@ -75,18 +77,22 @@ func (errorNormalizedComparator) ErrorEquals(actualErr, expectedErr any) bool {
 // according to ErrorEquals.
 //
 // Order and slice length must match exactly.
-func (c errorNormalizedComparator) EachErrorEquals(actual, expected []any) bool {
+func (c errorNormalizedComparator) EachErrorEquals(actual, expected []any) *CompareResult {
+	result := NewCompareResult()
 	if len(actual) != len(expected) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected %d errors, got %d", len(expected), len(actual)))
+		return result
 	}
 
 	for i := range len(actual) {
-		if !c.ErrorEquals(actual[i], expected[i]) {
-			return false
+		res := c.ErrorEquals(actual[i], expected[i])
+
+		for _, diff := range res.Diff {
+			result.AddDiff(fmt.Sprintf("Errors[%d] %s", i, diff))
 		}
 	}
 
-	return true
+	return result
 }
 
 func jsonBodyMatch(actual []byte, expected string) bool {

--- a/test/utils/mockutils/readResult.go
+++ b/test/utils/mockutils/readResult.go
@@ -1,7 +1,7 @@
 package mockutils
 
 import (
-	"reflect"
+	"fmt"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -11,9 +11,11 @@ var ReadResultComparator = readResultComparator{}
 type readResultComparator struct{}
 
 // SubsetRaw checks that expected ReadResult.Raw is a subset of actual ReadResult.Raw
-func (readResultComparator) SubsetRaw(actual, expected *common.ReadResult) bool {
+func (readResultComparator) SubsetRaw(actual, expected *common.ReadResult) *CompareResult {
+	result := NewCompareResult()
 	if len(actual.Data) < len(expected.Data) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected at least %d data entries, got %d", len(expected.Data), len(actual.Data)))
+		return result
 	}
 
 	if len(expected.Data) == 0 || len(expected.Data[0].Raw) == 0 {
@@ -22,19 +24,21 @@ func (readResultComparator) SubsetRaw(actual, expected *common.ReadResult) bool 
 
 	for i := range expected.Data {
 		for field := range expected.Data[i].Raw {
-			if !reflect.DeepEqual(actual.Data[i].Raw[field], expected.Data[i].Raw[field]) {
-				return false
-			}
+			got := actual.Data[i].Raw[field]
+			exp := expected.Data[i].Raw[field]
+			result.Assert(fmt.Sprintf("Data[%d].Raw[%s]", i, field), exp, got)
 		}
 	}
 
-	return true
+	return result
 }
 
 // SubsetFields checks that expected ReadResult.Fields is a subset of actual ReadResult.Fields
-func (readResultComparator) SubsetFields(actual, expected *common.ReadResult) bool {
+func (readResultComparator) SubsetFields(actual, expected *common.ReadResult) *CompareResult {
+	result := NewCompareResult()
 	if len(actual.Data) < len(expected.Data) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected at least %d data entries, got %d", len(expected.Data), len(actual.Data)))
+		return result
 	}
 
 	if len(expected.Data) == 0 || len(expected.Data[0].Fields) == 0 {
@@ -43,71 +47,75 @@ func (readResultComparator) SubsetFields(actual, expected *common.ReadResult) bo
 
 	for i := range expected.Data {
 		for field := range expected.Data[i].Fields {
-			if !reflect.DeepEqual(actual.Data[i].Fields[field], expected.Data[i].Fields[field]) {
-				return false
-			}
+			got := actual.Data[i].Fields[field]
+			exp := expected.Data[i].Fields[field]
+			result.Assert(fmt.Sprintf("Data[%d].Fields[%s]", i, field), exp, got)
 		}
 	}
 
-	return true
+	return result
 }
 
 // SubsetAssociationsRaw checks that expected ReadResult.Associations are matching exactly,
 // but for each Association.Raw it only checks if every mentioned expected field is present in actual raw.
-func (readResultComparator) SubsetAssociationsRaw(actual, expected *common.ReadResult) bool {
+func (readResultComparator) SubsetAssociationsRaw(actual, expected *common.ReadResult) *CompareResult {
+	result := NewCompareResult()
 	if len(actual.Data) < len(expected.Data) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected at least %d data entries, got %d", len(expected.Data), len(actual.Data)))
+		return result
 	}
 
 	for i := range expected.Data {
-		if len(actual.Data[i].Associations) != len(expected.Data[i].Associations) {
-			return false
+		message := fmt.Sprintf("Data[%d].Associations length", i)
+		if result.Assert(message, len(expected.Data[i].Associations), len(actual.Data[i].Associations)) {
+			continue
 		}
 
 		for key, expectedAssociations := range expected.Data[i].Associations {
 			actualAssociations, ok := actual.Data[i].Associations[key]
 			if !ok {
-				return false
+				result.AddDiff(fmt.Sprintf("Data[%d].Associations[%s] missing", i, key))
+				continue
 			}
 
-			if len(actualAssociations) != len(expectedAssociations) {
-				return false
+			message = fmt.Sprintf("Data[%d].Associations[%s] length", i, key)
+			if result.Assert(message, len(expectedAssociations), len(actualAssociations)) {
+				continue
 			}
 
 			for j := range expectedAssociations {
-				if actualAssociations[j].ObjectId != expectedAssociations[j].ObjectId {
-					return false
-				}
-
-				if actualAssociations[j].AssociationType != expectedAssociations[j].AssociationType {
-					return false
-				}
+				result.Assert(fmt.Sprintf("Data[%d].Associations[%s][%d].ObjectId", i, key, j),
+					expectedAssociations[j].ObjectId, actualAssociations[j].ObjectId)
+				result.Assert(fmt.Sprintf("Data[%d].Associations[%s][%d].ObjectId", i, key, j),
+					expectedAssociations[j].AssociationType, actualAssociations[j].AssociationType)
 
 				// Check if expected Raw is a subset of actual Raw
 				for field := range expectedAssociations[j].Raw {
-					if !reflect.DeepEqual(actualAssociations[j].Raw[field], expectedAssociations[j].Raw[field]) {
-						return false
-					}
+					exp := expectedAssociations[j].Raw[field]
+					got := actualAssociations[j].Raw[field]
+					message = fmt.Sprintf("Data[%d].Associations[%s][%d].Raw[%s]", i, key, j, field)
+					result.Assert(message, exp, got)
 				}
 			}
 		}
 	}
 
-	return true
+	return result
 }
 
 // Identifiers checks that actual rows have identifiers matching with expected.
-// Empty strings signify nothing should be compared.
-func (c readResultComparator) Identifiers(actual *common.ReadResult, expected *common.ReadResult) bool {
-	for key, datum := range expected.Data {
-		if datum.Id != "" {
-			if actual.Data[key].Id != datum.Id {
-				return false
-			}
+// NOTE: Empty strings signify nothing should be compared.
+func (c readResultComparator) Identifiers(actual *common.ReadResult, expected *common.ReadResult) *CompareResult {
+	result := NewCompareResult()
+	for index, datum := range expected.Data {
+		expectedID := datum.Id
+		if expectedID != "" {
+			actualID := actual.Data[index].Id
+			result.Assert(fmt.Sprintf("Data[%v].Id", index), expectedID, actualID)
 		}
 	}
 
-	return true
+	return result
 }
 
 func invalidTest(message string) {

--- a/test/utils/mockutils/writeResult.go
+++ b/test/utils/mockutils/writeResult.go
@@ -1,7 +1,7 @@
 package mockutils
 
 import (
-	"reflect"
+	"fmt"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -12,27 +12,29 @@ type writeResultComparator struct{}
 
 // SubsetData checks that expected WriteResult.Data is a subset of actual WriteResult.Data
 // other fields are strictly compared.
-func (writeResultComparator) SubsetData(actual, expected *common.WriteResult) bool {
+func (writeResultComparator) SubsetData(actual, expected *common.WriteResult) *CompareResult {
+	result := NewCompareResult()
 	// We are expecting more fields than there in the existence.
 	if len(actual.Data) < len(expected.Data) {
-		return false
+		result.AddDiff(fmt.Sprintf("expected at least %d data fields, got %d", len(expected.Data), len(actual.Data)))
+		return result
 	}
 
 	// At least one field should be mentioned.
 	if len(actual.Data) > 0 && len(expected.Data) == 0 {
-		return false
+		result.AddDiff("expected some data fields, but none were specified in expected")
+		return result
 	}
 
-	for k, expectedValue := range expected.Data {
-		actualValue, ok := actual.Data[k]
+	for key, expectedValue := range expected.Data {
+		actualValue, ok := actual.Data[key]
 		if !ok {
-			return false
+			result.AddDiff(fmt.Sprintf("Data[%s] missing", key))
+			continue
 		}
 
-		if !reflect.DeepEqual(actualValue, expectedValue) {
-			return false
-		}
+		result.Assert(fmt.Sprintf("Data[%s]", key), expectedValue, actualValue)
 	}
 
-	return true
+	return result
 }

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -1,6 +1,7 @@
 package testroutines
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -13,21 +14,25 @@ import (
 // For usage please refer to ComparatorPagination.
 const URLTestServer = "{{testServerURL}}"
 
-// Comparator is an equality function with custom rules.
-// This package provides the most commonly used comparators.
-type Comparator[Output any] func(serverURL string, actual, expected Output) bool
+// Comparator is an equality function with custom rules for specific test scenarios.
+// Takes server URL actual output, expected output, and returns detailed comparison result.
+//
+// This package provides the most commonly used comparators like ComparatorSubsetRead, ComparatorPagination,
+// ComparatorSubsetWrite, ComparatorSubsetMetadata for partial field matching in large API responses.
+type Comparator[Output any] func(serverURL string, actual, expected Output) *mockutils.CompareResult
 
 // ComparatorSubsetRead ensures that a subset of fields or raw data is present in the response.
 // This is convenient for cases where the returned data is large,
 // allowing for a more concise test that still validates the desired behavior.
-func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult) bool {
-	a := mockutils.ReadResultComparator.SubsetFields(actual, expected)
-	b := mockutils.ReadResultComparator.SubsetRaw(actual, expected)
-	c := mockutils.ReadResultComparator.SubsetAssociationsRaw(actual, expected)
-	d := ComparatorPagination(serverURL, actual, expected)
-	e := mockutils.ReadResultComparator.Identifiers(actual, expected)
+func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+	result.Merge(mockutils.ReadResultComparator.SubsetFields(actual, expected))
+	result.Merge(mockutils.ReadResultComparator.SubsetRaw(actual, expected))
+	result.Merge(mockutils.ReadResultComparator.SubsetAssociationsRaw(actual, expected))
+	result.Merge(mockutils.ReadResultComparator.Identifiers(actual, expected))
+	result.Merge(ComparatorPagination(serverURL, actual, expected))
 
-	return a && b && c && d && e
+	return result
 }
 
 // ComparatorPagination will check pagination related fields.
@@ -41,16 +46,20 @@ func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult)
 // At runtime this may look as follows: http://127.0.0.1:38653/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=.
 // The query parameters in URL can be in different order, encoding could differ as soon as the URL content matches
 // the check will conclude that pagination matches.
-func ComparatorPagination(serverURL string, actual *common.ReadResult, expected *common.ReadResult) bool {
+func ComparatorPagination(
+	serverURL string, actual *common.ReadResult, expected *common.ReadResult,
+) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
 	expectedNextPage := resolveTestServerURL(expected.NextPage.String(), serverURL)
 
-	a := compareNextPageToken(actual.NextPage.String(), expectedNextPage)
-	b := actual.Rows == expected.Rows
-	c := actual.Done == expected.Done
+	if !compareNextPageToken(actual.NextPage.String(), expectedNextPage) {
+		result.Assert(fmt.Sprintf("NextPage mismatch"), expectedNextPage, actual.NextPage.String())
+	}
 
-	return a &&
-		b &&
-		c
+	result.Assert(fmt.Sprintf("Rows mismatch"), expected.Rows, actual.Rows)
+	result.Assert(fmt.Sprintf("Done mismatch"), expected.Done, actual.Done)
+
+	return result
 }
 
 func compareNextPageToken(actual, expected string) bool {
@@ -89,11 +98,14 @@ func compareNextPageToken(actual, expected string) bool {
 //
 // This comparator is typically used when only a subset of Data fields
 // needs verification rather than a full equality check.
-func ComparatorSubsetWrite(_ string, actual, expected *common.WriteResult) bool {
-	return mockutils.WriteResultComparator.SubsetData(actual, expected) &&
-		mockutils.ErrorNormalizedComparator.EachErrorEquals(actual.Errors, expected.Errors) &&
-		actual.Success == expected.Success &&
-		actual.RecordId == expected.RecordId
+func ComparatorSubsetWrite(_ string, actual, expected *common.WriteResult) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+	result.Assert(fmt.Sprintf("Success mismatch"), expected.Success, actual.Success)
+	result.Assert(fmt.Sprintf("RecordId mismatch"), expected.RecordId, actual.RecordId)
+	result.Merge(mockutils.WriteResultComparator.SubsetData(actual, expected))
+	result.Merge(mockutils.ErrorNormalizedComparator.EachErrorEquals(actual.Errors, expected.Errors))
+
+	return result
 }
 
 // ComparatorSubsetBatchWrite compares two BatchWriteResult objects,
@@ -106,15 +118,15 @@ func ComparatorSubsetWrite(_ string, actual, expected *common.WriteResult) bool 
 //
 // This enables expressive, stable tests that verify meaningful fields
 // without enforcing strict structural equality across the entire batch.
-func ComparatorSubsetBatchWrite(_ string, actual, expected *common.BatchWriteResult) bool {
-	if actual.Status != expected.Status ||
-		actual.SuccessCount != expected.SuccessCount ||
-		actual.FailureCount != expected.FailureCount {
-		return false
-	}
+func ComparatorSubsetBatchWrite(_ string, actual, expected *common.BatchWriteResult) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+	result.Assert(fmt.Sprintf("Status mismatch"), expected.Status, actual.Status)
+	result.Assert(fmt.Sprintf("SuccessCount mismatch"), expected.SuccessCount, actual.SuccessCount)
+	result.Assert(fmt.Sprintf("FailureCount mismatch"), expected.FailureCount, actual.FailureCount)
+	result.Merge(mockutils.BatchWriteResultComparator.SubsetWriteResults(actual, expected))
+	result.Merge(mockutils.ErrorNormalizedComparator.EachErrorEquals(actual.Errors, expected.Errors))
 
-	return mockutils.BatchWriteResultComparator.SubsetWriteResults(actual, expected) &&
-		mockutils.ErrorNormalizedComparator.EachErrorEquals(actual.Errors, expected.Errors)
+	return result
 }
 
 // ComparatorSubsetMetadata will check a subset of fields is present.
@@ -132,13 +144,16 @@ func ComparatorSubsetBatchWrite(_ string, actual, expected *common.BatchWriteRes
 //		"arsenal": common.NewHTTPError(http.StatusBadRequest,		// Is doing exact match.
 //			headers, body, fmt.Errorf("%w: %s", common.ErrCaller, string(unsupportedResponse))),
 //	},
-func ComparatorSubsetMetadata(_ string, actual, expected *common.ListObjectMetadataResult) bool {
+func ComparatorSubsetMetadata(_ string, actual, expected *common.ListObjectMetadataResult) *mockutils.CompareResult {
 	if len(expected.Result)+len(expected.Errors) == 0 {
 		panic("please specify expected Result or Errors in Metadata response")
 	}
 
-	return mockutils.MetadataResultComparator.SubsetFields(actual, expected) &&
-		mockutils.MetadataResultComparator.SubsetErrors(actual, expected)
+	result := mockutils.NewCompareResult()
+	result.Merge(mockutils.MetadataResultComparator.SubsetFields(actual, expected))
+	result.Merge(mockutils.MetadataResultComparator.SubsetErrors(actual, expected))
+
+	return result
 }
 
 func resolveTestServerURL(urlTemplate string, serverURL string) string {
@@ -160,43 +175,43 @@ func resolveTestServerURL(urlTemplate string, serverURL string) string {
 //   - Metadata is compared using subset semantics — all key/value
 //     pairs defined in expected.Metadata must be present in
 //     actual.Metadata, but actual may contain additional entries.
-func ComparatorSubsetUpsertMetadata(_ string, actual, expected *common.UpsertMetadataResult) bool {
-	if actual.Success != expected.Success || len(actual.Fields) != len(expected.Fields) {
-		return false
-	}
+func ComparatorSubsetUpsertMetadata(_ string, actual, expected *common.UpsertMetadataResult) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+	result.Assert(fmt.Sprintf("Success mismatch"), expected.Success, actual.Success)
+	result.Assert(fmt.Sprintf("Fields length mismatch"), len(expected.Fields), len(actual.Fields))
 
 	// Compare field results.
-	// When first difference is found, return with failure.
 	for propertyName, property := range expected.Fields {
 		for fieldName, expectedField := range property {
 			actualProperty, ok := actual.Fields[propertyName]
 			if !ok {
-				return false
+				result.AddDiff(fmt.Sprintf("Fields[%s] missing", propertyName))
+				continue
 			}
 
 			actualField, ok := actualProperty[fieldName]
 			if !ok {
-				return false
+				result.AddDiff(fmt.Sprintf("Fields[%s][%s] missing", propertyName, fieldName))
+				continue
 			}
 
 			// Field properties should be the same. This is a hard comparison.
-			generalPropertiesIdentical := actualField.FieldName == expectedField.FieldName &&
-				actualField.Action == expectedField.Action &&
-				reflect.DeepEqual(actualField.Warnings, expectedField.Warnings)
-
-			if !generalPropertiesIdentical {
-				return false
-			}
+			result.Assert(fmt.Sprintf("Fields[%s][%s].FieldName mismatch", propertyName, fieldName),
+				expectedField.FieldName, actualField.FieldName)
+			result.Assert(fmt.Sprintf("Fields[%s][%s].Action mismatch", propertyName, fieldName),
+				expectedField.Action, actualField.Action)
+			result.Assert(fmt.Sprintf("Fields[%s][%s].Warnings mismatch", propertyName, fieldName),
+				expectedField.Warnings, actualField.Warnings)
 
 			// A set of expected fields must be present
 			if !mapIsSubsetMap(expectedField.Metadata, actualField.Metadata) {
-				return false
+				result.Assert(fmt.Sprintf("Fields[%s][%s].Metadata mismatch", propertyName, fieldName),
+					expectedField.Metadata, actualField.Metadata)
 			}
 		}
 	}
 
-	// Everything is the same.
-	return true
+	return result
 }
 
 func mapIsSubsetMap(subset, superset map[string]any) bool {

--- a/test/utils/testroutines/outline.go
+++ b/test/utils/testroutines/outline.go
@@ -1,10 +1,12 @@
 package testroutines
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/go-test/deep"
 )
@@ -45,16 +47,32 @@ func (c TestCase[Input, Output]) checkError(t *testing.T, err error) {
 
 func (c TestCase[Input, Output]) checkValue(t *testing.T, output Output) {
 	// compare desired output
-	var ok bool
+	var result *mockutils.CompareResult
 	if c.Comparator == nil {
 		// default comparison is concerned about all fields
-		ok = reflect.DeepEqual(output, c.Expected)
+		result = c.defaultDeepCompare(output, c.Expected)
 	} else {
-		ok = c.Comparator(c.Server.URL, output, c.Expected)
+		result = c.Comparator(c.Server.URL, output, c.Expected)
 	}
 
-	if !ok {
-		diff := deep.Equal(output, c.Expected)
-		t.Fatalf("%s:, \nexpected: (%v), \ngot: (%v), \ndiff: (%v)", c.Name, c.Expected, output, diff)
+	if !result.OK {
+		message := fmt.Sprintf("[%s] some expectations were not satisfied:\n", c.Name)
+		for index, text := range result.Diff {
+			message += fmt.Sprintf("(%v) %v\n", index+1, text)
+		}
+
+		t.Fatal(message)
 	}
+}
+
+func (c TestCase[Input, Output]) defaultDeepCompare(actual, expected Output) *mockutils.CompareResult {
+	result := mockutils.NewCompareResult()
+
+	if !reflect.DeepEqual(actual, expected) {
+		for _, diff := range deep.Equal(actual, expected) {
+			result.AddDiff(diff)
+		}
+	}
+
+	return result
 }

--- a/test/utils/testroutines/post-auth-info.go
+++ b/test/utils/testroutines/post-auth-info.go
@@ -1,11 +1,11 @@
 package testroutines
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 )
 
 type (
@@ -21,36 +21,29 @@ func (r PostAuthInfo) Run(t *testing.T, builder ConnectorBuilder[connectors.Auth
 		PostAuthInfoType(r).Close()
 	})
 
-	r.Comparator = func(serverURL string, actual, expected *common.PostAuthInfo) bool {
-		if actual.ProviderWorkspaceRef != expected.ProviderWorkspaceRef {
-			return false
-		}
+	r.Comparator = func(serverURL string, actual, expected *common.PostAuthInfo) *mockutils.CompareResult {
+		result := mockutils.NewCompareResult()
 
-		if !reflect.DeepEqual(actual.CatalogVars, expected.CatalogVars) {
-			return false
-		}
+		result.Assert("ProviderWorkspaceRef", expected.ProviderWorkspaceRef, actual.ProviderWorkspaceRef)
+		result.Assert("CatalogVars", expected.CatalogVars, actual.CatalogVars)
 
 		if actual.RawResponse == nil && expected.RawResponse != nil {
-			return false
+			result.AddDiff("RawResponse is nil, expected non-nil")
 		}
 
 		if actual.RawResponse != nil && expected.RawResponse == nil {
-			return false
+			result.AddDiff("RawResponse is non-nil, expected nil")
 		}
 
 		if actual.RawResponse != nil && expected != nil {
-			if actual.RawResponse.Code != expected.RawResponse.Code {
-				return false
-			}
+			result.Assert("RawResponse.Code", expected.RawResponse.Code, actual.RawResponse.Code)
 
 			if expected.RawResponse.Headers != nil {
-				t.Fatalf("RawResoponse.Headers is not supported by PostAuthInfo TestCase")
-
-				return false
+				result.AddDiff("RawResponse.Headers is not supported by PostAuthInfo TestCase")
 			}
 		}
 
-		return true
+		return result
 	}
 
 	conn := builder.Build(t, r.Name)


### PR DESCRIPTION
# Description

Custom comparators now collect **all** failure details instead of stopping at the first error, making test failures instantly actionable without a debugger. Each failure message pinpoints exactly what mismatched (field name, row index, expected vs actual values).

**Key improvements:**
- **Pretty print** -- prints essential messages, tabulated, focusing on root causes.
- **Continues on failure** -- collects ALL differences.
- **Precise locations** -- "Data[0].Fields[stagename]" not buried in deep diff.

# Unit Tests before and after
Examples of deliberately failing unit tests showing the dramatic improvement (modified `main` branch VS modified `test-utils` branch).

## ListObjectMetadata

### Before
<img width="1202" height="592" alt="image" src="https://github.com/user-attachments/assets/d5d8339e-04e9-45bd-8ff1-7b38147a0dbb" />
there is even more.

### After
<img width="923" height="541" alt="image" src="https://github.com/user-attachments/assets/f8ac5984-7a9d-41b2-b2af-78501e3b1239" />

## Read with associations

### Before
<img width="1193" height="823" alt="image" src="https://github.com/user-attachments/assets/a85e7d84-421e-4b1e-b8c7-92b1d5c7de1d" />

### After
<img width="1195" height="688" alt="image" src="https://github.com/user-attachments/assets/aaad428f-1f33-4adf-89a0-fae8197607f7" />


## Batch Write
### Before
<img width="1207" height="767" alt="image" src="https://github.com/user-attachments/assets/3209e1c0-e7ad-45f9-8170-1980ca9bd309" />

### After
<img width="1199" height="730" alt="image" src="https://github.com/user-attachments/assets/9ab26a98-55bf-4ece-9e88-63dd6dd1412b" />

## Write

### Before
<img width="1178" height="563" alt="image" src="https://github.com/user-attachments/assets/f4e364cf-2e49-4062-a479-4347c90d969d" />

### After
<img width="814" height="485" alt="image" src="https://github.com/user-attachments/assets/28f5c9e5-4913-45cc-a0e5-dc138be9a1c7" />

# PS
Even ListObjectMetadata without any custom comparators which uses the exact match comparison is displayed better, where one can see the path clearly:
<img width="1157" height="309" alt="image" src="https://github.com/user-attachments/assets/8b4ce4b0-f80b-47f2-9d69-355b269b6b01" />

