### PR TITLE
[CON-2051] feat: [breakcold] proxy connector

### DIFF
--- a/providers/breakcold.go
+++ b/providers/breakcold.go
@@ -1,0 +1,40 @@
+package providers
+
+const Breakcold Provider = "breakcold"
+
+func init() {
+	SetInfo(Breakcold, ProviderInfo{
+		DisplayName: "Breakcold",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.breakcold.com/rest",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name: "X-API-KEY",
+			},
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753365294/media/breakcold.com_1753365295.svg",
+				LogoURL: "https://mintlify.s3.us-west-1.amazonaws.com/breakcold/logo/dark.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753365294/media/breakcold.com_1753365295.svg",
+				LogoURL: "https://mintlify.s3.us-west-1.amazonaws.com/breakcold/logo/light.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}

--- a/providers/breakcold.go
+++ b/providers/breakcold.go
@@ -12,6 +12,7 @@ func init() {
 			Header: &ApiKeyOptsHeader{
 				Name: "X-API-KEY",
 			},
+			DocsURL: "https://developer.breakcold.com/v3/api-reference/introduction#authentication",
 		},
 		//nolint:lll
 		Media: &Media{


### PR DESCRIPTION
# Conventions
- [ ] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/tags
<img width="512" height="279" alt="image" src="https://github.com/user-attachments/assets/3d608a6b-6171-4982-9b76-4daffe5f428b" />

### POST
URL: http://localhost:4444/tags
<img width="1474" height="531" alt="image" src="https://github.com/user-attachments/assets/6eb825ad-6541-4a6a-90c8-521031b4c17f" />

### PATCH
URL: http://localhost:4444/tags/ef58b421-a5f2-42b6-93df-be72770457e4
<img width="1485" height="543" alt="image" src="https://github.com/user-attachments/assets/876c70c9-b4e7-4b54-9580-befa4f7aef90" />

### DELETE
URL: http://localhost:4444/tags/ef58b421-a5f2-42b6-93df-be72770457e4
<img width="1486" height="385" alt="image" src="https://github.com/user-attachments/assets/7c582eae-bcf8-4302-a331-abb95cb42389" />

# Logo & Icons
**Icons for dark and regular mode**
<img width="196" height="185" alt="image" src="https://github.com/user-attachments/assets/5520589a-9aae-46a7-8311-ddca8e7af865" />

**Logo for  dark mode**
<img width="706" height="178" alt="image" src="https://github.com/user-attachments/assets/aace5933-5930-4df2-86ee-14d9ad17e976" />

**Logo for regular mode**
<img width="825" height="204" alt="image" src="https://github.com/user-attachments/assets/3af7a29c-72eb-47b3-b209-ea746f9a9fa3" />

**Note:**
In the retool, there is no logo for dark and regular mode. So I resourced them through online.
Link: 
https://mintlify.s3.us-west-1.amazonaws.com/breakcold/logo/dark.svg
https://mintlify.s3.us-west-1.amazonaws.com/breakcold/logo/light.svg



