### PR TITLE
[CON-1702] feat: Enable proxy for the avoma connector

### DIFF
--- a/providers/avoma.go
+++ b/providers/avoma.go
@@ -24,7 +24,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Testing

## Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
- [ ] The same base URL cannot be used to make a proxy call to objects in all modules
- [ ] Different base URLs (drive.google.com vs google.com)
- [ ] Object name collisions (same object name exists in two or more modules)

### GET
URL: https://proxy.withampersand.com/v1/smart_categories/
![image](https://github.com/user-attachments/assets/a37d724d-aec8-4e0e-83d0-ae7f7ec1f106)

### GET by Id
URL: https://proxy.withampersand.com/v1/smart_categories/e58331ce-e062-49cb-9366-ee170359689e/
![image](https://github.com/user-attachments/assets/ed04bd09-c579-4edf-8a9c-9604d7b4eaa6)

## POST
URL: https://proxy.withampersand.com/v1/smart_categories/
![image](https://github.com/user-attachments/assets/b85251e0-5655-48b8-bc21-27e1cea9b2e7)

## PATCH
URL: https://proxy.withampersand.com/v1/smart_categories/74dda07e-d8a7-4f61-a4e0-2b6c9107d4bf/
![image](https://github.com/user-attachments/assets/50ec54d1-e344-4e5d-a38f-9dc0fe6c1ab2)

## Invalid requests
**Invalid endpoint**
![image](https://github.com/user-attachments/assets/875be322-ee17-407f-995d-a5f5e0488a41)

**Invalid method**
![image](https://github.com/user-attachments/assets/cae89e38-5b1b-4785-9c37-d744e314b0e9)

## Pagination
Requesting a paginated list of meetings using the **page_size** parameter to set the record limit
![image](https://github.com/user-attachments/assets/a3205c22-4fdb-4766-a0d3-08ae818dc7c9)

Requesting a next page of meetings by using the link in the **next** field.
![image](https://github.com/user-attachments/assets/6e95bcaa-3e84-4625-bcb7-080eac05700e)

## Successful console operation (operation & events)
![image](https://github.com/user-attachments/assets/4fb27eae-f3e4-491a-8132-e85abcceb0c1)
![image](https://github.com/user-attachments/assets/60e040b4-531e-441d-b1e9-0a7439b81e25)

## Failed console operation (operation & events)
![image](https://github.com/user-attachments/assets/4631c9e8-d74e-4f93-a636-4f241e039184)