### PR TITLE
fix: Make hubspot use NewHTTPError for errors

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -21,7 +21,7 @@ func InterpretError(res *http.Response, body []byte) error {
 		}
 	}
 
-	headers := getResponseHeaders(res)
+	headers := GetResponseHeaders(res)
 
 	switch res.StatusCode {
 	case http.StatusUnauthorized:

--- a/common/http.go
+++ b/common/http.go
@@ -542,7 +542,7 @@ func GetResponseBodyOnce(response *http.Response) []byte {
 	return body
 }
 
-func getResponseHeaders(response *http.Response) Headers {
+func GetResponseHeaders(response *http.Response) Headers {
 	if response == nil {
 		return nil
 	}

--- a/common/json.go
+++ b/common/json.go
@@ -139,7 +139,7 @@ func ParseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, erro
 	// Unmarshall the response body into JSON
 	jsonBody, err := ajson.Unmarshal(body)
 	if err != nil {
-		headers := getResponseHeaders(res)
+		headers := GetResponseHeaders(res)
 
 		return nil, NewHTTPError(res.StatusCode, body, headers,
 			fmt.Errorf("failed to unmarshall response body into JSON: %w", err))

--- a/common/xml.go
+++ b/common/xml.go
@@ -96,7 +96,7 @@ func parseXMLResponse(res *http.Response, body []byte) (*XMLHTTPResponse, error)
 	// Unmarshall the response body into XML
 	xmlBody, err := xquery.NewXML(body)
 	if err != nil {
-		headers := getResponseHeaders(res)
+		headers := GetResponseHeaders(res)
 
 		return nil, NewHTTPError(res.StatusCode, body, headers,
 			fmt.Errorf("failed to unmarshall response body into XML: %w", err))

--- a/providers/hubspot/errors.go
+++ b/providers/hubspot/errors.go
@@ -75,18 +75,20 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error {
 		return fmt.Errorf("json.Unmarshal failed: %w", err)
 	}
 
+	headers := common.GetResponseHeaders(res)
+
 	switch res.StatusCode {
 	// Hubspot sends us a 400 when the search endpoint returns over 10K records.
 	case http.StatusBadRequest:
-		return createError(common.ErrBadRequest, apiError)
+		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrBadRequest, apiError))
 	case http.StatusUnauthorized:
-		return createError(common.ErrAccessToken, apiError)
+		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrAccessToken, apiError))
 	case http.StatusForbidden:
-		return createError(common.ErrForbidden, apiError)
+		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrForbidden, apiError))
 	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusGatewayTimeout:
-		return createError(common.ErrLimitExceeded, apiError)
+		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrLimitExceeded, apiError))
 	case http.StatusServiceUnavailable:
-		return createError(common.ErrApiDisabled, apiError)
+		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrApiDisabled, apiError))
 	default:
 		return common.InterpretError(res, body)
 	}


### PR DESCRIPTION
We rely on common.HTTPError to populate certain fields. Most connectors return this, hubspot doesn't. This PR makes it so that hubspot wraps its errors in this type so that we can extract what we need when errors happen.