### PR TITLE
[CON-2025] chore: [Meta] Combine the Facebook and WhatsApp provider configurations into Meta configuration

### DIFF
--- a/providers/meta.go
+++ b/providers/meta.go
@@ -1,21 +1,18 @@
 package providers
 
 const (
-	Facebook Provider = "facebook"
-	WhatsApp Provider = "whatsApp"
+	Meta Provider = "meta"
 )
 
-// nolint:funlen
 func init() {
-	// Facebook Ads Manager Configuration
-	SetInfo(Facebook, ProviderInfo{
-		DisplayName: "Facebook",
+	SetInfo(Meta, ProviderInfo{
+		DisplayName: "Meta",
 		AuthType:    Oauth2,
 		BaseURL:     "https://graph.facebook.com",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://www.facebook.com/v19.0/dialog/oauth",
-			TokenURL:                  "https://graph.facebook.com/v19.0/oauth/access_token",
+			AuthURL:                   "https://www.facebook.com/v23.0/dialog/oauth",
+			TokenURL:                  "https://graph.facebook.com/v23.0/oauth/access_token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},
@@ -33,48 +30,12 @@ func init() {
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478709/media/facebook_1722478708.svg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478689/media/facebook_1722478688.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098801/media/meta.com_1753098801.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098836/media/meta.com_1753098836.svg",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478709/media/facebook_1722478708.svg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722478689/media/facebook_1722478688.svg",
-			},
-		},
-	})
-
-	// WhatsApp configuration
-	SetInfo(WhatsApp, ProviderInfo{
-		DisplayName: "whatsApp",
-		AuthType:    Oauth2,
-		BaseURL:     "https://graph.facebook.com",
-		Oauth2Opts: &Oauth2Opts{
-			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://www.facebook.com/v23.0/dialog/oauth",
-			TokenURL:                  "https://graph.facebook.com/v23.0/oauth/access_token",
-			ExplicitScopesRequired:    true,
-			ExplicitWorkspaceRequired: false,
-		},
-		Support: Support{
-			BulkWrite: BulkWriteSupport{
-				Insert: false,
-				Update: false,
-				Upsert: false,
-				Delete: false,
-			},
-			Proxy:     false,
-			Read:      false,
-			Subscribe: false,
-			Write:     false,
-		},
-		Media: &Media{
-			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752068006/media/whatsApp.com_1752068015.jpg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752068046/media/whatsApp.com_1752068056.svg",
-			},
-			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752068006/media/whatsApp.com_1752068015.jpg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1752068046/media/whatsApp.com_1752068056.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098801/media/meta.com_1753098801.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098858/media/meta.com_1753098858.svg",
 			},
 		},
 	})


### PR DESCRIPTION
## Checklist
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [x] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Logo & Icons
**Icons for Dark and Regular mode**
<img width="556" height="452" alt="image" src="https://github.com/user-attachments/assets/83e1067b-3289-4c37-b521-b8e54c4e1849" />

**Logo for Regular mode**
<img width="1551" height="554" alt="image" src="https://github.com/user-attachments/assets/eff4e278-efc9-4065-b82b-d676f6d1d8f8" />

**Logo for Dark mode**
<img width="680" height="282" alt="image" src="https://github.com/user-attachments/assets/81623fe9-3f4e-4a82-873e-91681d37acd7" />

**Notes:**
Facebook and WhatsApp connectors share the same base URL, auth URL, and token URL. As they both belong to Meta, I merged their provider configurations into a single Meta configuration.