### PR TITLE
[CON-1175] feat: Enable Groove Connector Read & Write

### DIFF
--- a/providers/groove.go
+++ b/providers/groove.go
@@ -36,9 +36,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
# Installation
Mailmonkey using Oauth2 with Authorization code grant.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination 
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read

- [x] Insert screenshot of metadata fields from read object installation.
<img width="993" alt="Screenshot 2025-07-09 at 13 16 29" src="https://github.com/user-attachments/assets/be3d98a6-389b-4831-a9e5-4a3fe16ab987" />

<img width="1123" alt="Screenshot 2025-07-09 at 13 16 43" src="https://github.com/user-attachments/assets/6c280886-e88e-4ef3-b530-2622f948a33a" />

<img width="993" alt="Screenshot 2025-07-09 at 13 17 06" src="https://github.com/user-attachments/assets/a76d8c16-f119-4bba-b21d-018977c38f54" />


- [x] Insert screenshot of Svix destination.
<img width="1267" alt="Screenshot 2025-07-09 at 13 17 32" src="https://github.com/user-attachments/assets/072da710-49c5-450b-8420-97936f537e4b" />

<img width="1276" alt="Screenshot 2025-07-09 at 13 17 42" src="https://github.com/user-attachments/assets/3f1eb69e-5811-4ed1-8eb1-aee1ef8d91b3" />

- [x] Screenshot of operations on dashboard
<img width="968" alt="Screenshot 2025-07-09 at 13 18 39" src="https://github.com/user-attachments/assets/65e6d212-dcf2-40e2-9e31-57b6198d2bd4" />

<img width="983" alt="Screenshot 2025-07-09 at 13 18 53" src="https://github.com/user-attachments/assets/67803387-c3d1-4bc7-9a28-8ca0b6ca5dd1" />


# Write
- [x] Insert screenshot of dashboard.
<img width="972" alt="Screenshot 2025-07-09 at 15 27 48" src="https://github.com/user-attachments/assets/cfa7ab69-7545-4148-b1e3-408349719e59" />

<img width="982" alt="Screenshot 2025-07-09 at 15 28 06" src="https://github.com/user-attachments/assets/39647ece-48a5-4ff7-bc1c-76790b290377" />

<img width="982" alt="Screenshot 2025-07-09 at 15 28 41" src="https://github.com/user-attachments/assets/36988429-30a6-4d1b-9230-ae075448fea1" />

- [x] Insert screenshot of HTTP call.
<img width="1224" alt="Screenshot 2025-07-09 at 13 33 31" src="https://github.com/user-attachments/assets/090e92fc-3cd1-477c-9c20-0c57d5305655" />

<img width="1221" alt="Screenshot 2025-07-09 at 14 42 55" src="https://github.com/user-attachments/assets/fc0b0cdb-241f-4d12-9985-55e817d99e46" />

<img width="1225" alt="Screenshot 2025-07-09 at 14 43 27" src="https://github.com/user-attachments/assets/5b573ee1-8f9f-4dcf-8140-b3d39ae92708" />

<img width="1225" alt="Screenshot 2025-07-09 at 14 43 55" src="https://github.com/user-attachments/assets/9b1a0452-48da-4613-8e3d-10f83ff73494" />


# Examples
[sample](https://github.com/amp-labs/testdata/pull/67)
