### PR TITLE
[CON-1949] feat(confluence): Confluence module

### DIFF
--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -7,6 +7,8 @@ const Atlassian Provider = "atlassian"
 const (
 	// ModuleAtlassianJira is the module used for listing Jira issues.
 	ModuleAtlassianJira common.ModuleID = "jira"
+	// ModuleAtlassianConfluence is the module used for Atlassian Confluence.
+	ModuleAtlassianConfluence common.ModuleID = "confluence"
 )
 
 // nolint:funlen
@@ -33,6 +35,15 @@ func init() {
 					Read:      true,
 					Subscribe: false,
 					Write:     true,
+				},
+			},
+			ModuleAtlassianConfluence: {
+				BaseURL:     "https://api.atlassian.com/ex/confluence/{{.cloudId}}/wiki/api",
+				DisplayName: "Atlassian Confluence",
+				Support: Support{
+					Read:      false,
+					Subscribe: false,
+					Write:     false,
 				},
 			},
 		},
@@ -62,9 +73,12 @@ func init() {
 		Metadata: &ProviderMetadata{
 			PostAuthentication: []MetadataItemPostAuthentication{
 				{
+					// Jira and Confluence modules require it for their BaseURLs.
+					// This is acquired using workspace.
 					Name: "cloudId",
 					ModuleDependencies: &ModuleDependencies{
-						ModuleAtlassianJira: ModuleDependency{},
+						ModuleAtlassianJira:       ModuleDependency{},
+						ModuleAtlassianConfluence: ModuleDependency{},
 					},
 				},
 			},
@@ -74,7 +88,8 @@ func init() {
 					DisplayName: "App name",
 					DocsURL:     "https://support.atlassian.com/organization-administration/docs/update-your-product-and-site-url/",
 					ModuleDependencies: &ModuleDependencies{
-						ModuleAtlassianJira: ModuleDependency{},
+						ModuleAtlassianJira:       ModuleDependency{},
+						ModuleAtlassianConfluence: ModuleDependency{},
 					},
 				},
 			},

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -221,9 +221,18 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 }
 
 func constructTestConnector(serverURL string) (*Connector, error) {
+	return constructTestConnectorGeneral(serverURL, providers.ModuleAtlassianJira)
+}
+
+// nolint:unused
+func constructTestConnectorConfluence(serverURL string) (*Connector, error) {
+	return constructTestConnectorGeneral(serverURL, providers.ModuleAtlassianConfluence)
+}
+
+func constructTestConnectorGeneral(serverURL string, module common.ModuleID) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
-			Module:              providers.ModuleAtlassianJira,
+			Module:              module,
 			AuthenticatedClient: mockutils.NewClient(),
 			Workspace:           "test-workspace",
 			Metadata: map[string]string{

--- a/test/atlassian/connector.go
+++ b/test/atlassian/connector.go
@@ -21,6 +21,10 @@ func GetJiraConnector(ctx context.Context) *atlassian.Connector {
 	return makeAtlassianConnector(ctx, providers.ModuleAtlassianJira)
 }
 
+func GetConfluenceConnector(ctx context.Context) *atlassian.Connector {
+	return makeAtlassianConnector(ctx, providers.ModuleAtlassianConfluence)
+}
+
 func makeAtlassianConnector(ctx context.Context, module common.ModuleID) *atlassian.Connector {
 	filePath := credscanning.LoadPath(providers.Atlassian)
 	reader := utils.MustCreateProvCredJSON(filePath, true, fieldCloudID)


### PR DESCRIPTION
# Description

Introduce Confluence module in provider catalog.
`GetPostAuthInfo` should work for either module. This concept is independent of what module/API is being in use.

# Live Tests

### GetPostAuthInfo
<img width="1000" height="265" alt="image" src="https://github.com/user-attachments/assets/3e283cbe-5d2f-4cc2-972d-4f7e3ccc9e07" />
