### PR TITLE
[CON-1837] feat(flatFile): enable Read and Write support

### DIFF
--- a/providers/flatFile.go
+++ b/providers/flatFile.go
@@ -33,9 +33,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
# Installation
Mailmonkey using Api key

# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.
<img width="936" height="686" alt="image" src="https://github.com/user-attachments/assets/27b63c01-194c-4ce5-a35c-c669e3e04bab" />
<img width="974" height="855" alt="image" src="https://github.com/user-attachments/assets/920697c9-ed65-475b-a02c-1d4adf402284" />
<img width="975" height="828" alt="image" src="https://github.com/user-attachments/assets/67673e41-9ccc-44c4-a951-701d3b597ac7" />
<img width="938" height="620" alt="image" src="https://github.com/user-attachments/assets/1492c30b-f3e9-4ad8-b836-59b65e6ce21f" />



- [x] Insert screenshot of Svix destination.
<img width="1607" height="894" alt="image" src="https://github.com/user-attachments/assets/ef8479c8-437b-46fc-9755-5e7416f73662" />
<img width="1608" height="938" alt="image" src="https://github.com/user-attachments/assets/283ee055-7c61-446f-b282-039b4cfe24c6" />
<img width="1607" height="942" alt="image" src="https://github.com/user-attachments/assets/a739c203-2e78-44a6-bca8-c0b63ee0a399" />



- [x] Screenshot of operations on dashboard
<img width="1497" height="843" alt="image" src="https://github.com/user-attachments/assets/1238744d-f22a-4e38-b28a-9d87d78cbd36" />
<img width="1500" height="836" alt="image" src="https://github.com/user-attachments/assets/e55c3110-e3d0-4f42-ac10-b5823829dfe1" />



# Write
- [x] Insert screenshot of dashboard.




- [x] Insert screenshot of HTTP call.


