### PR TITLE
[CON-1734] feat(aha): Read until

### DIFF
--- a/providers/aha/handlers.go
+++ b/providers/aha/handlers.go
@@ -21,6 +21,7 @@ const (
 	pageSize    = "200"
 	pageKey     = "page"
 	sinceKey    = "created_since"
+	untilKey    = "created_before"
 	apiVersion  = "v1"
 )
 
@@ -105,8 +106,11 @@ func addQueryParams(url *urlbuilder.URL, params common.ReadParams, page int64) {
 	url.WithQueryParam(pageKey, strconv.FormatInt(page, 10))
 
 	if supportSince.Has(params.ObjectName) && !params.Since.IsZero() {
-		// https://www.aha.io/api/resources/ideas/list_ideas
 		url.WithQueryParam(sinceKey, datautils.Time.FormatRFC3339inUTC(params.Since))
+	}
+
+	if supportUntil.Has(params.ObjectName) && !params.Until.IsZero() {
+		url.WithQueryParam(untilKey, datautils.Time.FormatRFC3339inUTC(params.Until))
 	}
 }
 

--- a/providers/aha/supports.go
+++ b/providers/aha/supports.go
@@ -27,9 +27,24 @@ const (
 )
 
 var supportSince = datautils.NewSet( //nolint:gochecknoglobals
+	// https://www.aha.io/api/resources/audits/retrieve_record_history
 	objectNameAudits,
+	// https://www.aha.io/api/resources/historical_audits/create_an_audit_search
 	objectNameHistoricalAudits,
+	// https://www.aha.io/api/resources/idea_votes/list_votes_for_an_account
 	objectNameIdeasEndorsements,
+	// https://www.aha.io/api/resources/ideas/list_ideas
+	objectNameIdeas,
+)
+
+var supportUntil = datautils.NewSet( //nolint:gochecknoglobals
+	// https://www.aha.io/api/resources/audits/retrieve_record_history
+	objectNameAudits,
+	// https://www.aha.io/api/resources/historical_audits/create_an_audit_search
+	objectNameHistoricalAudits,
+	// https://www.aha.io/api/resources/idea_votes/list_votes_for_an_account
+	objectNameIdeasEndorsements,
+	// https://www.aha.io/api/resources/ideas/list_ideas
 	objectNameIdeas,
 )
 


### PR DESCRIPTION
# Notes
Aha plan has expired.

# Description
* Until is now supported for every object that supports Since.
* Verified against the official docs — each `created_since` field has a corresponding `created_before` field.
