### PR TITLE
[CON-1929] feat(linear): add ListObjectMetadata

### DIFF
--- a/common/naming/formatting.go
+++ b/common/naming/formatting.go
@@ -20,3 +20,13 @@ func CapitalizeFirstLetterEveryWord(text string) string {
 
 	return text
 }
+
+func CapitalizeFirstLetter(text string) string {
+	if len(text) == 0 {
+		return text
+	}
+
+	caser := cases.Title(language.English)
+
+	return caser.String(text[:1]) + text[1:]
+}

--- a/providers/linear/connector.go
+++ b/providers/linear/connector.go
@@ -1,0 +1,41 @@
+package linear
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.Linear, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/linear/handlers.go
+++ b/providers/linear/handlers.go
@@ -1,0 +1,118 @@
+package linear
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build URL: %w", err)
+	}
+
+	// Use introspection query to get field information
+	query := fmt.Sprintf(`{
+		__type(name: "%s") {
+			name
+			fields {
+				name
+				type {
+					name
+					kind
+					ofType {
+					  name
+					  kind
+					}
+				}
+			}
+		}
+	}`, naming.NewSingularString(naming.CapitalizeFirstLetter(objectName)).String())
+
+	// Create the request body as a map
+	requestBody := map[string]string{
+		"query": query,
+	}
+
+	// Marshal the request body to JSON
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	metadataResp, err := common.UnmarshalJSON[MetadataResponse](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if len(metadataResp.Data.Type.Fields) == 0 {
+		return nil, fmt.Errorf(
+			"missing or empty fields for object: %s, error: %w",
+			objectName,
+			common.ErrMissingExpectedValues,
+		)
+	}
+
+	// Process each field from the introspection result
+	for _, field := range metadataResp.Data.Type.Fields {
+		valueType := field.Type.Name
+
+		if valueType == "" {
+			valueType = field.Type.OfType.Name
+		}
+
+		objectMetadata.Fields[field.Name] = common.FieldMetadata{
+			DisplayName:  field.Name,
+			ValueType:    getFieldValueType(valueType),
+			ProviderType: valueType,
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return &objectMetadata, nil
+}
+
+func getFieldValueType(field string) common.ValueType {
+	if field == "" {
+		return ""
+	}
+
+	switch strings.ToLower(field) {
+	case "float":
+		return common.ValueTypeFloat
+	case "string", "id":
+		return common.ValueTypeString
+	case "boolean":
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
+}

--- a/providers/linear/types.go
+++ b/providers/linear/types.go
@@ -1,0 +1,42 @@
+package linear
+
+type TypeKind string
+
+const (
+	KindScalar  TypeKind = "SCALAR"
+	KindObject  TypeKind = "OBJECT"
+	KindNonNull TypeKind = "NON_NULL"
+	KindList    TypeKind = "LIST"
+)
+
+// TypeInfo represents the type information in the GraphQL schema.
+type TypeInfo struct {
+	Name   string     `json:"name"`
+	Kind   TypeKind   `json:"kind"`
+	OfType OfTypeInfo `json:"ofType"`
+}
+
+type OfTypeInfo struct {
+	Name string   `json:"name"`
+	Kind TypeKind `json:"kind"`
+}
+
+// Field represents a field in the GraphQL schema.
+type Field struct {
+	Name string   `json:"name"`
+	Type TypeInfo `json:"type"`
+}
+
+// TypeMetadata represents the type metadata in the GraphQL schema.
+type TypeMetadata struct {
+	Name   string  `json:"name"`
+	Fields []Field `json:"fields"`
+}
+
+// MetadataResponse represents the response structure for metadata queries.
+// nolint
+type MetadataResponse struct {
+	Data struct {
+		Type TypeMetadata `json:"__type"`
+	} `json:"data"`
+}

--- a/test/linear/connector.go
+++ b/test/linear/connector.go
@@ -1,0 +1,58 @@
+package linear
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/linear"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetLinearConnector(ctx context.Context) *linear.Connector {
+	filePath := credscanning.LoadPath(providers.Linear)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	conn, err := linear.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating Linear App connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	cfg := oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://linear.app/oauth/authorize",
+			TokenURL:  "https://api.linear.app/oauth/token",
+			AuthStyle: oauth2.AuthStyleAutoDetect,
+		},
+		Scopes: []string{
+			"read",
+			"write",
+			"issues:create",
+			"comments:create",
+			"timeSchedule:write",
+			"admin",
+		},
+	}
+
+	return &cfg
+}

--- a/test/linear/metadata/main.go
+++ b/test/linear/metadata/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/test/linear"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := linear.GetLinearConnector(ctx)
+
+	m, err := conn.ListObjectMetadata(ctx, []string{"Template"})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/linear/metadata/main.go
+++ b/test/linear/metadata/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	conn := linear.GetLinearConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"Template"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"teams", "users"})
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Metadata Response
<img width="829" alt="image" src="https://github.com/user-attachments/assets/6d673770-82d5-49c3-a2ca-38f5275e4569" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/b7cf884b-d1a6-4865-8ab2-b6d8a675c1f5" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/b3105cf4-77cb-4441-8543-19426d5ef324" />

