### PR TITLE
chore(atlassian): Fix read-write script

### DIFF
--- a/test/atlassian/write-delete/main.go
+++ b/test/atlassian/write-delete/main.go
@@ -2,16 +2,13 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/providers/atlassian"
+	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/atlassian"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
 type issuePayload struct {
@@ -30,7 +27,7 @@ type identifier struct {
 
 const (
 	projectID   = "10001"
-	issueTypeID = "10005"
+	issueTypeID = "10007"
 )
 
 // For this script replace project id and issue types with your values.
@@ -44,120 +41,43 @@ func main() {
 
 	conn := connTest.GetAtlassianConnector(ctx)
 
-	slog.Info("> TEST Create/Update/Delete issue")
-	slog.Info("Creating issue")
-
-	view := createIssue(ctx, conn, &issuePayload{
-		Fields: issueFields{
-			Project: identifier{
-				Id: projectID,
-			},
-			Issuetype: identifier{
-				Id: issueTypeID,
-			},
-			Summary: "The very new title of Jira issue",
-		},
-	})
-
-	slog.Info("Updating some issue properties")
-
+	oldTitle := "The very new title of Jira issue"
 	newTitle := "Fix button dropdown in main menu"
-	updateIssue(ctx, conn, view.RecordId, &issuePayload{
-		Fields: issueFields{
-			Project: identifier{
-				Id: projectID,
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"issues",
+		issuePayload{
+			Fields: issueFields{
+				Project: identifier{
+					Id: projectID,
+				},
+				Issuetype: identifier{
+					Id: issueTypeID,
+				},
+				Summary: oldTitle,
 			},
-			Issuetype: identifier{
-				Id: issueTypeID,
-			},
-			Summary: newTitle,
 		},
-	})
-
-	slog.Info("View that issue has changed accordingly")
-
-	res := readIssue(ctx, conn)
-
-	updatedView := searchIssue(res, "id", view.RecordId)
-
-	summaryProperty, ok := updatedView["summary"]
-	if !ok {
-		utils.Fail("couldn't find summary property")
-	}
-
-	if summaryProperty != newTitle {
-		utils.Fail("error updated Jira Issue Title does not match")
-	}
-
-	slog.Info("Removing this issue")
-	removeIssue(ctx, conn, view.RecordId)
-	slog.Info("> Successful test completion")
-}
-
-func searchIssue(res *common.ReadResult, key, value string) map[string]any {
-	for _, data := range res.Data {
-		if mockutils.DoesObjectCorrespondToString(data.Fields[key], value) {
-			return data.Raw
-		}
-	}
-
-	utils.Fail("error finding issue")
-
-	return nil
-}
-
-func readIssue(ctx context.Context, conn *atlassian.Connector) *common.ReadResult {
-	res, err := conn.Read(ctx, common.ReadParams{
-		Fields: connectors.Fields("id", "fields"),
-	})
-	if err != nil {
-		utils.Fail("error reading from Atlassian", "error", err)
-	}
-
-	return res
-}
-
-func createIssue(ctx context.Context, conn *atlassian.Connector, payload *issuePayload) *common.WriteResult {
-	res, err := conn.Write(ctx, common.WriteParams{
-		RecordId:   "",
-		RecordData: payload,
-	})
-	if err != nil {
-		utils.Fail("error writing to Atlassian", "error", err)
-	}
-
-	if !res.Success {
-		utils.Fail("failed to create a issue")
-	}
-
-	return res
-}
-
-func updateIssue(ctx context.Context, conn *atlassian.Connector, viewID string, payload *issuePayload) *common.WriteResult {
-	res, err := conn.Write(ctx, common.WriteParams{
-		RecordId:   viewID,
-		RecordData: payload,
-	})
-	if err != nil {
-		utils.Fail("error writing to Atlassian", "error", err)
-	}
-
-	if !res.Success {
-		utils.Fail("failed to update a issue")
-	}
-
-	return res
-}
-
-func removeIssue(ctx context.Context, conn *atlassian.Connector, viewID string) {
-	res, err := conn.Delete(ctx, common.DeleteParams{
-		RecordId: viewID,
-	})
-	if err != nil {
-		utils.Fail("error deleting for Atlassian", "error", err)
-	}
-
-	if !res.Success {
-		utils.Fail("failed to remove a issue")
-	}
+		issuePayload{
+			Fields: issueFields{
+				Project: identifier{
+					Id: projectID,
+				},
+				Issuetype: identifier{
+					Id: issueTypeID,
+				},
+				Summary: newTitle,
+			},
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("id", "summary"),
+			SearchBy: testscenario.Property{
+				Key:   "summary",
+				Value: oldTitle,
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"summary": newTitle,
+			},
+		},
+	)
 }


### PR DESCRIPTION
Fixes read-write script for atlassian.

Dynamically uses cloud id from credential file.

![image](https://github.com/user-attachments/assets/ef5a74a6-545e-4b37-a446-71ceecad829b)

