### PR TITLE
[CON-1824] feat: add FlatFile connector

### DIFF
--- a/providers/flatFile.go
+++ b/providers/flatFile.go
@@ -1,0 +1,41 @@
+package providers
+
+const flatFile Provider = "flatFile"
+
+func init() {
+	SetInfo(flatFile, ProviderInfo{
+		DisplayName: "FlatFile",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.x.flatfile.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://reference.flatfile.com/overview/welcome",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: " https://res.cloudinary.com/dycvts6vp/image/upload/v1750081977/media/flatfile.com_1750081977.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1750082071/media/flatfile.com_1750082071.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1750081956/media/flatfile.com_1750081954.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1750082112/media/flatfile.com_1750082111.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Configuration

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing



## Pagination
FlatFile pagination works using a cursor.
 The server returns a fixed number of items and includes a new cursor for the next page in the response.
 The client uses this cursor to load the next set of items.


First Page



# Logo & Icons

Icon for dark theme
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1750081977/media/flatfile.com_1750081977.svg" />

Icon for Regular theme 
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1750100764/flatfileicon_gjerpl_ag7via.svg" />

---

Logo for dark theme
<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1750082071/media/flatfile.com_1750082071.svg" />


Logo for Regular theme
<img width="1497" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1750082112/media/flatfile.com_1750082111.svg" />

