### PR TITLE
chore: extend associations type to allow sending full record from the connector

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -262,7 +262,9 @@ type Association struct {
 	// ObjectID is the ID of the associated object.
 	ObjectId string `json:"objectId"`
 	// AssociationType is the type of association.
-	AssociationType string `json:"associationType,omitempty"`
+	AssociationType string         `json:"associationType,omitempty"`
+	Raw             map[string]any `json:"raw,omitempty"`
+	Fields          map[string]any `json:"fields"`
 }
 
 // WriteResult is what's returned from writing data via the Write call.

--- a/common/types.go
+++ b/common/types.go
@@ -264,7 +264,7 @@ type Association struct {
 	// AssociationType is the type of association.
 	AssociationType string         `json:"associationType,omitempty"`
 	Raw             map[string]any `json:"raw,omitempty"`
-	Fields          map[string]any `json:"fields"`
+	Fields          map[string]any `json:"fields,omitempty"`
 }
 
 // WriteResult is what's returned from writing data via the Write call.


### PR DESCRIPTION
- Currently, our associations type doesn't let the connector send associations as full records
- Salesforce can fetch associations directly in the Read call, so we can populate it within the connector