### PR TITLE
fix(Braze): support reading next page for campaigns, canvas objects

### DIFF
--- a/providers/braze/handlers.go
+++ b/providers/braze/handlers.go
@@ -22,9 +22,8 @@ var ErrInvalidData = errors.New("invalid request data provided")
 func (c *Connector) metadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
 	path := objectName
 
-	// map objectName to the braze APIs endpoints.
+	// maps objectName to the braze APIs endpoints path.
 	if objectName, exists := readEndpointsByObject[objectName]; exists {
-		// map the objectName to the appropriate endpoint
 		path = objectName
 	}
 
@@ -33,6 +32,7 @@ func (c *Connector) metadataRequest(ctx context.Context, objectName string) (*ht
 		return nil, err
 	}
 
+	// sets single page request for metadata response.
 	url.WithQueryParam(limitQuery, metadataPageSize)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
@@ -61,9 +61,7 @@ func (c *Connector) parseMetadataResponse(
 		return nil, err
 	}
 
-	// map objectName to the braze APIs endpoints.
 	if endpoint, exists := readEndpointsByObject[objectName]; exists {
-		// map the objectName to the appropriate endpoint
 		path = endpoint
 	}
 
@@ -98,9 +96,7 @@ func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL,
 		return urlbuilder.New(params.NextPage.String())
 	}
 
-	// map objectName to the braze APIs endpoints.
 	if obj, exists := readEndpointsByObject[params.ObjectName]; exists {
-		// map the objectName to the appropriate endpoint
 		path = obj
 	}
 
@@ -185,6 +181,8 @@ func (c *Connector) constructCatalogPayload(recordData any) ([]byte, error) {
 }
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	path := params.ObjectName
+
 	var (
 		jsonData []byte
 		err      error
@@ -194,11 +192,10 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 
 	// map objectName to the braze APIs endpoints.
 	if objectName, exists := writeEndpointsByObject[params.ObjectName]; exists {
-		// map the objectName to the appropriate endpoint
-		params.ObjectName = objectName
+		path = objectName
 	}
 
-	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, path)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/braze/handlers.go
+++ b/providers/braze/handlers.go
@@ -20,15 +20,15 @@ type catalogPayload struct {
 var ErrInvalidData = errors.New("invalid request data provided")
 
 func (c *Connector) metadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	endpoint := objectName
+	path := objectName
 
 	// map objectName to the braze APIs endpoints.
 	if objectName, exists := readEndpointsByObject[objectName]; exists {
 		// map the objectName to the appropriate endpoint
-		endpoint = objectName
+		path = objectName
 	}
 
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, endpoint)
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +49,8 @@ func (c *Connector) parseMetadataResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
+	path := objectName
+
 	objectMetadata := common.ObjectMetadata{
 		FieldsMap:   make(map[string]string),
 		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
@@ -62,10 +64,10 @@ func (c *Connector) parseMetadataResponse(
 	// map objectName to the braze APIs endpoints.
 	if endpoint, exists := readEndpointsByObject[objectName]; exists {
 		// map the objectName to the appropriate endpoint
-		objectName = endpoint
+		path = endpoint
 	}
 
-	fld := dataFields.Get(objectName)
+	fld := dataFields.Get(path)
 
 	rcds, okay := (*data)[fld].([]any)
 	if !okay {
@@ -90,17 +92,19 @@ func (c *Connector) parseMetadataResponse(
 }
 
 func (c *Connector) constructReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	path := params.ObjectName
+
 	if params.NextPage != "" {
 		return urlbuilder.New(params.NextPage.String())
 	}
 
 	// map objectName to the braze APIs endpoints.
-	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
+	if obj, exists := readEndpointsByObject[params.ObjectName]; exists {
 		// map the objectName to the appropriate endpoint
-		params.ObjectName = objectName
+		path = obj
 	}
 
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
 	if err != nil {
 		return nil, err
 	}
@@ -118,12 +122,6 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		return nil, err
 	}
 
-	// map objectName to the braze APIs endpoints.
-	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
-		// map the objectName to the appropriate endpoint
-		params.ObjectName = objectName
-	}
-
 	if err := setSinceQuery(params, url); err != nil {
 		return nil, err
 	}
@@ -137,10 +135,20 @@ func (c *Connector) parseReadResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	path := params.ObjectName
+
+	// map objectName to the braze APIs endpoints.
+	if obj, exists := readEndpointsByObject[params.ObjectName]; exists {
+		// map the objectName to the appropriate endpoint
+		path = obj
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
 	if err != nil {
 		return nil, err
 	}
+
+	prevPage := request.URL.Query().Get(page)
 
 	// map objectName to the braze APIs endpoints.
 	if objectName, exists := readEndpointsByObject[params.ObjectName]; exists {
@@ -150,7 +158,7 @@ func (c *Connector) parseReadResponse(
 
 	return common.ParseResult(response,
 		common.ExtractRecordsFromPath(dataFields.Get(params.ObjectName)),
-		getNextRecordsURL(params.ObjectName, url, response),
+		getNextRecordsURL(params.ObjectName, prevPage, url, response),
 		common.GetMarshaledData,
 		params.Fields,
 	)

--- a/providers/dynamicsbusiness/responses.go
+++ b/providers/dynamicsbusiness/responses.go
@@ -32,7 +32,7 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 
 	for _, entity := range data.Value {
 		if strings.EqualFold(entity.EntitySetName, objectName) {
-			object = &entity
+			object = &entity //nolint: exportloopref
 		}
 	}
 

--- a/test/braze/metadata/main.go
+++ b/test/braze/metadata/main.go
@@ -14,7 +14,9 @@ func main() {
 
 	conn := braze.NewBrazeConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"catalogs", "campaigns", "templates/email"})
+	objectNames := []string{"catalogs", "campaigns", "templates/email"}
+
+	m, err := conn.ListObjectMetadata(ctx, objectNames)
 
 	if err != nil {
 		log.Fatal(err)

--- a/test/braze/read/main.go
+++ b/test/braze/read/main.go
@@ -42,10 +42,11 @@ func main() {
 }
 
 func testReadCampaigns(ctx context.Context, conn *br.Connector) error {
+
 	params := common.ReadParams{
 		ObjectName: "campaigns",
 		Fields:     connectors.Fields("id", "name"),
-		Since:      time.Now().Add(-1 * time.Hour),
+		Since:      time.Now().Add(-13000 * time.Hour),
 		// NextPage:   "https://rest.iad-03.braze.com/campaigns/list?page=1",
 	}
 
@@ -94,8 +95,8 @@ func testReadEmailTemplates(ctx context.Context, conn *br.Connector) error {
 	params := common.ReadParams{
 		ObjectName: "templates/email",
 		Fields:     connectors.Fields("template_name", "email_template_id"),
-		Since:      time.Now().Add(-1 * time.Hour),
-		// NextPage:   "https://rest.iad-03.braze.com/templates/email/list?offset=101",
+		Since:      time.Now().Add(-13000 * time.Hour),
+		NextPage:   "https://rest.iad-03.braze.com/templates/email/list?offset=101",
 	}
 
 	res, err := conn.Read(ctx, params)

--- a/test/braze/write/main.go
+++ b/test/braze/write/main.go
@@ -37,9 +37,9 @@ func MainFn() int {
 
 func createEmailTemplate(ctx context.Context, conn *br.Connector) error {
 	prms := common.WriteParams{
-		ObjectName: "templates/email/create",
+		ObjectName: "templates/email",
 		RecordData: map[string]any{
-			"template_name":     "welcome_email",
+			"template_name":     "welcome_email___",
 			"subject":           "Welcome to [Company Name]!",
 			"body":              "<p>Hi {{first_name}},</p><p>Thank you for joining us! We're excited to have you.</p><p>Get started by exploring your account <a href='{{dashboard_url}}'>here</a>.</p><p>Cheers,<br>The {{company_name}} Team</p>",
 			"plaintext_body":    "Hi {{first_name}},\n\nThank you for joining us! Get started here: {{dashboard_url}}\n\nCheers,\nThe {{company_name}} Team",


### PR DESCRIPTION
- Adds support reading next page the objects using defaultPagination. 

With the previous implementation. 
It was failing to correctly construct next page for campaigns + other related objects:
<img width="718" height="129" alt="Screenshot 2025-07-29 at 13 11 38" src="https://github.com/user-attachments/assets/7927a8fc-2608-42d8-9355-b900d07be3b1" />

Now:
<img width="709" height="134" alt="Screenshot 2025-07-29 at 13 10 47" src="https://github.com/user-attachments/assets/3b59e168-1281-406a-b2b1-09d319b056fa" />
