### PR TITLE
[CON-1995] feat: Add initialization to Lever connector

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -49,6 +49,7 @@ import (
 	"github.com/amp-labs/connectors/providers/kit"
 	"github.com/amp-labs/connectors/providers/klaviyo"
 	"github.com/amp-labs/connectors/providers/lemlist"
+	"github.com/amp-labs/connectors/providers/lever"
 	"github.com/amp-labs/connectors/providers/marketo"
 	"github.com/amp-labs/connectors/providers/mixmax"
 	"github.com/amp-labs/connectors/providers/monday"
@@ -122,6 +123,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Kit:                 wrapper(newKitConnector),
 	providers.Klaviyo:             wrapper(newKlaviyoConnector),
 	providers.Lemlist:             wrapper(newLemlistConnector),
+	providers.LeverSandbox:        wrapper(newLeverConnector),
 	providers.Marketo:             wrapper(newMarketoConnector),
 	providers.Mixmax:              wrapper(newMixmaxConnector),
 	providers.Monday:              wrapper(newMondayConnector),
@@ -570,4 +572,10 @@ func newGoogleConnector(
 	params common.ConnectorParams,
 ) (*google.Connector, error) {
 	return google.NewConnector(params)
+}
+
+func newLeverConnector(
+	params common.ConnectorParams,
+) (*lever.Connector, error) {
+	return lever.NewConnector(params)
 }


### PR DESCRIPTION
Notes:
       In the Lever connector, there are two types of configurations: one for production and one for testing. For now, I have added the initialization to the testing configuration because I only have access to the testing setup. After completing the integration testing, I will switch to the production configuration.