### PR TITLE
fix: Gracefully handle unsupported objects via Errors map

### DIFF
--- a/internal/components/schema/openapi_test.go
+++ b/internal/components/schema/openapi_test.go
@@ -23,10 +23,15 @@ func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"someUnknownObject"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"someUnknownObject"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"someUnknownObject": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",

--- a/internal/staticschema/convertors.go
+++ b/internal/staticschema/convertors.go
@@ -34,7 +34,7 @@ func (m *Metadata[F, C]) Select(
 			// move metadata from scrapper object to common object
 			list.Result[objectName] = *v.getObjectMetadata()
 		} else {
-			return nil, fmt.Errorf("%w: unknown object [%v]", common.ErrObjectNotSupported, objectName)
+			list.Errors[objectName] = common.ErrObjectNotSupported
 		}
 	}
 

--- a/providers/asana/metadata_test.go
+++ b/providers/asana/metadata_test.go
@@ -21,10 +21,15 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"groot"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"groot"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"groot": common.ErrObjectNotSupported,
+				},
+			},
 		},
 
 		{

--- a/providers/chilipiper/metadata.go
+++ b/providers/chilipiper/metadata.go
@@ -94,7 +94,10 @@ func metadataFallback(moduleID common.ModuleID, objectName string) (*common.Obje
 		return nil, err
 	}
 
-	data := metadatResult.Result[objectName]
+	data, exists := metadatResult.Result[objectName]
+	if !exists {
+		return nil, metadatResult.Errors[objectName]
+	}
 
 	return &data, nil
 }

--- a/providers/chilipiper/metadata_test.go
+++ b/providers/chilipiper/metadata_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -54,9 +53,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					},
 				},
 				Errors: map[string]error{
-					"meme": mockutils.ExpectedSubsetErrors{
-						common.ErrObjectNotSupported,
-					},
+					"meme": common.ErrObjectNotSupported,
 				},
 			},
 			ExpectedErrs: nil,

--- a/providers/constantcontact/metadata_test.go
+++ b/providers/constantcontact/metadata_test.go
@@ -25,10 +25,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",

--- a/providers/insightly/metadata_test.go
+++ b/providers/insightly/metadata_test.go
@@ -21,10 +21,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully return metadata for an object",

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/intercom/metadata_test.go
+++ b/providers/intercom/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/providers/iterable/metadata_test.go
+++ b/providers/iterable/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:   "Successfully describe multiple objects with metadata",

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -28,10 +28,15 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:  "Successfully describe multiple objects with metadata",

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/pipeliner/metadata_test.go
+++ b/providers/pipeliner/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:   "Successfully describe one object with metadata",

--- a/providers/salesloft/metadata_test.go
+++ b/providers/salesloft/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/stripe/metadata_test.go
+++ b/providers/stripe/metadata_test.go
@@ -20,10 +20,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"butterflies"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"butterflies"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"butterflies": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -27,10 +27,15 @@ func TestListObjectMetadataZendeskSupportModule(t *testing.T) { // nolint:funlen
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Object coming from different module is unknown",
-			Input:        []string{"articles"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Object coming from different module is unknown",
+			Input:      []string{"articles"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"articles": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",
@@ -183,10 +188,15 @@ func TestListObjectMetadataHelpCenterModule(t *testing.T) { // nolint:funlen,goc
 
 	tests := []testroutines.Metadata{
 		{
-			Name:         "Object coming from different module is unknown",
-			Input:        []string{"brands"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Object coming from different module is unknown",
+			Input:      []string{"brands"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"brands": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe one object with metadata",

--- a/providers/zoom/metadata_test.go
+++ b/providers/zoom/metadata_test.go
@@ -22,10 +22,15 @@ func TestListObjectMetaUserModule(t *testing.T) {
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
-			Name:         "Unknown object requested",
-			Input:        []string{"godzilla"},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			Name:       "Unknown object requested",
+			Input:      []string{"godzilla"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"godzilla": common.ErrObjectNotSupported,
+				},
+			},
 		},
 		{
 			Name:       "Successfully describe multiple objects with metadata",


### PR DESCRIPTION
In scenarios where an object is not supported (i.e., it does not have a static schema), we currently fail the entire call. This PR adds the error to the Errors map.
This change will enable future flexibility—for example, if we implement a fallback schema provider, we can later use it for the failed objects.