### PR TITLE
[CON-1349] feat(teamleader): add Read

### DIFF
--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -17,6 +18,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -33,6 +35,23 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.SingleObjectMetadataHandlers{
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the read provider for the connector
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		common.ModuleRoot,
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
 		},
 	)
 

--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -31,8 +31,6 @@ func constructor(base *components.Connector) (*Connector, error) {
 		connector.HTTPClient().Client,
 		schema.FetchModeSerial,
 		operations.SingleObjectMetadataHandlers{
-			// Retrieving metadata using individual object calls can lead to rate limiting issues.
-			// Additionally, the rate limits may vary depending on the caller's roles.
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
 		},

--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -1,0 +1,42 @@
+package teamleader
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Initialize(providers.Teamleader, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeSerial,
+		operations.SingleObjectMetadataHandlers{
+			// Retrieving metadata using individual object calls can lead to rate limiting issues.
+			// Additionally, the rate limits may vary depending on the caller's roles.
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	objectNameSuffix = ".list"
-	pageSize         = 2
+	pageSize         = 1
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -1,0 +1,67 @@
+package teamleader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	objectNameSuffix = ".list"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	fullObjectName := objectName + objectNameSuffix
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, fullObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		FieldsMap:   make(map[string]string),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	res, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if len(*res) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	records, ok := (*res)["data"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := records[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field := range firstRecord {
+		objectMetadata.FieldsMap[field] = field
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	objectNameSuffix = ".list"
-	pageSize         = 1
+	pageSize         = 100
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -1,9 +1,14 @@
 package teamleader
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
@@ -12,6 +17,7 @@ import (
 
 const (
 	objectNameSuffix = ".list"
+	pageSize         = "2"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
@@ -64,4 +70,81 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	}
 
 	return &objectMetadata, nil
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	var (
+		url *urlbuilder.URL
+		err error
+	)
+
+	fullObjectName := params.ObjectName + objectNameSuffix
+
+	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, fullObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	body := buildRequestBody(params)
+
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+
+		return nil, err
+	}
+
+	if params.NextPage != "" {
+		url, err = urlbuilder.New(params.NextPage.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonData))
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	return common.ParseResult(
+		response,
+		records(),
+		nextRecordsURL(request),
+		common.GetMarshaledData,
+		params.Fields,
+	)
+}
+
+func buildRequestBody(params common.ReadParams) map[string]any {
+	body := make(map[string]any)
+
+	if !params.Since.IsZero() {
+		body["filter"] = map[string]any{
+			"updated_since": params.Since.Format(time.RFC3339),
+		}
+	}
+
+	if params.NextPage != "" {
+		pageNumber, err := strconv.Atoi(params.NextPage.String())
+		if err != nil {
+			pageNumber = 1 // Default to page 1 if conversion fails
+		}
+
+		log.Printf("Next page number: %d\n", pageNumber)
+
+		body["page"] = map[string]any{
+			"size":   pageSize,
+			"number": pageNumber,
+		}
+	} else {
+		body["page"] = map[string]any{
+			"size":   pageSize,
+			"number": 1,
+		}
+	}
+
+	return body
 }

--- a/providers/teamleader/parse.go
+++ b/providers/teamleader/parse.go
@@ -1,0 +1,68 @@
+package teamleader
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+func records() common.RecordsFunc {
+	return func(node *ajson.Node) ([]map[string]any, error) {
+		records, err := jsonquery.New(node).ArrayRequired("data")
+		if err != nil {
+			return nil, err
+		}
+
+		return jsonquery.Convertor.ArrayToMap(records)
+	}
+}
+
+func nextRecordsURL(req *http.Request) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+
+		res, err := jsonquery.New(node).ArrayRequired("data")
+		if err != nil {
+			return "", err
+		}
+
+		if res == nil {
+			return "", nil
+		}
+
+		if len(res) > 0 {
+			reqBody := req.Body
+			if reqBody == nil {
+				return "", nil
+			}
+
+			bodyBytes, err := io.ReadAll(reqBody)
+			if err != nil {
+				return "", err
+			}
+
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			var body map[string]any
+			if err := json.Unmarshal(bodyBytes, &body); err != nil {
+				return "", err
+			}
+
+			if offset, ok := body["page"].(map[string]any); ok {
+				if number, ok := offset["number"].(int); ok {
+
+					nextPage := number + 1
+
+					return string(nextPage), nil
+
+				}
+			}
+		}
+
+		return "", nil
+	}
+}

--- a/providers/teamleader/read_test.go
+++ b/providers/teamleader/read_test.go
@@ -1,0 +1,94 @@
+package teamleader
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	responseContactFirst := testutils.DataFromFile(t, "contacts-first-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "users"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+
+		{
+			Name:  "Successful read with chosen fields",
+			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("id", "first_name", "last_name")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/contacts.list"),
+				Then:  mockserver.Response(http.StatusOK, responseContactFirst),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"id":         "2a39e420-3ba3-4384-8024-fa702ef99c9f",
+						"first_name": "Erlich",
+						"last_name":  "Bachman",
+					},
+					Raw: map[string]any{
+						"id":         "2a39e420-3ba3-4384-8024-fa702ef99c9f",
+						"first_name": "Erlich",
+						"last_name":  "Bachman",
+						"status":     "active",
+						"salutation": "Mr",
+						"website":    "https://piedpiper.com",
+						"gender":     "unknown",
+						"birthdate":  "1987-04-25",
+						"iban":       "BE12123412341234",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+
+	return connector, nil
+}

--- a/providers/teamleader/supports.go
+++ b/providers/teamleader/supports.go
@@ -10,7 +10,12 @@ import (
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{
-		"departments", "contacts",
+		"departments", "contacts", "users", "teams", "customFieldDefinitions",
+		"workTypes", "closingDays", "companies", "tags", "deals", "dealPipelines", "dealPhases", "dealSources",
+		"quotations", "orders", "meetings", "calls", "callOutcomes", "events", "activityTypes", "invoices", "creditNotes",
+		"subscriptions", "taxRates", "withholdingTaxRates", "commercialDiscounts", "paymentMethods", "productCategories",
+		"products", "unitsOfMeasure", "priceLists", "projects", "milestones", "tasks", "timeTracking", "tickets", "ticketStatus",
+		"files", "mailTemplates",
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/teamleader/supports.go
+++ b/providers/teamleader/supports.go
@@ -1,0 +1,24 @@
+package teamleader
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := []string{
+		"departments", "contacts",
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/teamleader/supports.go
+++ b/providers/teamleader/supports.go
@@ -9,6 +9,7 @@ import (
 )
 
 func supportedOperations() components.EndpointRegistryInput {
+	//nolint:lll
 	readSupport := []string{
 		"departments", "contacts", "users", "teams", "customFieldDefinitions",
 		"workTypes", "closingDays", "companies", "tags", "deals", "dealPipelines", "dealPhases", "dealSources",

--- a/providers/teamleader/test/contacts-first-page.json
+++ b/providers/teamleader/test/contacts-first-page.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "2a39e420-3ba3-4384-8024-fa702ef99c9f",
+      "first_name": "Erlich",
+      "last_name": "Bachman",
+      "status": "active",
+      "salutation": "Mr",
+      "website": "https://piedpiper.com",
+      "gender": "unknown",
+      "birthdate": "1987-04-25",
+      "iban": "BE12123412341234",
+      "bic": "BICBANK",
+      "national_identification_number": "86792345-L",
+      "language": "en",
+      "payment_term": {
+        "type": "cash"
+      },
+      "invoicing_preferences": {
+        "electronic_invoicing_address": null
+      },
+      "added_at": "2016-02-04T16:44:33+00:00",
+      "updated_at": "2016-02-05T16:44:33+00:00",
+      "web_url": "https://focus.teamleader.eu/contact_detail.php?id=2a39e420-3ba3-4384-8024-fa702ef99c9f"
+    }
+  ]
+}

--- a/providers/teamleader/test/contacts-second-page.json
+++ b/providers/teamleader/test/contacts-second-page.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "id": "2a39e420-3ba3-4384-8024-fa702ef99c9f",
+      "first_name": "Marcus",
+      "last_name": "Thompson",
+      "status": "active",
+      "salutation": "Dr",
+      "website": "https://techcorp.com",
+      "gender": "male",
+      "birthdate": "1985-11-15",
+      "iban": "BE98765432109876",
+      "bic": "CREDBANK",
+      "national_identification_number": "85112345-M",
+      "language": "en",
+      "payment_term": {
+        "type": "net_30"
+      },
+      "invoicing_preferences": {
+        "electronic_invoicing_address": "invoices@techcorp.com"
+      },
+      "added_at": "2016-02-04T16:44:33+00:00",
+      "updated_at": "2016-02-05T16:44:33+00:00",
+      "web_url": "https://focus.teamleader.eu/contact_detail.php?id=2a39e420-3ba3-4384-8024-fa702ef99c9f"
+    },
+    {
+      "id": "2a3efh20-3ba3-4384-8024-fa702ef99c9f",
+      "first_name": "Sarah",
+      "last_name": "Mitchell",
+      "status": "inactive",
+      "salutation": "Ms",
+      "website": "https://designstudio.io",
+      "gender": "female",
+      "birthdate": "1992-07-08",
+      "iban": "BE45678901234567",
+      "bic": "TRUSTBNK",
+      "national_identification_number": "92070845-F",
+      "language": "fr",
+      "payment_term": {
+        "type": "net_15"
+      },
+      "invoicing_preferences": {
+        "electronic_invoicing_address": null
+      },
+      "added_at": "2016-02-04T17:44:33+00:00",
+      "updated_at": "2016-02-05T17:44:33+00:00",
+      "web_url": "https://focus.teamleader.eu/contact_detail.php?id=2a3efh20-3ba3-4384-8024-fa702ef99c9f"
+    }
+  ]
+}

--- a/test/teamleader/connector.go
+++ b/test/teamleader/connector.go
@@ -1,0 +1,50 @@
+package teamleader
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/teamleader"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetConnector(ctx context.Context) *teamleader.Connector {
+	filePath := credscanning.LoadPath(providers.Teamleader)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := teamleader.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	cfg := oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://focus.teamleader.eu/oauth2/authorize",
+			TokenURL:  "https://focus.teamleader.eu/oauth2/access_token",
+			AuthStyle: oauth2.AuthStyleAutoDetect,
+		},
+	}
+
+	return &cfg
+}

--- a/test/teamleader/metadata/main.go
+++ b/test/teamleader/metadata/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/amp-labs/connectors/test/teamleader"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	if err := run(); err != nil {
+		utils.Fail(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+	connector := teamleader.GetConnector(ctx)
+
+	m, err := connector.ListObjectMetadata(ctx, []string{"teams"})
+	if err != nil {
+		return err
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+
+	return nil
+}

--- a/test/teamleader/metadata/main.go
+++ b/test/teamleader/metadata/main.go
@@ -18,7 +18,7 @@ func run() error {
 	ctx := context.Background()
 	connector := teamleader.GetConnector(ctx)
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"teams"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"teams", "departments", "users", "workTypes", "contacts", "companies"})
 	if err != nil {
 		return err
 	}

--- a/test/teamleader/read/main.go
+++ b/test/teamleader/read/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/teamleader"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := teamleader.GetConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("emails", "tags", "id", "status"),
+	})
+
+	if err != nil {
+		utils.Fail("error reading from Teamleader", "error", err)
+	}
+
+	slog.Info("Reading contacts..")
+	utils.DumpJSON(res, os.Stdout)
+
+	slog.Info("Read operation completed successfully.")
+}

--- a/test/teamleader/read/main.go
+++ b/test/teamleader/read/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -24,8 +25,22 @@ func main() {
 	conn := teamleader.GetConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "departments",
+		Fields:     connectors.Fields("id", "name", "currency"),
+		Since:      time.Date(2025, 03, 01, 0, 0, 0, 0, time.UTC),
+	})
+
+	if err != nil {
+		utils.Fail("error reading from Teamleader", "error", err)
+	}
+
+	slog.Info("Reading departments..")
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Read(ctx, common.ReadParams{
 		ObjectName: "contacts",
-		Fields:     connectors.Fields("emails", "tags", "id", "status"),
+		Fields:     connectors.Fields("id", "first_name", "last_name", "emails"),
+		Since:      time.Date(2025, 03, 01, 0, 0, 0, 0, time.UTC),
 	})
 
 	if err != nil {
@@ -33,6 +48,19 @@ func main() {
 	}
 
 	slog.Info("Reading contacts..")
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "users",
+		Fields:     connectors.Fields("id", "first_name", "last_name", "email"),
+		Since:      time.Date(2025, 03, 01, 0, 0, 0, 0, time.UTC),
+	})
+
+	if err != nil {
+		utils.Fail("error reading from Teamleader", "error", err)
+	}
+
+	slog.Info("Reading users..")
 	utils.DumpJSON(res, os.Stdout)
 
 	slog.Info("Read operation completed successfully.")


### PR DESCRIPTION
## Checklist
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Read Response
<img width="689" alt="image" src="https://github.com/user-attachments/assets/a58bda0c-fc0f-4dbd-95af-6711987bdd67" />
<img width="669" alt="image" src="https://github.com/user-attachments/assets/7d4f625c-c3ac-4e43-a50f-37f64e9e3da3" />
<img width="689" alt="image" src="https://github.com/user-attachments/assets/24d57509-3b96-424f-a9c7-16b09ca0dbd5" />


## Test cases Result
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/ce3268fa-de13-4755-bb53-df99b83aee09" />

