### PR TITLE
fix: reading next page records serviceNow connector

### DIFF
--- a/providers/servicenow/handlers.go
+++ b/providers/servicenow/handlers.go
@@ -61,20 +61,16 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 }
 
 func (c *Connector) constructReadURL(params common.ReadParams) (string, error) {
-	var url string
-
 	if params.NextPage != "" {
-		url = params.NextPage.String()
-	} else {
-		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, params.ObjectName)
-		if err != nil {
-			return "", err
-		}
-
-		url = u.String()
+		return params.NextPage.String(), nil
 	}
 
-	return url, nil
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, params.ObjectName)
+	if err != nil {
+		return "", err
+	}
+
+	return url.String(), nil
 }
 
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {

--- a/providers/servicenow/handlers.go
+++ b/providers/servicenow/handlers.go
@@ -60,13 +60,30 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	return &objectMetadata, nil
 }
 
+func (c *Connector) constructReadURL(params common.ReadParams) (string, error) {
+	var url string
+
+	if params.NextPage != "" {
+		url = params.NextPage.String()
+	} else {
+		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, params.ObjectName)
+		if err != nil {
+			return "", err
+		}
+
+		url = u.String()
+	}
+
+	return url, nil
+}
+
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, params.ObjectName)
+	url, err := c.constructReadURL(params)
 	if err != nil {
 		return nil, err
 	}
 
-	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	return http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 }
 
 func (c *Connector) parseReadResponse(

--- a/test/servicenow/read/read.go
+++ b/test/servicenow/read/read.go
@@ -36,6 +36,10 @@ func run() error {
 		return err
 	}
 
+	if err := readNextPageContacts(ctx, conn); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -85,6 +89,29 @@ func readContacts(ctx context.Context, conn *serviceNow.Connector) error {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "now/contact",
 		Fields:     datautils.NewStringSet("country", "last_login_device", "phone"),
+		// NextPage:   "https://dev212375.service-now.com/api/now/contact?\u0026sysparm_offset=10",
+	})
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func readNextPageContacts(ctx context.Context, conn *serviceNow.Connector) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "now/contact",
+		Fields:     datautils.NewStringSet("country", "last_login_device", "phone"),
+		NextPage:   "https://dev212375.service-now.com/api/now/contact?\u0026sysparm_offset=10",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Tests:
- The last read is reading next-page of the previous read activity.
![Screenshot 2025-06-10 at 13 03 59](https://github.com/user-attachments/assets/aadf5280-35d5-432d-acd5-4671105dbf1c)
