### PR TITLE
[CON-1732] feat(clariCopilot): enable write support

### DIFF
--- a/providers/clariCopilot.go
+++ b/providers/clariCopilot.go
@@ -43,7 +43,7 @@ func init() {
 			Proxy:     true,
 			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Read supports  incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read

- [x] Insert screenshot of metadata fields from read object installation.
<img width="948" alt="image" src="https://github.com/user-attachments/assets/90d62253-6e48-4354-b9af-743b2e935fb3" />



# Write
- [x] Insert screenshot of dashboard.
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/e4019e0b-94aa-4453-b161-af4a9af616bf" />
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/3dd95a0b-6645-40cf-afab-34251f7eab76" />
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/add82e95-cd51-47ae-9b94-06f6d51e7498" />
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/a618ab38-25f0-4191-971e-2833f9584846" />


- [x] Insert screenshot of HTTP call. 
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/5aa2b669-13f3-4c79-ab7e-87254bc0c991" />
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/aa1493ac-8e72-46ef-817d-0d5080db9479" />
<img width="1423" alt="image" src="https://github.com/user-attachments/assets/621b894c-66f6-4049-9114-a2bf31d3e4d5" />
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/8c3d6a28-2e3b-4914-a338-343973dd0574" />



# Examples
[test-data Link](https://github.com/amp-labs/testdata/tree/main/claricopilot)
