### PR TITLE
[CON-1888] feat: Added lever metadata functionality

### DIFF
--- a/providers/lever.go
+++ b/providers/lever.go
@@ -45,6 +45,14 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231953/media/lever.co_1733231938.svg",
 			},
 		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "opportunity",
+					DisplayName: "Opportunity ID",
+				},
+			},
+		},
 	})
 
 	// Lever Sandbox configuration
@@ -83,6 +91,14 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231877/media/lever.co_1733231842.svg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231953/media/lever.co_1733231938.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "opportunity",
+					DisplayName: "Opportunity ID",
+				},
 			},
 		},
 	})

--- a/providers/lever.go
+++ b/providers/lever.go
@@ -45,14 +45,6 @@ func init() {
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231953/media/lever.co_1733231938.svg",
 			},
 		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:        "opportunity",
-					DisplayName: "Opportunity ID",
-				},
-			},
-		},
 	})
 
 	// Lever Sandbox configuration
@@ -91,14 +83,6 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231877/media/lever.co_1733231842.svg",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1733231953/media/lever.co_1733231938.svg",
-			},
-		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:        "opportunity",
-					DisplayName: "Opportunity ID",
-				},
 			},
 		},
 	})

--- a/providers/lever/README.md
+++ b/providers/lever/README.md
@@ -1,0 +1,41 @@
+# Lever connector
+
+
+## Supported Objects 
+Below is an exhaustive list of objects & methods supported on the objects
+
+Lever API version : v1
+
+Below endpoints having url path like opportunities/:opportunity/Object
+
+| Object                  | Resource         | Method       |
+| ----------------------- | ---------------- | ------------ |
+| feedback                | feedback         | read         |
+| files                   | files            | read         |
+| interviews              | interviews       | read         | 
+| notes                   | notes            | read         |
+| offers                  | offers           | read         |
+| panels                  | panels           | read         |
+| forms                   | forms            | read         |
+| referrals               | referrals        | read         |
+| resumes                 | resumes          | read         |
+
+| Object                  | Resource           | Method       |
+| ----------------------- | ------------------ | ------------ |
+| archive_reasons         | archive_reasons    | read         |
+| audit_events            | audit_events       | read         |
+| sources                 | sources            | read         |
+| stages                  | stages             | read         |
+| tags                    | tags               | read         |
+| users                   | users              | read         |
+| feedback_templates      | feedback_templates | read         |
+| opportunities           | opportunities      | read         |
+| postings                | postings           | read         |
+| form_templates          | form_templates     | read         |
+| requisitions            | requisitions       | read         |
+| requisition_fields      | requisition_fields | read         |
+
+
+Notes:
+- Excluded the endpoints /eeo/responses/pii and /eeo/responses because they are not direct endpoints, and their responses are embedded within their respective objectName under data. Other endpoints follow a consistent structure where responses are contained under data.
+- Excluded the endpoint /surveys/diversity/:posting because it includes a posting ID in the URL path, only one endpoints with posting in the connector.

--- a/providers/lever/README.md
+++ b/providers/lever/README.md
@@ -6,20 +6,6 @@ Below is an exhaustive list of objects & methods supported on the objects
 
 Lever API version : v1
 
-Below endpoints having url path like opportunities/:opportunity/Object
-
-| Object                  | Resource         | Method       |
-| ----------------------- | ---------------- | ------------ |
-| feedback                | feedback         | read         |
-| files                   | files            | read         |
-| interviews              | interviews       | read         | 
-| notes                   | notes            | read         |
-| offers                  | offers           | read         |
-| panels                  | panels           | read         |
-| forms                   | forms            | read         |
-| referrals               | referrals        | read         |
-| resumes                 | resumes          | read         |
-
 | Object                  | Resource           | Method       |
 | ----------------------- | ------------------ | ------------ |
 | archive_reasons         | archive_reasons    | read         |

--- a/providers/lever/README.md
+++ b/providers/lever/README.md
@@ -25,3 +25,13 @@ Lever API version : v1
 Notes:
 - Excluded the endpoints /eeo/responses/pii and /eeo/responses because they are not direct endpoints, and their responses are embedded within their respective objectName under data. Other endpoints follow a consistent structure where responses are contained under data.
 - Excluded the endpoint /surveys/diversity/:posting because it includes a posting ID in the URL path, only one endpoints with posting in the connector.
+- Currently we do not support below endpoints because they requires an opportunity ID in the URL path.
+   - feedback
+   - files
+   - interviews
+   - notes
+   - offers
+   - panels
+   - forms
+   - referrals
+   - resumes

--- a/providers/lever/connector.go
+++ b/providers/lever/connector.go
@@ -20,13 +20,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
-
-	opportunityId string
 }
-
-const (
-	metadataKeyopportunityID = "opportunityId"
-)
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
@@ -34,8 +28,6 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	conn.opportunityId = params.Metadata[metadataKeyopportunityID]
 
 	return conn, nil
 }

--- a/providers/lever/connector.go
+++ b/providers/lever/connector.go
@@ -24,7 +24,7 @@ type Connector struct {
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	conn, err := components.Initialize(providers.LeverSandbox, params, constructor)
+	conn, err := components.Initialize(providers.Lever, params, constructor)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/lever/connector.go
+++ b/providers/lever/connector.go
@@ -1,0 +1,60 @@
+package lever
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+
+	opportunityId string
+}
+
+const (
+	metadataKeyopportunityID = "opportunityId"
+)
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	conn, err := components.Initialize(providers.LeverSandbox, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.opportunityId = params.Metadata[metadataKeyopportunityID]
+
+	return conn, nil
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/lever/errors.go
+++ b/providers/lever/errors.go
@@ -1,0 +1,32 @@
+package lever
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var ErrNoMetadataFound = errors.New("no metadata found in response") // nolint:gochecknoglobals
+
+// Implement error abstraction layers to streamline provider error handling.
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+// ResponseError represents an error response from the Pinterest API.
+// Code contains the Pinterest-specific error code and Message contains
+// a human-readable description of the error.
+type ResponseError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	return fmt.Errorf("%w: [%v] %v", base, r.Code, r.Message)
+}

--- a/providers/lever/handlers.go
+++ b/providers/lever/handlers.go
@@ -14,9 +14,7 @@ type responseObject struct {
 }
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	urlPath := c.constructURL(objectName)
-
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, urlPath)
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, objectName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/lever/handlers.go
+++ b/providers/lever/handlers.go
@@ -19,6 +19,9 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 		return nil, err
 	}
 
+	// limited the result set by one.
+	url.WithQueryParam("limit", "1")
+
 	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 }
 

--- a/providers/lever/handlers.go
+++ b/providers/lever/handlers.go
@@ -1,0 +1,52 @@
+package lever
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+type responseObject struct {
+	Data []map[string]any `json:"data"`
+}
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	urlPath := c.constructURL(objectName)
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, urlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		FieldsMap:   make(map[string]string),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	data, err := common.UnmarshalJSON[responseObject](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if len(data.Data) == 0 {
+		return nil, ErrNoMetadataFound
+	}
+
+	for field := range data.Data[0] {
+		objectMetadata.FieldsMap[field] = field
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/lever/metadata_test.go
+++ b/providers/lever/metadata_test.go
@@ -1,0 +1,113 @@
+package lever
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	opportunitiesResponse := testutils.DataFromFile(t, "opportunities.json")
+	requisitionFieldsResponse := testutils.DataFromFile(t, "requisition_fields.json")
+
+	tests := []testroutines.Metadata{
+		{
+			Name:  "Successfully describe multiple objects with metadata",
+			Input: []string{"opportunities", "requisition_fields"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/v1/opportunities"),
+					Then: mockserver.Response(http.StatusOK, opportunitiesResponse),
+				}, {
+					If:   mockcond.Path("/v1/requisition_fields"),
+					Then: mockserver.Response(http.StatusOK, requisitionFieldsResponse),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"opportunities": {
+						DisplayName: "Opportunities",
+						Fields:      nil,
+						FieldsMap: map[string]string{
+							"id":                  "id",
+							"name":                "name",
+							"contact":             "contact",
+							"headline":            "headline",
+							"stage":               "stage",
+							"confidentiality":     "confidentiality",
+							"location":            "location",
+							"phones":              "phones",
+							"emails":              "emails",
+							"links":               "links",
+							"archived":            "archived",
+							"tags":                "tags",
+							"sources":             "sources",
+							"stageChanges":        "stageChanges",
+							"origin":              "origin",
+							"sourcedBy":           "sourcedBy",
+							"owner":               "owner",
+							"followers":           "followers",
+							"applications":        "applications",
+							"createdAt":           "createdAt",
+							"updatedAt":           "updatedAt",
+							"lastInteractionAt":   "lastInteractionAt",
+							"lastAdvancedAt":      "lastAdvancedAt",
+							"snoozedUntil":        "snoozedUntil",
+							"urls":                "urls",
+							"isAnonymized":        "isAnonymized",
+							"dataProtection":      "dataProtection",
+							"opportunityLocation": "opportunityLocation",
+						},
+					},
+					"requisition_fields": {
+						DisplayName: "Requisition_fields",
+						Fields:      nil,
+						FieldsMap: map[string]string{
+							"id":         "id",
+							"text":       "text",
+							"type":       "type",
+							"isRequired": "isRequired",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+
+	return connector, nil
+}

--- a/providers/lever/metadata_test.go
+++ b/providers/lever/metadata_test.go
@@ -101,9 +101,6 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
 		AuthenticatedClient: mockutils.NewClient(),
-		Metadata: map[string]string{
-			"opportunityId": "2087af84-f146-4535-9368-2309e33e049f",
-		},
 	})
 	if err != nil {
 		return nil, err

--- a/providers/lever/metadata_test.go
+++ b/providers/lever/metadata_test.go
@@ -101,6 +101,9 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
 		AuthenticatedClient: mockutils.NewClient(),
+		Metadata: map[string]string{
+			"opportunityId": "2087af84-f146-4535-9368-2309e33e049f",
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/providers/lever/test/opportunities.json
+++ b/providers/lever/test/opportunities.json
@@ -1,0 +1,57 @@
+{
+    "data": [
+        {
+            "id": "2087af84-f146-4535-9368-2309e33e049f",
+            "name": "karan",
+            "contact": "e2719ee1-21f5-4287-a60a-59bd29deac80",
+            "headline": "",
+            "stage": "lead-new",
+            "confidentiality": "non-confidential",
+            "location": "",
+            "phones": [],
+            "emails": [],
+            "links": [],
+            "archived": null,
+            "tags": [
+                "Hiring Software developer",
+                "Go tech",
+                "kovilpatti",
+                "Service based",
+                "hiring"
+            ],
+            "sources": [
+                "Added manually"
+            ],
+            "stageChanges": [
+                {
+                    "toStageId": "lead-new",
+                    "toStageIndex": 0,
+                    "updatedAt": 1750233426190,
+                    "userId": "2c713392-d0e4-4355-8673-378d6a851cb8"
+                }
+            ],
+            "origin": "sourced",
+            "sourcedBy": "2c713392-d0e4-4355-8673-378d6a851cb8",
+            "owner": "2c713392-d0e4-4355-8673-378d6a851cb8",
+            "followers": [
+                "2c713392-d0e4-4355-8673-378d6a851cb8",
+                "e0a9f3e3-bd9b-4eb1-8d2c-0d9a572bf641"
+            ],
+            "applications": [
+                "2b7f3433-111a-4659-a302-58a32cd2e33c"
+            ],
+            "createdAt": 1750233426190,
+            "updatedAt": 1750247948243,
+            "lastInteractionAt": 1750247948074,
+            "lastAdvancedAt": 1750233426190,
+            "snoozedUntil": null,
+            "urls": {
+                "list": "https://hire.sandbox.lever.co/candidates",
+                "show": "https://hire.sandbox.lever.co/candidates/2087af84-f146-4535-9368-2309e33e049f"
+            },
+            "isAnonymized": false,
+            "dataProtection": null,
+            "opportunityLocation": "kovilpatti"
+        }
+    ]
+}

--- a/providers/lever/test/requisition_fields.json
+++ b/providers/lever/test/requisition_fields.json
@@ -1,0 +1,10 @@
+{
+    "data": [
+        {
+            "id": "field1",
+            "text": "Area of Interest",
+            "type": "text",
+            "isRequired": false
+        }
+    ]
+}

--- a/providers/lever/utils.go
+++ b/providers/lever/utils.go
@@ -1,0 +1,29 @@
+package lever
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+const apiVersion = "v1"
+
+var EndpointWithOpportunityID = datautils.NewSet( //nolint:gochecknoglobals
+	"feedback",
+	"files",
+	"interviews",
+	"notes",
+	"offers",
+	"panels",
+	"forms",
+	"referrals",
+	"resumes",
+)
+
+func (c *Connector) constructURL(objName string) string {
+	if EndpointWithOpportunityID.Has(objName) {
+		return fmt.Sprintf("opportunities/%s/%s", c.opportunityId, objName)
+	}
+
+	return objName
+}

--- a/providers/lever/utils.go
+++ b/providers/lever/utils.go
@@ -1,29 +1,3 @@
 package lever
 
-import (
-	"fmt"
-
-	"github.com/amp-labs/connectors/internal/datautils"
-)
-
 const apiVersion = "v1"
-
-var EndpointWithOpportunityID = datautils.NewSet( //nolint:gochecknoglobals
-	"feedback",
-	"files",
-	"interviews",
-	"notes",
-	"offers",
-	"panels",
-	"forms",
-	"referrals",
-	"resumes",
-)
-
-func (c *Connector) constructURL(objName string) string {
-	if EndpointWithOpportunityID.Has(objName) {
-		return fmt.Sprintf("opportunities/%s/%s", c.opportunityId, objName)
-	}
-
-	return objName
-}

--- a/test/lever/connector.go
+++ b/test/lever/connector.go
@@ -12,17 +12,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var (
-	fieldOpportunityId = credscanning.Field{
-		Name:      "opportunityId",
-		PathJSON:  "metadata.opportunityId",
-		SuffixENV: "OPPORTUNITY_ID",
-	}
-)
-
 func GetConnector(ctx context.Context) *lever.Connector {
 	filePath := credscanning.LoadPath(providers.LeverSandbox)
-	reader := utils.MustCreateProvCredJSON(filePath, true, fieldOpportunityId)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),
@@ -35,9 +27,6 @@ func GetConnector(ctx context.Context) *lever.Connector {
 
 	conn, err := lever.NewConnector(common.ConnectorParams{
 		AuthenticatedClient: client,
-		Metadata: map[string]string{
-			"opportunityId": reader.Get(fieldOpportunityId),
-		},
 	})
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/lever/connector.go
+++ b/test/lever/connector.go
@@ -1,0 +1,110 @@
+package lever
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/lever"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+var (
+	fieldOpportunityId = credscanning.Field{
+		Name:      "opportunityId",
+		PathJSON:  "metadata.opportunityId",
+		SuffixENV: "OPPORTUNITY_ID",
+	}
+)
+
+func GetConnector(ctx context.Context) *lever.Connector {
+	filePath := credscanning.LoadPath(providers.LeverSandbox)
+	reader := utils.MustCreateProvCredJSON(filePath, true, fieldOpportunityId)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	conn, err := lever.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+		Metadata: map[string]string{
+			"opportunityId": reader.Get(fieldOpportunityId),
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	cfg := oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://sandbox-lever.auth0.com/authorize",
+			TokenURL:  "https://sandbox-lever.auth0.com/oauth/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"offline_access",
+			"applications:read:admin",
+			"archive_reasons:read:admin",
+			"audit_events:read:admin",
+			"confidential:access:admin",
+			"contact:read:admin",
+			"contact:write:admin",
+			"feedback:read:admin",
+			"feedback:write:admin",
+			"feedback_templates:read:admin",
+			"feedback_templates:write:admin",
+			"files:read:admin",
+			"files:write:admin",
+			"forms:read:admin",
+			"forms:write:admin",
+			"form_templates:read:admin",
+			"form_templates:write:admin",
+			"groups:read:admin",
+			"groups:write:admin",
+			"interviews:read:admin",
+			"interviews:write:admin",
+			"notes:read:admin",
+			"notes:write:admin",
+			"offers:read:admin",
+			"opportunities:read:admin",
+			"opportunities:write:admin",
+			"panels:read:admin",
+			"panels:write:admin",
+			"permissions:read:admin",
+			"permissions:write:admin",
+			"postings:read:admin",
+			"postings:write:admin",
+			"referrals:read:admin",
+			"requisitions:read:admin",
+			"requisitions:write:admin",
+			"requisition_fields:read:admin",
+			"requisition_fields:write:admin",
+			"resumes:read:admin",
+			"roles:read:admin",
+			"roles:write:admin",
+			"sources:read:admin",
+			"stages:read:admin",
+			"tags:read:admin",
+			"tasks:read:admin",
+			"uploads:write:admin",
+			"users:read:admin",
+			"users:write:admin",
+		},
+	}
+
+	return &cfg
+}

--- a/test/lever/metadata/main.go
+++ b/test/lever/metadata/main.go
@@ -13,15 +13,6 @@ func main() {
 	connector := lever.GetConnector(ctx)
 
 	m, err := connector.ListObjectMetadata(ctx, []string{
-		"feedback",
-		"files",
-		"interviews",
-		"notes",
-		"offers",
-		"panels",
-		"forms",
-		"referrals",
-		"resumes",
 		"archive_reasons",
 		"audit_events",
 		"sources",

--- a/test/lever/metadata/main.go
+++ b/test/lever/metadata/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/amp-labs/connectors/test/lever"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+	connector := lever.GetConnector(ctx)
+
+	m, err := connector.ListObjectMetadata(ctx, []string{
+		"feedback",
+		"files",
+		"interviews",
+		"notes",
+		"offers",
+		"panels",
+		"forms",
+		"referrals",
+		"resumes",
+		"archive_reasons",
+		"audit_events",
+		"sources",
+		"stages",
+		"tags",
+		"users",
+		"feedback_templates",
+		"opportunities",
+		"postings",
+		"form_templates",
+		"requisitions",
+		"requisition_fields",
+	})
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Metadata Response

![image](https://github.com/user-attachments/assets/c16ceb07-74f1-481d-acf4-4699ede81be0)
![image](https://github.com/user-attachments/assets/2d7b5501-9a30-441e-b48d-3afcd7696316)

## Sample Testcase Result
![image](https://github.com/user-attachments/assets/215c99ad-7942-472c-bbb5-894c31b6b716)