### PR TITLE
[CON-1734] feat(salesloft): Read until

### DIFF
--- a/internal/datautils/timing.go
+++ b/internal/datautils/timing.go
@@ -26,3 +26,11 @@ func (timing) FormatRFC3339inUTCWithMilliseconds(input time.Time) string {
 
 	return utcTime.Format("2006-01-02T15:04:05.000Z")
 }
+
+// FormatRFC3339inUTCWithMicrosecondsAndOffset similar to FormatRFC3339inUTCWithMilliseconds but uses microseconds.
+// It is more granular and has timezone offset.
+func (timing) FormatRFC3339inUTCWithMicrosecondsAndOffset(input time.Time) string {
+	utcTime := input.UTC()
+
+	return utcTime.Format("2006-01-02T15:04:05.000000-07:00")
+}

--- a/test/salesloft/read/calls/main.go
+++ b/test/salesloft/read/calls/main.go
@@ -26,8 +26,9 @@ func main() {
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "activities/calls",
-		Since:      time.Now().Add(-1 * time.Second * 60 * 4),
-		Fields:     connectors.Fields("notes", "created_at", "recordings"),
+		Since:      timestamp("2025-03-17T20:00:22.806808-04:00"),
+		Until:      timestamp("2025-03-17T21:14:43.917967-04:00"),
+		Fields:     connectors.Fields("updated_at"),
 	})
 	if err != nil {
 		utils.Fail("error reading from Salesloft", "error", err)
@@ -35,4 +36,13 @@ func main() {
 
 	fmt.Println("Reading people..")
 	utils.DumpJSON(res, os.Stdout)
+}
+
+func timestamp(timeText string) time.Time {
+	result, err := time.Parse("2006-01-02T15:04:05.000000-07:00", timeText)
+	if err != nil {
+		utils.Fail("bad timestamp", "error", err)
+	}
+
+	return result
 }


### PR DESCRIPTION
# Live Test
Activity calls.
There are 3 records. Scoping `Since` and `Until` to get the middle record:
![image](https://github.com/user-attachments/assets/0dfbf5e5-0f49-478a-8de0-c636facf1527)
Increasing the `Until` timestamp by 1 second includes the third record. Keeping since means we get 2nd and 3rd records out of all existing:
![image](https://github.com/user-attachments/assets/a1dfdc57-a602-47ca-910d-7fed3c67e429)
