### PR TITLE
[CON-1713] feat: Enable read+write: avoma

### DIFF
--- a/providers/avoma.go
+++ b/providers/avoma.go
@@ -25,9 +25,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
<img width="1858" height="881" alt="image" src="https://github.com/user-attachments/assets/60ffe8e5-8c98-4bf9-92d9-d2cdf70f04b9" />

# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1858" height="881" alt="image" src="https://github.com/user-attachments/assets/3698ccfa-996d-46a5-95c9-5586d1340842" />

- [x] Insert screenshot of Svix destination.
- [x] Screenshot of operations on dashboard


<img width="1858" height="902" alt="image" src="https://github.com/user-attachments/assets/195f89c8-225a-4236-a6b3-1c4188e73620" />

<img width="1563" height="895" alt="image" src="https://github.com/user-attachments/assets/47259ead-46dd-406d-a7df-bce4b5b1692b" />

<img width="1857" height="900" alt="image" src="https://github.com/user-attachments/assets/1a462beb-a1f4-436d-9c46-3b690afb35af" />

<img width="1567" height="894" alt="image" src="https://github.com/user-attachments/assets/fc7c5877-a6dd-4f31-b957-4b723dbbd9ab" />

<img width="1855" height="901" alt="image" src="https://github.com/user-attachments/assets/5e6e9908-20cb-443a-bb30-695d659a8f82" />

<img width="1557" height="891" alt="image" src="https://github.com/user-attachments/assets/182f4191-8ac0-466e-858e-215ca7a31900" />

# Write
For each write object:
- [x] Insert screenshot of dashboard.
- [x] Insert screenshot of HTTP call.

**For template object**
<img width="1764" height="883" alt="image" src="https://github.com/user-attachments/assets/a041ed3d-3e0f-4810-82c4-4ac0196ae6f5" />

<img width="1567" height="691" alt="image" src="https://github.com/user-attachments/assets/023c39ce-cdd6-4378-a06c-0b066964f6c0" />

<img width="1460" height="897" alt="image" src="https://github.com/user-attachments/assets/1ad01812-6636-45b7-ba3e-19fdf9076d7e" />

<img width="1566" height="662" alt="image" src="https://github.com/user-attachments/assets/67f45b8a-5033-4f0f-9969-4e632ef3e52b" />

**For smart_categories object**
<img width="1752" height="887" alt="image" src="https://github.com/user-attachments/assets/46ea29da-f949-4fcf-ad11-30bf46a9f0d8" />

<img width="1572" height="691" alt="image" src="https://github.com/user-attachments/assets/80cb7d0b-d24f-4c04-b0f2-a7c3f0c4960f" />

<img width="1822" height="901" alt="image" src="https://github.com/user-attachments/assets/b106dfc5-7f3f-4ec2-8960-26837cd616ec" />

<img width="1566" height="666" alt="image" src="https://github.com/user-attachments/assets/63be6c12-1851-4c86-8f87-3486bc359b79" />

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata/pull/68
