### PR TITLE
feat(businesscentral): Handle XML error

### DIFF
--- a/common/interpreter/formatTemplate.go
+++ b/common/interpreter/formatTemplate.go
@@ -13,8 +13,12 @@ type FormatTemplate struct {
 	// MustKeys is a list of important keys that if all present will signify the match for Template.
 	MustKeys []string
 	// Template is a factory that returns a struct, which will be used to flush the data into.
-	Template func() ErrorDescriptor
+	Template Template
 }
+
+type Template func() ErrorDescriptor
+
+type Templates []Template
 
 // when all required keys are present in the payload it returns true.
 func (t FormatTemplate) matches(payload map[string]any) bool {

--- a/common/interpreter/responder.go
+++ b/common/interpreter/responder.go
@@ -1,8 +1,12 @@
 package interpreter
 
 import (
+	"encoding/xml"
 	"errors"
+	"fmt"
 	"net/http"
+
+	"github.com/amp-labs/connectors/common"
 )
 
 var ErrCannotParseErrorResponse = errors.New("implementation cannot process error response")
@@ -10,8 +14,8 @@ var ErrCannotParseErrorResponse = errors.New("implementation cannot process erro
 // FaultyResponder is an implementation of FaultyResponseHandler.
 // It uses common techniques to handle error response returned by provider.
 type FaultyResponder struct {
-	errorSwitch   *FormatSwitch
-	statusCodeMap map[int]error
+	errorSwitch *FormatSwitch
+	statusCodeMapper
 }
 
 // NewFaultyResponder creates error responder that will be used when provider responds with erroneous payload.
@@ -21,8 +25,8 @@ type FaultyResponder struct {
 //     This is an optional map that will precede any default status to error mapping.
 func NewFaultyResponder(errorSwitch *FormatSwitch, statusCodeMap map[int]error) *FaultyResponder {
 	return &FaultyResponder{
-		errorSwitch:   errorSwitch,
-		statusCodeMap: statusCodeMap,
+		errorSwitch:      errorSwitch,
+		statusCodeMapper: statusCodeMapper{registry: statusCodeMap},
 	}
 }
 
@@ -38,13 +42,17 @@ func (r FaultyResponder) HandleErrorResponse(res *http.Response, body []byte) er
 	return schema.CombineErr(r.matchStatusCodeError(res, body))
 }
 
-func (r FaultyResponder) matchStatusCodeError(res *http.Response, body []byte) error {
-	if r.statusCodeMap == nil {
+type statusCodeMapper struct {
+	registry map[int]error
+}
+
+func (m statusCodeMapper) matchStatusCodeError(res *http.Response, body []byte) error {
+	if m.registry == nil {
 		return DefaultStatusCodeMappingToErr(res, body)
 	}
 
 	// Check if status code was overridden.
-	mappedErr, ok := r.statusCodeMap[res.StatusCode]
+	mappedErr, ok := m.registry[res.StatusCode]
 	if !ok {
 		return DefaultStatusCodeMappingToErr(res, body)
 	}
@@ -65,4 +73,44 @@ func (r DirectFaultyResponder) HandleErrorResponse(res *http.Response, body []by
 	}
 
 	return r.Callback(res, body)
+}
+
+// XMLFaultyResponder is an implementation of FaultyResponseHandler.
+type XMLFaultyResponder struct {
+	templates Templates
+	statusCodeMapper
+}
+
+// NewXMLFaultyResponder creates error responder that will be used when provider responds with erroneous payload.
+//   - Templates will attempt to release XML data into each template until the first successful format.
+//   - StatusCodeMap will be used to enhance error message.
+//     This is an optional map that will precede any default status to error mapping.
+func NewXMLFaultyResponder(templates Templates, statusCodeMap map[int]error) *XMLFaultyResponder {
+	return &XMLFaultyResponder{
+		templates:        templates,
+		statusCodeMapper: statusCodeMapper{registry: statusCodeMap},
+	}
+}
+
+func (r XMLFaultyResponder) HandleErrorResponse(res *http.Response, body []byte) error {
+	if len(r.templates) == 0 {
+		return ErrCannotParseErrorResponse
+	}
+
+	// Choose the first XML template that can be unmarshalled.
+	for _, template := range r.templates {
+		if template == nil {
+			// Nil templates are not allowed.
+			return ErrCannotParseErrorResponse
+		}
+
+		tmpl := template()
+		if err := xml.Unmarshal(body, &tmpl); err == nil {
+			return fmt.Errorf("provider error: %w", tmpl.CombineErr(r.matchStatusCodeError(res, body)))
+		}
+	}
+
+	// Response body cannot be understood in the form of valid XML structure.
+	// Default error handling.
+	return common.InterpretError(res, body)
 }

--- a/providers/dynamicsbusiness/connector.go
+++ b/providers/dynamicsbusiness/connector.go
@@ -68,6 +68,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 
 	errorHandler := interpreter.ErrorHandler{
 		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		XML:  interpreter.NewXMLFaultyResponder(xmlErrorFormats, nil),
 	}.Handle
 
 	connector.Reader = reader.NewHTTPReader(

--- a/providers/dynamicsbusiness/errors.go
+++ b/providers/dynamicsbusiness/errors.go
@@ -25,3 +25,16 @@ type ResponseError struct {
 func (r ResponseError) CombineErr(base error) error {
 	return fmt.Errorf("%w: %v", base, r.Error.Message)
 }
+
+var xmlErrorFormats = interpreter.Templates{ // nolint:gochecknoglobals
+	func() interpreter.ErrorDescriptor { return &xmlResponseError{} },
+}
+
+type xmlResponseError struct {
+	Code    string `xml:"code"`
+	Message string `xml:"message"`
+}
+
+func (r xmlResponseError) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, r.Message)
+}

--- a/providers/dynamicsbusiness/requests.go
+++ b/providers/dynamicsbusiness/requests.go
@@ -38,6 +38,14 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 
 const defaultPageSize = 100
 
+// nolint:lll
+// Supports:
+// * Pagination
+// * Incremental reading for some objects
+// * Selects a subset of fields to return (can include nested fields).
+//
+// Reference:
+// https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/api-reference/v2.0/endpoints-apis-for-dynamics#section
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
 	url, err := c.buildReadURL(ctx, params)
 	if err != nil {

--- a/providers/dynamicsbusiness/test/err-missing-environment.xml
+++ b/providers/dynamicsbusiness/test/err-missing-environment.xml
@@ -1,0 +1,4 @@
+<error xmlns="http://docs.oasis-open.org/odata/ns/metadata">
+    <code>NoEnvironment</code>
+    <message>Environment does not exist.</message>
+</error>

--- a/providers/dynamicsbusiness/url.go
+++ b/providers/dynamicsbusiness/url.go
@@ -30,8 +30,10 @@ func (c *Connector) getMetadataURL() (*urlbuilder.URL, error) {
 		"/api/v2.0/entityDefinitions")
 }
 
+// nolint:lll
 // Every endpoint belongs to the company REST API resource.
 // Therefore, supported objects exist only within the scope of the company.
+// https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/api-reference/v2.0/endpoints-apis-for-dynamics#section
 func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
 	return constructURL(c.ProviderInfo().BaseURL,
 		"v2.0", c.tenantID, c.environmentName,


### PR DESCRIPTION
# Goal

```
errorHandler := interpreter.ErrorHandler{
	JSON: interpreter.NewFaultyResponder(errorFormats, nil),
	XML:  interpreter.NewXMLFaultyResponder(xmlErrorFormats, nil),
}.Handle
```
Where `xmlErrorFormats` is a list of structs that serve as a format expected to be returned on server error.

Any connector in future can only declare the following:

![image](https://github.com/user-attachments/assets/f75644ba-d961-4762-9b2c-4a3347de6a55)

# Note
Business Central can return XML errors. This was discovered when EnvironmentName was invalid.