### PR TITLE
tidy(creds): Infer Workspace requirement

### DIFF
--- a/common/scanning/credscanning/fields.go
+++ b/common/scanning/credscanning/fields.go
@@ -129,7 +129,7 @@ func (f Field) GetENVReader(providerName string) *scanning.EnvReader {
 
 // nolint:cyclop
 func getFields(info providers.ProviderInfo,
-	withRequiredAccessToken, withRequiredWorkspace bool, customFields []Field,
+	withRequiredAccessToken bool, customFields []Field,
 ) (datautils.NamedLists[Field], error) {
 	lists := datautils.NamedLists[Field]{}
 	requiredType := "required"
@@ -160,19 +160,13 @@ func getFields(info providers.ProviderInfo,
 		return nil, ErrProviderInfo
 	}
 
-	options := info.Oauth2Opts
-	if options != nil {
-		// FIXME imply workspace requirement when provider info will change
-		// As of now Workspace can only be implied for connectors supporting Oauth2.
-		// The changes extending to all connectors will happen
-		// at later time as indicated by https://github.com/amp-labs/openapi/pull/15.
-		// This field should be a general/universal workspace flag in which ever place it will be under ProviderInfo.
-		if options.ExplicitWorkspaceRequired {
-			withRequiredWorkspace = true
-		}
+	var withRequiredWorkspace bool
+	if info.Oauth2Opts != nil {
+		// ExplicitWorkspaceRequired will be deprecated.
+		withRequiredWorkspace = info.Oauth2Opts.ExplicitWorkspaceRequired
 	}
 
-	if withRequiredWorkspace {
+	if info.RequiresWorkspace() || withRequiredWorkspace {
 		lists.Add(requiredType, Fields.Workspace)
 	}
 

--- a/common/scanning/credscanning/provider.go
+++ b/common/scanning/credscanning/provider.go
@@ -31,11 +31,10 @@ type ProviderCredentials struct {
 func NewJSONProviderCredentials(
 	filePath string,
 	withRequiredAccessToken bool,
-	withRequiredWorkspace bool,
 	customFields ...Field,
 ) (*ProviderCredentials, error) {
 	return createProviderCreds(
-		getProviderName(filePath), withRequiredAccessToken, withRequiredWorkspace, filePath, customFields,
+		getProviderName(filePath), withRequiredAccessToken, filePath, customFields,
 	)
 }
 
@@ -43,16 +42,15 @@ func NewJSONProviderCredentials(
 func NewENVProviderCredentials(
 	providerName string,
 	withRequiredAccessToken bool,
-	withRequiredWorkspace bool,
 	customFields ...Field,
 ) (*ProviderCredentials, error) {
 	return createProviderCreds(
-		providerName, withRequiredAccessToken, withRequiredWorkspace, "", customFields,
+		providerName, withRequiredAccessToken, "", customFields,
 	)
 }
 
 func createProviderCreds(
-	providerName string, withRequiredAccessToken, withRequiredWorkspace bool, filePath string, customFields []Field,
+	providerName string, withRequiredAccessToken bool, filePath string, customFields []Field,
 ) (*ProviderCredentials, error) {
 	// load provider from catalog to imply fields in JSON or ENV vars
 	catalog, err := providers.ReadCatalog()
@@ -65,7 +63,7 @@ func createProviderCreds(
 		return nil, ErrProviderNotFound
 	}
 
-	fields, err := getFields(info, withRequiredAccessToken, withRequiredWorkspace, customFields)
+	fields, err := getFields(info, withRequiredAccessToken, customFields)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/utils/proxyserv/common.go
+++ b/scripts/utils/proxyserv/common.go
@@ -59,7 +59,7 @@ func validateRequiredOAuth2Flags(provider, clientId, clientSecret string) {
 }
 
 func getTokensFromRegistry(credsFile string) *oauth2.Token {
-	reader, err := credscanning.NewJSONProviderCredentials(credsFile, true, false)
+	reader, err := credscanning.NewJSONProviderCredentials(credsFile, true)
 	if err != nil {
 		panic(err)
 	}

--- a/test/aha/connector.go
+++ b/test/aha/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetAhaConnector(ctx context.Context) *aha.Connector {
 	filePath := credscanning.LoadPath(providers.Aha)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := aha.NewConnector(
 		common.ConnectorParams{

--- a/test/apollo/connector.go
+++ b/test/apollo/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetApolloConnector(ctx context.Context) *apollo.Connector {
 	filePath := credscanning.LoadPath(providers.Apollo)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, false)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := apollo.NewConnector(
 		apollo.WithClient(ctx, http.DefaultClient,

--- a/test/asana/connector.go
+++ b/test/asana/connector.go
@@ -14,7 +14,7 @@ import (
 func GetAsanaConnector(ctx context.Context) *asana.Connector {
 	filePath := credscanning.LoadPath(providers.Asana)
 
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := asana.NewConnector(
 		asana.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/ashby/connector.go
+++ b/test/ashby/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetAshbyConnector(ctx context.Context) *ashby.Connector {
 	filePath := credscanning.LoadPath(providers.Ashby)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, false)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewBasicAuthHTTPClient(ctx, reader.Get(credscanning.Fields.Username), reader.Get(credscanning.Fields.Password))
 

--- a/test/atlassian/connector.go
+++ b/test/atlassian/connector.go
@@ -16,7 +16,7 @@ const cloudId = "35745fff-f0de-466c-b08e-a63f69888611"
 
 func GetAtlassianConnector(ctx context.Context) *atlassian.Connector {
 	filePath := credscanning.LoadPath(providers.Atlassian)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := atlassian.NewConnector(
 		atlassian.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
@@ -38,7 +38,7 @@ func GetAtlassianConnector(ctx context.Context) *atlassian.Connector {
 
 func GetAtlassianConnectConnector(ctx context.Context, claims map[string]any) *atlassian.Connector {
 	filePath := credscanning.LoadPath(providers.Atlassian)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	opts := []common.HeaderAuthClientOption{
 		common.WithHeaderClient(http.DefaultClient),

--- a/test/attio/connector.go
+++ b/test/attio/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetAttioConnector(ctx context.Context) *attio.Connector {
 	filePath := credscanning.LoadPath(providers.Attio)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := attio.NewConnector(
 		attio.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/aws/connector.go
+++ b/test/aws/connector.go
@@ -46,7 +46,7 @@ var (
 
 func GetAWSConnector(ctx context.Context, module common.ModuleID) *aws.Connector {
 	filePath := credscanning.LoadPath(providers.AWS)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, false,
+	reader := testUtils.MustCreateProvCredJSON(filePath, false,
 		fieldRegion, fieldIdentityStoreID, fieldInstanceArn,
 	)
 

--- a/test/blueshift/connector.go
+++ b/test/blueshift/connector.go
@@ -13,7 +13,7 @@ import (
 func GetBlueshiftConnector(ctx context.Context) *blueshift.Connector {
 	filePath := credscanning.LoadPath(providers.Blueshift)
 
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewBasicAuthHTTPClient(ctx, reader.Get(credscanning.Fields.Username), reader.Get(credscanning.Fields.Password))
 

--- a/test/brevo/connector.go
+++ b/test/brevo/connector.go
@@ -13,7 +13,7 @@ import (
 func GetBrevoConnector(ctx context.Context) *brevo.Connector {
 	filePath := credscanning.LoadPath(providers.Brevo)
 
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyHeaderAuthHTTPClient(ctx, "api-key", reader.Get(credscanning.Fields.ApiKey))
 

--- a/test/capsule/connector.go
+++ b/test/capsule/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetCapsuleConnector(ctx context.Context) *capsule.Connector {
 	filePath := credscanning.LoadPath(providers.Capsule)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	clientBuilder := &paramsbuilder.Client{}
 	clientBuilder.WithApiKeyHeaderClient(ctx,

--- a/test/chilipiper/connector.go
+++ b/test/chilipiper/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetChiliPiperConnector(ctx context.Context) *chilipiper.Connector {
 	filePath := credscanning.LoadPath(providers.ChiliPiper)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, false)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := chilipiper.NewConnector(
 		chilipiper.WithClient(ctx, http.DefaultClient,

--- a/test/clickup/connector.go
+++ b/test/clickup/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetClickupConnector(ctx context.Context) *clickup.Connector {
 	filePath := credscanning.LoadPath(providers.ClickUp)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	options := []common.OAuthOption{
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/closecrm/connector.go
+++ b/test/closecrm/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetCloseConnector(ctx context.Context) *closecrm.Connector {
 	filePath := credscanning.LoadPath(providers.Close)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := closecrm.NewConnector(
 		closecrm.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/constantcontact/connector.go
+++ b/test/constantcontact/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetConstantContactConnector(ctx context.Context) *constantcontact.Connector {
 	filePath := credscanning.LoadPath(providers.ConstantContact)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := constantcontact.NewConnector(
 		constantcontact.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/customerio/journeysapp/connector.go
+++ b/test/customerio/journeysapp/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetCustomerJourneysAppConnector(ctx context.Context) *customerapp.Connector {
 	filePath := credscanning.LoadPath(providers.CustomerJourneysApp)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := customerapp.NewConnector(
 		customerapp.WithClient(ctx, http.DefaultClient,

--- a/test/dixa/connector.go
+++ b/test/dixa/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetConnector(ctx context.Context) *dixa.Connector {
 	filePath := credscanning.LoadPath(providers.Dixa)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyHeaderAuthHTTPClient(ctx, "Authorization", reader.Get(credscanning.Fields.ApiKey))
 	if err != nil {

--- a/test/docusign/connector.go
+++ b/test/docusign/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetDocusignConnector(ctx context.Context) *docusign.Connector {
 	filePath := credscanning.LoadPath(providers.Docusign)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := docusign.NewConnector(
 		docusign.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/drift/connector.go
+++ b/test/drift/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetConnector(ctx context.Context) *drift.Connector {
 	filePath := credscanning.LoadPath(providers.Drift)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/dynamicscrm/connector.go
+++ b/test/dynamicscrm/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetMSDynamics365CRMConnector(ctx context.Context) *dynamicscrm.Connector {
 	filePath := credscanning.LoadPath(providers.DynamicsCRM)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := dynamicscrm.NewConnector(
 		dynamicscrm.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/fireflies/connector.go
+++ b/test/fireflies/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetFirefliesConnector(ctx context.Context) *fireflies.Connector {
 	filePath := credscanning.LoadPath(providers.Fireflies)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client := utils.NewAPIKeyClient(ctx, reader, providers.Fireflies)
 

--- a/test/freshdesk/connector.go
+++ b/test/freshdesk/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetFreshdeskConnector(ctx context.Context) *freshdesk.Connector {
 	filePath := credscanning.LoadPath(providers.Freshdesk)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, true)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := freshdesk.NewConnector(
 		freshdesk.WithClient(ctx, http.DefaultClient, reader.Get(credscanning.Fields.Username), reader.Get(credscanning.Fields.Password)),

--- a/test/front/connector.go
+++ b/test/front/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetFrontConnector(ctx context.Context) *front.Connector {
 	filePath := credscanning.LoadPath(providers.Front)
-	reader := testUtils.MustCreateProvCredJSON(filePath, false, false)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := front.NewConnector(common.ConnectorParams{
 		AuthenticatedClient: utils.NewAPIKeyClient(ctx, reader, providers.Front),

--- a/test/github/connector.go
+++ b/test/github/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetGithubConnector(ctx context.Context) *github.Connector {
 	filePath := credscanning.LoadPath(providers.Github)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	options := []common.OAuthOption{
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/gitlab/connector.go
+++ b/test/gitlab/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetConnector(ctx context.Context) *gitlab.Connector {
 	filePath := credscanning.LoadPath(providers.GitLab)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/gong/connector.go
+++ b/test/gong/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetGongConnector(ctx context.Context) *gong.Connector {
 	filePath := credscanning.LoadPath(providers.Gong)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := gong.NewConnector(
 		gong.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/gorgias/connector.go
+++ b/test/gorgias/connector.go
@@ -15,7 +15,7 @@ import (
 
 func GetConnector(ctx context.Context) *gorgias.Connector {
 	filePath := credscanning.LoadPath(providers.Gorgias)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/groove/connector.go
+++ b/test/groove/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetConnector(ctx context.Context) *groove.Connector {
 	filePath := credscanning.LoadPath(providers.Groove)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/helpscout/connector.go
+++ b/test/helpscout/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetHelpScoutConnector(ctx context.Context) *helpscout.Connector {
 	filePath := credscanning.LoadPath(providers.HelpScoutMailbox)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/heyreach/connector.go
+++ b/test/heyreach/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetHeyreachConnector(ctx context.Context) *heyreach.Connector {
 	filePath := credscanning.LoadPath(providers.HeyReach)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	info, err := providers.ReadInfo(providers.HeyReach)
 	if err != nil {

--- a/test/hubspot/connector.go
+++ b/test/hubspot/connector.go
@@ -27,7 +27,7 @@ func GetHubspotConnector(ctx context.Context) *hubspot.Connector {
 
 func CredsReader() *credscanning.ProviderCredentials {
 	filePath := credscanning.LoadPath(providers.Hubspot)
-	return utils.MustCreateProvCredJSON(filePath, true, false)
+	return utils.MustCreateProvCredJSON(filePath, true)
 }
 
 func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {

--- a/test/hunter/connector.go
+++ b/test/hunter/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetHunterConnector(ctx context.Context) *hunter.Connector {
 	filePath := credscanning.LoadPath(providers.Hunter)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx, "api_key", reader.Get(credscanning.Fields.ApiKey))
 	if err != nil {

--- a/test/insightly/connector.go
+++ b/test/insightly/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetInsightlyConnector(ctx context.Context) *insightly.Connector {
 	filePath := credscanning.LoadPath(providers.Insightly)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := insightly.NewConnector(
 		common.ConnectorParams{

--- a/test/instantly/connector.go
+++ b/test/instantly/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetInstantlyConnector(ctx context.Context) *instantly.Connector {
 	filePath := credscanning.LoadPath(providers.Instantly)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := instantly.NewConnector(
 		instantly.WithClient(ctx, http.DefaultClient,

--- a/test/instantlyai/connector.go
+++ b/test/instantlyai/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetInstantlyAIConnector(ctx context.Context) *instantlyai.Connector {
 	filePath := credscanning.LoadPath(providers.InstantlyAI)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client := utils.NewAPIKeyClient(ctx, reader, providers.InstantlyAI)
 

--- a/test/intercom/connector.go
+++ b/test/intercom/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetIntercomConnector(ctx context.Context) *intercom.Connector {
 	filePath := credscanning.LoadPath(providers.Intercom)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := intercom.NewConnector(
 		intercom.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/iterable/connector.go
+++ b/test/iterable/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetIterableConnector(ctx context.Context) *iterable.Connector {
 	filePath := credscanning.LoadPath(providers.Iterable)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := iterable.NewConnector(
 		iterable.WithClient(ctx, http.DefaultClient,

--- a/test/keap/connector.go
+++ b/test/keap/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetKeapConnector(ctx context.Context) *keap.Connector {
 	filePath := credscanning.LoadPath(providers.Keap)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := keap.NewConnector(
 		keap.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/kit/connector.go
+++ b/test/kit/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetKitConnector(ctx context.Context) *kit.Connector {
 	filePath := credscanning.LoadPath(providers.Kit)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := kit.NewConnector(
 		kit.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/klaviyo/connector.go
+++ b/test/klaviyo/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetKlaviyoConnector(ctx context.Context) *klaviyo.Connector {
 	filePath := credscanning.LoadPath(providers.Klaviyo)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := klaviyo.NewConnector(
 		klaviyo.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/lemlist/connector.go
+++ b/test/lemlist/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetLemlistConnector(ctx context.Context) *lemlist.Connector {
 	filePath := credscanning.LoadPath(providers.Lemlist)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx, "access_token", reader.Get(credscanning.Fields.ApiKey))
 	if err != nil {

--- a/test/marketo/connector.go
+++ b/test/marketo/connector.go
@@ -59,7 +59,7 @@ func GetMarketoAccessToken() string {
 
 func getMarketoJSONReader() *credscanning.ProviderCredentials {
 	filePath := credscanning.LoadPath(providers.Marketo)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	return reader
 }

--- a/test/mixmax/connector.go
+++ b/test/mixmax/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetConnector(ctx context.Context) *mixmax.Connector {
 	filePath := credscanning.LoadPath(providers.Mixmax)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyHeaderAuthHTTPClient(ctx, "X-API-Token", reader.Get(credscanning.Fields.ApiKey))
 	if err != nil {

--- a/test/monday/connector.go
+++ b/test/monday/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetMondayConnector(ctx context.Context) *monday.Connector {
 	filePath := credscanning.LoadPath(providers.Monday)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyHeaderAuthHTTPClient(ctx, "Authorization", reader.Get(credscanning.Fields.ApiKey))
 

--- a/test/netsuite/connector.go
+++ b/test/netsuite/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetNetsuiteConnector(ctx context.Context) *netsuite.Connector {
 	filePath := credscanning.LoadPath(providers.Netsuite)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	options := []common.OAuthOption{
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/outreach/connector.go
+++ b/test/outreach/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetOutreachConnector(ctx context.Context) *outreach.Connector {
 	filePath := credscanning.LoadPath(providers.Outreach)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := outreach.NewConnector(
 		outreach.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/pinterest/connector.go
+++ b/test/pinterest/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetConnector(ctx context.Context) *pinterest.Connector {
 	filePath := credscanning.LoadPath(providers.Pinterest)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/pipedrive/connector.go
+++ b/test/pipedrive/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetPipedriveConnector(ctx context.Context) *pipedrive.Connector {
 	filePath := credscanning.LoadPath(providers.Pipedrive)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := pipedrive.NewConnector(
 		pipedrive.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/pipeliner/connector.go
+++ b/test/pipeliner/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetPipelinerConnector(ctx context.Context) *pipeliner.Connector {
 	filePath := credscanning.LoadPath(providers.Pipeliner)
-	reader := utils.MustCreateProvCredJSON(filePath, false, true)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := pipeliner.NewConnector(
 		pipeliner.WithClient(ctx, http.DefaultClient,

--- a/test/podium/connector.go
+++ b/test/podium/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetConnector(ctx context.Context) *podium.Connector {
 	filePath := credscanning.LoadPath(providers.Podium)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/salesforce/connector.go
+++ b/test/salesforce/connector.go
@@ -49,7 +49,7 @@ func GetSalesforceAccessToken() string {
 
 func getSalesforceJSONReader() *credscanning.ProviderCredentials {
 	filePath := credscanning.LoadPath(providers.Salesforce)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	return reader
 }

--- a/test/salesloft/connector.go
+++ b/test/salesloft/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetSalesloftConnector(ctx context.Context) *salesloft.Connector {
 	filePath := credscanning.LoadPath(providers.Salesloft)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := salesloft.NewConnector(
 		salesloft.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/servicenow/connector.go
+++ b/test/servicenow/connector.go
@@ -15,7 +15,7 @@ import (
 
 func GetServiceNowConnector(ctx context.Context) *servicenow.Connector {
 	filePath := credscanning.LoadPath(providers.ServiceNow)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/smartlead/connector.go
+++ b/test/smartlead/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetSmartleadConnector(ctx context.Context) *smartlead.Connector {
 	filePath := credscanning.LoadPath(providers.Smartlead)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := smartlead.NewConnector(
 		smartlead.WithClient(ctx, http.DefaultClient,

--- a/test/smartleadv2/connector.go
+++ b/test/smartleadv2/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetSmartleadV2Connector(ctx context.Context) *smartleadv2.Connector {
 	filePath := credscanning.LoadPath(providers.Smartlead)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	client, err := common.NewApiKeyQueryParamAuthHTTPClient(ctx, "api_key", reader.Get(credscanning.Fields.ApiKey))
 	if err != nil {

--- a/test/stripe/connector.go
+++ b/test/stripe/connector.go
@@ -12,7 +12,7 @@ import (
 
 func GetStripeConnector(ctx context.Context) *stripe.Connector {
 	filePath := credscanning.LoadPath(providers.Stripe)
-	reader := utils.MustCreateProvCredJSON(filePath, false, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
 
 	conn, err := stripe.NewConnector(
 		stripe.WithClient(ctx, http.DefaultClient,

--- a/test/utils/creds.go
+++ b/test/utils/creds.go
@@ -11,11 +11,11 @@ import (
 )
 
 func MustCreateProvCredJSON(filePath string,
-	withRequiredAccessToken, withRequiredWorkspace bool,
+	withRequiredAccessToken bool,
 	customFields ...credscanning.Field,
 ) *credscanning.ProviderCredentials {
 	reader, err := credscanning.NewJSONProviderCredentials(
-		filePath, withRequiredAccessToken, withRequiredWorkspace, customFields...,
+		filePath, withRequiredAccessToken, customFields...,
 	)
 	if err != nil {
 		Fail("json creds file error", "error", err)
@@ -26,9 +26,9 @@ func MustCreateProvCredJSON(filePath string,
 
 // MustCreateProvCredENV can be used by tests supplying variables via environment.
 func MustCreateProvCredENV(providerName string,
-	withRequiredAccessToken, withRequiredWorkspace bool,
+	withRequiredAccessToken bool,
 ) *credscanning.ProviderCredentials {
-	reader, err := credscanning.NewENVProviderCredentials(providerName, withRequiredAccessToken, withRequiredWorkspace)
+	reader, err := credscanning.NewENVProviderCredentials(providerName, withRequiredAccessToken)
 	if err != nil {
 		Fail("environment error", "error", err)
 	}

--- a/test/zendeskchat/connector.go
+++ b/test/zendeskchat/connector.go
@@ -15,7 +15,7 @@ import (
 
 func GetConnector(ctx context.Context) *zendeskchat.Connector {
 	filePath := credscanning.LoadPath(providers.ZendeskChat)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/zendesksupport/connector.go
+++ b/test/zendesksupport/connector.go
@@ -14,7 +14,7 @@ import (
 
 func GetZendeskSupportConnector(ctx context.Context) *zendesksupport.Connector {
 	filePath := credscanning.LoadPath(providers.ZendeskSupport)
-	reader := utils.MustCreateProvCredJSON(filePath, true, true)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := zendesksupport.NewConnector(
 		zendesksupport.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/zohocrm/connector.go
+++ b/test/zohocrm/connector.go
@@ -13,7 +13,7 @@ import (
 
 func GetZohoConnector(ctx context.Context) *zohocrm.Connector {
 	filePath := credscanning.LoadPath(providers.Zoho)
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := zohocrm.NewConnector(
 		zohocrm.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),

--- a/test/zoom/connector.go
+++ b/test/zoom/connector.go
@@ -14,7 +14,7 @@ import (
 func GetZoomConnector(ctx context.Context) *zoom.Connector {
 	filePath := credscanning.LoadPath(providers.Zoom)
 
-	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	conn, err := zoom.NewConnector(zoom.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()))
 	if err != nil {


### PR DESCRIPTION
Previously, initializing a connector for local testing required an explicit flag to indicate workspace requirement. 
PR https://github.com/amp-labs/connectors/pull/1647 provides the check, so it is used in this PR.

# Verification
First of all, Dynamics CRM test script works with existing `creds.json`.
Removing the workspace produces expected validation error:
![image](https://github.com/user-attachments/assets/64c19738-a496-4334-b232-3f84b7b5c292)

# Review
First commit has the major changes.
Second commit is just a signature change where the flag is removed for every connector init method.
