### PR TITLE
fix: Get rid of explicit content-length handling

### DIFF
--- a/common/csv.go
+++ b/common/csv.go
@@ -43,13 +43,12 @@ func (j *JSONHTTPClient) httpPutCSV(ctx context.Context, url string,
 }
 
 func makeTextCSVPutRequest(ctx context.Context, url string, headers []Header, body []byte) (*http.Request, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
 	headers = append(headers, Header{Key: "Content-Type", Value: "text/csv"})
-	req.ContentLength = int64(len(body))
 
 	return addHeaders(req, headers), nil
 }


### PR DESCRIPTION
We don't need to explicitly set the Content-Length header for requests. Go will automatically fill this in, especially if the request body is a bytes.Reader or similar.

Example success run (test/salesforce/read/account):
```
time=2025-07-23T13:38:17.376-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2025-07-23T13:38:17.381-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-b3cb75c050-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Name%2CBillingCity%2CIsDeleted%2CSystemModstamp%2CId+FROM+Account+WHERE+SystemModstamp+%3E+2024-08-28T13%3A47%3A37Z+AND+SystemModstamp+%3C%3D+2025-01-01T00%3A00%3A00Z" correlationId=06a42771-c94e-4da5-98c3-3a1b86fc805d headers.Accept=application/json
time=2025-07-23T13:38:17.728-07:00 level=DEBUG msg="HTTP response" method=GET url="https://orgfarm-b3cb75c050-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Name%2CBillingCity%2CIsDeleted%2CSystemModstamp%2CId+FROM+Account+WHERE+SystemModstamp+%3E+2024-08-28T13%3A47%3A37Z+AND+SystemModstamp+%3C%3D+2025-01-01T00%3A00%3A00Z" correlationId=06a42771-c94e-4da5-98c3-3a1b86fc805d headers.X-Content-Type-Options=nosniff headers.X-Sfdc-Request-Id=a9691f2d0771168c96a7dcc931d59946 headers.Content-Type="application/json;charset=UTF-8" headers.Strict-Transport-Security="max-age=63072000; includeSubDomains" headers.X-Request-Id=a9691f2d0771168c96a7dcc931d59946 headers.Date="Wed, 23 Jul 2025 20:38:17 GMT" headers.Vary=Accept-Encoding headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Server=sfdcedge headers.X-Sfdc-Edge-Cache=MISS headers.X-Robots-Tag=none headers.Sforce-Limit-Info="api-usage=242/15000" headers.Cache-Control="no-cache,must-revalidate,max-age=0,no-store,private"
Reading..
{
  "rows": 0,
  "data": [],
  "done": true
}
```

Example failure run (test/salesforce/read/account):
```
time=2025-07-23T13:39:04.583-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2025-07-23T13:39:04.586-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-b3cb75c050-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName%2CBillingCity%2CIsDeleted%2CSystemModstamp%2Cnotreal+FROM+Account+WHERE+SystemModstamp+%3E+2024-08-28T13%3A47%3A37Z+AND+SystemModstamp+%3C%3D+2025-01-01T00%3A00%3A00Z" correlationId=7b8b3f5e-cfff-4dbc-8ad8-46525da36bcd headers.Accept=application/json
time=2025-07-23T13:39:05.073-07:00 level=DEBUG msg="HTTP response" method=GET url="https://orgfarm-b3cb75c050-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName%2CBillingCity%2CIsDeleted%2CSystemModstamp%2Cnotreal+FROM+Account+WHERE+SystemModstamp+%3E+2024-08-28T13%3A47%3A37Z+AND+SystemModstamp+%3C%3D+2025-01-01T00%3A00%3A00Z" correlationId=7b8b3f5e-cfff-4dbc-8ad8-46525da36bcd headers.Content-Type="application/json;charset=UTF-8" headers.Cache-Control="no-cache,must-revalidate,max-age=0,no-store,private" headers.Sforce-Limit-Info="api-usage=242/15000" headers.X-Content-Type-Options=nosniff headers.Strict-Transport-Security="max-age=63072000; includeSubDomains" headers.X-Robots-Tag=none headers.Server=sfdcedge headers.Date="Wed, 23 Jul 2025 20:39:05 GMT" headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.Set-Cookie=<redacted> headers.X-Sfdc-Request-Id=f811b8035a051b370baf8c656d8070b5 headers.X-Request-Id=f811b8035a051b370baf8c656d8070b5
time=2025-07-23T13:39:05.073-07:00 level=ERROR msg="HTTP request failed" method=GET url="https://orgfarm-b3cb75c050-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName%2CBillingCity%2CIsDeleted%2CSystemModstamp%2Cnotreal+FROM+Account+WHERE+SystemModstamp+%3E+2024-08-28T13%3A47%3A37Z+AND+SystemModstamp+%3C%3D+2025-01-01T00%3A00%3A00Z" correlationId=7b8b3f5e-cfff-4dbc-8ad8-46525da36bcd error="bad request: \nBillingCity,IsDeleted,SystemModstamp,notreal FROM Account WHERE SystemModstamp\n                                     ^\nERROR at Row:1:Column:53\nNo such column 'notreal' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names. (HTTP status 400)"
time=2025-07-23T13:39:05.073-07:00 level=ERROR msg="error reading" error="bad request: \nBillingCity,IsDeleted,SystemModstamp,notreal FROM Account WHERE SystemModstamp\n                                     ^\nERROR at Row:1:Column:53\nNo such column 'notreal' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names. (HTTP status 400)"
exit status 1
```