### PR TITLE
[CON-993] feat: enable read, write Chilipiper connector

### DIFF
--- a/providers/chilipiper.go
+++ b/providers/chilipiper.go
@@ -33,9 +33,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.

![Screenshot 2025-06-04 at 14 30 31](https://github.com/user-attachments/assets/4332ed0b-7aee-43c6-824d-c1a9b3ce5cbc)

![Screenshot 2025-06-04 at 14 30 43](https://github.com/user-attachments/assets/eb6c35ed-7126-4496-bf2b-d176fd736b4d)

![Screenshot 2025-06-04 at 14 30 50](https://github.com/user-attachments/assets/18c9a657-d73e-4989-a1df-0a340fc8c754)

- [x] Insert screenshot of Svix destination.
![Screenshot 2025-06-04 at 14 01 03](https://github.com/user-attachments/assets/c92681d7-a530-4727-969d-9e0b78206cf5)

![Screenshot 2025-06-04 at 14 01 13](https://github.com/user-attachments/assets/eb5924af-5cae-4558-be72-413c50df3633)

- [x] Screenshot of operations on dashboard
![Screenshot 2025-06-04 at 14 01 48](https://github.com/user-attachments/assets/3aff2c39-daca-4c13-b294-7ffb2d16d386)

![Screenshot 2025-06-04 at 14 02 10](https://github.com/user-attachments/assets/7696334c-aa00-4871-b064-ff23ddb9594a)


# Write
- [x] Insert screenshot of dashboard.
![Screenshot 2025-06-04 at 14 36 27](https://github.com/user-attachments/assets/f232f577-2f9a-4250-aa66-b2c24e30b9d6)

![Screenshot 2025-06-04 at 14 36 08](https://github.com/user-attachments/assets/68cadba0-1275-4dcc-91bf-2a873a029994)

![Screenshot 2025-06-04 at 14 35 51](https://github.com/user-attachments/assets/c8de31ba-9bf1-4ecc-8cba-9bb5d78357be)

- [x] Insert screenshot of HTTP call.
![Screenshot 2025-06-04 at 14 38 11](https://github.com/user-attachments/assets/323fe8c8-e764-4b2a-9050-0c86d037c8f8)

![Screenshot 2025-06-04 at 14 37 56](https://github.com/user-attachments/assets/ee23de7e-e757-4357-9654-8f0ac2e702ee)

![Screenshot 2025-06-04 at 14 37 34](https://github.com/user-attachments/assets/ff95c099-534d-4381-87ac-1a007e3265f6)


# Examples
[sample test-data link](https://github.com/amp-labs/testdata/tree/main/chilipiper)
