### PR TITLE
[CON-2071] feat: [Blackbaud] proxy connector

### DIFF
--- a/providers/blackbaud.go
+++ b/providers/blackbaud.go
@@ -1,0 +1,41 @@
+package providers
+
+const Blackbaud Provider = "blackbaud"
+
+func init() {
+	// Blackbaud configuration
+	SetInfo(Blackbaud, ProviderInfo{
+		DisplayName: "Blackbaud",
+		AuthType:    Oauth2,
+		BaseURL:     "https://api.sky.blackbaud.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://app.blackbaud.com/oauth/authorize",
+			TokenURL:                  "https://oauth2.sky.blackbaud.com/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753783203/media/blackbaud.com_1753783202.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753783228/media/blackbaud.com_1753783228.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753783203/media/blackbaud.com_1753783202.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753783228/media/blackbaud.com_1753783228.png",
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/statistical-unit/v1/units
<img width="1482" height="817" alt="image" src="https://github.com/user-attachments/assets/8d62014d-9d1c-40b3-bbfa-f467f00a4299" />

### POST
URL: http://localhost:4444/statistical-unit/v1/units
<img width="1499" height="486" alt="image" src="https://github.com/user-attachments/assets/6a15c4b3-0418-4f00-9435-f2bfc668cabc" />

### GET by Id
URL: http://localhost:4444/statistical-unit/v1/units/2539
<img width="1487" height="579" alt="image" src="https://github.com/user-attachments/assets/46f9cd19-851f-4dc3-9a8c-897b16d18956" />

### PATCH
URL: http://localhost:4444/statistical-unit/v1/units/2539
<img width="1493" height="495" alt="image" src="https://github.com/user-attachments/assets/36f88c3f-3d66-4c2d-b5b4-bc35ec7eb50d" />

### DELETE
URL: http://localhost:4444/statistical-unit/v1/units/2539
<img width="1487" height="544" alt="image" src="https://github.com/user-attachments/assets/8abe6db5-15f0-4340-85cf-31c261619bbd" />

## Pagination
Result of requested **units** paginated list by uisng the **limit** query parameter.
URL: http://localhost:4444/statistical-unit/v1/units?limit=1
<img width="1483" height="692" alt="image" src="https://github.com/user-attachments/assets/98cfaeb3-e65a-42f4-974f-6c3517152898" />

Result of next requested **units** paginated list by using the **offset** query parameter.
URL: http://localhost:4444/statistical-unit/v1/units?limit=1&offset=1
<img width="1475" height="705" alt="image" src="https://github.com/user-attachments/assets/62f7fc91-8479-4030-aa50-8efbff54d8da" />

## Raw token response
<img width="1470" height="819" alt="image" src="https://github.com/user-attachments/assets/082989b9-2cae-4ef5-b25d-497b98c6f9af" />

# Logo & Icons
**Icons for Dark & Regular mode**
<img width="401" height="404" alt="image" src="https://github.com/user-attachments/assets/9eb3a058-7970-44db-847f-c2e6cb107b6c" />

**Logo for Dark & Regular mode**
<img width="749" height="513" alt="image" src="https://github.com/user-attachments/assets/394b13e5-7be5-4eaa-b982-875c409f4c2f" />

