### PR TITLE
feat: enable freshdesk proxy

### DIFF
--- a/providers/freshdesk.go
+++ b/providers/freshdesk.go
@@ -14,7 +14,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
I think It was blocked before as it uses workspace + basic Auth.

# Conventions
- [x] Provider name is camelcase
- [x] Should cover all modules within the connector 
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked

Tests:
## GET
<img width="1140" alt="Screenshot 2025-05-27 at 14 43 48" src="https://github.com/user-attachments/assets/49991928-acbe-4e17-b4a1-58612eb26f86" />

## POST
<img width="1155" alt="Screenshot 2025-05-27 at 15 21 25" src="https://github.com/user-attachments/assets/f6cbb65a-9c17-4903-89c5-cb76cf6488b0" />


## PUT
<img width="1138" alt="Screenshot 2025-05-27 at 15 22 19" src="https://github.com/user-attachments/assets/047fff50-e642-4f6f-a995-8d4a05803921" />


## DELETE
<img width="1135" alt="Screenshot 2025-05-27 at 15 24 43" src="https://github.com/user-attachments/assets/86517b00-12d8-4566-b40a-ba40254f75ff" />


## Invalid Requests
<img width="1136" alt="Screenshot 2025-05-27 at 15 22 46" src="https://github.com/user-attachments/assets/482f5f8c-153a-4193-9efc-2bec689e5042" />

## Pagination
<img width="1128" alt="Screenshot 2025-05-27 at 15 27 14" src="https://github.com/user-attachments/assets/bc229c96-f000-4086-9ab6-6a1439dd3b1f" />

Using the `Link` header next page
<img width="1134" alt="Screenshot 2025-05-27 at 15 32 17" src="https://github.com/user-attachments/assets/7b41be97-6f4f-458c-b48a-1bb974939965" />

## Successful console operation (operation & events)
<img width="979" alt="Screenshot 2025-05-27 at 15 34 05" src="https://github.com/user-attachments/assets/17245729-269f-4481-8ac2-7f4dbcb41e4f" />

## Failed console operation (operation & events)
<img width="971" alt="Screenshot 2025-05-27 at 15 34 26" src="https://github.com/user-attachments/assets/afca9af6-98da-4038-935d-99358ba06c82" />
