### PR TITLE
feat: Add incremental read contacts Front Connector

### DIFF
--- a/providers/front/parse.go
+++ b/providers/front/parse.go
@@ -10,7 +10,7 @@ const (
 	pageSizeKey         = "limit"
 	paginationResultKey = "_pagination"
 	nextURLKey          = "next"
-	pageSize            = "1"
+	pageSize            = "100"
 	dataResponseKey     = "_results"
 )
 

--- a/test/front/read/main.go
+++ b/test/front/read/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -43,6 +44,10 @@ func testRead(ctx context.Context, conn *fr.Connector, objectName string, fields
 	params := common.ReadParams{
 		ObjectName: objectName,
 		Fields:     connectors.Fields(fields...),
+	}
+
+	if objectName == "contacts" {
+		params.Since = time.Now().Add(-50 * time.Hour)
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
With this we can support incremental reads for contacts object in Front Connector.
Updated the pageSize as well (it was 1 by mistake)

Tests:
<img width="1227" alt="Screenshot 2025-05-21 at 14 49 14" src="https://github.com/user-attachments/assets/08d136cd-b3da-4536-9fa2-cf6b4975533c" />
