### PR TITLE
[CON-1727] feat(clariCopilot): add ListObjectMetadata

### DIFF
--- a/providers/claricopilot/connector.go
+++ b/providers/claricopilot/connector.go
@@ -1,0 +1,42 @@
+package claricopilot
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.ClariCopilot, params, constructor)
+}
+
+//nolint:funlen
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/claricopilot/handlers.go
+++ b/providers/claricopilot/handlers.go
@@ -1,0 +1,74 @@
+package claricopilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	limitQuery       = "limit"
+	metadataPageSize = "1"
+	pageSize         = "100"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build URL: '%w", err)
+	}
+
+	url.WithQueryParam(limitQuery, metadataPageSize)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		FieldsMap:   make(map[string]string),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	data, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if len(*data) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	records, ok := (*data)[objectName].([]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := records[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field := range firstRecord {
+		objectMetadata.FieldsMap[field] = field
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/claricopilot/metadata_test.go
+++ b/providers/claricopilot/metadata_test.go
@@ -1,0 +1,108 @@
+package claricopilot
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	usersResponse := testutils.DataFromFile(t, "users.json")
+	callsResponse := testutils.DataFromFile(t, "calls.json")
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Successfully describe multiple objects with metadata",
+			Input: []string{"users", "calls"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/users"),
+					Then: mockserver.Response(http.StatusOK, usersResponse),
+				}, {
+					If:   mockcond.Path("/calls"),
+					Then: mockserver.Response(http.StatusOK, callsResponse),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"calls": {
+						DisplayName: "Calls",
+						Fields:      nil,
+						FieldsMap: map[string]string{
+							"audio_url":            "audio_url",
+							"bot_not_join_reason":  "bot_not_join_reason",
+							"call_review_page_url": "call_review_page_url",
+							"disposition":          "disposition",
+							"externalParticipants": "externalParticipants",
+							"id":                   "id",
+							"joinedParticipants":   "joinedParticipants",
+							"last_modified_time":   "last_modified_time",
+							"metrics":              "metrics",
+							"source_id":            "source_id",
+							"status":               "status",
+							"time":                 "time",
+							"title":                "title",
+							"type":                 "type",
+							"users":                "users",
+							"video_url":            "video_url",
+						},
+					},
+					"users": {
+						DisplayName: "Users",
+						Fields:      nil,
+						FieldsMap: map[string]string{
+							"email":        "email",
+							"id":           "id",
+							"is_recording": "is_recording",
+							"name":         "name",
+							"role":         "role",
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+
+	return connector, nil
+}

--- a/providers/claricopilot/test/calls.json
+++ b/providers/claricopilot/test/calls.json
@@ -1,0 +1,117 @@
+{
+    "calls": [
+        {
+            "id": "7549847e-4e97-4650-a20d-87791520e529",
+            "source_id": "REQUESTED_POST",
+            "title": "Ampersand promo",
+            "users": [
+                {
+                    "userId": "e04483dd-fb82-460a-a14e-b6f3e6a2b7a4",
+                    "userEmail": "integration.user+clari@withampersand.com",
+                    "isOrganizer": false,
+                    "personId": 0
+                }
+            ],
+            "externalParticipants": [],
+            "joinedParticipants": [],
+            "status": "POST_PROCESSING_DONE",
+            "bot_not_join_reason": [],
+            "type": "RECORDING",
+            "time": "2025-06-11T14:25:00.000Z",
+            "last_modified_time": "2025-06-11T14:53:06.310Z",
+            "audio_url": null,
+            "video_url": null,
+            "disposition": "CALL_DID_NOT_CONNECT_WITH_PROSPECT",
+            "metrics": {
+                "talk_listen_ratio": 1,
+                "num_questions_asked": 0,
+                "num_questions_asked_by_reps": 0,
+                "call_duration": 8,
+                "total_speak_duration": 6.440000057220459,
+                "longest_monologue_duration": 6.440000057220459,
+                "longest_monologue_start_time": 0,
+                "engaging_questions": 0,
+                "categories": []
+            },
+            "call_review_page_url": "https://copilot.clari.com/call/7549847e-4e97-4650-a20d-87791520e529"
+        },
+        {
+            "id": "7b891784-ba59-47bd-9f19-62247e9e6484",
+            "title": "Ampersand test",
+            "users": [
+                {
+                    "userId": "e04483dd-fb82-460a-a14e-b6f3e6a2b7a4",
+                    "userEmail": "integration.user+clari@withampersand.com",
+                    "isOrganizer": true,
+                    "personId": 0
+                }
+            ],
+            "externalParticipants": [],
+            "joinedParticipants": [
+                {
+                    "name": "Dipu Chaurasiya"
+                }
+            ],
+            "status": "NO_DATA_INCALL",
+            "bot_not_join_reason": [],
+            "type": "ZOOM",
+            "time": "2025-06-10T10:26:38.681Z",
+            "calendar_id": "195bf7b8-5c6b-4992-9adf-2c2fd5ce3e94",
+            "last_modified_time": "2025-06-10T10:29:51.937Z",
+            "audio_url": null,
+            "video_url": null,
+            "disposition": "UNKNOWN_CALL_DISPOSITION",
+            "metrics": {
+                "talk_listen_ratio": 0,
+                "num_questions_asked": 0,
+                "num_questions_asked_by_reps": 0,
+                "call_duration": 0,
+                "total_speak_duration": 0,
+                "longest_monologue_duration": 0,
+                "longest_monologue_start_time": 0,
+                "engaging_questions": 0,
+                "categories": []
+            },
+            "call_review_page_url": "https://copilot.clari.com/call/7b891784-ba59-47bd-9f19-62247e9e6484"
+        },
+        {
+            "id": "31f12970-040d-4186-9b6f-ad0a08afbfb8",
+            "source_id": "REQUESTED_POST",
+            "title": "Ampersand Demo",
+            "users": [
+                {
+                    "userId": "e04483dd-fb82-460a-a14e-b6f3e6a2b7a4",
+                    "userEmail": "integration.user+clari@withampersand.com",
+                    "isOrganizer": false,
+                    "personId": 0
+                }
+            ],
+            "externalParticipants": [],
+            "joinedParticipants": [],
+            "status": "POST_PROCESSING_DONE",
+            "bot_not_join_reason": [],
+            "type": "RECORDING",
+            "time": "2025-06-10T08:14:00.000Z",
+            "last_modified_time": "2025-06-10T10:39:36.637Z",
+            "audio_url": null,
+            "video_url": null,
+            "disposition": "CALL_DID_NOT_CONNECT_WITH_PROSPECT",
+            "metrics": {
+                "talk_listen_ratio": 1,
+                "num_questions_asked": 0,
+                "num_questions_asked_by_reps": 1,
+                "call_duration": 104,
+                "total_speak_duration": 98.23999786376953,
+                "longest_monologue_duration": 98.23999786376953,
+                "longest_monologue_start_time": 2.3499999046325684,
+                "engaging_questions": 0,
+                "categories": []
+            },
+            "call_review_page_url": "https://copilot.clari.com/call/31f12970-040d-4186-9b6f-ad0a08afbfb8"
+        }
+    ],
+    "pagination": {
+        "matched": 3,
+        "hasMore": false
+    }
+}

--- a/providers/claricopilot/test/users.json
+++ b/providers/claricopilot/test/users.json
@@ -1,0 +1,11 @@
+{
+    "users": [
+        {
+            "id": "e04483dd-fb82-460a-a14e-b6f3e6a2b7a4",
+            "email": "integration.user+clari@withampersand.com",
+            "name": "April",
+            "role": "MANAGER",
+            "is_recording": true
+        }
+    ]
+}

--- a/test/claricopilot/connector.go
+++ b/test/claricopilot/connector.go
@@ -12,9 +12,12 @@ import (
 
 func GetConnector(ctx context.Context) *claricopilot.Connector {
 	filePath := credscanning.LoadPath(providers.ClariCopilot)
-	reader := utils.MustCreateProvCredJSON(filePath, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false, credscanning.Fields.ApiKey, credscanning.Fields.Secret)
 
-	client, err := common.NewCustomAuthHTTPClient(ctx, reader.Get(credscanning.Fields.ApiKey))
+	apiKey := reader.Get(credscanning.Fields.ApiKey)
+	apiSecret := reader.Get(credscanning.Fields.Secret)
+
+	client, err := common.NewCustomAuthHTTPClient(ctx, common.WithCustomHeaders(common.Header{Key: "X-Api-Key", Value: apiKey}, common.Header{Key: "X-Api-Password", Value: apiSecret}))
 	if err != nil {
 		utils.Fail("error creating client", "error", err)
 	}
@@ -22,6 +25,7 @@ func GetConnector(ctx context.Context) *claricopilot.Connector {
 	conn, err := claricopilot.NewConnector(
 		common.ConnectorParams{AuthenticatedClient: client},
 	)
+
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)
 	}

--- a/test/claricopilot/connector.go
+++ b/test/claricopilot/connector.go
@@ -1,0 +1,30 @@
+package claricopilot
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/claricopilot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetConnector(ctx context.Context) *claricopilot.Connector {
+	filePath := credscanning.LoadPath(providers.ClariCopilot)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
+
+	client, err := common.NewCustomAuthHTTPClient(ctx, reader.Get(credscanning.Fields.ApiKey))
+	if err != nil {
+		utils.Fail("error creating client", "error", err)
+	}
+
+	conn, err := claricopilot.NewConnector(
+		common.ConnectorParams{AuthenticatedClient: client},
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/claricopilot/metadata/main.go
+++ b/test/claricopilot/metadata/main.go
@@ -1,0 +1,1 @@
+package metadata

--- a/test/claricopilot/metadata/main.go
+++ b/test/claricopilot/metadata/main.go
@@ -1,1 +1,32 @@
-package metadata
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/test/claricopilot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	if err := run(); err != nil {
+		utils.Fail(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+	connector := claricopilot.GetConnector(ctx)
+
+	m, err := connector.ListObjectMetadata(ctx, []string{"users", "calls"})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the results
+	utils.DumpJSON(m, os.Stdout)
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Metadata Response
<img width="861" alt="image" src="https://github.com/user-attachments/assets/651aa012-80f1-49cc-a407-b1d3d37d3426" />



## Sample Testcase Result
<img width="1755" alt="image" src="https://github.com/user-attachments/assets/0e10443f-a85a-4cbd-b29f-650a0df2f253" />


