### PR TITLE
feat(flatfile): enhance pagination handling

### DIFF
--- a/providers/flatfile/parse.go
+++ b/providers/flatfile/parse.go
@@ -29,7 +29,7 @@ func nextRecordsURL(url *url.URL) common.NextPageFunc {
 		nextURL := *url
 
 		// Try to parse pagination object from the response
-		nextURLStr, shouldStop := handlePaginationObject(node, nextURL)
+		nextURLStr, shouldStop := handlePaginationObject(node, &nextURL)
 
 		if nextURLStr != "" {
 			return nextURLStr, nil
@@ -40,7 +40,7 @@ func nextRecordsURL(url *url.URL) common.NextPageFunc {
 		}
 
 		// Fallback: no pagination object, increment based on URL query
-		return handleURLQueryFallback(nextURL)
+		return handleURLQueryFallback(&nextURL)
 	}
 }
 
@@ -48,7 +48,7 @@ func nextRecordsURL(url *url.URL) common.NextPageFunc {
 // Returns: (nextURL, shouldStop).
 // - nextURL: the next page URL if pagination is valid and not at end.
 // - shouldStop: true if we've reached the last page.
-func handlePaginationObject(n *ajson.Node, url url.URL) (string, bool) {
+func handlePaginationObject(n *ajson.Node, url *url.URL) (string, bool) {
 	pagination, err := jsonquery.New(n).ObjectOptional("pagination")
 	if err != nil || pagination == nil {
 		return "", false
@@ -74,7 +74,7 @@ func handlePaginationObject(n *ajson.Node, url url.URL) (string, bool) {
 }
 
 // handleURLQueryFallback handles pagination when no pagination object is present.
-func handleURLQueryFallback(url url.URL) (string, error) {
+func handleURLQueryFallback(url *url.URL) (string, error) {
 	query := url.Query()
 	currentPage := 1
 	currentPageStr := query.Get(pageQuery)

--- a/providers/flatfile/parse.go
+++ b/providers/flatfile/parse.go
@@ -37,9 +37,9 @@ func nextRecordsURL(url *url.URL) common.NextPageFunc {
 
 			if err1 == nil && err2 == nil && currentPage != nil && totalPages != nil {
 				if *currentPage >= *totalPages {
-					return "", nil // No more pages to fetch
+					return "", nil
 				}
-				// If pagination is present, we can use it to build the next page URL
+				// If pagination is present, build the next page URL
 				query := nextURL.Query()
 				query.Set(pageQuery, strconv.Itoa(int(*currentPage+1)))
 				nextURL.RawQuery = query.Encode()

--- a/providers/flatfile/parse.go
+++ b/providers/flatfile/parse.go
@@ -22,10 +22,10 @@ func records() common.RecordsFunc {
 
 // Two-phase pagination approach is required for Flatfile API:
 //  1. Some endpoints (like environments) return a pagination object with currentPage/pageCount
-//     but don't return empty responses for invalid pages, which can cause infinite loops
-//  2. Other endpoints follow standard pagination (return empty when no more data)
+//     but don't return empty responses for invalid pages, which can cause infinite loops.
+//  2. Other endpoints follow standard pagination (return empty when no more data).
 //
-// We prioritize pagination object when available to avoid infinite loops
+// We prioritize pagination object when available to avoid infinite loops.
 func nextRecordsURL(url *url.URL) common.NextPageFunc {
 	return func(node *ajson.Node) (string, error) {
 		if url == nil {

--- a/providers/flatfile/parse.go
+++ b/providers/flatfile/parse.go
@@ -20,9 +20,8 @@ func records() common.RecordsFunc {
 	}
 }
 
-// nolint: cyclop
 func nextRecordsURL(url *url.URL) common.NextPageFunc {
-	return func(n *ajson.Node) (string, error) {
+	return func(node *ajson.Node) (string, error) {
 		if url == nil {
 			return "", nil
 		}
@@ -30,42 +29,68 @@ func nextRecordsURL(url *url.URL) common.NextPageFunc {
 		nextURL := *url
 
 		// Try to parse pagination object from the response
-		pagination, err := jsonquery.New(n).ObjectOptional("pagination")
-		if err == nil && pagination != nil {
-			currentPage, err1 := jsonquery.New(pagination).IntegerOptional("currentPage")
-			totalPages, err2 := jsonquery.New(pagination).IntegerOptional("pageCount")
+		nextURLStr, shouldStop := handlePaginationObject(node, nextURL)
 
-			if err1 == nil && err2 == nil && currentPage != nil && totalPages != nil {
-				if *currentPage >= *totalPages {
-					return "", nil
-				}
-				// If pagination is present, build the next page URL
-				query := nextURL.Query()
-				query.Set(pageQuery, strconv.Itoa(int(*currentPage+1)))
-				nextURL.RawQuery = query.Encode()
+		if nextURLStr != "" {
+			return nextURLStr, nil
+		}
 
-				return nextURL.String(), nil
-			}
+		if shouldStop {
+			return "", nil // No more pages, stop pagination
 		}
 
 		// Fallback: no pagination object, increment based on URL query
-		query := nextURL.Query()
-		currentPage := 1
-		currentPageStr := query.Get(pageQuery)
-
-		if currentPageStr != "" {
-			var err error
-
-			currentPage, err = strconv.Atoi(currentPageStr)
-			if err != nil {
-				return "", err
-			}
-		}
-
-		nextPage := currentPage + 1
-		query.Set(pageQuery, strconv.Itoa(nextPage))
-		nextURL.RawQuery = query.Encode()
-
-		return nextURL.String(), nil
+		return handleURLQueryFallback(nextURL)
 	}
+}
+
+// handlePaginationObject extracts pagination info from response.
+// Returns: (nextURL, shouldStop).
+// - nextURL: the next page URL if pagination is valid and not at end.
+// - shouldStop: true if we've reached the last page.
+func handlePaginationObject(n *ajson.Node, url url.URL) (string, bool) {
+	pagination, err := jsonquery.New(n).ObjectOptional("pagination")
+	if err != nil || pagination == nil {
+		return "", false
+	}
+
+	currentPage, err1 := jsonquery.New(pagination).IntegerOptional("currentPage")
+	totalPages, err2 := jsonquery.New(pagination).IntegerOptional("pageCount")
+
+	if err1 != nil || err2 != nil || currentPage == nil || totalPages == nil {
+		return "", false
+	}
+
+	// Check if we've reached the last page
+	if *currentPage >= *totalPages {
+		return "", true
+	}
+
+	query := url.Query()
+	query.Set(pageQuery, strconv.Itoa(int(*currentPage+1)))
+	url.RawQuery = query.Encode()
+
+	return url.String(), false
+}
+
+// handleURLQueryFallback handles pagination when no pagination object is present.
+func handleURLQueryFallback(url url.URL) (string, error) {
+	query := url.Query()
+	currentPage := 1
+	currentPageStr := query.Get(pageQuery)
+
+	if currentPageStr != "" {
+		var err error
+
+		currentPage, err = strconv.Atoi(currentPageStr)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	nextPage := currentPage + 1
+	query.Set(pageQuery, strconv.Itoa(nextPage))
+	url.RawQuery = query.Encode()
+
+	return url.String(), nil
 }

--- a/test/flatfile/read/main.go
+++ b/test/flatfile/read/main.go
@@ -60,5 +60,16 @@ func main() {
 	slog.Info("Reading apps..")
 	utils.DumpJSON(res, os.Stdout)
 
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "environments",
+		Fields:     connectors.Fields("id", "accountId", "name"),
+	})
+
+	if err != nil {
+		utils.Fail("error reading from flatfile", "error", err)
+	}
+	slog.Info("Reading environments..")
+	utils.DumpJSON(res, os.Stdout)
+
 	slog.Info("Read operation completed successfully.")
 }


### PR DESCRIPTION
### Background

 `environments` object returns a pagination object in the response. However, unlike others, when fetching a non-existent page, it doesn't return an empty array—instead, it returns the records from the last page. This change handles that behavior.