### PR TITLE
[CON-1050] feat: enable read, write serviceNow connector

### DIFF
--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -37,9 +37,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth2 Authorization code flow grant.

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
![Screenshot 2025-06-17 at 14 11 38](https://github.com/user-attachments/assets/0139c758-3c76-4202-95c7-0322d173c7a3)

![Screenshot 2025-06-17 at 14 11 49](https://github.com/user-attachments/assets/df516a6f-1b5d-4970-89d7-6f8200072bdf)

![Screenshot 2025-06-17 at 14 12 02](https://github.com/user-attachments/assets/1eb164db-3ec9-4dc9-980e-be63ee1d8c40)

- [x] Insert screenshot of Svix destination.
![Screenshot 2025-06-17 at 14 14 17](https://github.com/user-attachments/assets/677df1dc-48d8-4d6f-8210-9ccdb90e9c0b)

![Screenshot 2025-06-17 at 14 14 29](https://github.com/user-attachments/assets/2c2a9cf9-86d2-42f2-b6a6-6cd4f322df89)

![Screenshot 2025-06-17 at 14 14 46](https://github.com/user-attachments/assets/ae9c4e95-29ec-49a9-900e-d4b5960e9cba)

- [x] Screenshot of operations on dashboard
![Screenshot 2025-06-17 at 14 16 20](https://github.com/user-attachments/assets/b9f89eac-67f9-4e31-a1f5-626e48612e1c)

![Screenshot 2025-06-17 at 14 16 30](https://github.com/user-attachments/assets/c157a2f9-f8f2-4264-849f-f895cfd1fa65)

![Screenshot 2025-06-17 at 14 16 43](https://github.com/user-attachments/assets/e1fb8fad-847e-41b8-bfd7-872dd2f0a505)


# Write
For each write object:
- [x] Insert screenshot of dashboard.
![Screenshot 2025-06-17 at 14 31 00](https://github.com/user-attachments/assets/efa035e5-cbab-4918-9fcb-31d3d6a985b5)

![Screenshot 2025-06-17 at 14 31 13](https://github.com/user-attachments/assets/1da5888d-9699-4bc7-9d12-5fed5d0a1ca6)

- [x] Insert screenshot of HTTP call.
![Screenshot 2025-06-17 at 14 20 45](https://github.com/user-attachments/assets/1a30d56d-9d95-4bf9-a547-3c99f0ced03e)

![Screenshot 2025-06-17 at 14 21 16](https://github.com/user-attachments/assets/b791d777-f5dd-4a4c-8ce2-01d3f08a402c)

![Screenshot 2025-06-17 at 14 21 40](https://github.com/user-attachments/assets/1c6fb636-607c-48f9-b409-a5e1f03bc99a)


# Examples
[Installation File PR](https://github.com/amp-labs/testdata/pull/54)
