### PR TITLE
[CON-402] feat: Enable proxy : vtiger

### DIFF
--- a/providers/vtiger.go
+++ b/providers/vtiger.go
@@ -28,7 +28,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Conventions
- [x] Provider name is camelcase
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
 
## Testing
### GET ALL
URL: https://proxy.withampersand.com/v1/vtiger/default/tags_retrieve?id=3x493
![image](https://github.com/user-attachments/assets/c8b4c246-b2d1-4d35-af6f-19ddbe5296a1)

### POST
URL: https://proxy.withampersand.com/v1/vtiger/default/tags_add
![image](https://github.com/user-attachments/assets/5acb9216-7a6c-4415-94b6-261c1d4ab745)

### DELETE
URL: https://proxy.withampersand.com/v1/vtiger/default/tags_delete
![image](https://github.com/user-attachments/assets/50437dbf-e1f3-434e-94c2-c9ee402f515f)

## Invalid Request
**Invalid Endpoint**
![image](https://github.com/user-attachments/assets/935377c0-fc28-4d88-8c6d-9416dd958f86)

**Invalid Method**
![image](https://github.com/user-attachments/assets/9b2c1c9a-ab7f-4e5f-b451-0bf601289d75)

## Successful console operation (operation & events)
![image](https://github.com/user-attachments/assets/1dc65684-3696-4ab9-95d6-4169ad6abff1)

## Failed console operation (operation & events)
![image](https://github.com/user-attachments/assets/219351e2-758f-4704-9b67-b6c85f9ac5a5)
