### PR TITLE
fix: ListObjectMetadata shouldn't mutate original object and fix gitlab casing

### DIFF
--- a/internal/components/schema/composite.go
+++ b/internal/components/schema/composite.go
@@ -37,7 +37,8 @@ func (c *CompositeSchemaProvider) ListObjectMetadata(
 
 	// Track objects that haven't been successfully processed yet
 	// Initialized with all objects.
-	remainingObjects := objects
+	remainingObjects := make([]string, len(objects))
+	copy(remainingObjects, objects)
 
 	for _, schemaProvider := range c.schemaProviders {
 		if len(remainingObjects) == 0 {

--- a/internal/components/schema/composite.go
+++ b/internal/components/schema/composite.go
@@ -38,6 +38,7 @@ func (c *CompositeSchemaProvider) ListObjectMetadata(
 	// Track objects that haven't been successfully processed yet
 	// Initialized with all objects.
 	var remainingObjects []string
+
 	copy(remainingObjects, objects)
 
 	for _, schemaProvider := range c.schemaProviders {

--- a/internal/components/schema/composite.go
+++ b/internal/components/schema/composite.go
@@ -37,7 +37,7 @@ func (c *CompositeSchemaProvider) ListObjectMetadata(
 
 	// Track objects that haven't been successfully processed yet
 	// Initialized with all objects.
-	remainingObjects := make([]string, len(objects))
+	var remainingObjects []string
 	copy(remainingObjects, objects)
 
 	for _, schemaProvider := range c.schemaProviders {

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -1,6 +1,6 @@
 package providers
 
-const GitLab Provider = "gitLab"
+const GitLab Provider = "gitlab"
 
 func init() {
 	SetInfo(GitLab, ProviderInfo{


### PR DESCRIPTION
this PR fixes 2 issues:
- ListObjectMetadata was actually mutating the objects param, instead of making a copy of it, this caused errors in getHydratedRevision
- `gitlab` is preferred over `gitLab`


