### PR TITLE
[CON-1390] feat: Added write functionality in the LinkedIn Connector

### DIFF
--- a/providers/linkedIn/README.md
+++ b/providers/linkedIn/README.md
@@ -1,0 +1,39 @@
+# LinkedIn connector
+
+
+## Supported Objects 
+Below is an exhaustive list of objects & methods supported on the objects
+
+Note: 
+- In this connector, there is no GetAll endpoint; it only has search endpoints. Currently this connector not supported metadata and read operation because  endpoints requires query params and shared ID in the URL path. Refer the link to know what the endpoints
+https://ampersand.slab.com/posts/linked-in-connector-cw5tqsrr#hklvo-deep-connector.
+- This connector supports write operation for some other objects. 
+- For creating the objects, it return a 201 Created HTTP status code and return shared ID in the Location response header instead of response body.
+- For updating the objects, it return a 204 No Content HTTP status code instead of response body.
+
+linkedIn API Environment: rest
+
+LinkedIn API version: v2
+---------------------------------------------------------------
+| Object                  | Resource                | Method  |
+| AdAccounts              | adAccounts              | write   |
+| AdTargetTemplates       | adTargetTemplates       | write   |
+| AdPublisherRestrictions | adPublisherRestrictions | write   |
+| InmailContents          | inMailContents          | write   |
+| ConversationAds         | conversationAds         | write   |
+| AdLiftTests             | adLiftTests             | write   |
+| AdExperiments           | adExperiments           | write   |
+| Conversions             | conversions             | write   |
+| ThirdPartyTrackingTags  | thirdPartyTrackingTags  | write   |
+| Events                  | events                  | write   |
+| InsightTags             | insightTags             | write   |
+| ConversionEvents        | conversionEvents        | write   |
+| AdPageSets              | adPageSets              | write   |
+| DmpSegments             | dmpSegments             | write   |
+| LeadForms               | leadForms               | write   |
+| UgcPosts                | ugcPosts                | write   | 
+| Posts                   | posts                   | write   |
+| Creatives               | creatives               | write   |
+---------------------------------------------------------------
+
+Note: In this connector, lot of endpoints having same name but differ in the body parameter which are Events, posts, creatives. Go through the Advertising & Targeting section in the link https://learn.microsoft.com/ru-ru/linkedin/marketing/overview?view=li-lms-2025-04.

--- a/providers/linkedIn/connector.go
+++ b/providers/linkedIn/connector.go
@@ -1,0 +1,52 @@
+package linkedIn
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/writer"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.Writer
+}
+
+func NewConnector(params common.Parameters) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.LinkedIn, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/linkedIn/connector.go
+++ b/providers/linkedIn/connector.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	_ "embed"

--- a/providers/linkedIn/errors.go
+++ b/providers/linkedIn/errors.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	"fmt"

--- a/providers/linkedIn/errors.go
+++ b/providers/linkedIn/errors.go
@@ -1,0 +1,27 @@
+package linkedIn
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	// Error field is the safest to return, though not very useful.
+	return fmt.Errorf("%w: %v", base, r.Message)
+}

--- a/providers/linkedIn/handlers.go
+++ b/providers/linkedIn/handlers.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	"bytes"
@@ -43,7 +43,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		req.Header.Add("X-Restli-Method", "PARTIAL_UPDATE")
 	}
 
-	req.Header.Add("LinkedIn-Version", LinkedInVersion)
+	req.Header.Add("LinkedIn-Version", LinkedInVersion) // nolint:canonicalheader
 	req.Header.Add("X-Restli-Protocol-Version", "2.0.0")
 
 	return req, nil

--- a/providers/linkedIn/handlers.go
+++ b/providers/linkedIn/handlers.go
@@ -1,0 +1,78 @@
+package linkedIn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+const LinkedInVersion = "202504"
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	var (
+		url *urlbuilder.URL
+		err error
+	)
+
+	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, "rest", params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.RecordId != "" {
+		url.AddPath(params.RecordId)
+	}
+
+	jsonData, err := json.Marshal(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	if params.RecordId != "" {
+		req.Header.Add("X-Restli-Method", "PARTIAL_UPDATE")
+	}
+
+	req.Header.Add("LinkedIn-Version", LinkedInVersion)
+	req.Header.Add("X-Restli-Protocol-Version", "2.0.0")
+
+	return req, nil
+}
+
+func (c *Connector) parseWriteResponse(
+	ctx context.Context,
+	params common.WriteParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		return &common.WriteResult{ // nolint:nilerr
+			Success: true,
+		}, nil
+	}
+
+	RecordId := strings.TrimPrefix(request.Header.Get("Location"), params.ObjectName+"/")
+
+	resp, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: RecordId,
+		Errors:   nil,
+		Data:     resp,
+	}, nil
+}

--- a/providers/linkedIn/supports.go
+++ b/providers/linkedIn/supports.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	"fmt"

--- a/providers/linkedIn/supports.go
+++ b/providers/linkedIn/supports.go
@@ -1,0 +1,41 @@
+package linkedIn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+func supportedOperations() components.EndpointRegistryInput {
+	supportWrite := []string{
+		"adAccounts",
+		"adTargetTemplates",
+		"adPublisherRestrictions",
+		"inMailContents",
+		"conversationAds",
+		"adLiftTests",
+		"adExperiments",
+		"conversions",
+		"thirdPartyTrackingTags",
+		"events",
+		"insightTags",
+		"conversionEvents",
+		"adPageSets",
+		"dmpSegments",
+		"leadForms",
+		"ugcPosts",
+		"posts",
+		"creatives",
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(supportWrite, ",")),
+				Support:  components.WriteSupport,
+			},
+		},
+	}
+}

--- a/providers/linkedIn/write_test.go
+++ b/providers/linkedIn/write_test.go
@@ -1,0 +1,93 @@
+package linkedIn
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "creating the adAccounts",
+			Input: common.WriteParams{ObjectName: "adAccounts", RecordData: "dummy"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.PathSuffix("/rest/adAccounts"),
+					mockcond.Header(http.Header{
+						"LinkedIn-Version":          []string{"202504"},
+						"X-Restli-Protocol-Version": []string{"2.0.0"},
+					}),
+					mockcond.MethodPOST(),
+				},
+				Then: mockserver.Response(http.StatusOK, nil),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update adAccounts as POST",
+			Input: common.WriteParams{
+				ObjectName: "adAccounts",
+				RecordId:   "514674276",
+				RecordData: "dummy",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.PathSuffix("/rest/adAccounts/514674276"),
+					mockcond.Header(http.Header{
+						"LinkedIn-Version":          []string{"202504"},
+						"X-Restli-Protocol-Version": []string{"2.0.0"},
+						"X-Restli-Method":           []string{"PARTIAL_UPDATE"},
+					}),
+					mockcond.MethodPOST(),
+				},
+				Then: mockserver.Response(http.StatusOK, nil),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success: true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.Parameters{
+		AuthenticatedClient: http.DefaultClient,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/providers/linkedIn/write_test.go
+++ b/providers/linkedIn/write_test.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	"net/http"

--- a/test/linkedIn/connector.go
+++ b/test/linkedIn/connector.go
@@ -1,0 +1,53 @@
+package linkedIn
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/linkedIn"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetConnector(ctx context.Context) *linkedIn.Connector {
+	filePath := credscanning.LoadPath(providers.LinkedIn)
+	reader := utils.MustCreateProvCredJSON(filePath, true, false)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := linkedIn.NewConnector(common.Parameters{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	cfg := oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://www.linkedin.com/oauth/v2/authorization",
+			TokenURL:  "https://www.linkedin.com/oauth/v2/accessToken",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"rw_ads", "r_ads",
+		},
+	}
+
+	return &cfg
+}

--- a/test/linkedIn/connector.go
+++ b/test/linkedIn/connector.go
@@ -1,4 +1,4 @@
-package linkedIn
+package linkedin
 
 import (
 	"context"
@@ -7,12 +7,12 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/providers"
-	"github.com/amp-labs/connectors/providers/linkedIn"
+	"github.com/amp-labs/connectors/providers/linkedin"
 	"github.com/amp-labs/connectors/test/utils"
 	"golang.org/x/oauth2"
 )
 
-func GetConnector(ctx context.Context) *linkedIn.Connector {
+func GetConnector(ctx context.Context) *linkedin.Connector {
 	filePath := credscanning.LoadPath(providers.LinkedIn)
 	reader := utils.MustCreateProvCredJSON(filePath, true, false)
 
@@ -25,7 +25,7 @@ func GetConnector(ctx context.Context) *linkedIn.Connector {
 		utils.Fail(err.Error())
 	}
 
-	conn, err := linkedIn.NewConnector(common.Parameters{
+	conn, err := linkedin.NewConnector(common.Parameters{
 		AuthenticatedClient: client,
 	})
 	if err != nil {

--- a/test/linkedIn/write/write.go
+++ b/test/linkedIn/write/write.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/amp-labs/connectors/common"
-	ap "github.com/amp-labs/connectors/providers/linkedIn"
-	"github.com/amp-labs/connectors/test/linkedIn"
+	ap "github.com/amp-labs/connectors/providers/linkedin"
+	"github.com/amp-labs/connectors/test/linkedin"
 )
 
 func main() {
@@ -38,7 +38,7 @@ func MainFn() int {
 }
 
 func testAdAccounts(ctx context.Context) error {
-	conn := linkedIn.GetConnector(ctx)
+	conn := linkedin.GetConnector(ctx)
 
 	slog.Info("Creating the Ad Account")
 
@@ -98,7 +98,7 @@ func testAdAccounts(ctx context.Context) error {
 }
 
 func TestAdTargetTemplates(ctx context.Context) error {
-	conn := linkedIn.GetConnector(ctx)
+	conn := linkedin.GetConnector(ctx)
 
 	slog.Info("Creating the Ad target templates")
 
@@ -173,7 +173,7 @@ func TestAdTargetTemplates(ctx context.Context) error {
 }
 
 func testConversationAds(ctx context.Context) error {
-	conn := linkedIn.GetConnector(ctx)
+	conn := linkedin.GetConnector(ctx)
 
 	slog.Info("Creating conversation Ads")
 

--- a/test/linkedIn/write/write.go
+++ b/test/linkedIn/write/write.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	ap "github.com/amp-labs/connectors/providers/linkedIn"
+	"github.com/amp-labs/connectors/test/linkedIn"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	ctx := context.Background()
+
+	err := testAdAccounts(ctx)
+	if err != nil {
+		return 1
+	}
+
+	err = TestAdTargetTemplates(ctx)
+	if err != nil {
+		return 1
+	}
+
+	err = testConversationAds(ctx)
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testAdAccounts(ctx context.Context) error {
+	conn := linkedIn.GetConnector(ctx)
+
+	slog.Info("Creating the Ad Account")
+
+	writeParams := common.WriteParams{
+		ObjectName: "adAccounts",
+		RecordData: map[string]any{
+			"currency":                       "USD",
+			"name":                           "Demo Account",
+			"notifiedOnCampaignOptimization": true,
+			"notifiedOnCreativeApproval":     true,
+			"notifiedOnCreativeRejection":    true,
+			"notifiedOnEndOfCampaign":        true,
+			"reference":                      "urn:li:organization:2414183",
+			"type":                           "BUSINESS",
+			"test":                           true,
+		},
+		RecordId: "",
+	}
+
+	writeRes, err := Write(ctx, conn, writeParams)
+	if err != nil {
+		fmt.Println("ERR: ", err)
+
+		return err
+	}
+
+	if err := constructResponse(writeRes); err != nil {
+		return err
+	}
+
+	slog.Info("updating the Ad Account")
+
+	updateParams := common.WriteParams{
+		ObjectName: "adAccounts",
+		RecordData: map[string]any{
+			"patch": map[string]any{
+				"$set": map[string]any{
+					"name": "This is a new account name.",
+				},
+			},
+		},
+		RecordId: writeRes.RecordId,
+	}
+
+	updateRes, err := Write(ctx, conn, updateParams)
+	if err != nil {
+		fmt.Println("ERR: ", err)
+
+		return err
+	}
+
+	if err := constructResponse(updateRes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestAdTargetTemplates(ctx context.Context) error {
+	conn := linkedIn.GetConnector(ctx)
+
+	slog.Info("Creating the Ad target templates")
+
+	writeParams := common.WriteParams{
+		ObjectName: "adTargetTemplates",
+		RecordData: map[string]any{
+			"name":        "AI Audience Template",
+			"description": "Tech Audience interested in Artificial Intelligence in North America",
+			"account":     "urn:li:sponsoredAccount:514674276",
+			"targetingCriteria": map[string]any{
+				"include": map[string]any{
+					"and": []map[string]any{
+						{
+							"or": map[string]any{
+								"urn:li:adTargetingFacet:interests": []string{
+									"urn:li:interest:308",
+								},
+							},
+						},
+					},
+				},
+				"exclude": map[string]any{
+					"or": map[string]any{
+						"urn:li:adTargetingFacet:seniorities": []string{
+							"urn:li:seniority:1",
+							"urn:li:seniority:2",
+						},
+					},
+				},
+			},
+		},
+		RecordId: "",
+	}
+
+	writeRes, err := Write(ctx, conn, writeParams)
+	if err != nil {
+		fmt.Println("ERR: ", err)
+
+		return err
+	}
+
+	if err := constructResponse(writeRes); err != nil {
+		return err
+	}
+
+	slog.Info("Updating the Ad target templates")
+
+	updateParams := common.WriteParams{
+		ObjectName: "adTargetTemplates",
+		RecordData: map[string]any{
+			"patch": map[string]any{
+				"$set": map[string]any{
+					"name": "This is a new account name.",
+				},
+			},
+		},
+		RecordId: writeParams.RecordId,
+	}
+
+	updateRes, err := Write(ctx, conn, updateParams)
+	if err != nil {
+		fmt.Println("ERR: ", err)
+
+		return err
+	}
+
+	if err := constructResponse(updateRes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testConversationAds(ctx context.Context) error {
+	conn := linkedIn.GetConnector(ctx)
+
+	slog.Info("Creating conversation Ads")
+
+	writeParams := common.WriteParams{
+		ObjectName: "conversationAds",
+		RecordData: map[string]any{
+			"parentAccount": "urn:li:sponsoredAccount:514674276",
+		},
+		RecordId: "",
+	}
+
+	writeRes, err := Write(ctx, conn, writeParams)
+	if err != nil {
+		fmt.Println("ERR: ", err)
+
+		return err
+	}
+
+	if err := constructResponse(writeRes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Write(ctx context.Context, conn *ap.Connector, payload common.WriteParams) (*common.WriteResult, error) {
+	res, err := conn.Write(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// unmarshal the write response.
+func constructResponse(res *common.WriteResult) error {
+	jsonStr, err := json.MarshalIndent(res, "", " ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
## Sample Write Response
**For AdAccounts object**
![image](https://github.com/user-attachments/assets/6e4b8830-e097-48ad-9fbe-f2ed863e143b)
![image](https://github.com/user-attachments/assets/72eaf42d-0d6c-424f-b22e-9bcdc4f75e10)

**For AdtargetTemplates object and conversationAds objects**

![image](https://github.com/user-attachments/assets/1428c53a-0359-459a-839d-aebba39fd99e)
![image](https://github.com/user-attachments/assets/e52357f2-fed7-4e72-9736-401a2eda55ed)

## Test Cases Results
![image](https://github.com/user-attachments/assets/c6e0d22a-d95a-4f50-b106-17698c9b9b2c)

**Note:** 
- For creating the objects, it return a 201 Created HTTP status code and return shared ID in the Location response header instead of response body.
- For updating the objects, it return a 204 No Content HTTP status code instead of response body.

