### PR TITLE
[CON-1951] feat(confluence): Read

### DIFF
--- a/providers/atlassian/internal/confluence/adapter.go
+++ b/providers/atlassian/internal/confluence/adapter.go
@@ -1,17 +1,26 @@
 package confluence
 
 import (
+	"strings"
+
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
+
+const apiVersion = "v2"
 
 type Adapter struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
 
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
@@ -23,7 +32,32 @@ func constructor(_ common.ConnectorParams, base *components.Connector) (*Adapter
 		Connector: base,
 	}
 
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
 	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(adapter.ProviderContext.Module(), Schemas)
 
+	adapter.Reader = reader.NewHTTPReader(
+		adapter.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		adapter.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  adapter.buildReadRequest,
+			ParseResponse: adapter.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
 	return adapter, nil
+}
+
+func (a *Adapter) getRawModuleURL() (*urlbuilder.URL, error) {
+	url := strings.ReplaceAll(a.ModuleInfo().BaseURL, "wiki/api", "")
+
+	return urlbuilder.New(url)
+}
+
+func (a *Adapter) getReadURL(objectName string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, objectName)
 }

--- a/providers/atlassian/internal/confluence/errors.go
+++ b/providers/atlassian/internal/confluence/errors.go
@@ -1,0 +1,65 @@
+package confluence
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: []string{"errors"},
+			Template: func() interpreter.ErrorDescriptor { return &ResponseCommonError{} },
+		},
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseMessageError{} },
+		},
+	}...,
+)
+
+type ResponseCommonError struct {
+	Errors []struct {
+		Status int    `json:"status"`
+		Code   string `json:"code"`
+		Title  string `json:"title"`
+		Detail any    `json:"detail"`
+	} `json:"errors"`
+}
+
+func (r ResponseCommonError) CombineErr(base error) error {
+	if len(r.Errors) == 0 {
+		return base
+	}
+
+	messages := make([]string, len(r.Errors))
+	for index, subErr := range r.Errors {
+		messages[index] = subErr.Title
+	}
+
+	var descriptions string
+	if len(messages) != 0 {
+		descriptions = strings.Join(messages, ",")
+	}
+
+	return fmt.Errorf("%w: %v", base, descriptions)
+}
+
+type ResponseMessageError struct {
+	Timestamp time.Time `json:"timestamp"`
+	Status    int       `json:"status"`
+	Error     string    `json:"error"`
+	Message   string    `json:"message"`
+	Path      string    `json:"path"`
+}
+
+func (r ResponseMessageError) CombineErr(base error) error {
+	if len(r.Message) == 0 {
+		return base
+	}
+
+	return fmt.Errorf("%w: %v", base, r.Message)
+}

--- a/providers/atlassian/internal/confluence/operations.go
+++ b/providers/atlassian/internal/confluence/operations.go
@@ -6,11 +6,6 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-func (a *Adapter) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
-	// TODO needs implementation.
-	return nil, common.ErrNotImplemented
-}
-
 func (a *Adapter) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
 	// TODO needs implementation.
 	return nil, common.ErrNotImplemented

--- a/providers/atlassian/internal/confluence/read.go
+++ b/providers/atlassian/internal/confluence/read.go
@@ -1,0 +1,149 @@
+package confluence
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/httpkit"
+	"github.com/spyzhov/ajson"
+)
+
+// DefaultPageSize is similar across all endpoints. One example:
+// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-label/#api-labels-get
+const DefaultPageSize = "250"
+
+type readObjectSpec struct {
+	sortingQuery string
+	sortOrder    readhelper.TimeOrder
+	timeField    string
+}
+
+var readObjectsSpec = datautils.NewDefaultMap(map[string]readObjectSpec{ // nolint:gochecknoglobals
+	"attachments": {
+		sortingQuery: "-created-date",
+		sortOrder:    readhelper.ReverseOrder,
+		timeField:    "createdAt",
+	},
+	"blogposts": {
+		sortingQuery: "-created-date",
+		sortOrder:    readhelper.ReverseOrder,
+		timeField:    "createdAt",
+	},
+	"inline-comments": {
+		sortingQuery: "-created-date",
+		sortOrder:    readhelper.ReverseOrder,
+		timeField:    "resolutionLastModifiedAt",
+	},
+	"pages": {
+		sortingQuery: "-created-date",
+		sortOrder:    readhelper.ReverseOrder,
+		timeField:    "createdAt",
+	},
+	"spaces": {
+		sortingQuery: "",
+		sortOrder:    readhelper.Unordered,
+		timeField:    "createdAt",
+	},
+	"tasks": {
+		sortingQuery: "",
+		sortOrder:    readhelper.Unordered,
+		timeField:    "updatedAt",
+	},
+}, func(objectName string) readObjectSpec {
+	// Default case: no sorting query and no response field available.
+	return readObjectSpec{
+		sortingQuery: "",
+		sortOrder:    readhelper.Unordered,
+		timeField:    "",
+	}
+})
+
+func (a *Adapter) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := a.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (a *Adapter) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	// First page
+	url, err := a.getReadURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if spec := readObjectsSpec.Get(params.ObjectName); spec.sortingQuery != "" {
+		// Sorting example:
+		// https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-blog-post/#api-blogposts-get
+		url.WithQueryParam("sort", spec.sortingQuery)
+	}
+
+	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, DefaultPageSize))
+
+	return url, nil
+}
+
+func (a *Adapter) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	return common.ParseResultFiltered(params,
+		resp,
+		common.MakeRecordsFunc("results"),
+		a.makeFilterFunc(params, resp),
+		common.MakeMarshaledDataFunc(nil),
+		params.Fields,
+	)
+}
+
+func (a *Adapter) makeFilterFunc(params common.ReadParams, resp *common.JSONHTTPResponse) common.RecordsFilterFunc {
+	spec := readObjectsSpec.Get(params.ObjectName)
+
+	nextPageFunc := a.makeNextRecordsURL(resp)
+	if spec.timeField == "" {
+		// Object has no time field that can be used for connector-side filtering.
+		return readhelper.MakeIdentityFilterFunc(nextPageFunc)
+	}
+
+	return readhelper.MakeTimeFilterFunc(
+		spec.sortOrder,
+		readhelper.NewTimeBoundary(),
+		spec.timeField,
+		time.RFC3339,
+		nextPageFunc,
+	)
+}
+
+// Next page is communicated via `Link` header under the `next` rel.
+// https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#about
+func (a *Adapter) makeNextRecordsURL(resp *common.JSONHTTPResponse) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		headerLink := httpkit.HeaderLink(resp, "next")
+		if headerLink == "" {
+			return "", nil
+		}
+
+		url, err := a.getRawModuleURL()
+		if err != nil {
+			return "", err
+		}
+
+		url.AddPath(headerLink)
+
+		return url.String(), nil
+	}
+}

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+func TestReadJira(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
 	responseErrorFormat := testutils.DataFromFile(t, "jql-error.json")
@@ -215,6 +215,180 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
 				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func TestReadConfluence(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	errorInvalidPath := testutils.DataFromFile(t, "confluence/read/err-invalid-path.json")
+	errorBadPageSize := testutils.DataFromFile(t, "confluence/read/err-page-size.json")
+	responseBlogpostsFirstPage := testutils.DataFromFile(t, "confluence/read/blogposts/1-first-page.json")
+	responseBlogpostsLastPage := testutils.DataFromFile(t, "confluence/read/blogposts/2-last-page.json")
+	responseBlogpostsManyRecords := testutils.DataFromFile(t, "confluence/read/blogposts/many-records.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "blogposts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:  "Error message page size out of range is parsed",
+			Input: common.ReadParams{ObjectName: "blogposts", Fields: connectors.Fields("body")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, errorBadPageSize),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				testutils.StringError("Provided size {300} for 'limit' is greater than the max allowed: 250"), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Error message invalid path is parsed",
+			Input: common.ReadParams{ObjectName: "blogposts", Fields: connectors.Fields("body")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, errorInvalidPath),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				testutils.StringError("No message available"), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "First page has next page reference",
+			Input: common.ReadParams{ObjectName: "blogposts", Fields: connectors.Fields("title")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/ex/confluence/ebc887b2-7e61-4059-ab35-71f15cc16e12/wiki/api/v2/blogposts"),
+					mockcond.QueryParam("limit", "250"),
+				},
+				Then: mockserver.ResponseChainedFuncs(
+					mockserver.Header("Link",
+						`</wiki/api/v2/blogposts?limit=2&cursor=eyJpZCI6Ijc1MzY2OSIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjc1MzY2OX0=>; rel="next", <https://withampersand-team-oqo0hkaj.atlassian.net/wiki>; rel="base"`), // nolint:lll
+					mockserver.Response(http.StatusOK, responseBlogpostsFirstPage),
+				),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"title": "First blog post ever!",
+					},
+					Raw: map[string]any{
+						"id":        "688129",
+						"spaceId":   "131189",
+						"createdAt": "2025-06-26T20:39:16.596Z",
+					},
+				}, {
+					Fields: map[string]any{
+						"title": "Second blog post!",
+					},
+					Raw: map[string]any{
+						"id":        "753669",
+						"spaceId":   "131189",
+						"createdAt": "2025-06-26T20:39:37.501Z",
+					},
+				}},
+				NextPage: testroutines.URLTestServer + "/ex/confluence/ebc887b2-7e61-4059-ab35-71f15cc16e12/wiki/api/v2/blogposts?limit=2&cursor=eyJpZCI6Ijc1MzY2OSIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjc1MzY2OX0=", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Successful read with chosen fields using next page token",
+			Input: common.ReadParams{
+				ObjectName: "blogposts",
+				NextPage: testroutines.URLTestServer + "/ex/confluence/ebc887b2-7e61-4059-ab35-71f15cc16e12/wiki/api/v2/blogposts/wiki/api/v2/blogposts" + // nolint:lll
+					"?limit=2&cursor=eyJpZCI6Ijc1MzY2OSIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjc1MzY2OX0=", // nolint:lll
+				Fields: connectors.Fields("title"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/ex/confluence/ebc887b2-7e61-4059-ab35-71f15cc16e12/wiki/api/v2/blogposts/wiki/api/v2/blogposts"), // nolint:lll
+					mockcond.QueryParam("limit", "2"),
+					mockcond.QueryParam("cursor", "eyJpZCI6Ijc1MzY2OSIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjc1MzY2OX0="), // nolint:lll
+				},
+				Then: mockserver.ResponseChainedFuncs(
+					mockserver.Header("Link",
+						`<https://withampersand-team-oqo0hkaj.atlassian.net/wiki>; rel="base"`),
+					mockserver.Response(http.StatusOK, responseBlogpostsLastPage),
+				),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"title": "Even a third blog post, on a roll!",
+					},
+					Raw: map[string]any{
+						"id":        "819206",
+						"spaceId":   "131189",
+						"createdAt": "2025-06-26T20:39:48.350Z",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Blogposts with connector side filtering",
+			Input: common.ReadParams{
+				ObjectName: "blogposts",
+				Fields:     connectors.Fields("title"),
+				Since:      time.Date(2026, time.February, 25, 5, 17, 45, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/ex/confluence/ebc887b2-7e61-4059-ab35-71f15cc16e12/wiki/api/v2/blogposts"),
+					mockcond.QueryParam("limit", "250"),
+					mockcond.QueryParam("sort", "-created-date"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseBlogpostsManyRecords),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"title": "4th post"},
+					Raw:    map[string]any{"id": "33390597"},
+				}, {
+					Fields: map[string]any{"title": "3rd post"},
+					Raw:    map[string]any{"id": "33456129"},
+				}, {
+					Fields: map[string]any{"title": "2nd post"},
+					Raw:    map[string]any{"id": "33292310"},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnectorConfluence(tt.Server.URL)
 			})
 		})
 	}

--- a/providers/atlassian/test/confluence/read/blogposts/1-first-page.json
+++ b/providers/atlassian/test/confluence/read/blogposts/1-first-page.json
@@ -1,0 +1,54 @@
+{
+  "results": [
+    {
+      "spaceId": "131189",
+      "createdAt": "2025-06-26T20:39:16.596Z",
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "version": {
+        "number": 1,
+        "message": "initial ideas",
+        "minorEdit": false,
+        "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+        "createdAt": "2025-06-26T20:39:16.607Z",
+        "ncsStepVersion": "4"
+      },
+      "body": {},
+      "status": "current",
+      "title": "First blog post ever!",
+      "id": "688129",
+      "_links": {
+        "editui": "/pages/resumedraft.action?draftId=688129",
+        "webui": "/spaces/SD/blog/2025/06/26/688129/First+blog+post+ever",
+        "edituiv2": "/spaces/SD/blog/edit-v2/688129",
+        "tinyui": "/x/AYAK"
+      }
+    },
+    {
+      "spaceId": "131189",
+      "createdAt": "2025-06-26T20:39:37.501Z",
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "version": {
+        "number": 1,
+        "message": "",
+        "minorEdit": false,
+        "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+        "createdAt": "2025-06-26T20:39:37.501Z",
+        "ncsStepVersion": "1"
+      },
+      "body": {},
+      "status": "current",
+      "title": "Second blog post!",
+      "id": "753669",
+      "_links": {
+        "editui": "/pages/resumedraft.action?draftId=753669",
+        "webui": "/spaces/SD/blog/2025/06/26/753669/Second+blog+post",
+        "edituiv2": "/spaces/SD/blog/edit-v2/753669",
+        "tinyui": "/x/BYAL"
+      }
+    }
+  ],
+  "_links": {
+    "next": "/wiki/api/v2/blogposts?limit=2&cursor=eyJpZCI6Ijc1MzY2OSIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjc1MzY2OX0=",
+    "base": "https://withampersand-team-oqo0hkaj.atlassian.net/wiki"
+  }
+}

--- a/providers/atlassian/test/confluence/read/blogposts/2-last-page.json
+++ b/providers/atlassian/test/confluence/read/blogposts/2-last-page.json
@@ -1,0 +1,30 @@
+{
+  "results": [
+    {
+      "createdAt": "2025-06-26T20:39:48.350Z",
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "version": {
+        "number": 1,
+        "message": "",
+        "minorEdit": false,
+        "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+        "createdAt": "2025-06-26T20:39:48.350Z",
+        "ncsStepVersion": "1"
+      },
+      "spaceId": "131189",
+      "status": "current",
+      "body": {},
+      "title": "Even a third blog post, on a roll!",
+      "id": "819206",
+      "_links": {
+        "editui": "/pages/resumedraft.action?draftId=819206",
+        "webui": "/spaces/SD/blog/2025/06/26/819206/Even+a+third+blog+post+on+a+roll",
+        "edituiv2": "/spaces/SD/blog/edit-v2/819206",
+        "tinyui": "/x/BoAM"
+      }
+    }
+  ],
+  "_links": {
+    "base": "https://withampersand-team-oqo0hkaj.atlassian.net/wiki"
+  }
+}

--- a/providers/atlassian/test/confluence/read/blogposts/many-records.json
+++ b/providers/atlassian/test/confluence/read/blogposts/many-records.json
@@ -1,0 +1,51 @@
+{
+  "results": [
+    {
+      "_links": {},
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "body": {},
+      "createdAt": "2026-02-25T05:18:12.185Z",
+      "id": "33390597",
+      "spaceId": "196612",
+      "status": "current",
+      "title": "4th post",
+      "version": {}
+    },
+    {
+      "_links": {},
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "body": {},
+      "createdAt": "2026-02-25T05:18:01.014Z",
+      "id": "33456129",
+      "spaceId": "196612",
+      "status": "current",
+      "title": "3rd post",
+      "version": {}
+    },
+    {
+      "_links": {},
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "body": {},
+      "createdAt": "2026-02-25T05:17:45.747Z",
+      "id": "33292310",
+      "spaceId": "196612",
+      "status": "current",
+      "title": "2nd post",
+      "version": {}
+    },
+    {
+      "_links": {},
+      "authorId": "712020:dcef0c39-e30a-405a-afe5-9d34bf00b73f",
+      "body": {},
+      "createdAt": "2026-02-25T05:17:34.013Z",
+      "id": "33423361",
+      "spaceId": "196612",
+      "status": "current",
+      "title": "1st post",
+      "version": {}
+    }
+  ],
+  "_links": {
+    "base": "https://withampersand-team-oqo0hkaj.atlassian.net/wiki"
+  }
+}

--- a/providers/atlassian/test/confluence/read/err-invalid-path.json
+++ b/providers/atlassian/test/confluence/read/err-invalid-path.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2025-06-25T21:28:19.914705831Z",
+  "status": 404,
+  "error": "Not Found",
+  "message": "No message available",
+  "path": "/wiki/api/v2/attachments"
+}

--- a/providers/atlassian/test/confluence/read/err-page-size.json
+++ b/providers/atlassian/test/confluence/read/err-page-size.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "status": 400,
+      "code": "INVALID_REQUEST_PARAMETER",
+      "title": "Provided size {300} for 'limit' is greater than the max allowed: 250",
+      "detail": null
+    }
+  ]
+}

--- a/test/atlassian/confluence/read/blogposts/main.go
+++ b/test/atlassian/confluence/read/blogposts/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/atlassian"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetConfluenceConnector(ctx)
+
+	/**
+	4 - "2026-02-25T05:18:12.185Z" -- newest
+	3 - "2026-02-25T05:18:01.014Z"
+	2 - "2026-02-25T05:17:45.747Z"
+	1 - "2026-02-25T05:17:34.013Z" -- oldest
+	*/
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "blogposts",
+		Fields:     connectors.Fields("title"),
+		Since:      utils.Timestamp("2026-02-25T05:18:01.014Z"),
+		PageSize:   3,
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
- [x] Connector uses `internal/components`
- [x] Read supports 
  - [x] pagination and 
  - [ ] incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Unit tests cover read logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

# Live Test
Connector-side filtering excludes records out of range. The below request queries records newer and including the 3rd post. There are 4 posts in total and 3 on this page (4th, 3rd and 2nd). The last 2nd post is out of range of `Since` which means no next page should exist, -- which is confirmed by empty next page token.
<img width="658" height="965" alt="image" src="https://github.com/user-attachments/assets/1ba6622d-6fdb-4171-994a-4c6a17c2cabf" />

