### PR TITLE
fix(CI): Go v1.23.3

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.23.3"
+          go-version: "1.23.3"
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Recently getting this issue once in a while:
![image](https://github.com/user-attachments/assets/634c5cd9-50b5-4414-ac3a-8bef76519cb7)
[Reference.](https://github.com/amp-labs/connectors/actions/runs/15593835862/job/43919286718?pr=1746)

Maybe enforcing building code with go version at `exactly` version 1.23.3 would solve this.