### PR TITLE
[CON-1734] feat(instantlyai): Read until

### DIFF
--- a/providers/instantlyai/handlers.go
+++ b/providers/instantlyai/handlers.go
@@ -24,8 +24,14 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
 	}
 
-	if sinceSupportedEndpoints.Has(params.ObjectName) {
+	// https://developer.instantly.ai/api/v2/analytics/getdailycampaignanalytics
+	if !params.Since.IsZero() && sinceSupportedEndpoints.Has(params.ObjectName) {
 		url.WithQueryParam("start_date", params.Since.Format(time.DateOnly))
+	}
+
+	// https://developer.instantly.ai/api/v2/analytics/getdailycampaignanalytics
+	if !params.Until.IsZero() && untilSupportedEndpoints.Has(params.ObjectName) {
+		url.WithQueryParam("end_date", params.Until.Format(time.DateOnly))
 	}
 
 	if len(params.NextPage) != 0 {

--- a/providers/instantlyai/utils.go
+++ b/providers/instantlyai/utils.go
@@ -24,7 +24,14 @@ var postEndpointsOfRead = datautils.NewSet( //nolint:gochecknoglobals
 	"leads/list",
 )
 
+// https://developer.instantly.ai/api/v2/analytics/getdailycampaignanalytics
 var sinceSupportedEndpoints = datautils.NewSet( //nolint:gochecknoglobals
+	"campaigns/analytics/daily",
+	"campaigns/analytics/steps",
+)
+
+// https://developer.instantly.ai/api/v2/analytics/getdailycampaignanalytics
+var untilSupportedEndpoints = datautils.NewSet( //nolint:gochecknoglobals
 	"campaigns/analytics/daily",
 	"campaigns/analytics/steps",
 )


### PR DESCRIPTION
# Description
Added `end_date` query parameters which goes alongside pre-existing `start_date`. Reference [docs](https://developer.instantly.ai/api/v2/analytics/getdailycampaignanalytics). 

Fixed since check, the query parameter should be supplied only if timestamp is a non-empty value.
`!params.Since.IsZero()` as well as `!params.Until.IsZero()`.

# Issues
Cannot validate the functionality but it looks straightforward and mimics `ReadParams.Since`.
![image](https://github.com/user-attachments/assets/2d458d94-8343-47f9-9688-85db4d753edc)
