### PR TITLE
[CON-1988] feat(fathom): enable Read and Write

### DIFF
--- a/providers/Fathom.go
+++ b/providers/Fathom.go
@@ -22,9 +22,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using Api key

# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.
<img width="962" height="681" alt="image" src="https://github.com/user-attachments/assets/5ac6f8d9-c16a-41f1-85d0-0e854703f6c0" />
<img width="991" height="646" alt="image" src="https://github.com/user-attachments/assets/7561bc08-7b31-4ac0-a1e1-ab1ea4d25569" />
<img width="939" height="634" alt="image" src="https://github.com/user-attachments/assets/d4dec421-868b-48e0-959a-52016f23ed39" />


- [x] Insert screenshot of Svix destination.
<img width="1573" height="792" alt="image" src="https://github.com/user-attachments/assets/472777af-caca-469f-99c9-a53a43d38a8e" />
<img width="1607" height="793" alt="image" src="https://github.com/user-attachments/assets/44f3ea6b-fa54-4a74-8404-314601cd55e0" />
<img width="1604" height="884" alt="image" src="https://github.com/user-attachments/assets/18a8d4ff-fb5d-4a1e-ac26-8e4f454af67e" />


- [x] Screenshot of operations on dashboard
<img width="1500" height="998" alt="image" src="https://github.com/user-attachments/assets/3d781ff2-dd78-4b30-9d3e-ae72b9f93037" />
<img width="1497" height="816" alt="image" src="https://github.com/user-attachments/assets/4a646d58-2f82-4cef-b878-292f21fff967" />
<img width="1500" height="795" alt="image" src="https://github.com/user-attachments/assets/16ef57db-bd49-40ce-b412-45b6e0088ebe" />



# Write
- [x] Insert screenshot of dashboard.
<img width="1498" height="693" alt="image" src="https://github.com/user-attachments/assets/00cdeede-8702-4121-9307-ea8cc7b0862a" />



- [x] Insert screenshot of HTTP call.
<img width="1726" height="725" alt="image" src="https://github.com/user-attachments/assets/acab875d-f2e3-44ae-b3e0-6669d5c7cb13" />

