### PR TITLE
chore: add catalog helper

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -644,3 +644,17 @@ func (i *ProviderInfo) Override(override *ProviderInfo) *ProviderInfo {
 
 	return i
 }
+
+func (i *ProviderInfo) RequiresWorkspace() bool {
+	if i.Metadata.Input == nil {
+		return false
+	}
+
+	for _, input := range i.Metadata.Input {
+		if input.Name == "workspace" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Workspace is a first class field on our API, so we need to keep supporting it. This is a helper that lets you quickly check if it exists as a requirement on the catalog.