### PR TITLE
feat: Extend merge_requests, projects supports Gitlab connector

### DIFF
--- a/providers/gitlab/handlers.go
+++ b/providers/gitlab/handlers.go
@@ -108,7 +108,8 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 	}
 
 	if params.ObjectName == projects {
-		// sets owned=true&membership=true
+		// sets owned=true&membership=true so that we are fetching the user's projects
+		// instead of all public projects on GitLab
 		url.WithQueryParam(ownedQuery, "true")
 		url.WithQueryParam(membershipQuery, "true")
 	}

--- a/providers/gitlab/handlers.go
+++ b/providers/gitlab/handlers.go
@@ -118,7 +118,7 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 		url.WithQueryParam(updatedAfterQuery, params.Since.Format(time.RFC3339))
 
 		if params.ObjectName == projects {
-			// This is required for reading Projects, if sice is provided.
+			// This is required for reading Projects, if since is provided.
 			// ref: https://docs.gitlab.com/api/projects/#list-projects
 			url.WithQueryParam("order_by", "updated_at")
 		}

--- a/test/gitlab/read/main.go
+++ b/test/gitlab/read/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -26,24 +27,32 @@ func main() {
 
 	conn := gitlab.GetConnector(ctx)
 
-	if err := testRead(ctx, conn, "templates/gitignores", []string{"key", "name"}); err != nil {
+	if err := testRead(ctx, conn, "templates/gitignores", []string{"key", "name"}, time.Now().Add(-10*time.Hour)); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := testRead(ctx, conn, "namespaces", []string{"id", "name", "full_path"}); err != nil {
+	if err := testRead(ctx, conn, "namespaces", []string{"id", "name", "full_path"}, time.Now().Add(-10*time.Hour)); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := testRead(ctx, conn, "snippets", []string{"title", "file_name", "id"}); err != nil {
+	if err := testRead(ctx, conn, "snippets", []string{"title", "file_name", "id"}, time.Now().Add(-10*time.Hour)); err != nil {
+		slog.Error(err.Error())
+	}
+
+	if err := testRead(ctx, conn, "merge_requests", []string{"description", "state", "title", "author"}, time.Now().Add(-10*time.Hour)); err != nil {
+		slog.Error(err.Error())
+	}
+
+	if err := testRead(ctx, conn, "projects", []string{"description", "name", "visibility", "path"}, time.Now().Add(-10*time.Hour)); err != nil {
 		slog.Error(err.Error())
 	}
 }
 
-func testRead(ctx context.Context, conn *gl.Connector, objectName string, fields []string) error {
+func testRead(ctx context.Context, conn *gl.Connector, objectName string, fields []string, since time.Time) error {
 	params := common.ReadParams{
 		ObjectName: objectName,
 		Fields:     connectors.Fields(fields...),
-		// NextPage:   "2",
+		Since:      since,
 	}
 
 	res, err := conn.Read(ctx, params)


### PR DESCRIPTION
- Adds support for reading user owned projects + membership projects. 
- Adds since parameter implementation, works for both merge_requests and projects.
- Adds live tests for `merge_requests` and `projects`

With this we can now:
-  read: `merge_requests`, `projects`
- write `projects`


Tests:
<img width="1992" height="111" alt="Screenshot 2025-07-27 at 21 09 11" src="https://github.com/user-attachments/assets/706aac87-9ef4-4f21-b471-3cf2c77f7ef4" />
<img width="1789" height="1020" alt="Screenshot 2025-07-27 at 21 10 12" src="https://github.com/user-attachments/assets/77417f4e-94ce-4ff6-b4ad-263582f39f5c" />
