### PR TITLE
[CON-1950] feat(confluence): ListObjectMetadata

### DIFF
--- a/providers/atlassian/internal/confluence/adapter.go
+++ b/providers/atlassian/internal/confluence/adapter.go
@@ -1,0 +1,29 @@
+package confluence
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Adapter struct {
+	*components.Connector
+	common.RequireAuthenticatedClient
+
+	components.SchemaProvider
+}
+
+func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
+	return components.Init(providers.Atlassian, params, constructor)
+}
+
+func constructor(_ common.ConnectorParams, base *components.Connector) (*Adapter, error) {
+	adapter := &Adapter{
+		Connector: base,
+	}
+
+	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(adapter.ProviderContext.Module(), Schemas)
+
+	return adapter, nil
+}

--- a/providers/atlassian/internal/confluence/operations.go
+++ b/providers/atlassian/internal/confluence/operations.go
@@ -1,0 +1,22 @@
+package confluence
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func (a *Adapter) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+	// TODO needs implementation.
+	return nil, common.ErrNotImplemented
+}
+
+func (a *Adapter) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+	// TODO needs implementation.
+	return nil, common.ErrNotImplemented
+}
+
+func (a *Adapter) Delete(ctx context.Context, config common.DeleteParams) (*common.DeleteResult, error) {
+	// TODO needs implementation.
+	return nil, common.ErrNotImplemented
+}

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -105,3 +105,80 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		})
 	}
 }
+
+func TestListObjectMetadataConfluence(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:       "Successfully describe one object with metadata",
+			Input:      []string{"pages", "blogposts"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"pages": {
+						DisplayName: "Pages",
+						Fields: map[string]common.FieldMetadata{
+							"parentType": {
+								DisplayName:  "parentType",
+								ValueType:    "singleSelect",
+								ProviderType: "string",
+								Values: []common.FieldValue{{
+									Value:        "page",
+									DisplayValue: "page",
+								}, {
+									Value:        "whiteboard",
+									DisplayValue: "whiteboard",
+								}, {
+									Value:        "database",
+									DisplayValue: "database",
+								}, {
+									Value:        "embed",
+									DisplayValue: "embed",
+								}, {
+									Value:        "folder",
+									DisplayValue: "folder",
+								}},
+							},
+						},
+					},
+					"blogposts": {
+						DisplayName: "Blog Posts",
+						Fields: map[string]common.FieldMetadata{
+							"title": {
+								DisplayName:  "title",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"version": {
+								DisplayName:  "version",
+								ValueType:    "other",
+								ProviderType: "object",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnectorConfluence(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -224,7 +224,6 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	return constructTestConnectorGeneral(serverURL, providers.ModuleAtlassianJira)
 }
 
-// nolint:unused
 func constructTestConnectorConfluence(serverURL string) (*Connector, error) {
 	return constructTestConnectorGeneral(serverURL, providers.ModuleAtlassianConfluence)
 }

--- a/test/atlassian/confluence/metadata/attachments/main.go
+++ b/test/atlassian/confluence/metadata/attachments/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetConfluenceConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"attachments",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/test/atlassian/confluence/metadata/blogposts/main.go
+++ b/test/atlassian/confluence/metadata/blogposts/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetConfluenceConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"blogposts",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}


### PR DESCRIPTION
- [x] Connector/Adapter uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Unit tests cover metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [x] Modules are only being added because:
  - [x] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Live Tests
Data comes from static files.
![image](https://github.com/user-attachments/assets/94936d81-c47f-46b0-945b-b147e8d2be0f)
![image](https://github.com/user-attachments/assets/f1e2eee0-b0e8-436f-b761-fd4e129de4cf)

Some fields are enums from OpenAPI:
![image](https://github.com/user-attachments/assets/1ad771e8-67ed-4432-8a0c-fab0f02f8a05)
