### PR TITLE
fix: Move response logging to happen before error handling

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -283,18 +283,19 @@ func (h *HTTPClient) httpGet(ctx context.Context, //nolint:dupl
 	}
 
 	rsp, body, err := h.sendRequest(req)
+
+	if logging.IsVerboseLogging(ctx) {
+		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "GET", correlationId, url, body)
+	} else {
+		logResponseWithoutBody(logging.Logger(ctx), rsp, "GET", correlationId, url)
+	}
+
 	if err != nil {
 		logging.Logger(ctx).Error("HTTP request failed",
 			"method", "GET", "url", url,
 			"correlationId", correlationId, "error", err)
 
 		return nil, nil, err
-	}
-
-	if logging.IsVerboseLogging(ctx) {
-		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "GET", correlationId, url, body)
-	} else {
-		logResponseWithoutBody(logging.Logger(ctx), rsp, "GET", correlationId, url)
 	}
 
 	return rsp, body, nil
@@ -318,18 +319,19 @@ func (h *HTTPClient) httpPost(ctx context.Context, url string, //nolint:dupl
 	}
 
 	rsp, body, err := h.sendRequest(req)
+
+	if logging.IsVerboseLogging(ctx) {
+		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "POST", correlationId, url, body)
+	} else {
+		logResponseWithoutBody(logging.Logger(ctx), rsp, "POST", correlationId, url)
+	}
+
 	if err != nil {
 		logging.Logger(ctx).Error("HTTP request failed",
 			"method", "POST", "url", url,
 			"correlationId", correlationId, "error", err)
 
 		return nil, nil, err
-	}
-
-	if logging.IsVerboseLogging(ctx) {
-		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "POST", correlationId, url, body)
-	} else {
-		logResponseWithoutBody(logging.Logger(ctx), rsp, "POST", correlationId, url)
 	}
 
 	return rsp, body, nil
@@ -364,18 +366,19 @@ func (h *HTTPClient) httpPatch(ctx context.Context, //nolint:dupl
 	}
 
 	rsp, rspBody, err := h.sendRequest(req)
+
+	if logging.IsVerboseLogging(ctx) {
+		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "PATCH", correlationId, url, rspBody)
+	} else {
+		logResponseWithoutBody(logging.Logger(ctx), rsp, "PATCH", correlationId, url)
+	}
+
 	if err != nil {
 		logging.Logger(ctx).Error("HTTP request failed",
 			"method", "PATCH", "url", url,
 			"correlationId", correlationId, "error", err)
 
 		return nil, nil, err
-	}
-
-	if logging.IsVerboseLogging(ctx) {
-		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "PATCH", correlationId, url, rspBody)
-	} else {
-		logResponseWithoutBody(logging.Logger(ctx), rsp, "PATCH", correlationId, url)
 	}
 
 	return rsp, rspBody, nil
@@ -410,18 +413,19 @@ func (h *HTTPClient) httpPut(ctx context.Context, //nolint:dupl
 	}
 
 	rsp, rspBody, err := h.sendRequest(req)
+
+	if logging.IsVerboseLogging(ctx) {
+		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "PUT", correlationId, url, rspBody)
+	} else {
+		logResponseWithoutBody(logging.Logger(ctx), rsp, "PUT", correlationId, url)
+	}
+
 	if err != nil {
 		logging.Logger(ctx).Error("HTTP request failed",
 			"method", "PUT", "url", url,
 			"correlationId", correlationId, "error", err)
 
 		return nil, nil, err
-	}
-
-	if logging.IsVerboseLogging(ctx) {
-		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "PUT", correlationId, url, rspBody)
-	} else {
-		logResponseWithoutBody(logging.Logger(ctx), rsp, "PUT", correlationId, url)
 	}
 
 	return rsp, rspBody, nil
@@ -445,18 +449,19 @@ func (h *HTTPClient) httpDelete(ctx context.Context, //nolint:dupl
 	}
 
 	rsp, rspBody, err := h.sendRequest(req)
+
+	if logging.IsVerboseLogging(ctx) {
+		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "DELETE", correlationId, url, rspBody)
+	} else {
+		logResponseWithoutBody(logging.Logger(ctx), rsp, "DELETE", correlationId, url)
+	}
+
 	if err != nil {
 		logging.Logger(ctx).Error("HTTP request failed",
 			"method", "DELETE", "url", url,
 			"correlationId", correlationId, "error", err)
 
 		return nil, nil, err
-	}
-
-	if logging.IsVerboseLogging(ctx) {
-		logResponseWithBody(logging.VerboseLogger(ctx), rsp, "DELETE", correlationId, url, rspBody)
-	} else {
-		logResponseWithoutBody(logging.Logger(ctx), rsp, "DELETE", correlationId, url)
 	}
 
 	return rsp, rspBody, nil
@@ -601,10 +606,10 @@ func (h *HTTPClient) sendRequest(req *http.Request) (*http.Response, []byte, err
 	// Check the response status code
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		if h.ErrorHandler != nil {
-			return nil, nil, h.ErrorHandler(res, body)
+			return res, body, h.ErrorHandler(res, body)
 		}
 
-		return nil, nil, InterpretError(res, body)
+		return res, body, InterpretError(res, body)
 	}
 
 	return res, body, nil


### PR DESCRIPTION
We're not seeing HTTP responses in the logs for non-2xx responses. We see the error but not the actual body and headers. Turns out we're bailing out before the log lines happened. This just moves things around so that the response logging happens before any error handling, so we always see the response.

Example success request: https://gist.github.com/eberle1080/dcd33c4ec65bc10dea6dac7dbd39ab68
Example failed request: https://gist.github.com/eberle1080/ee89dae9855911dfecb36afc0d54dc35
