### PR TITLE
fix: Map ObjectName to endpoints in Braze connector

### DIFF
--- a/providers/braze/handlers.go
+++ b/providers/braze/handlers.go
@@ -20,7 +20,15 @@ type catalogPayload struct {
 var ErrInvalidData = errors.New("invalid request data provided")
 
 func (c *Connector) metadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
+	endpoint := objectName
+
+	// map objectName to the braze APIs endpoints.
+	if objectName, exists := readEndpointsByObject[objectName]; exists {
+		// map the objectName to the appropriate endpoint
+		endpoint = objectName
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +57,12 @@ func (c *Connector) parseMetadataResponse(
 	data, err := common.UnmarshalJSON[map[string]any](response)
 	if err != nil {
 		return nil, err
+	}
+
+	// map objectName to the braze APIs endpoints.
+	if endpoint, exists := readEndpointsByObject[objectName]; exists {
+		// map the objectName to the appropriate endpoint
+		objectName = endpoint
 	}
 
 	fld := dataFields.Get(objectName)
@@ -80,6 +94,12 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 		return urlbuilder.New(params.NextPage.String())
 	}
 
+	// map objectName to the braze APIs endpoints.
+	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
+		// map the objectName to the appropriate endpoint
+		params.ObjectName = objectName
+	}
+
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
 	if err != nil {
 		return nil, err
@@ -98,6 +118,12 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		return nil, err
 	}
 
+	// map objectName to the braze APIs endpoints.
+	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
+		// map the objectName to the appropriate endpoint
+		params.ObjectName = objectName
+	}
+
 	if err := setSinceQuery(params, url); err != nil {
 		return nil, err
 	}
@@ -114,6 +140,12 @@ func (c *Connector) parseReadResponse(
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
 	if err != nil {
 		return nil, err
+	}
+
+	// map objectName to the braze APIs endpoints.
+	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
+		// map the objectName to the appropriate endpoint
+		params.ObjectName = objectName
 	}
 
 	return common.ParseResult(response,
@@ -151,6 +183,12 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		url      *urlbuilder.URL
 		method   = http.MethodPost
 	)
+
+	// map objectName to the braze APIs endpoints.
+	if objectName, exists := writeEndpointsByObject[params.ObjectName]; exists {
+		// map the objectName to the appropriate endpoint
+		params.ObjectName = objectName
+	}
 
 	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
 	if err != nil {

--- a/providers/braze/support.go
+++ b/providers/braze/support.go
@@ -25,3 +25,20 @@ func supportedOperations() components.EndpointRegistryInput {
 		},
 	}
 }
+
+var readEndpointsByObject = map[string]string{ //nolint: gochecknoglobals
+	"campaigns":           "campaigns/list",
+	"canvas":              "canvas/list",
+	"segments":            "segments/list",
+	"preference_center":   "preference_center/v1/list",
+	"subscription/status": "subscription/status/get",
+	"content_blocks":      "content_blocks/list",
+	"templates/email":     "templates/email/list",
+}
+
+var writeEndpointsByObject = map[string]string{ //nolint: gochecknoglobals
+	"subscription/status": "subscription/status/set",
+	"preference_center":   "preference_center/v1",
+	"content_blocks":      "content_blocks/create",
+	"templates/email":     "templates/email/create",
+}

--- a/test/braze/metadata/main.go
+++ b/test/braze/metadata/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	conn := braze.NewBrazeConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"catalogs", "campaigns/list", "templates/email/list"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"catalogs", "campaigns", "templates/email"})
 
 	if err != nil {
 		log.Fatal(err)

--- a/test/braze/read/main.go
+++ b/test/braze/read/main.go
@@ -43,7 +43,7 @@ func main() {
 
 func testReadCampaigns(ctx context.Context, conn *br.Connector) error {
 	params := common.ReadParams{
-		ObjectName: "campaigns/list",
+		ObjectName: "campaigns",
 		Fields:     connectors.Fields("id", "name"),
 		Since:      time.Now().Add(-1 * time.Hour),
 		// NextPage:   "https://rest.iad-03.braze.com/campaigns/list?page=1",
@@ -92,7 +92,7 @@ func testReadEvents(ctx context.Context, conn *br.Connector) error {
 
 func testReadEmailTemplates(ctx context.Context, conn *br.Connector) error {
 	params := common.ReadParams{
-		ObjectName: "templates/email/list",
+		ObjectName: "templates/email",
 		Fields:     connectors.Fields("template_name", "email_template_id"),
 		Since:      time.Now().Add(-1 * time.Hour),
 		// NextPage:   "https://rest.iad-03.braze.com/templates/email/list?offset=101",


### PR DESCRIPTION
With this builders can use `campaigns` instead of `campaigns/list` and similar objects while reading.

# Checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination 
- [ ] Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)


Metadata Live Tests:
<img width="1226" height="99" alt="Screenshot 2025-07-20 at 12 10 20" src="https://github.com/user-attachments/assets/e7bf7811-60ed-4db3-ac65-998368a0d3ee" />
<img width="1020" height="526" alt="Screenshot 2025-07-20 at 12 10 41" src="https://github.com/user-attachments/assets/020ac45f-bb07-4deb-bfb3-fd7fe6f10092" />

Read Live Tests:
<img width="1203" height="36" alt="Screenshot 2025-07-20 at 12 11 41" src="https://github.com/user-attachments/assets/c490ab46-5629-42ea-b844-78e826d36333" />
<img width="1022" height="462" alt="Screenshot 2025-07-20 at 12 12 01" src="https://github.com/user-attachments/assets/a6a6b72b-a39f-4a63-ae0e-04cc720c61f5" />

Write Live Tests:
<img width="1203" height="198" alt="Screenshot 2025-07-20 at 12 13 49" src="https://github.com/user-attachments/assets/d37ebe46-d50c-4d49-baf8-61495b50cce0" />
