### PR TITLE
[CON-1826] feat: enable Flatfile connector

### DIFF
--- a/providers/flatFile.go
+++ b/providers/flatFile.go
@@ -32,7 +32,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Testing

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

### GET
URL: https://proxy.withampersand.com/v1/events
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/e7a46146-6c09-4e56-8c21-9c55d6e03bde" />


### POST
URL: https://proxy.withampersand.com/v1/jobs
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/d5a54943-c398-4b7d-9e9f-bc8ef3e94a91" />

### PATCH
URL: https://proxy.withampersand.com/v1/jobs/us_jb_8UXI8zqD
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/660808e8-7e21-4ed4-92bd-fc344322a5f8" />

### DELETE
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/3a6d0de8-0b56-4fab-a026-6639d2f8ad6d" />

## Pagination
FlatFile pagination works using pageSize and pageNumber.
The user sends:
pageSize — how many items to return per page (default is 20 if not provided).
pageNumber — which page of results to return based on the pageSize.
The response includes pagination info such as currentPage, pageCount, and totalCount to help navigate through pages.

First Page
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/100a2c99-d442-43da-a562-99eafb13ec7b" />

Second Page
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/fdc15d85-6777-4724-b706-6a36af5263a2" />


## Invalid requests
Wrong URL path
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/aa3442e3-e6ac-470d-aef6-5cbaf7c60dc4" />

Wrong payload
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/92a70aa9-5c85-44ad-80d4-e7227a637de7" />


## Successful console operation (operation & events)
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/ac640d78-05da-4d15-bf33-9b030c27db84" />

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/23dc459d-e430-4092-aa6e-007929af5967" />


## Failed console operation (operation & events)
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/75351f52-f54a-4103-a0f9-985f4f2a60bb" />
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/145bfdc4-0f50-4954-bbed-c43b0b5c5a2d" />

