### PR TITLE
[CON-1895] feat: Enable read, write Braze connector

### DIFF
--- a/providers/braze.go
+++ b/providers/braze.go
@@ -33,9 +33,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{


### PR DESCRIPTION
# Installation

Mailmonkey using API key.

# Conventions

Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read

- [x] Insert screenshot of metadata fields from read object installation.
      
<img width="993" height="579" alt="Screenshot 2025-07-22 at 11 21 20" src="https://github.com/user-attachments/assets/af4d9e65-2dac-43dc-947e-4552593f4e5a" />

<img width="1005" height="584" alt="Screenshot 2025-07-22 at 11 21 27" src="https://github.com/user-attachments/assets/4a30ac0a-aead-42d3-a00c-4c184b0315aa" />

<img width="1003" height="583" alt="Screenshot 2025-07-22 at 11 21 36" src="https://github.com/user-attachments/assets/5ebafbba-0903-4f3d-abb1-a73ccf5ad2be" />

- [x] Insert screenshot of Svix destination.
<img width="1280" height="687" alt="Screenshot 2025-07-22 at 11 22 51" src="https://github.com/user-attachments/assets/bad254fc-dd75-4c40-81fc-e976bd54f4e4" />

<img width="1280" height="660" alt="Screenshot 2025-07-22 at 11 34 47" src="https://github.com/user-attachments/assets/8c9457d6-fe38-4027-a994-e604c513662a" />

<img width="1272" height="666" alt="Screenshot 2025-07-22 at 11 34 57" src="https://github.com/user-attachments/assets/a25e73ff-b37c-431f-88ab-e039ed5a3ca6" />

- [x] Screenshot of operations on dashboard
<img width="982" height="634" alt="Screenshot 2025-07-22 at 11 35 49" src="https://github.com/user-attachments/assets/bcf90dde-0ae9-4ab5-a40c-a866be2e1439" />

<img width="981" height="635" alt="Screenshot 2025-07-22 at 11 35 59" src="https://github.com/user-attachments/assets/2d759cb5-c809-49fb-ba5d-7b5791567f17" />

<img width="980" height="632" alt="Screenshot 2025-07-22 at 11 36 09" src="https://github.com/user-attachments/assets/c2f338c6-997f-43f7-b8fd-29ae981ae430" />


# Write

- [x] Insert screenshot of dashboard.
<img width="981" height="636" alt="Screenshot 2025-07-22 at 13 03 24" src="https://github.com/user-attachments/assets/3c8c2042-4206-4916-84be-bd836c063ed5" />

<img width="983" height="634" alt="Screenshot 2025-07-22 at 13 03 47" src="https://github.com/user-attachments/assets/7029849e-882d-430d-95c2-40c96a5d9635" />

<img width="984" height="635" alt="Screenshot 2025-07-22 at 13 04 17" src="https://github.com/user-attachments/assets/740f682d-d3e7-44e7-a3c5-10df32cf47ca" />

- [x] Insert screenshot of HTTP call.
<img width="1227" height="669" alt="Screenshot 2025-07-22 at 12 50 49" src="https://github.com/user-attachments/assets/6b70989e-95d2-48db-be56-8e989669dd23" />

<img width="1228" height="670" alt="Screenshot 2025-07-22 at 12 55 34" src="https://github.com/user-attachments/assets/ce88a055-9960-46b9-934f-766be3b4de33" />

<img width="1227" height="671" alt="Screenshot 2025-07-22 at 12 56 36" src="https://github.com/user-attachments/assets/886c361e-5f0d-4503-8261-5c2d08f0f5da" />


# Examples

[Test-data](https://github.com/amp-labs/testdata/pull/72)
