### PR TITLE
fix: update base URLs of Atlassian connector

### DIFF
--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -7,8 +7,8 @@ const Atlassian Provider = "atlassian"
 const (
 	// ModuleAtlassianJira is the module used for listing Jira issues.
 	ModuleAtlassianJira common.ModuleID = "jira"
-	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
-	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
+	// ModuleAtlassianConnect is the module used for Atlassian Connect.
+	ModuleAtlassianConnect common.ModuleID = "atlassian-connect"
 )
 
 // nolint:funlen
@@ -37,7 +37,7 @@ func init() {
 					Write:     true,
 				},
 			},
-			ModuleAtlassianJiraConnect: {
+			ModuleAtlassianConnect: {
 				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api",
 				DisplayName: "Atlassian Connect",
 				Support: Support{

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -17,7 +17,7 @@ func init() {
 	SetInfo(Atlassian, ProviderInfo{
 		DisplayName: "Atlassian",
 		AuthType:    Oauth2,
-		BaseURL:     "https://api.atlassian.com",
+		BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://auth.atlassian.com/authorize",

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -29,7 +29,7 @@ func init() {
 		DefaultModule:      ModuleAtlassianJira,
 		Modules: &Modules{
 			ModuleAtlassianJira: {
-				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api/3",
+				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api",
 				DisplayName: "Atlassian Jira",
 				Support: Support{
 					Read:      true,
@@ -38,7 +38,7 @@ func init() {
 				},
 			},
 			ModuleAtlassianJiraConnect: {
-				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api/3",
+				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api",
 				DisplayName: "Atlassian Connect",
 				Support: Support{
 					Read:      true,

--- a/providers/atlassian.go
+++ b/providers/atlassian.go
@@ -7,8 +7,8 @@ const Atlassian Provider = "atlassian"
 const (
 	// ModuleAtlassianJira is the module used for listing Jira issues.
 	ModuleAtlassianJira common.ModuleID = "jira"
-	// ModuleAtlassianConnect is the module used for Atlassian Connect.
-	ModuleAtlassianConnect common.ModuleID = "atlassian-connect"
+	// ModuleAtlassianJiraConnect is the module used for Atlassian Connect.
+	ModuleAtlassianJiraConnect common.ModuleID = "atlassian-connect"
 )
 
 // nolint:funlen
@@ -37,7 +37,7 @@ func init() {
 					Write:     true,
 				},
 			},
-			ModuleAtlassianConnect: {
+			ModuleAtlassianJiraConnect: {
 				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api",
 				DisplayName: "Atlassian Connect",
 				Support: Support{

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -234,22 +234,6 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 		},
 		// Root for providers that have multiple modules.
 		{
-			name: "Atlassian root module",
-			input: inType{
-				provider: Atlassian,
-				moduleID: common.ModuleRoot,
-			},
-			expected: &ModuleInfo{
-				BaseURL:     "https://api.atlassian.com",
-				DisplayName: "Atlassian",
-				Support: Support{
-					Proxy: true,
-					Read:  true,
-					Write: true,
-				},
-			},
-		},
-		{
 			name: "Hubspot root module",
 			input: inType{
 				provider: Hubspot,

--- a/providers/utils_test.go
+++ b/providers/utils_test.go
@@ -326,14 +326,13 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 				moduleID: "random-module-name",
 			},
 			expected: &ModuleInfo{
-				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api/3",
+				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api",
 				DisplayName: "Atlassian Jira",
 				Support: Support{
 					Read:  true,
 					Write: true,
 				},
 			},
-			// expectedErr: common.ErrMissingModule,
 		},
 		{
 			name: "Hubspot unknown module",
@@ -349,7 +348,6 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 					Write: true,
 				},
 			},
-			// expectedErr: common.ErrMissingModule,
 		},
 		{
 			name: "Marketo unknown module",
@@ -374,7 +372,6 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 					Write:     true,
 				},
 			},
-			// expectedErr: common.ErrMissingModule,
 		},
 		// Choosing non-root module for providers supporting several modules.
 		{
@@ -384,7 +381,7 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 				moduleID: ModuleAtlassianJira,
 			},
 			expected: &ModuleInfo{
-				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api/3",
+				BaseURL:     "https://api.atlassian.com/ex/jira/{{.cloudId}}/rest/api",
 				DisplayName: "Atlassian Jira",
 				Support: Support{
 					Read:  true,
@@ -399,7 +396,7 @@ func TestReadModuleInfo(t *testing.T) { // nolint:funlen,maintidx
 				moduleID: ModuleAtlassianJiraConnect,
 			},
 			expected: &ModuleInfo{
-				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api/3",
+				BaseURL:     "https://{{.workspace}}.atlassian.net/rest/api",
 				DisplayName: "Atlassian Connect",
 				Support: Support{
 					Read:  true,

--- a/test/utils/testutils/checks.go
+++ b/test/utils/testutils/checks.go
@@ -13,7 +13,7 @@ func CheckOutput(t *testing.T, name string,
 	t.Helper()
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("%s: expected: (%v), got: (%v)", name, expected, actual)
+		t.Fatalf("%s: expected: (%v),\n got: (%v)", name, expected, actual)
 	}
 }
 


### PR DESCRIPTION
This PR makes 2 updates:
- Removes version numbers. As a general rule of thumb, base URLs should never contain version numbers. This allows customers who are making proxy calls to use any version of the API they would like to use.
- Update the URL of the base module's base URL to match that of the Jira module (which is the default module.) This is because `api.atlassian.com` is a pretty unusable base URL for proxy request since the builder won't know the cloud ID. I've also double checked our logs and nobody is using Atlassian proxy actions yet, so this isn't going to break any customers.