### PR TITLE
tidy(testscenario): Compare Read/Metadata fields match

### DIFF
--- a/test/constantcontact/metadata/privileges/main.go
+++ b/test/constantcontact/metadata/privileges/main.go
@@ -2,60 +2,20 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/constantcontact"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "privileges"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
-	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetConstantContactConnector(ctx)
-	defer utils.Close(conn)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for ConstantContact", "error", err)
-	}
-
-	slog.Info("Read object using all fields from ListObjectMetadata")
-
-	requestFields := datautils.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     requestFields,
-	})
-	if err != nil {
-		utils.Fail("error reading from Customer Journeys App", "error", err)
-	} else {
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
-
-		difference := givenFields.Diff(requestFields)
-		if len(difference) != 0 {
-			utils.Fail("connector read didn't match requested fields", "difference", difference)
-		}
-	}
-
-	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "privileges")
 }

--- a/test/customerio/journeysapp/metadata/main.go
+++ b/test/customerio/journeysapp/metadata/main.go
@@ -2,59 +2,20 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/customerio/journeysapp"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "segments"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
-	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetCustomerJourneysAppConnector(ctx)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Customers Journeys App", "error", err)
-	}
-
-	slog.Info("Read object using all fields from ListObjectMetadata")
-
-	requestFields := datautils.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     requestFields,
-	})
-	if err != nil {
-		utils.Fail("error reading from Customer Journeys App", "error", err)
-	} else {
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
-
-		difference := givenFields.Diff(requestFields)
-		if len(difference) != 0 {
-			utils.Fail("connector read didn't match requested fields", "difference", difference)
-		}
-	}
-
-	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "segments")
 }

--- a/test/dynamicscrm/metadata/main.go
+++ b/test/dynamicscrm/metadata/main.go
@@ -2,62 +2,21 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/dynamicscrm"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "contacts"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetMSDynamics365CRMConnector(ctx)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for microsoft CRM", "error", err)
-	}
-
-	fmt.Println("Read object using all fields from ListObjectMetadata")
-
-	requestFields := datautils.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     requestFields,
-	})
-	if err != nil {
-		utils.Fail("error reading from microsoft CRM", "error", err)
-	} else {
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
-
-		difference := givenFields.Diff(requestFields)
-		if len(difference) != 0 {
-			utils.Fail("connector read didn't match requested fields", "difference", difference)
-		}
-	}
-
-	fmt.Println("==> success fields requested from ListObjectMetadata are all present in Read.")
-
-	utils.DumpJSON(metadata, os.Stdout)
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "contacts")
 }

--- a/test/gong/metadata/main.go
+++ b/test/gong/metadata/main.go
@@ -2,56 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/gong"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "users" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetGongConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     connectors.Fields("firstName", "lastName", "emailAddress"),
-	})
-	if err != nil {
-		utils.Fail("error reading from Gong", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Gong", "error", err)
-	}
-
-	slog.Info("Compare object metadata against endpoint response:")
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("==> success fields match.")
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "users")
 }

--- a/test/instantly/metadata/main.go
+++ b/test/instantly/metadata/main.go
@@ -2,54 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/instantly"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "tags" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetInstantlyConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-	})
-	if err != nil {
-		utils.Fail("error reading from Instantly", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Instantly", "error", err)
-	}
-
-	slog.Info("Comparing")
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
-	if mismatchErr != nil {
-		utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("Success: Object metadata schema and endpoint response have the same fields")
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "tags")
 }

--- a/test/intercom/metadata/main.go
+++ b/test/intercom/metadata/main.go
@@ -2,79 +2,21 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	msTest "github.com/amp-labs/connectors/test/intercom"
+	connTest "github.com/amp-labs/connectors/test/intercom"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "admins"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
+	conn := connTest.GetIntercomConnector(ctx)
 
-	conn := msTest.GetIntercomConnector(ctx)
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-	})
-	if err != nil {
-		utils.Fail("error reading from Intercom", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Intercom", "error", err)
-	}
-
-	fmt.Println("Compare object metadata against endpoint response:")
-
-	mismatchErr := compareFieldsMatch(metadata, response.Data[0].Raw)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		fmt.Println("==> success fields match.")
-	}
-}
-
-func compareFieldsMatch(metadata *common.ListObjectMetadataResult, response map[string]any) error {
-	fields := make(map[string]bool)
-
-	for field := range response {
-		fields[field] = false
-	}
-
-	mismatch := make([]error, 0)
-
-	for _, displayName := range metadata.Result[objectName].FieldsMap {
-		if _, found := fields[displayName]; found {
-			fields[displayName] = true
-		}
-	}
-
-	// every field from Read must be known to ListObjectMetadata
-	for name, found := range fields {
-		if !found {
-			mismatch = append(mismatch, fmt.Errorf("metadata schema is missing field %v", name))
-		}
-	}
-
-	return errors.Join(mismatch...)
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "admins", nil)
 }

--- a/test/iterable/metadata/main.go
+++ b/test/iterable/metadata/main.go
@@ -2,56 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/iterable"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "messageTypes"
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetIterableConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     connectors.Fields("name"),
-	})
-	if err != nil {
-		utils.Fail("error reading from Iterable", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Iterable", "error", err)
-	}
-
-	slog.Info("Comparing")
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
-	if mismatchErr != nil {
-		utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("Success: Object metadata schema and endpoint response have the same fields")
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "messageTypes")
 }

--- a/test/klaviyo/metadata/main.go
+++ b/test/klaviyo/metadata/main.go
@@ -2,59 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/klaviyo"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "accounts"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetKlaviyoConnector(ctx)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Klaviyo", "error", err)
-	}
-
-	slog.Info("Read object using all fields from ListObjectMetadata")
-
-	requestFields := datautils.Map[string, string](metadata.Result[objectName].FieldsMap).KeySet()
-
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     requestFields,
-	})
-	if err != nil {
-		utils.Fail("error reading from Klaviyo", "error", err)
-	} else {
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
-
-		difference := givenFields.Diff(requestFields)
-		if len(difference) != 0 {
-			utils.Fail("connector read didn't match requested fields", "difference", difference)
-		}
-	}
-
-	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "accounts")
 }

--- a/test/pipeliner/metadata/main.go
+++ b/test/pipeliner/metadata/main.go
@@ -2,59 +2,24 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"strings"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/pipeliner"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "Leads" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetPipelinerConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-	})
-	if err != nil {
-		utils.Fail("error reading from Pipeliner", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Pipeliner", "error", err)
-	}
-
-	slog.Info("Compare object metadata against endpoint response:")
-
-	data := sanitizeReadResponse(response.Data[0].Raw)
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, data, metadata)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("==> success fields match.")
-	}
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "Leads", sanitizeReadResponse)
 }
 
 func sanitizeReadResponse(response map[string]any) map[string]any {

--- a/test/salesforce/metadata/read/organizations/main.go
+++ b/test/salesforce/metadata/read/organizations/main.go
@@ -2,61 +2,23 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os/signal"
-	"strings"
 	"syscall"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/salesforce"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "Organization" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetSalesforceConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     connectors.Fields("*"),
-	})
-	if err != nil {
-		utils.Fail("error reading from Salesforce", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Salesforce", "error", err)
-	}
-
-	fmt.Println("Compare object metadata against endpoint response:")
-
-	data := sanitizeReadResponse(response.Data[0].Raw)
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(strings.ToLower(objectName), data, metadata)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		fmt.Println("==> success fields match.")
-	}
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "Organization", sanitizeReadResponse)
 }
 
 func sanitizeReadResponse(response map[string]any) map[string]any {

--- a/test/salesloft/metadata/main.go
+++ b/test/salesloft/metadata/main.go
@@ -2,79 +2,21 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/salesloft"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectNamePlural = "groups"
-
-// we want to compare fields returned by read and schema properties provided by metadata methods
-// they must match for all such objects
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetSalesloftConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectNamePlural,
-	})
-	if err != nil {
-		utils.Fail("error reading from Salesloft", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectNamePlural,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Salesloft", "error", err)
-	}
-
-	fmt.Println("Compare object metadata against endpoint response:")
-
-	mismatchErr := compareFieldsMatch(metadata, response.Data[0].Raw)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		fmt.Println("==> success fields match.")
-	}
-}
-
-func compareFieldsMatch(metadata *common.ListObjectMetadataResult, response map[string]any) error {
-	fields := make(map[string]bool)
-
-	for field := range response {
-		fields[field] = false
-	}
-
-	mismatch := make([]error, 0)
-
-	for name := range metadata.Result[objectNamePlural].FieldsMap {
-		if _, found := fields[name]; found {
-			fields[name] = true
-		}
-	}
-
-	// every field from Read must be known to ListObjectMetadata
-	for name, found := range fields {
-		if !found {
-			mismatch = append(mismatch, fmt.Errorf("metadata schema is missing field %v", name))
-		}
-	}
-
-	return errors.Join(mismatch...)
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "groups", nil)
 }

--- a/test/smartlead/metadata/main.go
+++ b/test/smartlead/metadata/main.go
@@ -2,54 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/smartlead"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objectName = "campaigns" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetSmartleadConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-	})
-	if err != nil {
-		utils.Fail("error reading from Smartlead", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for Smartlead", "error", err)
-	}
-
-	slog.Info("Comparing")
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
-	if mismatchErr != nil {
-		utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("Success: Object metadata schema and endpoint response have the same fields")
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "campaigns")
 }

--- a/test/smartleadv2/metadata/main.go
+++ b/test/smartleadv2/metadata/main.go
@@ -2,56 +2,22 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/smartleadv2"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
-var objects = []string{"client", "campaigns"} // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetSmartleadV2Connector(ctx)
 
-	for _, object := range objects {
-		response, err := conn.Read(ctx, common.ReadParams{
-			ObjectName: object,
-		})
-		if err != nil {
-			utils.Fail("error reading from Smartlead", "error", err)
-		}
-
-		if response.Rows == 0 {
-			utils.Fail("expected to read at least one record", "error", err)
-		}
-
-		metadata, err := conn.ListObjectMetadata(ctx, []string{
-			object,
-		})
-		if err != nil {
-			utils.Fail("error listing metadata for Smartlead", "error", err)
-		}
-
-		slog.Info("Comparing")
-
-		mismatchErr := mockutils.ValidateReadConformsMetadata(object, response.Data[0].Raw, metadata)
-		if mismatchErr != nil {
-			utils.Fail("Failure: Schema and payload response have mismatching fields", "error", mismatchErr)
-		} else {
-			slog.Info("Success: Object metadata schema and endpoint response have the same fields")
-		}
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "client")
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "campaigns")
 }

--- a/test/utils/mockutils/metadataResult.go
+++ b/test/utils/mockutils/metadataResult.go
@@ -2,9 +2,7 @@ package mockutils
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -74,51 +72,4 @@ func (metadataResultComparator) SubsetErrors(actual, expected *common.ListObject
 	}
 
 	return true
-}
-
-// ValidateReadConformsMetadata this will check that all the fields that were returned by `Read` method
-// are a subset of ObjectMetadata. It is possible that Read will not return all the possible fields
-// which is fine and not a cause for an error.
-// However, it will return a Joined error for every Read field that is missing in Metadata.
-func ValidateReadConformsMetadata(objectName string,
-	readResponse map[string]any, metadata *common.ListObjectMetadataResult,
-) error {
-	fields := make(checkList)
-
-	for field := range readResponse {
-		fields.Add(field)
-	}
-
-	for name := range metadata.Result[objectName].FieldsMap {
-		fields.CheckIfExists(name)
-	}
-
-	// every field from Read must be known to ListObjectMetadata
-	mismatch := make([]error, 0)
-
-	for name, checked := range fields {
-		if !checked {
-			mismatch = append(mismatch, fmt.Errorf("metadata schema is missing field %v", name))
-		}
-	}
-
-	return errors.Join(mismatch...)
-}
-
-type checkList map[string]bool
-
-func (l checkList) Add(value string) {
-	l[strings.ToLower(value)] = false
-}
-
-func (l checkList) Has(value string) bool {
-	_, found := l[strings.ToLower(value)]
-
-	return found
-}
-
-func (l checkList) CheckIfExists(value string) {
-	if l.Has(value) {
-		l[strings.ToLower(value)] = true
-	}
 }

--- a/test/utils/testscenario/README.md
+++ b/test/utils/testscenario/README.md
@@ -1,0 +1,65 @@
+# Package testscenario
+
+**`testscenario`** provides reusable, configurable procedures for **live testing** connector operations.
+
+## Purpose
+
+This package defines common test scenarios for connectors that make real API calls. It helps ensure that different connector implementations correctly handle key combinations of high-level interfaces, like **Create**, **Read**, **Update**, **Delete**, and **Object Metadata**.
+
+# Features
+
+| Method                             | Testing Target                                          | Primary Focus & Scenario                                        |
+|------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------|
+| ValidateCreateDelete               | ReadConnector, WriteConnector (Create), DeleteConnector | Create a record, verify it can be found, then delete it         |
+| ValidateCreateUpdateDelete         | ReadConnector, WriteConnector, DeleteConnector          | Full CRUD: create, update, verify update, and delete            |
+| ValidateMetadataExactlyMatchesRead | ObjectMetadataConnector, ReadConnector                  | Validate that metadata **exactly** matches Read output          |
+| ValidateMetadataContainsRead       | ObjectMetadataConnector, ReadConnector                  | Validate that metadata **includes all** fields returned by Read |
+
+# Usage
+
+## CRUD
+
+**`ValidateCreateDelete`** and **`ValidateCreateUpdateDelete`** use `CRDTestSuite` and `CRUDTestSuite` respectively to control scenario configuration.
+
+**Key parameters:**
+- `ReadFields` — required. Fields that must be verified in Read/Update.
+- `WaitBeforeSearch` — optional. Add a delay if the backend needs time to reflect changes.
+- `SearchBy` — optional. Lookup a record by a unique property instead of the primary ID. Good for validating create.
+- `RecordIdentifierKey` — required. The field name for the record ID, primary key.
+- `UpdatedFields` — for update scenarios: checks that specific fields have the expected new values.
+- `PreprocessUpdatePayload` — optional. Modify the update payload dynamically using the result from Create.
+- `ValidateUpdatedFields` — optional. Provide custom logic to verify updates instead of static `UpdatedFields`.
+
+```go
+testscenario.ValidateCreateUpdateDelete(ctx, conn,
+    "<object_name>",
+    createPayload{},
+    updatePayload{},
+    testscenario.CRUDTestSuite{
+        ReadFields: datautils.NewSet("id", "name"),
+        WaitBeforeSearch: time.Second,
+        SearchBy: testscenario.Property{
+            Key:   "<fieldName>",
+            Value: fieldValue,
+        },
+        RecordIdentifierKey: "id", 
+        PreprocessUpdatePayload: func(createResult *common.WriteResult, updatePayload any) {},
+        UpdatedFields: map[string]string{
+            "name": updatedName,
+        },
+        ValidateUpdatedFields: func(record map[string]any){}
+    },
+)
+```
+
+## Metadata
+
+**`ValidateMetadataExactlyMatchesRead`** and **`ValidateMetadataContainsRead`** validate that the connector's declared metadata is in sync with it's Read behavior.
+** Use **`ValidateMetadataExactlyMatchesRead`** if your connector always returns the same complete set of fields for an object. This test ensures ListObjectMetadata describes exactly what Read returns — no extra, no missing.
+** Use **`ValidateMetadataContainsRead`** if your connector may omit fields in Read output (e.g., optional or empty fields). This test ensures that every field returned by Read is known to ListObjectMetadata — extra declared fields are fine, but undocumented fields are not.
+
+```go
+testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "users")
+testscenario.ValidateMetadataContainsRead(ctx, conn, "Organization", sanitizeReadResponse)
+```
+Tip: Use the `responsePostProcess` argument in `ValidateMetadataContainsRead` to adjust or filter the raw Read response before comparison.

--- a/test/utils/testscenario/matching-metadata.go
+++ b/test/utils/testscenario/matching-metadata.go
@@ -1,0 +1,155 @@
+package testscenario
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+type connectorReadMetadata interface {
+	connectors.ReadConnector
+	connectors.ObjectMetadataConnector
+}
+
+type readResponsePostProcessor func(before map[string]any) (after map[string]any)
+
+// ValidateMetadataExactlyMatchesRead verifies that *all* metadata fields returned by ListObjectMetadata
+// are present in the Read response for the object.
+//
+// If any field from the metadata list is missing in the Read output, the test fails.
+// Use this when you expect Read to return *exactly* the same set of metadata fields.
+//
+// Use this for connectors where every possible field is always present in Read,
+// so the metadata must match exactly. For connectors with optional fields,
+// see ValidateMetadataContainsRead instead.
+func ValidateMetadataExactlyMatchesRead(ctx context.Context, conn connectorReadMetadata, objectName string) {
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for connector", "error", err)
+	}
+
+	slog.Info("Reading an object using all fields from ListObjectMetadata", "objectName", objectName)
+
+	requestFields := datautils.Map[string, common.FieldMetadata](
+		metadata.Result[objectName].Fields,
+	).KeySet()
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     requestFields,
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	givenFields := datautils.Map[string, any](response.Data[0].Fields).KeySet()
+
+	difference := givenFields.Diff(requestFields)
+	if len(difference) != 0 {
+		utils.Fail("connector read didn't match requested fields", "difference", difference)
+	}
+
+	slog.Info("==> success fields requested from ListObjectMetadata are all present in Read.")
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}
+
+// ValidateMetadataContainsRead checks that every field present in the Read response
+// is declared in the metadata returned by ListObjectMetadata for the same object.
+//
+// This ensures that the connector does not return any undocumented or unexpected fields:
+// the metadata acts as a schema, and Read must conform to it.
+//
+// It is valid if the metadata includes fields that are not returned by Read
+// (e.g., because they are optional or empty).
+//
+// The test fails if any field in the Read output is missing from the declared metadata,
+// and it returns a combined error listing all such violations.
+func ValidateMetadataContainsRead(
+	ctx context.Context,
+	conn connectorReadMetadata,
+	objectName string,
+	responsePostProcess readResponsePostProcessor,
+) {
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		objectName,
+	})
+	if err != nil {
+		utils.Fail("error listing metadata for connector", "error", err)
+	}
+
+	slog.Info("Reading an object using all fields from ListObjectMetadata", "objectName", objectName)
+
+	requestFields := datautils.Map[string, common.FieldMetadata](
+		metadata.Result[objectName].Fields,
+	).KeySet()
+
+	response, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     requestFields,
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	if response.Rows == 0 {
+		utils.Fail("expected to read at least one record", "error", err)
+	}
+
+	slog.Info("Compare object metadata against endpoint response")
+
+	if responsePostProcess == nil {
+		responsePostProcess = goutils.Identity[map[string]any]
+	}
+
+	rawData := responsePostProcess(response.Data[0].Raw)
+
+	if mismatchErr := compareFieldsMatch(objectName, metadata, rawData); mismatchErr != nil {
+		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
+	}
+
+	slog.Info("==> Success fields match!")
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}
+
+func compareFieldsMatch(objectName string, metadata *common.ListObjectMetadataResult, response map[string]any) error {
+	fields := make(map[string]bool)
+
+	for field := range response {
+		fields[field] = false
+	}
+
+	mismatch := make([]error, 0)
+
+	for fieldName := range metadata.Result[objectName].Fields {
+		if _, found := fields[fieldName]; found {
+			fields[fieldName] = true
+		}
+	}
+
+	// every field from Read must be known to ListObjectMetadata
+	for name, found := range fields {
+		if !found {
+			mismatch = append(mismatch, fmt.Errorf("metadata schema is missing field %v", name))
+		}
+	}
+
+	return errors.Join(mismatch...)
+}

--- a/test/zendesksupport/metadata/brands/main.go
+++ b/test/zendesksupport/metadata/brands/main.go
@@ -2,56 +2,21 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os/signal"
 	"syscall"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 	connTest "github.com/amp-labs/connectors/test/zendesksupport"
 )
 
-var objectName = "brands" // nolint: gochecknoglobals
-
-// We want to compare fields returned by read and schema properties provided by metadata methods.
-// Properties from read must all be present in schema definition.
 func main() {
 	// Handle Ctrl-C gracefully.
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
 	utils.SetupLogging()
-
 	conn := connTest.GetZendeskSupportConnector(ctx)
 
-	response, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: objectName,
-		Fields:     connectors.Fields("name", "time_zone", "role"),
-	})
-	if err != nil {
-		utils.Fail("error reading from ZendeskSupport", "error", err)
-	}
-
-	if response.Rows == 0 {
-		utils.Fail("expected to read at least one record", "error", err)
-	}
-
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		objectName,
-	})
-	if err != nil {
-		utils.Fail("error listing metadata for ZendeskSupport", "error", err)
-	}
-
-	slog.Info("Compare object metadata against endpoint response:")
-
-	mismatchErr := mockutils.ValidateReadConformsMetadata(objectName, response.Data[0].Raw, metadata)
-	if mismatchErr != nil {
-		utils.Fail("schema and payload response have mismatching fields", "error", mismatchErr)
-	} else {
-		slog.Info("==> success fields match.")
-	}
+	testscenario.ValidateMetadataExactlyMatchesRead(ctx, conn, "brands")
 }


### PR DESCRIPTION
# Description

The live tests were overly verbose, duplicated, and relied on the deprecated `FieldsMap`.
This PR introduces reusable live test templates to simplify and standardize metadata validation.

Available live test templates:
* `testscenario.ValidateMetadataExactlyMatchesRead` -- Verifies that the `ListObjectMetadata` implementation returns all fields present in the `Read` response.
* `testscenario.ValidateMetadataContainsRead` -- Verifies that `ListObjectMetadata` returns all fields provided by `Read`, even if `Read` omits null or empty fields. The test fails if `ListObjectMetadata` does not include a field present in the `Read` response.