### PR TITLE
[ENG-2214]Zoho: fix field grouping for more than 2 fields 

### DIFF
--- a/providers/zohocrm/subscribe.go
+++ b/providers/zohocrm/subscribe.go
@@ -494,13 +494,15 @@ func (c *Connector) getNotificationConditions(
 	}, nil
 }
 
-// buildFieldSelection creates field selection with proper nesting for any number of fields
-// according to Zoho CRM API requirements (max 2 objects per group)
+// according to Zoho CRM API requirements (max 2 objects per group).
+//
+//nolint:cyclop,funlen
 func buildFieldSelection(
 	fieldNames []string,
 	watchFieldsMetadata map[string]map[string]any,
 ) (FieldSelection, error) {
 	var result FieldSelection
+
 	var err error
 
 	switch len(fieldNames) {
@@ -509,6 +511,7 @@ func buildFieldSelection(
 	case 1:
 		fieldName := fieldNames[0]
 		fm := watchFieldsMetadata[fieldName]
+
 		id, ok := fm["id"].(string)
 		if !ok {
 			return FieldSelection{}, fmt.Errorf("%w: %s", errFieldIDNotString, fieldName)
@@ -522,8 +525,10 @@ func buildFieldSelection(
 		}
 	case maxGroupSize:
 		fieldGroups := make([]FieldGroup, 0)
+
 		for _, fieldName := range fieldNames {
 			fm := watchFieldsMetadata[fieldName]
+
 			id, ok := fm["id"].(string)
 			if !ok {
 				return FieldSelection{}, fmt.Errorf("%w: %s", errFieldIDNotString, fieldName)
@@ -545,6 +550,7 @@ func buildFieldSelection(
 		// More than 2 fields - binary nest: first field, and the rest as a nested group
 		firstField := fieldNames[0]
 		fm := watchFieldsMetadata[firstField]
+
 		id, ok := fm["id"].(string)
 		if !ok {
 			return FieldSelection{}, fmt.Errorf("%w: %s", errFieldIDNotString, firstField)

--- a/providers/zohocrm/subscribe.go
+++ b/providers/zohocrm/subscribe.go
@@ -494,7 +494,8 @@ func (c *Connector) getNotificationConditions(
 	}, nil
 }
 
-// according to Zoho CRM API requirements (max 2 objects per group).
+// according to Zoho CRM API requirements (max 2 objects per group). So we need to nest the fields
+// to subscribe for more fields.
 //
 //nolint:cyclop,funlen
 func buildFieldSelection(

--- a/providers/zohocrm/subscribe.go
+++ b/providers/zohocrm/subscribe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -520,7 +521,7 @@ func buildFieldSelection(
 
 		result = FieldSelection{
 			Field: &Field{
-				APIName: naming.CapitalizeFirstLetterEveryWord(fieldName),
+				APIName: formatAPIName(fieldName),
 				ID:      id,
 			},
 		}
@@ -537,7 +538,7 @@ func buildFieldSelection(
 
 			fieldGroups = append(fieldGroups, FieldGroup{
 				Field: &Field{
-					APIName: naming.CapitalizeFirstLetterEveryWord(fieldName),
+					APIName: formatAPIName(fieldName),
 					ID:      id,
 				},
 			})
@@ -559,7 +560,7 @@ func buildFieldSelection(
 
 		firstGroup := FieldGroup{
 			Field: &Field{
-				APIName: naming.CapitalizeFirstLetterEveryWord(firstField),
+				APIName: formatAPIName(firstField),
 				ID:      id,
 			},
 		}
@@ -681,4 +682,14 @@ func hashString(uniqueRef string) (string, error) {
 
 	//nolint:gosec
 	return strconv.FormatInt(int64(hashedChannelID), 10), nil
+}
+
+func formatAPIName(apiName string) string {
+	parts := strings.Split(apiName, "_")
+
+	for i, part := range parts {
+		parts[i] = naming.CapitalizeFirstLetterEveryWord(part)
+	}
+
+	return strings.Join(parts, "_")
 }

--- a/providers/zohocrm/subscribe_test.go
+++ b/providers/zohocrm/subscribe_test.go
@@ -70,6 +70,7 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
+
 	assert.Assert(t, result1.Field != nil)
 	assert.Equal(t, result1.Field.APIName, "Field1")
 	assert.Equal(t, result1.Field.ID, "1")
@@ -85,6 +86,7 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
+
 	assert.Assert(t, result2.Group != nil)
 	assert.Equal(t, string(result2.GroupOperator), string(GroupOperatorOr))
 	assert.Equal(t, len(result2.Group), 2)
@@ -96,6 +98,7 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
+
 	assert.Assert(t, result3.Field == nil)
 	assert.Assert(t, result3.Group == nil)
 }

--- a/providers/zohocrm/subscribe_test.go
+++ b/providers/zohocrm/subscribe_test.go
@@ -1,0 +1,93 @@
+package zohocrm
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBuildNestedFieldGroups(t *testing.T) {
+	t.Parallel()
+
+	connector := &Connector{}
+
+	// Test data
+	watchFieldsMetadata := map[string]map[string]any{
+		"field1": {"id": "1", "api_name": "field1"},
+		"field2": {"id": "2", "api_name": "field2"},
+		"field3": {"id": "3", "api_name": "field3"},
+		"field4": {"id": "4", "api_name": "field4"},
+	}
+
+	fieldNames := []string{"field1", "field2", "field3", "field4"}
+
+	// Test the nested field groups
+	result := connector.buildNestedFieldGroups(fieldNames, watchFieldsMetadata)
+
+	// Top-level should have 2 groups: field1 and a nested group
+	assert.Assert(t, result.Group != nil)
+	assert.Equal(t, string(result.GroupOperator), string(GroupOperatorOr))
+	assert.Equal(t, len(result.Group), 2)
+
+	// First group should be field1
+	assert.Assert(t, result.Group[0].Field != nil)
+	assert.Equal(t, result.Group[0].Field.APIName, "Field1")
+	assert.Equal(t, result.Group[0].Field.ID, "1")
+
+	// Second group should be a nested group for field2, field3, field4
+	nested := result.Group[1]
+	assert.Assert(t, nested.Group != nil)
+	assert.Equal(t, len(nested.Group), 2)
+	assert.Equal(t, nested.GroupOperator, string(GroupOperatorOr))
+
+	// nested.Group[0] should be field2
+	assert.Assert(t, nested.Group[0].Field != nil)
+	assert.Equal(t, nested.Group[0].Field.APIName, "Field2")
+	assert.Equal(t, nested.Group[0].Field.ID, "2")
+
+	// nested.Group[1] should be a nested group for field3, field4
+	nested2 := nested.Group[1]
+	assert.Assert(t, nested2.Group != nil)
+	assert.Equal(t, len(nested2.Group), 2)
+	assert.Equal(t, nested2.GroupOperator, string(GroupOperatorOr))
+	assert.Equal(t, nested2.Group[0].Field.APIName, "Field3")
+	assert.Equal(t, nested2.Group[0].Field.ID, "3")
+	assert.Equal(t, nested2.Group[1].Field.APIName, "Field4")
+	assert.Equal(t, nested2.Group[1].Field.ID, "4")
+}
+
+func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	connector := &Connector{}
+
+	// Test with 1 field
+	watchFieldsMetadata1 := map[string]map[string]any{
+		"field1": {"id": "1", "api_name": "field1"},
+	}
+	fieldNames1 := []string{"field1"}
+
+	result1 := connector.buildNestedFieldGroups(fieldNames1, watchFieldsMetadata1)
+	assert.Assert(t, result1.Field != nil)
+	assert.Equal(t, result1.Field.APIName, "Field1")
+	assert.Equal(t, result1.Field.ID, "1")
+
+	// Test with 2 fields
+	watchFieldsMetadata2 := map[string]map[string]any{
+		"field1": {"id": "1", "api_name": "field1"},
+		"field2": {"id": "2", "api_name": "field2"},
+	}
+	fieldNames2 := []string{"field1", "field2"}
+
+	result2 := connector.buildNestedFieldGroups(fieldNames2, watchFieldsMetadata2)
+	assert.Assert(t, result2.Group != nil)
+	assert.Equal(t, string(result2.GroupOperator), string(GroupOperatorOr))
+	assert.Equal(t, len(result2.Group), 2)
+	assert.Equal(t, result2.Group[0].Field.APIName, "Field1")
+	assert.Equal(t, result2.Group[1].Field.APIName, "Field2")
+
+	// Test with empty fields
+	result3 := connector.buildNestedFieldGroups([]string{}, map[string]map[string]any{})
+	assert.Assert(t, result3.Field == nil)
+	assert.Assert(t, result3.Group == nil)
+}

--- a/providers/zohocrm/subscribe_test.go
+++ b/providers/zohocrm/subscribe_test.go
@@ -9,8 +9,6 @@ import (
 func TestBuildNestedFieldGroups(t *testing.T) {
 	t.Parallel()
 
-	connector := &Connector{}
-
 	// Test data
 	watchFieldsMetadata := map[string]map[string]any{
 		"field1": {"id": "1", "api_name": "field1"},
@@ -22,7 +20,10 @@ func TestBuildNestedFieldGroups(t *testing.T) {
 	fieldNames := []string{"field1", "field2", "field3", "field4"}
 
 	// Test the nested field groups
-	result := connector.buildNestedFieldGroups(fieldNames, watchFieldsMetadata)
+	result, err := buildFieldSelection(fieldNames, watchFieldsMetadata)
+	if err != nil {
+		t.Fatalf("buildFieldSelection failed: %v", err)
+	}
 
 	// Top-level should have 2 groups: field1 and a nested group
 	assert.Assert(t, result.Group != nil)
@@ -59,15 +60,16 @@ func TestBuildNestedFieldGroups(t *testing.T) {
 func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	t.Parallel()
 
-	connector := &Connector{}
-
 	// Test with 1 field
 	watchFieldsMetadata1 := map[string]map[string]any{
 		"field1": {"id": "1", "api_name": "field1"},
 	}
 	fieldNames1 := []string{"field1"}
 
-	result1 := connector.buildNestedFieldGroups(fieldNames1, watchFieldsMetadata1)
+	result1, err := buildFieldSelection(fieldNames1, watchFieldsMetadata1)
+	if err != nil {
+		t.Fatalf("buildFieldSelection failed: %v", err)
+	}
 	assert.Assert(t, result1.Field != nil)
 	assert.Equal(t, result1.Field.APIName, "Field1")
 	assert.Equal(t, result1.Field.ID, "1")
@@ -79,7 +81,10 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	}
 	fieldNames2 := []string{"field1", "field2"}
 
-	result2 := connector.buildNestedFieldGroups(fieldNames2, watchFieldsMetadata2)
+	result2, err := buildFieldSelection(fieldNames2, watchFieldsMetadata2)
+	if err != nil {
+		t.Fatalf("buildFieldSelection failed: %v", err)
+	}
 	assert.Assert(t, result2.Group != nil)
 	assert.Equal(t, string(result2.GroupOperator), string(GroupOperatorOr))
 	assert.Equal(t, len(result2.Group), 2)
@@ -87,7 +92,10 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	assert.Equal(t, result2.Group[1].Field.APIName, "Field2")
 
 	// Test with empty fields
-	result3 := connector.buildNestedFieldGroups([]string{}, map[string]map[string]any{})
+	result3, err := buildFieldSelection([]string{}, map[string]map[string]any{})
+	if err != nil {
+		t.Fatalf("buildFieldSelection failed: %v", err)
+	}
 	assert.Assert(t, result3.Field == nil)
 	assert.Assert(t, result3.Group == nil)
 }

--- a/providers/zohocrm/subscribe_test.go
+++ b/providers/zohocrm/subscribe_test.go
@@ -11,16 +11,16 @@ func TestBuildNestedFieldGroups(t *testing.T) {
 
 	// Test data
 	watchFieldsMetadata := map[string]map[string]any{
-		"field1": {"id": "1", "api_name": "field1"},
-		"field2": {"id": "2", "api_name": "field2"},
-		"field3": {"id": "3", "api_name": "field3"},
-		"field4": {"id": "4", "api_name": "field4"},
+		"field1": {"id": "1", "api_name": "Field1"},
+		"field2": {"id": "2", "api_name": "Field2"},
+		"field3": {"id": "3", "api_name": "Field3"},
+		"field4": {"id": "4", "api_name": "Field4"},
 	}
 
 	fieldNames := []string{"field1", "field2", "field3", "field4"}
 
 	// Test the nested field groups
-	result, err := buildFieldSelection(fieldNames, watchFieldsMetadata)
+	result, err := recursiveFieldSelectionBuild(fieldNames, watchFieldsMetadata)
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
@@ -62,11 +62,11 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 
 	// Test with 1 field
 	watchFieldsMetadata1 := map[string]map[string]any{
-		"field1": {"id": "1", "api_name": "field1"},
+		"field1": {"id": "1", "api_name": "Field1"},
 	}
 	fieldNames1 := []string{"field1"}
 
-	result1, err := buildFieldSelection(fieldNames1, watchFieldsMetadata1)
+	result1, err := recursiveFieldSelectionBuild(fieldNames1, watchFieldsMetadata1)
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
@@ -77,12 +77,12 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 
 	// Test with 2 fields
 	watchFieldsMetadata2 := map[string]map[string]any{
-		"field1": {"id": "1", "api_name": "field1"},
-		"field2": {"id": "2", "api_name": "field2"},
+		"field1": {"id": "1", "api_name": "Field1"},
+		"field2": {"id": "2", "api_name": "Field2"},
 	}
 	fieldNames2 := []string{"field1", "field2"}
 
-	result2, err := buildFieldSelection(fieldNames2, watchFieldsMetadata2)
+	result2, err := recursiveFieldSelectionBuild(fieldNames2, watchFieldsMetadata2)
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
@@ -94,11 +94,47 @@ func TestBuildNestedFieldGroupsEdgeCases(t *testing.T) {
 	assert.Equal(t, result2.Group[1].Field.APIName, "Field2")
 
 	// Test with empty fields
-	result3, err := buildFieldSelection([]string{}, map[string]map[string]any{})
+	result3, err := recursiveFieldSelectionBuild([]string{}, map[string]map[string]any{})
 	if err != nil {
 		t.Fatalf("buildFieldSelection failed: %v", err)
 	}
 
 	assert.Assert(t, result3.Field == nil)
 	assert.Assert(t, result3.Group == nil)
+}
+
+func TestFormatAPIName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"first_name", "First_Name"},
+		{"last_name", "Last_Name"},
+		{"phone", "Phone"},
+		{"company", "Company"},
+		{"industry", "Industry"},
+	}
+
+	watchFieldsMetadata := map[string]map[string]any{
+		"first_name": {"id": "1", "api_name": "First_Name"},
+		"last_name":  {"id": "2", "api_name": "Last_Name"},
+		"phone":      {"id": "3", "api_name": "Phone"},
+		"company":    {"id": "4", "api_name": "Company"},
+		"industry":   {"id": "5", "api_name": "Industry"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := formatAPIName(tc.input, watchFieldsMetadata)
+			if err != nil {
+				t.Fatalf("formatAPIName failed: %v", err)
+			}
+
+			assert.Equal(t, result, tc.expected)
+		})
+	}
 }

--- a/providers/zohocrm/vars.go
+++ b/providers/zohocrm/vars.go
@@ -32,6 +32,10 @@ var (
 	errInconsistentChannelIdsMismatch = errors.New("all events must have the same channel id")
 	errChannelIdMismatch              = errors.New("channel id does not match provided unique ref")
 	errInvalidDuration                = errors.New("duration cannot be greater than 1 week")
+	errModuleNameNotString            = errors.New("module_name is not a string")
+	errAPINameNotString               = errors.New("api_name is not a string")
+	errIDNotString                    = errors.New("id is not a string")
+	errFieldIDNotString               = errors.New("field id is not a string")
 )
 
 // uniqueFields maps the fields to the uniquely required fields.

--- a/test/zohocrm/subscribe/subscribe.go
+++ b/test/zohocrm/subscribe/subscribe.go
@@ -80,6 +80,7 @@ func main() {
 					"company",
 					"last_name",
 					"first_name",
+					"industry",
 				},
 			},
 			"Accounts": {
@@ -107,6 +108,8 @@ func main() {
 
 		return
 	}
+
+	time.Sleep(time.Minute * 3)
 
 	err = conn.DeleteSubscription(ctx, *updateResult)
 	if err != nil {

--- a/test/zohocrm/subscribe/subscribe.go
+++ b/test/zohocrm/subscribe/subscribe.go
@@ -47,7 +47,8 @@ func main() {
 				},
 				WatchFields: []string{
 					"phone",
-					"last_name",
+					"Last_Name",
+					"First_Name",
 				},
 			},
 		},
@@ -78,8 +79,8 @@ func main() {
 				WatchFields: []string{
 					"phone",
 					"company",
-					"last_name",
-					"first_name",
+					"Last_Name",
+					"First_Name",
 					"industry",
 				},
 			},
@@ -108,8 +109,6 @@ func main() {
 
 		return
 	}
-
-	time.Sleep(time.Minute * 3)
 
 	err = conn.DeleteSubscription(ctx, *updateResult)
 	if err != nil {

--- a/test/zohocrm/subscribe/subscribe.go
+++ b/test/zohocrm/subscribe/subscribe.go
@@ -47,6 +47,8 @@ func main() {
 				},
 				WatchFields: []string{
 					"phone",
+					"last_name",
+					"first_name",
 				},
 			},
 		},
@@ -77,6 +79,8 @@ func main() {
 				WatchFields: []string{
 					"phone",
 					"company",
+					"last_name",
+					"first_name",
 				},
 			},
 			"Accounts": {

--- a/test/zohocrm/subscribe/subscribe.go
+++ b/test/zohocrm/subscribe/subscribe.go
@@ -48,7 +48,6 @@ func main() {
 				WatchFields: []string{
 					"phone",
 					"last_name",
-					"first_name",
 				},
 			},
 		},


### PR DESCRIPTION
This PR fixes the error when more than 2 fields are being watched for subscription. 

<img width="1274" height="1258" alt="Screenshot 2025-07-10 at 4 34 52 PM" src="https://github.com/user-attachments/assets/6523a3d0-ab26-4f44-a197-828c4500c870" />



```
jlim@Mac connectors % go run ./test/zohocrm/subscribe/subscribe.go
time=2025-07-10T15:45:28.827-07:00 level=DEBUG msg="loading credentials file" path=./zoho-creds.json
time=2025-07-10T15:45:28.830-07:00 level=DEBUG msg="HTTP request" method=GET url=https://www.zohoapis.com/crm/v7/settings/modules correlationId=29ce682c-8a10-44e4-b335-ec763d13a50e headers.Accept=application/json
time=2025-07-10T15:45:29.307-07:00 level=DEBUG msg="HTTP response" method=GET url=https://www.zohoapis.com/crm/v7/settings/modules correlationId=29ce682c-8a10-44e4-b335-ec763d13a50e headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Frame-Options=SAMEORIGIN headers.Server=ZGS headers.Date="Thu, 10 Jul 2025 22:45:29 GMT" headers.X-Content-Type-Options=nosniff headers.X-Xss-Protection="0; mode=block" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Clientversion=10994587 headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Type="application/json;charset=UTF-8" headers.Referrer-Policy=strict-origin headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Content-Disposition="attachment; filename=response.json" headers.Vary=accept-encoding headers.Content-Language=en-US headers.Connection=keep-alive headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Pragma=no-cache headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload"
time=2025-07-10T15:45:29.309-07:00 level=DEBUG msg="HTTP request" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Contacts&type=all" correlationId=b0e6bf4d-7977-458e-8f7c-3a4996010d57 headers.Accept=application/json
time=2025-07-10T15:45:29.309-07:00 level=DEBUG msg="HTTP request" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Leads&type=all" correlationId=fe3ed79a-29ac-48af-8852-405e800d3750 headers.Accept=application/json
time=2025-07-10T15:45:29.567-07:00 level=DEBUG msg="HTTP response" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Contacts&type=all" correlationId=b0e6bf4d-7977-458e-8f7c-3a4996010d57 headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Date="Thu, 10 Jul 2025 22:45:29 GMT" headers.Connection=keep-alive headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Pragma=no-cache headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Clientversion=10994587 headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Type="application/json;charset=UTF-8" headers.Referrer-Policy=strict-origin headers.X-Content-Type-Options=nosniff headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Frame-Options=SAMEORIGIN headers.Content-Language=en-US headers.Server=ZGS headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.X-Xss-Protection="0; mode=block" headers.Content-Disposition="attachment; filename=response.json" headers.Vary=accept-encoding
time=2025-07-10T15:45:29.630-07:00 level=DEBUG msg="HTTP response" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Leads&type=all" correlationId=fe3ed79a-29ac-48af-8852-405e800d3750 headers.Content-Disposition="attachment; filename=response.json" headers.Content-Language=en-US headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Date="Thu, 10 Jul 2025 22:45:29 GMT" headers.Content-Type="application/json;charset=UTF-8" headers.X-Content-Type-Options=nosniff headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Server=ZGS headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.X-Xss-Protection="0; mode=block" headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Pragma=no-cache headers.X-Frame-Options=SAMEORIGIN headers.Clientversion=10994587 headers.Vary=accept-encoding headers.Connection=keep-alive headers.Referrer-Policy=strict-origin headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00
time=2025-07-10T15:45:29.633-07:00 level=DEBUG msg="HTTP request" method=POST url=https://www.zohoapis.com/crm/v7/actions/watch correlationId=6cff9010-ebe4-4f1b-b5dd-d4dbbbd3529a headers.Accept=application/json headers.Content-Length=896 headers.Content-Type=application/json
time=2025-07-10T15:45:29.846-07:00 level=DEBUG msg="HTTP response" method=POST url=https://www.zohoapis.com/crm/v7/actions/watch correlationId=6cff9010-ebe4-4f1b-b5dd-d4dbbbd3529a headers.Date="Thu, 10 Jul 2025 22:45:29 GMT" headers.X-Xss-Protection="0; mode=block" headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Disposition="attachment; filename=response.json" headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Content-Length=548 headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.X-Frame-Options=SAMEORIGIN headers.Content-Type="application/json;charset=UTF-8" headers.Connection=keep-alive headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Pragma=no-cache headers.Clientversion=10994587 headers.Server=ZGS headers.Referrer-Policy=strict-origin headers.X-Content-Type-Options=nosniff headers.Content-Language=en-US
Subscribe results: {
  "Result": {
    "code": "SUCCESS",
    "details": {
      "events": [
        {
          "channel_expiry": "2025-07-10T16:47:29-07:00",
          "resource_uri": "https://www.zohoapis.com/crm/v2/Contacts",
          "resource_id": "6756839000000002179",
          "resource_name": "Contacts",
          "channel_id": "-6597234318226515511"
        },
        {
          "channel_expiry": "2025-07-10T16:47:29-07:00",
          "resource_uri": "https://www.zohoapis.com/crm/v2/Leads",
          "resource_id": "6756839000000002175",
          "resource_name": "Leads",
          "channel_id": "-6597234318226515511"
        }
      ]
    },
    "message": "Successfully subscribed for actions-watch of the given module",
    "status": "success"
  },
  "ObjectEvents": {
    "Contacts": {
      "Events": [
        "create",
        "update",
        "delete"
      ],
      "WatchFields": [
        "phone",
        "last_name",
        "first_name"
      ],
      "WatchFieldsAll": false,
      "PassThroughEvents": null
    },
    "Leads": {
      "Events": [
        "create",
        "update",
        "delete"
      ],
      "WatchFields": [
        "phone"
      ],
      "WatchFieldsAll": false,
      "PassThroughEvents": null
    }
  },
  "Status": "success",
  "Objects": null,
  "Events": null,
  "UpdateFields": null,
  "PassThroughEvents": null
}
time=2025-07-10T15:45:29.847-07:00 level=DEBUG msg="HTTP request" method=GET url=https://www.zohoapis.com/crm/v7/settings/modules correlationId=f7955717-47cf-4aa1-8630-4ffb900083d9 headers.Accept=application/json
time=2025-07-10T15:45:29.967-07:00 level=DEBUG msg="HTTP response" method=GET url=https://www.zohoapis.com/crm/v7/settings/modules correlationId=f7955717-47cf-4aa1-8630-4ffb900083d9 headers.Content-Type="application/json;charset=UTF-8" headers.Connection=keep-alive headers.X-Content-Type-Options=nosniff headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Date="Thu, 10 Jul 2025 22:45:29 GMT" headers.Referrer-Policy=strict-origin headers.X-Xss-Protection="0; mode=block" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Pragma=no-cache headers.X-Frame-Options=SAMEORIGIN headers.Content-Disposition="attachment; filename=response.json" headers.Content-Language=en-US headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Server=ZGS headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Clientversion=10994587 headers.Vary=accept-encoding
time=2025-07-10T15:45:29.968-07:00 level=DEBUG msg="HTTP request" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Accounts&type=all" correlationId=eb5ff90b-58d0-46f6-b34c-dd9a6ed86611 headers.Accept=application/json
time=2025-07-10T15:45:29.968-07:00 level=DEBUG msg="HTTP request" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Leads&type=all" correlationId=15f84225-81c8-4828-8996-86ec44ea8ca8 headers.Accept=application/json
time=2025-07-10T15:45:30.184-07:00 level=DEBUG msg="HTTP response" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Accounts&type=all" correlationId=eb5ff90b-58d0-46f6-b34c-dd9a6ed86611 headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Clientversion=10994587 headers.Referrer-Policy=strict-origin headers.X-Content-Type-Options=nosniff headers.Pragma=no-cache headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Content-Type="application/json;charset=UTF-8" headers.X-Xss-Protection="0; mode=block" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.X-Frame-Options=SAMEORIGIN headers.Content-Disposition="attachment; filename=response.json" headers.Content-Language=en-US headers.Date="Thu, 10 Jul 2025 22:45:30 GMT" headers.Connection=keep-alive headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Vary=accept-encoding headers.Server=ZGS
time=2025-07-10T15:45:30.211-07:00 level=DEBUG msg="HTTP response" method=GET url="https://www.zohoapis.com/crm/v6/settings/fields?module=Leads&type=all" correlationId=15f84225-81c8-4828-8996-86ec44ea8ca8 headers.X-Frame-Options=SAMEORIGIN headers.Server=ZGS headers.Date="Thu, 10 Jul 2025 22:45:30 GMT" headers.Connection=keep-alive headers.Pragma=no-cache headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Disposition="attachment; filename=response.json" headers.Content-Language=en-US headers.X-Content-Type-Options=nosniff headers.X-Xss-Protection="0; mode=block" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Clientversion=10994587 headers.Vary=accept-encoding headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Referrer-Policy=strict-origin headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.Content-Type="application/json;charset=UTF-8"
time=2025-07-10T15:45:30.214-07:00 level=DEBUG msg="HTTP request" method=PUT url=https://www.zohoapis.com/crm/v7/actions/watch correlationId=9b552ae9-c992-4937-95b0-222244967fbb headers.Accept=application/json headers.Content-Type=application/json
time=2025-07-10T15:45:30.373-07:00 level=DEBUG msg="HTTP response" method=PUT url=https://www.zohoapis.com/crm/v7/actions/watch correlationId=9b552ae9-c992-4937-95b0-222244967fbb headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Date="Thu, 10 Jul 2025 22:45:30 GMT" headers.Content-Type="application/json;charset=UTF-8" headers.Content-Length=548 headers.X-Content-Type-Options=nosniff headers.Pragma=no-cache headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2 headers.Content-Disposition="attachment; filename=response.json" headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Connection=keep-alive headers.Referrer-Policy=strict-origin headers.X-Xss-Protection="0; mode=block" headers.Content-Language=en-US headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.Clientversion=10994587 headers.Server=ZGS headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.X-Frame-Options=SAMEORIGIN
time=2025-07-10T15:45:30.374-07:00 level=DEBUG msg="HTTP request" method=DELETE url="https://www.zohoapis.com/crm/v7/actions/watch?channel_ids=-6597234318226515511" correlationId=d52820fe-3e00-4860-90ec-4d3f42d556f9 headers.Accept=application/json
time=2025-07-10T15:45:30.445-07:00 level=DEBUG msg="HTTP response" method=DELETE url="https://www.zohoapis.com/crm/v7/actions/watch?channel_ids=-6597234318226515511" correlationId=d52820fe-3e00-4860-90ec-4d3f42d556f9 headers.Connection=keep-alive headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Strict-Transport-Security="max-age=64072000; includeSubDomains; preload" headers.Server=ZGS headers.Date="Thu, 10 Jul 2025 22:45:30 GMT" headers.Content-Type="application/json;charset=UTF-8" headers.Referrer-Policy=strict-origin headers.X-Content-Type-Options=nosniff headers.Pragma=no-cache headers.Content-Disposition="attachment; filename=response.json" headers.Content-Length=484 headers.Content-Security-Policy="default-src 'none';frame-ancestors 'self'; report-uri https://logsapi.zoho.com/csplog?service=crm" headers.Cache-Control="no-store, no-cache, must-revalidate, private" headers.Content-Language=en-US headers.X-Xss-Protection="0; mode=block" headers.Expires="Thu, 01 Jan 1970 00:00:00 GMT" headers.X-Frame-Options=SAMEORIGIN headers.X-Accesstoken-Reset=2025-07-10T16:45:28-07:00 headers.Clientversion=10994587 headers.Clientsubversion=e7e8d31da446b323b2579c0ce555c3f2
Delete subscription successful
```