### PR TITLE
[CON-1931] feat(Linear): add Write 

### DIFF
--- a/providers/linear/connector.go
+++ b/providers/linear/connector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -20,6 +21,7 @@ type Connector struct {
 	// Supported operations
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -52,6 +54,19 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler: interpreter.ErrorHandler{
 				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
 			}.Handle,

--- a/providers/linear/graphql/attachments-write.graphql
+++ b/providers/linear/graphql/attachments-write.graphql
@@ -1,0 +1,14 @@
+mutation AttachmentCreate($input: AttachmentCreateInput!) {
+  attachmentCreate(input: $input) {
+    success
+    attachment {
+      id
+      title
+      subtitle
+      sourceType
+      url
+      updatedAt
+      createdAt
+    }
+  }
+}

--- a/providers/linear/graphql/comments-write.graphql
+++ b/providers/linear/graphql/comments-write.graphql
@@ -1,0 +1,14 @@
+mutation CommentCreate($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    success
+    comment {
+      url
+      id
+      body
+      bodyData
+      createdAt
+      editedAt
+      quotedText
+    }
+  }
+}

--- a/providers/linear/graphql/customers-write.graphql
+++ b/providers/linear/graphql/customers-write.graphql
@@ -1,0 +1,23 @@
+mutation CustomerCreate($input: CustomerCreateInput!) {
+  customerCreate(input: $input) {
+    success
+    customer {
+      slugId
+      name
+      logoUrl
+      mainSourceId
+      id
+      externalIds
+      size
+      domains
+      tier {
+        color
+        createdAt
+        description
+        displayName
+        id
+        name
+      }
+    }
+  }
+}

--- a/providers/linear/graphql/cycles-write.graphql
+++ b/providers/linear/graphql/cycles-write.graphql
@@ -1,0 +1,15 @@
+mutation CycleCreate($input: CycleCreateInput!) {
+  cycleCreate(input: $input) {
+    success
+    cycle {
+      updatedAt
+      progress
+      number
+      name
+      id
+      description
+      createdAt
+      completedAt
+    }
+  }
+}

--- a/providers/linear/graphql/documents-write.graphql
+++ b/providers/linear/graphql/documents-write.graphql
@@ -1,0 +1,20 @@
+mutation DocumentCreate($input: DocumentCreateInput!) {
+  documentCreate(input: $input) {
+    success
+    document {
+      id
+      updatedAt
+      title
+      hiddenAt
+      createdAt
+      content
+      creator {
+        name
+        id
+        email
+        displayName
+        description
+      }
+    }
+  }
+}

--- a/providers/linear/graphql/issues-write.graphql
+++ b/providers/linear/graphql/issues-write.graphql
@@ -1,0 +1,12 @@
+mutation IssueCreate($input: IssueCreateInput!) {
+  issueCreate(input: $input) {
+    success
+    issue {
+      title
+      id
+      number
+      trashed
+      url
+    }
+  }
+}

--- a/providers/linear/graphql/projects-write.graphql
+++ b/providers/linear/graphql/projects-write.graphql
@@ -1,0 +1,14 @@
+mutation ProjectCreate($input: ProjectCreateInput!) {
+  projectCreate(input: $input) {
+    success
+    project {
+      content
+      description
+      id
+      name
+      slugId
+      updatedAt
+      createdAt
+    }
+  }
+}

--- a/providers/linear/graphql/teams-write.graphql
+++ b/providers/linear/graphql/teams-write.graphql
@@ -1,0 +1,17 @@
+mutation TeamCreate($input: TeamCreateInput!) {
+  teamCreate(input: $input) {
+    success
+    team {
+      timezone
+      name
+      id
+      displayName
+      description
+      createdAt
+      archivedAt
+      key
+      updatedAt
+      upcomingCycleCount
+    }
+  }
+}

--- a/providers/linear/support.go
+++ b/providers/linear/support.go
@@ -29,11 +29,26 @@ func supportedOperations() components.EndpointRegistryInput {
 		"workflowStates",
 	}
 
+	writeSupport := []string{
+		"attachments",
+		"comments",
+		"customers",
+		"cycles",
+		"documents",
+		"issues",
+		"projects",
+		"teams",
+	}
+
 	return components.EndpointRegistryInput{
 		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,
+			},
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
+				Support:  components.WriteSupport,
 			},
 		},
 	}

--- a/test/linear/write/main.go
+++ b/test/linear/write/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	ln "github.com/amp-labs/connectors/providers/linear"
+	"github.com/amp-labs/connectors/test/linear"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	conn := linear.GetLinearConnector(ctx)
+
+	err := testCreateIssue(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	err = testCreateDocument(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	err = testCreateProject(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testCreateIssue(ctx context.Context, conn *ln.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "issues",
+		RecordData: map[string]any{
+			"title":  "this is a test issue",
+			"teamId": "f34f6ac8-918c-4d7b-b1c3-25e8e53b8c0d",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testCreateDocument(ctx context.Context, conn *ln.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "documents",
+		RecordData: map[string]any{
+			"title":   "this is a test document",
+			"teamId":  "f34f6ac8-918c-4d7b-b1c3-25e8e53b8c0d",
+			"content": "This is the content of the document.",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testCreateProject(ctx context.Context, conn *ln.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "projects",
+		RecordData: map[string]any{
+			"name":    "this is a test project",
+			"teamIds": []string{"f34f6ac8-918c-4d7b-b1c3-25e8e53b8c0d"},
+			"content": "the content is empty",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
## Sample read response
<img width="705" alt="image" src="https://github.com/user-attachments/assets/447978a8-283d-411b-ac15-bc1783696cfd" />
