### PR TITLE
feat(clariCopilot): enable Read support in Clari Copilot provider

### DIFF
--- a/providers/clariCopilot.go
+++ b/providers/clariCopilot.go
@@ -41,7 +41,7 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
 			Write:     false,
 		},


### PR DESCRIPTION
# Installation
Mailmonkey using API key/Oauth2 with scopes/Password, etc.

# Conventions
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.
<img width="967" alt="image" src="https://github.com/user-attachments/assets/958626e5-d264-4739-af09-7496a9c16853" />

- [x] Insert screenshot of Svix destination.
<img width="1566" alt="image" src="https://github.com/user-attachments/assets/5b8bacc5-1533-45e3-92fc-14e085d00c60" />
<img width="1584" alt="image" src="https://github.com/user-attachments/assets/fe9b62ca-3999-4b65-9ff7-f62525013077" />


- [x] Screenshot of operations on dashboard
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/7f16c6bc-dfd5-4291-8ec0-9866a6dd20ab" />
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/820dc4fa-c2d0-497a-92b1-c465297ce1e5" />


# Examples
https://github.com/amp-labs/testdata/pull/57