### PR TITLE
[CON-1068] feat: enable read, write Front connector

### DIFF
--- a/providers/front.go
+++ b/providers/front.go
@@ -23,9 +23,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ] Read supports  incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read

- [x] Insert screenshot of metadata fields from read object installation.
![Screenshot 2025-06-06 at 10 26 25](https://github.com/user-attachments/assets/e7e467b1-2367-49d1-9e8e-6b7545ead60d)
![Screenshot 2025-06-06 at 10 26 32](https://github.com/user-attachments/assets/35f0e510-6385-4595-9942-dfbd27802e8f)

- [x] Insert screenshot of Svix destination.
![Screenshot 2025-06-06 at 10 28 29](https://github.com/user-attachments/assets/0d3cd173-d095-4d22-a73f-c2e01d16b866)

![Screenshot 2025-06-06 at 10 28 42](https://github.com/user-attachments/assets/f85f6fe7-6b09-4310-a845-fd8b0ba63af8)

- [x] Screenshot of operations on dashboard
![Screenshot 2025-06-06 at 10 27 37](https://github.com/user-attachments/assets/4843e378-dce9-4726-b34c-948bf2f71b1b)


# Write
- [x] Insert screenshot of dashboard.
![Screenshot 2025-06-06 at 10 31 17](https://github.com/user-attachments/assets/17bef074-0e28-456a-bed4-e99271429c26)

![Screenshot 2025-06-06 at 10 31 31](https://github.com/user-attachments/assets/04721452-4cc5-436c-8dd4-918d53b4052d)

- [x] Insert screenshot of HTTP call. 
![Screenshot 2025-06-06 at 10 32 51](https://github.com/user-attachments/assets/2ab1603c-5417-4990-9508-83cf9f44916a)

![Screenshot 2025-06-06 at 10 33 31](https://github.com/user-attachments/assets/6b916010-3dea-4507-a754-5bb768105e1c)


# Examples
[test-data Link](https://github.com/amp-labs/testdata/tree/main/front)
