### PR TITLE
[CON-2027] chore: [HighLevel] Support extra OAuth2 fields in proxy connector

### DIFF
--- a/providers/highlevel.go
+++ b/providers/highlevel.go
@@ -21,6 +21,28 @@ func init() {
 			TokenMetadataFields: TokenMetadataFields{
 				ScopesField:      "scope",
 				ConsumerRefField: "userId",
+				OtherFields: &TokenMetadataFieldsOtherFields{
+					{
+						DisplayName: "Location Id",
+						Name:        "locationId",
+						Path:        "",
+					},
+					{
+						DisplayName: "User Type",
+						Name:        "userType",
+						Path:        "",
+					},
+					{
+						DisplayName: "Plan Id",
+						Name:        "planId",
+						Path:        "",
+					},
+					{
+						DisplayName: "Company Id",
+						Name:        "companyId",
+						Path:        "",
+					},
+				},
 			},
 		},
 		Support: Support{


### PR DESCRIPTION
## Note:
In the HighLevel connector, most of the endpoints require a `locationId` as a query parameter. We can get the `locationId` from the token response, so I added the necessary field in the OtherFields section of the TokenMetadataFields struct.

FYI:- There are two types of access tokens — one is the Agency Access Token and the other is the Sub-Account Access Token. When a sub-account is selected during installation, the `locationId` will be included in the token response. If the agency account is selected instead, the `locationId` will not be returned in the response, because it is available only for the Sub-Account Access Token. The locationId is unique since only one sub-account is selected during installation.
<img width="720" height="541" alt="image" src="https://github.com/user-attachments/assets/e2c174f1-9b89-44c7-af0c-4751136b88d2" />



