### PR TITLE
[CON-57] feat: enable chargeover proxy connector

### DIFF
--- a/providers/chargeOver.go
+++ b/providers/chargeOver.go
@@ -14,7 +14,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Testing

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
![Screenshot 2025-06-23 at 17 32 38](https://github.com/user-attachments/assets/ebca7863-b282-465b-916c-a3ec364ff7a8)


## POST
![Screenshot 2025-06-23 at 17 34 34](https://github.com/user-attachments/assets/dcff7052-8ee9-44ed-b946-0192b5d0edda)

## PUT
![Screenshot 2025-06-23 at 17 34 59](https://github.com/user-attachments/assets/127cb9ee-af5a-4760-91dd-9a59de69859b)


## DELETE
![Screenshot 2025-06-23 at 17 35 25](https://github.com/user-attachments/assets/e6a595bc-48a3-4ed6-b7a6-3280c085fb0e)


## Invalid requests
Wrong verb applied,
![Screenshot 2025-06-23 at 17 40 51](https://github.com/user-attachments/assets/76cfefe6-764a-432d-b69c-9a8160d384b0)


invalid path.
![Screenshot 2025-06-23 at 17 35 44](https://github.com/user-attachments/assets/92a209cd-57ca-476a-9fdf-e416ca6ca698)



## Pagination
There is no explicit data to indicate there is next page. You manually iterate to check if there is. usig the `limit` and `offset` params
![Screenshot 2025-06-23 at 17 43 46](https://github.com/user-attachments/assets/6bdf1ac6-53ba-4212-8332-26dcbb65f238)

![Screenshot 2025-06-23 at 17 43 35](https://github.com/user-attachments/assets/8fbdc3ac-0b73-417e-a57e-33b585270c14)

 
## Successful console operation (operation & events)
![Screenshot 2025-06-23 at 17 45 29](https://github.com/user-attachments/assets/5edcfa92-538c-4e83-a54c-cd69e31bf93f)


## Failed console operation (operation & events)
![Screenshot 2025-06-23 at 17 45 39](https://github.com/user-attachments/assets/2caf47fa-0432-4c70-ab2c-faf3dc88f54f)
