### PR TITLE
[CON-1082] feat: Enable read, write actions Gorgias Connector

### DIFF
--- a/providers/gorgias.go
+++ b/providers/gorgias.go
@@ -28,9 +28,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using Oauth2 Authorization code grant.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1031" height="574" alt="Screenshot 2025-07-18 at 09 38 20" src="https://github.com/user-attachments/assets/22f8f753-d09a-4103-a8c5-f03a7c5d2e4b" />

<img width="1235" height="640" alt="Screenshot 2025-07-18 at 09 38 28" src="https://github.com/user-attachments/assets/69634d7e-703e-4ac2-962e-e42e4839beba" />

<img width="1236" height="596" alt="Screenshot 2025-07-18 at 09 38 35" src="https://github.com/user-attachments/assets/0cd9e19c-c524-4a0e-a4b9-fc988a375a97" />

- [x] Insert screenshot of Svix destination.
<img width="1274" height="658" alt="Screenshot 2025-07-18 at 09 39 54" src="https://github.com/user-attachments/assets/fc986825-04f2-482b-aef3-2dbfd8ac8bae" />

<img width="1279" height="720" alt="Screenshot 2025-07-18 at 09 40 04" src="https://github.com/user-attachments/assets/4549e592-ff04-42e1-a183-807b749b9d43" />

<img width="1278" height="708" alt="Screenshot 2025-07-18 at 09 40 14" src="https://github.com/user-attachments/assets/123a13ee-6148-4f2a-b261-a513fb7f1a5e" />

- [x] Screenshot of operations on dashboard
<img width="984" height="634" alt="Screenshot 2025-07-18 at 09 41 45" src="https://github.com/user-attachments/assets/4e33d76b-ea9a-4b49-90e5-637da5eb5eb9" />

<img width="981" height="633" alt="Screenshot 2025-07-18 at 09 41 55" src="https://github.com/user-attachments/assets/c077ec17-2f1f-47bc-b8f8-4cb16dbda298" />

<img width="981" height="634" alt="Screenshot 2025-07-18 at 09 42 05" src="https://github.com/user-attachments/assets/0e216701-dbe3-4408-b634-ade0dc4e6070" />


# Write
- [x] Insert screenshot of dashboard.
<img width="984" height="637" alt="Screenshot 2025-07-18 at 10 08 46" src="https://github.com/user-attachments/assets/75769d0b-81e6-4608-9600-06f2ff3ccd8d" />

<img width="984" height="634" alt="Screenshot 2025-07-18 at 10 08 58" src="https://github.com/user-attachments/assets/540447c1-54a4-4ae7-992e-567967c40ca0" />


- [x] Insert screenshot of HTTP call.
<img width="1225" height="665" alt="Screenshot 2025-07-18 at 09 56 54" src="https://github.com/user-attachments/assets/c63be18f-5c75-4b26-885f-089a42fdc286" />

<img width="1224" height="602" alt="Screenshot 2025-07-18 at 10 00 20" src="https://github.com/user-attachments/assets/4b43d73e-5993-4474-9e60-19915d51afc2" />

<img width="1221" height="667" alt="Screenshot 2025-07-18 at 10 04 11" src="https://github.com/user-attachments/assets/4cbbad51-012d-40cd-8428-cbc6ce8f136e" />

# Examples
[Test-data](https://github.com/amp-labs/testdata/pull/70)
