### PR TITLE
[CON-1997] feat: Enable read+write : Lever

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -123,7 +123,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Kit:                 wrapper(newKitConnector),
 	providers.Klaviyo:             wrapper(newKlaviyoConnector),
 	providers.Lemlist:             wrapper(newLemlistConnector),
-	providers.LeverSandbox:        wrapper(newLeverConnector),
+	providers.Lever:               wrapper(newLeverConnector),
 	providers.Marketo:             wrapper(newMarketoConnector),
 	providers.Mixmax:              wrapper(newMixmaxConnector),
 	providers.Monday:              wrapper(newMondayConnector),

--- a/providers/lever.go
+++ b/providers/lever.go
@@ -31,9 +31,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
@@ -71,9 +71,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/lever/README.md
+++ b/providers/lever/README.md
@@ -15,8 +15,8 @@ Lever API version : v1
 | tags                    | tags               | read         |
 | users                   | users              | read, write  |
 | feedback_templates      | feedback_templates | read, write  |
-| opportunities           | opportunities      | read, write  |
-| postings                | postings           | read, write  |
+| opportunities           | opportunities      | read         |
+| postings                | postings           | read         |
 | form_templates          | form_templates     | read, write  |
 | requisitions            | requisitions       | read, write  |
 | requisition_fields      | requisition_fields | read, write  |
@@ -43,6 +43,9 @@ Notes:
   - user ID
     - deactivate
     - reactivate 
+  - Below write endpoints are not supported because it requires query params perform_as.
+    - opportunities
+    - postings
 - The delete endpoints below cannot be removed if they were created within the Lever application. Only endpoints created through the API are eligible for deletion via API.
     - feedback_templates
-	- form_templates
+	  - form_templates

--- a/providers/lever/connector.go
+++ b/providers/lever/connector.go
@@ -30,7 +30,7 @@ type Connector struct {
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	conn, err := components.Initialize(providers.LeverSandbox, params, constructor)
+	conn, err := components.Initialize(providers.Lever, params, constructor)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/lever/support.go
+++ b/providers/lever/support.go
@@ -32,8 +32,6 @@ func supportedOperations() components.EndpointRegistryInput { // nolint:funlen
 		"users",
 		"feedback_templates",
 		"contacts",
-		"opportunities",
-		"postings",
 	}
 
 	deleteSupport := []string{


### PR DESCRIPTION
# Installation
<img width="1858" height="863" alt="image" src="https://github.com/user-attachments/assets/bce3c71f-13e6-4a97-aee8-5037e948c7e1" />

# Conventions
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1858" height="863" alt="image" src="https://github.com/user-attachments/assets/0d672046-dced-45df-99cf-31b9df9342f5" />

- [x] Insert screenshot of Svix destination.
- [x] Screenshot of operations on dashboard

<img width="1588" height="902" alt="image" src="https://github.com/user-attachments/assets/347817b5-ee2b-4d61-9c1c-8d7d6eb83de8" />
<img width="1570" height="732" alt="image" src="https://github.com/user-attachments/assets/30d5ff8f-a572-4f38-af0a-f807c08f5d47" />

<img width="1584" height="896" alt="image" src="https://github.com/user-attachments/assets/13ae8b0b-9add-43c5-9353-afb56ae2187f" />
<img width="1562" height="734" alt="image" src="https://github.com/user-attachments/assets/9901a9a7-14fb-4b37-b722-ce63c3897274" />

<img width="1586" height="904" alt="image" src="https://github.com/user-attachments/assets/13cf288b-a554-49fb-b5e0-f4fa8e37ebe3" />
<img width="1546" height="820" alt="image" src="https://github.com/user-attachments/assets/be6fe32f-abe6-4c82-b7fb-bae3bbf6edb0" />

# Write
For each write object:
- [x] Insert screenshot of dashboard.
- [x] Insert screenshot of HTTP call.

<img width="1859" height="787" alt="image" src="https://github.com/user-attachments/assets/90cd5214-f5d2-4c30-8b5a-f9e7f78de84d" />

**For object requisitions**
<img width="1747" height="772" alt="image" src="https://github.com/user-attachments/assets/9d526613-5eb6-4b83-971c-18f0aabaf8cf" />
<img width="1563" height="601" alt="image" src="https://github.com/user-attachments/assets/ffd74f0e-149f-4ebf-a17b-3511238a5764" />

<img width="1475" height="903" alt="image" src="https://github.com/user-attachments/assets/d305daf0-0bbd-4145-99e0-3293f4759de6" />
<img width="1570" height="630" alt="image" src="https://github.com/user-attachments/assets/86925364-432b-4afe-90b1-ad343cb85fad" />

**For object requistion_fields**
<img width="1461" height="883" alt="image" src="https://github.com/user-attachments/assets/ec96e75e-8f3f-42ce-923b-05431acbadeb" />
<img width="1566" height="596" alt="image" src="https://github.com/user-attachments/assets/ce03b763-ef69-4725-85f7-aef6503fd8bd" />

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata/pull/69
