### PR TITLE
[CON-1058] feat: Enable read, write zedeskChat Connector

### DIFF
--- a/providers/zendesk.go
+++ b/providers/zendesk.go
@@ -84,9 +84,9 @@ func init() { // nolint:funlen
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{


### PR DESCRIPTION
# Installation
Mailmonkey using Oauth2 with Authorizatio code grant.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ] Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1021" alt="Screenshot 2025-07-08 at 13 22 45" src="https://github.com/user-attachments/assets/c920b028-bfb0-4027-ba24-a96c9e627dcf" />

<img width="967" alt="Screenshot 2025-07-08 at 13 22 50" src="https://github.com/user-attachments/assets/53c8ee57-c33a-42d0-ae39-395fd687b235" />

<img width="945" alt="Screenshot 2025-07-08 at 13 22 58" src="https://github.com/user-attachments/assets/134a6e59-31e3-4feb-b753-055a326164f5" />

- [x] Insert screenshot of Svix destination.
<img width="1266" alt="Screenshot 2025-07-08 at 13 27 59" src="https://github.com/user-attachments/assets/8c4fc925-bf83-4128-a102-bc9873e24cef" />

<img width="1269" alt="Screenshot 2025-07-08 at 13 28 09" src="https://github.com/user-attachments/assets/b6608664-82d5-47d5-8db6-b4c79dcb6ea8" />

<img width="1276" alt="Screenshot 2025-07-08 at 13 28 32" src="https://github.com/user-attachments/assets/33c48f76-d758-4191-a414-f143189911d4" />

- [x] Screenshot of operations on dashboard
<img width="973" alt="Screenshot 2025-07-08 at 13 26 50" src="https://github.com/user-attachments/assets/e562c413-1987-449e-aa03-d417aeb70279" />


# Write
- [x] Insert screenshot of dashboard.
<img width="981" alt="Screenshot 2025-07-08 at 14 20 27" src="https://github.com/user-attachments/assets/2b7459de-1dde-4c60-9e07-a50e5a7666ed" />

<img width="980" alt="Screenshot 2025-07-08 at 14 24 56" src="https://github.com/user-attachments/assets/295f2f3e-9fdf-43b3-84cd-1bb8250153a6" />

- [x] Insert screenshot of HTTP call.
<img width="1229" alt="Screenshot 2025-07-08 at 13 43 12" src="https://github.com/user-attachments/assets/972a69ce-38ba-4b7f-a0da-8d9efa7a6550" />

<img width="1227" alt="Screenshot 2025-07-08 at 13 45 40" src="https://github.com/user-attachments/assets/382eac66-b9be-4f3f-af15-e86532dd3863" />

<img width="1227" alt="Screenshot 2025-07-08 at 13 45 40" src="https://github.com/user-attachments/assets/1cd502a6-63ce-436f-9308-d2217adfef0f" />


# Examples
[zendeskChat samples](https://github.com/amp-labs/testdata/pull/66)
