### PR TITLE
[CON-2018] feat: [Highlevel] Read functionality

### DIFF
--- a/providers/highlevelstandard/connector.go
+++ b/providers/highlevelstandard/connector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -21,6 +22,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
+	components.Reader
 
 	locationId string
 }
@@ -51,6 +53,24 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.SingleObjectMetadataHandlers{
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
 			ErrorHandler: interpreter.ErrorHandler{
 				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
 			}.Handle,

--- a/providers/highlevelstandard/handlers.go
+++ b/providers/highlevelstandard/handlers.go
@@ -3,6 +3,7 @@ package highlevelstandard
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -102,4 +103,98 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	}
 
 	return &objectMetadata, nil
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	var (
+		nextPage int
+		err      error
+	)
+
+	if params.NextPage != "" {
+		// Parse the page number from NextPage
+		nextPage, err = strconv.Atoi(params.NextPage.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if objectsWithLocationIdInParam.Has(params.ObjectName) {
+		url.WithQueryParam("locationId", c.locationId)
+	}
+
+	if objectWithAltTypeAndIdQueryParam.Has(params.ObjectName) {
+		url.WithQueryParam("altId", c.locationId)
+		url.WithQueryParam("altType", "location")
+	}
+
+	if paginationObjects.Has(params.ObjectName) {
+		url.WithQueryParam("limit", strconv.Itoa(defaultPageSize))
+
+		if objectWithSkipQueryParam.Has(params.ObjectName) {
+			url.WithQueryParam("skip", strconv.Itoa(nextPage))
+		} else {
+			url.WithQueryParam("offset", strconv.Itoa(nextPage))
+		}
+	}
+
+	// For single-segment paths (e.g., "businesses"), the URL must have a trailing slash at the end.
+	// Example: https://highlevel.stoplight.io/docs/integrations/a8db8afcbe0a3-get-businesses-by-location
+	//
+	// For multi-segment paths (e.g., "calendars/groups"), the URL does not require a trailing slash.
+	// Example: https://highlevel.stoplight.io/docs/integrations/89e47b6c05e67-get-groups
+	if !(strings.Contains(params.ObjectName, "/")) {
+		urlRaw, err := url.ToURL()
+		if err != nil {
+			return nil, err
+		}
+
+		urlRaw.Path = urlRaw.Path + "/" // nolint:gocritic
+
+		url, err = urlbuilder.FromRawURL(urlRaw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Version", apiVersion)
+
+	return req, nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	var (
+		offset int
+		err    error
+	)
+
+	if params.NextPage.String() != "" {
+		offset, err = strconv.Atoi(params.NextPage.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return common.ParseResult(
+		response,
+		common.ExtractRecordsFromPath(objectsNodePath.Get(params.ObjectName)),
+		makeNextRecord(offset),
+		common.GetMarshaledData,
+		params.Fields,
+	)
 }

--- a/providers/highlevelstandard/read_test.go
+++ b/providers/highlevelstandard/read_test.go
@@ -1,0 +1,139 @@
+package highlevelstandard
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	businessesResponse := testutils.DataFromFile(t, "businesses.json")
+	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
+	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Read list of all businesses",
+			Input: common.ReadParams{ObjectName: "businesses", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/businesses/"),
+					mockcond.QueryParam("locationId", "iV1BEzddaWWLqU2kXhcN"),
+				},
+				Then: mockserver.Response(http.StatusOK, businessesResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"customFields": []any{},
+							"name":         "Msoft",
+							"locationId":   "iV1BEzddaWWLqU2kXhcN",
+							"createdBy": map[string]any{
+								"source":    "INTEGRATION",
+								"channel":   "OAUTH",
+								"sourceId":  "6789ed53f93f9a428151c88f-m60czadz",
+								"createdAt": "2025-01-23T12:01:48.429Z",
+							},
+							"createdAt": "2025-01-23T12:01:48.430Z",
+							"updatedAt": "2025-01-23T12:01:48.430Z",
+							"id":        "67922facc1844a515a6d72e5",
+						},
+					},
+				},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of all calendars groups",
+			Input: common.ReadParams{ObjectName: "calendars/groups", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/calendars/groups"),
+					mockcond.QueryParam("locationId", "iV1BEzddaWWLqU2kXhcN"),
+				},
+				Then: mockserver.Response(http.StatusOK, calendarsGroupsResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"id":          "c5d87HDX906XNUdQD3rS",
+							"name":        "test",
+							"description": "test description",
+							"slug":        "update",
+							"isActive":    true,
+							"dateAdded":   "2025-01-24T13:13:05.541Z",
+							"dateUpdated": "2025-01-24T13:22:00.493Z",
+						},
+					},
+				},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of all products collections",
+			Input: common.ReadParams{ObjectName: "products/collections", Fields: connectors.Fields(""), NextPage: "1"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/products/collections"),
+					mockcond.QueryParam("altId", "iV1BEzddaWWLqU2kXhcN"),
+					mockcond.QueryParam("altType", "location"),
+					mockcond.QueryParam("limit", "1"),
+					mockcond.QueryParam("offset", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, productsCollectionsResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"_id":       "68906b97862c0c73e894b772",
+							"altId":     "iV1BEzddaWWLqU2kXhcN",
+							"name":      "Best Sellers",
+							"slug":      "best-sellers",
+							"createdAt": "2025-08-04T08:13:11.574Z",
+						},
+					},
+				},
+				NextPage: "2",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/highlevelstandard/support.go
+++ b/providers/highlevelstandard/support.go
@@ -1,0 +1,62 @@
+package highlevelstandard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+// nolint:funlen
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := []string{
+		"businesses",
+		"calendars",
+		"calendars/groups",
+		"campaigns",
+		"conversations/search",
+		"emails/schedule",
+		"forms/submissions",
+		"forms",
+		"invoices",
+		"invoices/template",
+		"invoices/schedule",
+		"invoices/estimate/list",
+		"invoices/estimate/template",
+		"links",
+		"blogs/authors",
+		"blogs/categories",
+		"funnels/lookup/redirect/list",
+		"funnels/funnel/list",
+		"opportunities/pipelines",
+		"payment/orders",
+		"payments/transactions",
+		"payments/subscriptions",
+		"payments/coupon/list",
+		"products",
+		"products/inventory",
+		"products/collections",
+		"products/reviews",
+		"proposals/document",
+		"proposals/templates",
+		"store/shipping-zone",
+		"store/shipping-carrier",
+		"store/store-setting",
+		"snapshots",
+		"surveys",
+		"users",
+		"workflows",
+		"locations/search",
+		"custom-menus",
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/highlevelstandard/test/products_collections.json
+++ b/providers/highlevelstandard/test/products_collections.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "_id": "68906b97862c0c73e894b772",
+            "altId": "iV1BEzddaWWLqU2kXhcN",
+            "name": "Best Sellers",
+            "slug": "best-sellers",
+            "createdAt": "2025-08-04T08:13:11.574Z"
+        }
+    ],
+    "total": 1,
+    "traceId": "17094830-e0ab-4e31-ae2a-19bb289d837c"
+}

--- a/providers/highlevelstandard/utils.go
+++ b/providers/highlevelstandard/utils.go
@@ -1,8 +1,17 @@
 package highlevelstandard
 
-import "github.com/amp-labs/connectors/internal/datautils"
+import (
+	"strconv"
 
-const apiVersion = "2021-07-28"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/spyzhov/ajson"
+)
+
+const (
+	apiVersion      = "2021-07-28"
+	defaultPageSize = 100
+)
 
 var objectsWithLocationIdInParam = datautils.NewSet( //nolint:gochecknoglobals
 	"businesses",
@@ -121,3 +130,16 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	return "id"
 },
 )
+
+// makeNextRecord creates a function that determines the next page token based on the current offset.
+func makeNextRecord(offset int) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		if offset == 0 {
+			return "", nil
+		}
+
+		nextStart := offset + defaultPageSize
+
+		return strconv.Itoa(nextStart), nil
+	}
+}

--- a/providers/highlevelwhitelabel/connector.go
+++ b/providers/highlevelwhitelabel/connector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -21,6 +22,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
+	components.Reader
 
 	locationId string
 }
@@ -51,6 +53,24 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.SingleObjectMetadataHandlers{
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
 			ErrorHandler: interpreter.ErrorHandler{
 				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
 			}.Handle,

--- a/providers/highlevelwhitelabel/read_test.go
+++ b/providers/highlevelwhitelabel/read_test.go
@@ -1,0 +1,139 @@
+package highlevelwhitelabel
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	businessesResponse := testutils.DataFromFile(t, "businesses.json")
+	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
+	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Read list of all businesses",
+			Input: common.ReadParams{ObjectName: "businesses", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/businesses/"),
+					mockcond.QueryParam("locationId", "iV1BEzddaWWLqU2kXhcN"),
+				},
+				Then: mockserver.Response(http.StatusOK, businessesResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"customFields": []any{},
+							"name":         "Msoft",
+							"locationId":   "iV1BEzddaWWLqU2kXhcN",
+							"createdBy": map[string]any{
+								"source":    "INTEGRATION",
+								"channel":   "OAUTH",
+								"sourceId":  "6789ed53f93f9a428151c88f-m60czadz",
+								"createdAt": "2025-01-23T12:01:48.429Z",
+							},
+							"createdAt": "2025-01-23T12:01:48.430Z",
+							"updatedAt": "2025-01-23T12:01:48.430Z",
+							"id":        "67922facc1844a515a6d72e5",
+						},
+					},
+				},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of all calendars groups",
+			Input: common.ReadParams{ObjectName: "calendars/groups", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/calendars/groups"),
+					mockcond.QueryParam("locationId", "iV1BEzddaWWLqU2kXhcN"),
+				},
+				Then: mockserver.Response(http.StatusOK, calendarsGroupsResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"id":          "c5d87HDX906XNUdQD3rS",
+							"name":        "test",
+							"description": "test description",
+							"slug":        "update",
+							"isActive":    true,
+							"dateAdded":   "2025-01-24T13:13:05.541Z",
+							"dateUpdated": "2025-01-24T13:22:00.493Z",
+						},
+					},
+				},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of all products collections",
+			Input: common.ReadParams{ObjectName: "products/collections", Fields: connectors.Fields(""), NextPage: "1"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/products/collections"),
+					mockcond.QueryParam("altId", "iV1BEzddaWWLqU2kXhcN"),
+					mockcond.QueryParam("altType", "location"),
+					mockcond.QueryParam("limit", "1"),
+					mockcond.QueryParam("offset", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, productsCollectionsResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"_id":       "68906b97862c0c73e894b772",
+							"altId":     "iV1BEzddaWWLqU2kXhcN",
+							"name":      "Best Sellers",
+							"slug":      "best-sellers",
+							"createdAt": "2025-08-04T08:13:11.574Z",
+						},
+					},
+				},
+				NextPage: "2",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/highlevelwhitelabel/support.go
+++ b/providers/highlevelwhitelabel/support.go
@@ -1,0 +1,62 @@
+package highlevelwhitelabel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+// nolint:funlen
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := []string{
+		"businesses",
+		"calendars",
+		"calendars/groups",
+		"campaigns",
+		"conversations/search",
+		"emails/schedule",
+		"forms/submissions",
+		"forms",
+		"invoices",
+		"invoices/template",
+		"invoices/schedule",
+		"invoices/estimate/list",
+		"invoices/estimate/template",
+		"links",
+		"blogs/authors",
+		"blogs/categories",
+		"funnels/lookup/redirect/list",
+		"funnels/funnel/list",
+		"opportunities/pipelines",
+		"payment/orders",
+		"payments/transactions",
+		"payments/subscriptions",
+		"payments/coupon/list",
+		"products",
+		"products/inventory",
+		"products/collections",
+		"products/reviews",
+		"proposals/document",
+		"proposals/templates",
+		"store/shipping-zone",
+		"store/shipping-carrier",
+		"store/store-setting",
+		"snapshots",
+		"surveys",
+		"users",
+		"workflows",
+		"locations/search",
+		"custom-menus",
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/highlevelwhitelabel/test/products_collections.json
+++ b/providers/highlevelwhitelabel/test/products_collections.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "_id": "68906b97862c0c73e894b772",
+            "altId": "iV1BEzddaWWLqU2kXhcN",
+            "name": "Best Sellers",
+            "slug": "best-sellers",
+            "createdAt": "2025-08-04T08:13:11.574Z"
+        }
+    ],
+    "total": 1,
+    "traceId": "17094830-e0ab-4e31-ae2a-19bb289d837c"
+}

--- a/providers/highlevelwhitelabel/utils.go
+++ b/providers/highlevelwhitelabel/utils.go
@@ -1,8 +1,17 @@
 package highlevelwhitelabel
 
-import "github.com/amp-labs/connectors/internal/datautils"
+import (
+	"strconv"
 
-const apiVersion = "2021-07-28"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/spyzhov/ajson"
+)
+
+const (
+	apiVersion      = "2021-07-28"
+	defaultPageSize = 1
+)
 
 var objectsWithLocationIdInParam = datautils.NewSet( //nolint:gochecknoglobals
 	"businesses",
@@ -121,3 +130,16 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	return "id"
 },
 )
+
+// makeNextRecord creates a function that determines the next page token based on the current offset.
+func makeNextRecord(offset int) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		if offset == 0 {
+			return "", nil
+		}
+
+		nextStart := offset + defaultPageSize
+
+		return strconv.Itoa(nextStart), nil
+	}
+}

--- a/test/highlevelstandard/read/main.go
+++ b/test/highlevelstandard/read/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	ap "github.com/amp-labs/connectors/providers/highlevelstandard"
+	"github.com/amp-labs/connectors/test/highlevelstandard"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	conn := highlevelstandard.GetHighLevelStandardConnector(context.Background())
+
+	err := testRead(context.Background(), conn, "businesses", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "products/collections", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "calendars/groups", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testRead(ctx context.Context, conn *ap.Connector, objName string, fields []string) error {
+	params := common.ReadParams{
+		ObjectName: objName,
+		Fields:     connectors.Fields(fields...),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", objName, err)
+	}
+
+	// Print the results.
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}

--- a/test/highlevelwhitelabel/read/main.go
+++ b/test/highlevelwhitelabel/read/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	ap "github.com/amp-labs/connectors/providers/highlevelwhitelabel"
+	"github.com/amp-labs/connectors/test/highlevelwhitelabel"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	conn := highlevelwhitelabel.GetHighLevelWhiteLabelConnector(context.Background())
+
+	err := testRead(context.Background(), conn, "businesses", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "products/collections", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "calendars/groups", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testRead(ctx context.Context, conn *ap.Connector, objName string, fields []string) error {
+	params := common.ReadParams{
+		ObjectName: objName,
+		Fields:     connectors.Fields(fields...),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", objName, err)
+	}
+
+	// Print the results.
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
# Conventions
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Sample Read Response
<img width="1150" height="740" alt="image" src="https://github.com/user-attachments/assets/fc03a77f-abc4-4a23-b675-54b20057a220" />

<img width="1145" height="708" alt="image" src="https://github.com/user-attachments/assets/85b4067a-55c2-4bb7-b526-c8f6410378fb" />

# Test case Result
<img width="1532" height="896" alt="image" src="https://github.com/user-attachments/assets/7654aded-99ce-4912-8e0a-e90c9eef7e11" />
