### PR TITLE
[CON-1303] feat: enable braze proxy connector

### DIFF
--- a/providers/braze.go
+++ b/providers/braze.go
@@ -32,7 +32,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
@@ -41,7 +41,7 @@ func init() {
 			Input: []MetadataItemInput{
 				{
 					Name:        "workspace",
-					DisplayName: "Workspace",
+					DisplayName: "Rest Instance Id",
 				},
 			},
 		},

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -41,7 +41,7 @@ func init() {
 			Input: []MetadataItemInput{
 				{
 					Name:        "workspace",
-					DisplayName: "Rest Instance Id",
+					DisplayName: "Instance ID",
 				},
 			},
 		},


### PR DESCRIPTION
# Testing

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
URL: https://proxy.withampersand.com/catalogs
![Screenshot 2025-06-16 at 14 02 08](https://github.com/user-attachments/assets/9329703a-92c5-4364-a1d8-909ed5973531)

## POST
URL: https://proxy.withampersand.com/catalogs
![Screenshot 2025-06-16 at 13 45 52](https://github.com/user-attachments/assets/c7edf251-a697-47c6-892c-1ba365af9e6d)

## PUT
URL: https://proxy.withampersand.com/preference_center/v1/615bd689-f825-4757-9f3c-addabd52b629
![Screenshot 2025-06-16 at 13 54 00](https://github.com/user-attachments/assets/30f6684b-9662-4d97-81b3-474e429308eb)

## Invalid requests
Wrong verb applied
![Screenshot 2025-06-16 at 14 07 51](https://github.com/user-attachments/assets/6ea35df9-147e-492f-a02f-dc18c186fdde)

 invalid path.
![Screenshot 2025-06-16 at 14 08 21](https://github.com/user-attachments/assets/5cc06cb9-8fd2-4b97-90ac-3efd344546f3)


## Pagination
Pagination uses `limit` and `offset` (for some endpoints)
![Screenshot 2025-06-16 at 14 26 45](https://github.com/user-attachments/assets/e564405d-4cad-49ab-b79c-3c94af286626)

increasing offset:
![Screenshot 2025-06-16 at 14 28 15](https://github.com/user-attachments/assets/773527f8-d30f-4966-ad60-d8417368beb4)


## Successful console operation (operation & events)
![Screenshot 2025-06-16 at 14 30 53](https://github.com/user-attachments/assets/0f765c7c-9fa9-4418-8404-74eaf4af35c9)

## Failed console operation (operation & events)
![Screenshot 2025-06-16 at 14 31 10](https://github.com/user-attachments/assets/d518b928-af12-4f4f-a8c7-d18b2a678330)
