### PR TITLE
feat: Add fallback to basic error handler when connector has no error handler

### DIFF
--- a/internal/components/operations/operations.go
+++ b/internal/components/operations/operations.go
@@ -78,6 +78,8 @@ func (op *HTTPOperation[RequestType, ResponseType]) ExecuteRequest(
 				return response, err
 			}
 		}
+
+		return response, common.InterpretError(resp, body)
 	}
 
 	jsonResp, err := common.ParseJSONResponse(resp, body)

--- a/providers/dynamicsbusiness/metadata_test.go
+++ b/providers/dynamicsbusiness/metadata_test.go
@@ -59,7 +59,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Errors: map[string]error{
 					"mailboxes": mockutils.ExpectedSubsetErrors{
-						ErrMetadataNotFound,
+						common.ErrRetryable,
 					},
 				},
 			},


### PR DESCRIPTION
In case the response is not OK and the connector has not initialised it's own error handler, we fallback to the basic error handler. 