### PR TITLE
[ENG-2284] feat: Include raw HTTP response in error messages

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -21,28 +21,30 @@ func InterpretError(res *http.Response, body []byte) error {
 		}
 	}
 
+	headers := getResponseHeaders(res)
+
 	switch res.StatusCode {
 	case http.StatusUnauthorized:
 		// Access token invalid, refresh token and retry
-		return NewHTTPStatusError(res.StatusCode, createError(ErrAccessToken))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrAccessToken))
 	case http.StatusForbidden:
 		// Forbidden, not retryable
-		return NewHTTPStatusError(res.StatusCode, createError(ErrForbidden))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrForbidden))
 	case http.StatusNotFound:
 		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
-		return NewHTTPStatusError(res.StatusCode, createError(ErrRetryable))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrRetryable))
 	case http.StatusTooManyRequests:
 		// Too many requests, retryable
-		return NewHTTPStatusError(res.StatusCode, createError(ErrRetryable))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrRetryable))
 	}
 
 	if res.StatusCode >= 400 && res.StatusCode < 500 {
-		return NewHTTPStatusError(res.StatusCode, createError(ErrCaller))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrCaller))
 	} else if res.StatusCode >= 500 && res.StatusCode < 600 {
-		return NewHTTPStatusError(res.StatusCode, createError(ErrServer))
+		return NewHTTPError(res.StatusCode, body, headers, createError(ErrServer))
 	}
 
-	return NewHTTPStatusError(res.StatusCode, createError(ErrUnknown))
+	return NewHTTPError(res.StatusCode, body, headers, createError(ErrUnknown))
 }
 
 type ErrorPostProcessor struct {

--- a/common/http.go
+++ b/common/http.go
@@ -541,3 +541,19 @@ func GetResponseBodyOnce(response *http.Response) []byte {
 
 	return body
 }
+
+func getResponseHeaders(response *http.Response) Headers {
+	if response == nil {
+		return nil
+	}
+
+	headers := make(Headers, 0, len(response.Header))
+
+	for key, values := range response.Header {
+		for _, value := range values {
+			headers = append(headers, Header{Key: key, Value: value})
+		}
+	}
+
+	return headers
+}

--- a/common/http.go
+++ b/common/http.go
@@ -547,8 +547,16 @@ func getResponseHeaders(response *http.Response) Headers {
 		return nil
 	}
 
-	headers := make(Headers, 0, len(response.Header))
+	// Pre-calculate the total number of header values
+	totalValues := 0
+	for _, values := range response.Header {
+		totalValues += len(values)
+	}
 
+	// Initialize the headers slice with accurate capacity
+	headers := make(Headers, 0, totalValues)
+
+	// Populate the headers slice
 	for key, values := range response.Header {
 		for _, value := range values {
 			headers = append(headers, Header{Key: key, Value: value})

--- a/common/http.go
+++ b/common/http.go
@@ -553,6 +553,11 @@ func getResponseHeaders(response *http.Response) Headers {
 		totalValues += len(values)
 	}
 
+	// Corner case: if there are no headers, return nil
+	if totalValues == 0 {
+		return nil
+	}
+
 	// Initialize the headers slice with accurate capacity
 	headers := make(Headers, 0, totalValues)
 

--- a/common/json.go
+++ b/common/json.go
@@ -139,7 +139,9 @@ func ParseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, erro
 	// Unmarshall the response body into JSON
 	jsonBody, err := ajson.Unmarshal(body)
 	if err != nil {
-		return nil, NewHTTPStatusError(res.StatusCode, fmt.Errorf("failed to unmarshall response body into JSON: %w", err))
+		headers := getResponseHeaders(res)
+
+		return nil, NewHTTPError(res.StatusCode, body, headers, fmt.Errorf("failed to unmarshall response body into JSON: %w", err))
 	}
 
 	return &JSONHTTPResponse{

--- a/common/json.go
+++ b/common/json.go
@@ -141,7 +141,8 @@ func ParseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, erro
 	if err != nil {
 		headers := getResponseHeaders(res)
 
-		return nil, NewHTTPError(res.StatusCode, body, headers, fmt.Errorf("failed to unmarshall response body into JSON: %w", err))
+		return nil, NewHTTPError(res.StatusCode, body, headers,
+			fmt.Errorf("failed to unmarshall response body into JSON: %w", err))
 	}
 
 	return &JSONHTTPResponse{

--- a/common/types.go
+++ b/common/types.go
@@ -277,36 +277,57 @@ type DeleteResult struct {
 // Ex: Post/Put/Patch.
 type WriteMethod func(context.Context, string, any, ...Header) (*JSONHTTPResponse, error)
 
-// NewHTTPStatusError creates a new error with the given HTTP status.
-func NewHTTPStatusError(status int, err error) error {
+// NewHTTPError creates a new error with the given HTTP status.
+func NewHTTPError(status int, body []byte, headers Headers, err error) error {
 	if status < 1 || status > 599 {
 		return err
 	}
 
-	return &HTTPStatusError{
-		HTTPStatus: status,
-		err:        err,
+	// Just in case the caller mutates the body after passing it in,
+	// we make a copy of the body to ensure that the error contains
+	// the original body.
+	var bodyCopy []byte
+
+	if body != nil {
+		bodyCopy = make([]byte, len(body))
+		copy(bodyCopy, body)
+	}
+
+	return &HTTPError{
+		Status:  status,
+		Headers: headers,
+		Body:    bodyCopy,
+		err:     err,
 	}
 }
 
-// HTTPStatusError is an error that contains an HTTP status code.
-type HTTPStatusError struct {
-	// HTTPStatus is the original HTTP status.
-	HTTPStatus int
+// HTTPError is an error that contains both an error and details
+// about the HTTP response that caused the error. It includes
+// the HTTP status code, headers, and body of the response.
+// Body and Headers are optional and may be nil if not available.
+type HTTPError struct {
+	// Status is the original HTTP status.
+	Status int
+
+	// Headers are the HTTP headers of the response, if available.
+	Headers Headers // optional
+
+	// Body is the raw response body, if available.
+	Body []byte // optional
 
 	// The underlying error
 	err error
 }
 
-func (r HTTPStatusError) Error() string {
-	if r.HTTPStatus > 0 {
-		return fmt.Sprintf("HTTP status %d: %v", r.HTTPStatus, r.err)
+func (r HTTPError) Error() string {
+	if r.Status > 0 {
+		return fmt.Sprintf("HTTP status %d: %v", r.Status, r.err)
 	}
 
 	return r.err.Error()
 }
 
-func (r HTTPStatusError) Unwrap() error {
+func (r HTTPError) Unwrap() error {
 	return r.err
 }
 

--- a/common/xml.go
+++ b/common/xml.go
@@ -96,7 +96,9 @@ func parseXMLResponse(res *http.Response, body []byte) (*XMLHTTPResponse, error)
 	// Unmarshall the response body into XML
 	xmlBody, err := xquery.NewXML(body)
 	if err != nil {
-		return nil, NewHTTPStatusError(res.StatusCode, fmt.Errorf("failed to unmarshall response body into XML: %w", err))
+		headers := getResponseHeaders(res)
+
+		return nil, NewHTTPError(res.StatusCode, body, headers, fmt.Errorf("failed to unmarshall response body into XML: %w", err))
 	}
 
 	return &XMLHTTPResponse{

--- a/common/xml.go
+++ b/common/xml.go
@@ -98,7 +98,8 @@ func parseXMLResponse(res *http.Response, body []byte) (*XMLHTTPResponse, error)
 	if err != nil {
 		headers := getResponseHeaders(res)
 
-		return nil, NewHTTPError(res.StatusCode, body, headers, fmt.Errorf("failed to unmarshall response body into XML: %w", err))
+		return nil, NewHTTPError(res.StatusCode, body, headers,
+			fmt.Errorf("failed to unmarshall response body into XML: %w", err))
 	}
 
 	return &XMLHTTPResponse{

--- a/connectors.go
+++ b/connectors.go
@@ -91,7 +91,7 @@ type BatchRecordReaderConnector interface {
 	GetRecordsByIds(
 		ctx context.Context,
 		objectName string,
-		//nolint:revive
+	//nolint:revive
 		recordIds []string,
 		fields []string,
 		associations []string) ([]common.ReadResultRow, error)
@@ -173,7 +173,7 @@ type (
 	DeleteResult             = common.DeleteResult
 	ListObjectMetadataResult = common.ListObjectMetadataResult
 
-	ErrorWithStatus = common.HTTPStatusError //nolint:errname
+	ErrorWithStatus = common.HTTPError //nolint:errname
 )
 
 var Fields = datautils.NewStringSet // nolint:gochecknoglobals

--- a/connectors.go
+++ b/connectors.go
@@ -91,7 +91,7 @@ type BatchRecordReaderConnector interface {
 	GetRecordsByIds(
 		ctx context.Context,
 		objectName string,
-	//nolint:revive
+		//nolint:revive
 		recordIds []string,
 		fields []string,
 		associations []string) ([]common.ReadResultRow, error)

--- a/providers/hubspot/associations.go
+++ b/providers/hubspot/associations.go
@@ -125,9 +125,9 @@ func (c *Connector) getObjectAssociations( //nolint:cyclop
 	// See https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#retrieve-associated-records
 	rsp, err := c.Client.Post(ctx, hsURL, &inputs)
 	if err != nil {
-		var httpErr *common.HTTPStatusError
+		var httpErr *common.HTTPError
 
-		if errors.As(err, &httpErr) && httpErr.HTTPStatus == 404 {
+		if errors.As(err, &httpErr) && httpErr.Status == 404 {
 			logging.Logger(ctx).Warn("no associations found", "fromObject", fromObject, "toObject", toObject)
 
 			return map[string][]common.Association{}, nil

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -95,8 +95,8 @@ func ComparatorSubsetWrite(_ string, actual, expected *common.WriteResult) bool 
 //			common.ErrCaller,
 //			errors.New(string(unsupportedResponse)),
 //		},
-//		"arsenal": common.NewHTTPStatusError(http.StatusBadRequest,		// Is doing exact match.
-//			fmt.Errorf("%w: %s", common.ErrCaller, string(unsupportedResponse))),
+//		"arsenal": common.NewHTTPError(http.StatusBadRequest,		// Is doing exact match.
+//			headers, body, fmt.Errorf("%w: %s", common.ErrCaller, string(unsupportedResponse))),
 //	},
 func ComparatorSubsetMetadata(_ string, actual, expected *common.ListObjectMetadataResult) bool {
 	if len(expected.Result)+len(expected.Errors) == 0 {


### PR DESCRIPTION
One of our customers wants to have access to the raw HTTP response -- no error prefixes added. This PR makes it possible to extract the original response, and pass it along so that the user can do their own parsing.