### PR TITLE
[CON-1734] feat(klaviyo): Read until

### DIFF
--- a/providers/klaviyo/internal/filtering/query.go
+++ b/providers/klaviyo/internal/filtering/query.go
@@ -1,0 +1,104 @@
+// Package filtering provides a helper to construct filtering query parameters
+// compatible with APIs that support time-based and custom filtering syntax,
+// such as Klaviyo's ?filter=... convention.
+package filtering
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// Query represents a composed filter string that can include
+// time-based and custom filters for a request.
+type Query struct {
+	since  string
+	until  string
+	custom string
+}
+
+// NewQuery initializes an empty filtering query which can be expanded using builder methods.
+func NewQuery() *Query {
+	return &Query{}
+}
+
+// WithSince adds a filter to retrieve records updated after the given timestamp.
+// If the timestamp is zero, the method is a no-op.
+//
+// Example output (Klaviyo format):
+//
+//	`greater-than(updated_at,2023-03-01T01:00:00Z)`
+//
+// See: https://developers.klaviyo.com/en/docs/filtering_
+func (q *Query) WithSince(timestamp time.Time, fieldName string) *Query {
+	if timestamp.IsZero() {
+		// No-op
+		return q
+	}
+
+	timeValue := datautils.Time.FormatRFC3339inUTC(timestamp)
+	q.since = fmt.Sprintf("greater-than(%v,%v)", fieldName, timeValue)
+
+	return q
+}
+
+// WithUntil adds a filter to retrieve records updated before the given timestamp.
+// If the timestamp is zero, the method is a no-op.
+//
+// Example output:
+//
+//	`less-than(updated_at,2023-03-01T00:00:00Z)`
+//
+// See: https://developers.klaviyo.com/en/docs/filtering_
+func (q *Query) WithUntil(timestamp time.Time, fieldName string) *Query {
+	if timestamp.IsZero() {
+		// No-op
+		return q
+	}
+
+	timeValue := datautils.Time.FormatRFC3339inUTC(timestamp)
+	q.until = fmt.Sprintf("less-than(%v,%v)", fieldName, timeValue)
+
+	return q
+}
+
+// WithCustomFiltering adds arbitrary filters to the query.
+// This can be used for provider-specific conditions outside time-based logic.
+//
+// Filters must be formatted as a comma-separated string, e.g.:
+//
+//	`equals(email,"sarah.mason@klaviyo-demo.com")`
+//	`contains(name,"marketing")`
+//
+// See: https://developers.klaviyo.com/en/docs/filtering_
+func (q *Query) WithCustomFiltering(customFilters string) *Query {
+	q.custom = customFilters
+
+	return q
+}
+
+// String returns the final filter string, combining since/until/custom parts.
+// The filters are joined using commas, which Klaviyo APIs interpret as implicit logical AND.
+//
+// See: https://developers.klaviyo.com/en/docs/filtering_#boolean-logic-operators
+func (q *Query) String() string {
+	filters := make([]string, 0)
+
+	if q.since != "" {
+		filters = append(filters, q.since)
+	}
+
+	if q.until != "" {
+		filters = append(filters, q.until)
+	}
+
+	if q.custom != "" {
+		filters = append(filters, q.custom)
+	}
+
+	// As per documentation filtering values are comma separated.
+	// Reference: https://developers.klaviyo.com/en/docs/filtering_
+	return strings.Join(filters, ",")
+}

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -114,7 +114,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Since:      time.Date(2024, 3, 4, 8, 22, 56, 0, time.UTC),
 				Filter:     "equals(messages.channel,'email')",
 			},
-			Comparator: testroutines.ComparatorSubsetRead,
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentMIME("application/vnd.api+json"),
 				If: mockcond.And{
@@ -125,6 +124,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCampaigns),
 			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -147,6 +147,33 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						},
 					},
 				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Incremental read of campaigns using until",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("name"),
+				Since:      time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				Until:      time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentMIME("application/vnd.api+json"),
+				If: mockcond.And{
+					mockcond.Path("/api/campaigns"),
+					mockcond.QueryParam("filter",
+						"greater-than(updated_at,2024-01-01T00:00:00Z),"+
+							"less-than(updated_at,2025-01-01T00:00:00Z)"),
+					mockcond.Header(header),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCampaigns),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     1,
 				NextPage: "",
 				Done:     true,
 			},

--- a/test/klaviyo/read/accounts/main.go
+++ b/test/klaviyo/read/accounts/main.go
@@ -28,9 +28,9 @@ func main() {
 		Fields:     connectors.Fields("contact_information"),
 	})
 	if err != nil {
-		utils.Fail("error reading from Klaviyo", "error", err)
+		utils.Fail("error reading from connector", "error", err)
 	}
 
-	fmt.Println("Reading accounts..")
+	fmt.Println("Reading...")
 	utils.DumpJSON(res, os.Stdout)
 }

--- a/test/klaviyo/read/profiles/main.go
+++ b/test/klaviyo/read/profiles/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/klaviyo"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetKlaviyoConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "profiles",
+		Fields:     connectors.Fields("updated"),
+		Since:      timestamp("2024-11-01T00:00:00.000Z"),
+		Until:      timestamp("2024-12-01T00:00:00.000Z"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func timestamp(timeText string) time.Time {
+	result, err := time.Parse("2006-01-02T15:04:05.000Z", timeText)
+	if err != nil {
+		utils.Fail("bad timestamp", "error", err)
+	}
+
+	return result
+}


### PR DESCRIPTION
# Changes
The existing query building is moved into internal package for better separation -- encapsulating [Klaviyo filtering](https://developers.klaviyo.com/en/docs/filtering_) with respect to `ReadParams` arguments.

# Live Tests
Reading profiles without `Since` and `Until` for my instance returns 6 records each updated at 3 dates(see code comments, they are not committed and are only for screenshot demonstration):
![image](https://github.com/user-attachments/assets/a24eebed-806a-4cff-a5e2-74f7b8e3cbbf)
Let's scope `Since` & `Until` to get middle 3 records updated last Novemeber. The query parameter includes comma separated list of filters:
![image](https://github.com/user-attachments/assets/550e08a5-5511-4408-8f1a-fe7bf8005d23)
