### PR TITLE
[CON-1588]feat (gitlab): enable read, write

### DIFF
--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -32,9 +32,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
This was tested using the OAuth client.

# Installation
Mailmonkey using Oauth2 with Authorization code grant.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
<img width="987" height="601" alt="Screenshot 2025-07-28 at 14 42 30" src="https://github.com/user-attachments/assets/4ea17f70-a725-4ffa-8acf-948c4e3f5dea" />

<img width="960" height="590" alt="Screenshot 2025-07-28 at 14 42 37" src="https://github.com/user-attachments/assets/698dac95-2906-4818-9a5b-95f53582316b" />

<img width="993" height="591" alt="Screenshot 2025-07-28 at 14 01 26" src="https://github.com/user-attachments/assets/2b573669-2352-4478-a1ea-be23aea185a4" />

- [x] Insert screenshot of Svix destination.
<img width="1266" height="693" alt="Screenshot 2025-07-28 at 14 45 24" src="https://github.com/user-attachments/assets/eefd83b0-6a3b-4acb-9b3f-ec84de28c55d" />

<img width="1274" height="569" alt="Screenshot 2025-07-28 at 14 45 10" src="https://github.com/user-attachments/assets/b36a6ba0-35e7-4fc2-8ff5-ffc30a383924" />

<img width="1268" height="647" alt="Screenshot 2025-07-28 at 14 54 36" src="https://github.com/user-attachments/assets/b8201c4d-c476-491f-abf0-b98f3fe2ed17" />

- [x] Screenshot of operations on dashboard
<img width="977" height="596" alt="Screenshot 2025-07-28 at 14 23 13" src="https://github.com/user-attachments/assets/805f68c5-60e0-4fd1-a1b0-b3ab59167bac" />

<img width="977" height="598" alt="Screenshot 2025-07-28 at 14 24 02" src="https://github.com/user-attachments/assets/5d998bf8-d5d2-471f-b950-0165c7285c59" />

<img width="975" height="596" alt="Screenshot 2025-07-28 at 14 24 12" src="https://github.com/user-attachments/assets/bcb9895b-37f2-4d29-aa1c-111cd931dc1e" />


# Write
- [x] Insert screenshot of dashboard.
<img width="976" height="598" alt="Screenshot 2025-07-28 at 14 24 26" src="https://github.com/user-attachments/assets/9be81c90-6b8f-4440-bab8-5d579f223f5b" />

<img width="979" height="598" alt="Screenshot 2025-07-28 at 14 24 49" src="https://github.com/user-attachments/assets/4eb8c1c0-70d3-4756-9acc-7ad973515e11" />

- [x] Insert screenshot of HTTP call.
<img width="1229" height="670" alt="Screenshot 2025-07-28 at 14 09 38" src="https://github.com/user-attachments/assets/07213333-98ed-4ca4-acdb-ddadd4b5866a" />

<img width="1226" height="667" alt="Screenshot 2025-07-28 at 14 30 31" src="https://github.com/user-attachments/assets/2a312cea-ed1b-4980-ae46-f78f74e53e8a" />


# Examples
[test-data](https://github.com/amp-labs/testdata/pull/75)