### PR TITLE
[CON-1348] feat(teamleader): add ListObjectMetadata

### DIFF
--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -31,8 +31,6 @@ func constructor(base *components.Connector) (*Connector, error) {
 		connector.HTTPClient().Client,
 		schema.FetchModeSerial,
 		operations.SingleObjectMetadataHandlers{
-			// Retrieving metadata using individual object calls can lead to rate limiting issues.
-			// Additionally, the rate limits may vary depending on the caller's roles.
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
 		},

--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -1,0 +1,42 @@
+package teamleader
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Initialize(providers.Teamleader, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeSerial,
+		operations.SingleObjectMetadataHandlers{
+			// Retrieving metadata using individual object calls can lead to rate limiting issues.
+			// Additionally, the rate limits may vary depending on the caller's roles.
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	objectNameSuffix = ".list"
+	apiListSuffix = ".list"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	fullObjectName := objectName + objectNameSuffix
+	fullObjectName := objectName + apiListSuffix
 
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, fullObjectName)
 	if err != nil {

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -1,0 +1,67 @@
+package teamleader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	objectNameSuffix = ".list"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	fullObjectName := objectName + objectNameSuffix
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, fullObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		FieldsMap:   make(map[string]string),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	res, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if len(*res) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	records, ok := (*res)["data"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := records[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field := range firstRecord {
+		objectMetadata.FieldsMap[field] = field
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -41,7 +41,7 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 		return nil, common.ErrFailedToUnmarshalBody
 	}
 
-	if len(*res) == 0 {
+	if res == nil || len(*res) == 0 {
 		return nil, common.ErrMissingExpectedValues
 	}
 

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -32,7 +32,7 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
 	objectMetadata := common.ObjectMetadata{
-		FieldsMap:   make(map[string]string),
+		Fields:      make(map[string]common.FieldMetadata),
 		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
 	}
 
@@ -59,9 +59,32 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
 	}
 
-	for field := range firstRecord {
-		objectMetadata.FieldsMap[field] = field
+	for field, value := range firstRecord {
+		objectMetadata.Fields[field] = common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    inferValueTypeFromData(value),
+			ProviderType: "", // not available
+			ReadOnly:     false,
+			Values:       nil,
+		}
 	}
 
 	return &objectMetadata, nil
+}
+
+func inferValueTypeFromData(value any) common.ValueType {
+	if value == nil {
+		return common.ValueTypeOther
+	}
+
+	switch value.(type) {
+	case string:
+		return common.ValueTypeString
+	case float64, int, int64:
+		return common.ValueTypeFloat
+	case bool:
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
 }

--- a/test/teamleader/connector.go
+++ b/test/teamleader/connector.go
@@ -1,0 +1,50 @@
+package teamleader
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/teamleader"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetConnector(ctx context.Context) *teamleader.Connector {
+	filePath := credscanning.LoadPath(providers.Teamleader)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := teamleader.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	cfg := oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://focus.teamleader.eu/oauth2/authorize",
+			TokenURL:  "https://focus.teamleader.eu/oauth2/access_token",
+			AuthStyle: oauth2.AuthStyleAutoDetect,
+		},
+	}
+
+	return &cfg
+}

--- a/test/teamleader/metadata/main.go
+++ b/test/teamleader/metadata/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/amp-labs/connectors/test/teamleader"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	if err := run(); err != nil {
+		utils.Fail(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+	connector := teamleader.GetConnector(ctx)
+
+	m, err := connector.ListObjectMetadata(ctx, []string{"teams"})
+	if err != nil {
+		return err
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+
+	return nil
+}

--- a/test/teamleader/metadata/main.go
+++ b/test/teamleader/metadata/main.go
@@ -18,7 +18,7 @@ func run() error {
 	ctx := context.Background()
 	connector := teamleader.GetConnector(ctx)
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"teams"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"teams", "departments", "users", "workTypes", "contacts", "companies"})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
## Sample read response
<img width="750" alt="image" src="https://github.com/user-attachments/assets/f4dd04a6-3de6-462b-9b9b-20d5926dedd5" />
<img width="561" alt="image" src="https://github.com/user-attachments/assets/c541037d-f78a-42c0-afcd-f9eb42bfd541" />


