### PR TITLE
[CON-1961] feat: add Xero connector

### DIFF
--- a/providers/xero.go
+++ b/providers/xero.go
@@ -11,6 +11,7 @@ func init() {
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://login.xero.com/identity/connect/authorize",
+			AuthURLParams:             map[string]string{"response_type": "code"},
 			TokenURL:                  "https://identity.xero.com/connect/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,

--- a/providers/xero.go
+++ b/providers/xero.go
@@ -1,0 +1,44 @@
+package providers
+
+const Xero Provider = "xero"
+
+func init() {
+	// Xero configuration
+	SetInfo(Xero, ProviderInfo{
+		DisplayName: "Xero",
+		AuthType:    Oauth2,
+		BaseURL:     "https://api.xero.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://login.xero.com/identity/connect/authorize",
+			TokenURL:                  "https://identity.xero.com/connect/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752052319/media/xero.com_1752052319.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752052319/media/xero.com_1752052319.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752052285/media/xero.com_1752052283.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752052285/media/xero.com_1752052283.svg",
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Configuration

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing

### GET
URL: http://localhost:4444/v1/events
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/6407d46c-d38a-43cf-9869-672913ca6915" />

### POST
URL: http://localhost:4444/v1/jobs
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/2a5cc96d-a2ab-4a37-9483-27485bd6232f" />

### PATCH
URL: http://localhost:4444/v1/jobs/us_jb_CgTlgZ9S
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/803fbb82-522d-470d-8292-57d578d54461" />

### DELETE
URL: http://localhost:4444/v1/jobs/us_jb_CgTlgZ9S
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/4d319e2c-1bf7-4fbe-8ecf-19e3a6e894a5" />



## Pagination
FlatFile pagination works using pageSize and pageNumber.
 The  user sends:
pageSize — how many items to return per page (default is 20 if not provided).
pageNumber — which page of results to return based on the pageSize.
The response includes pagination info such as currentPage, pageCount, and totalCount to help navigate through pages.

First Page
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/eb04107d-1d81-4324-8d8d-bdd3590c82f3" />

Next Page
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/45d8e3e9-5ff1-4641-8f8f-40f80f401256" />



## Errors

Invalid url path
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/1ca214f0-2cea-4faf-b7fe-f54327459dad" />

missing payload data
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/8028c315-9d0a-4e4c-9b80-472b91165ab2" />


# Logo & Icons

Icon for dark theme


Icon for Regular theme 


---

Logo for dark theme



Logo for Regular theme


