### PR TITLE
[CON-1266] feat(copper): Metadata

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -25,6 +25,7 @@ import (
 	"github.com/amp-labs/connectors/providers/clickup"
 	"github.com/amp-labs/connectors/providers/closecrm"
 	"github.com/amp-labs/connectors/providers/constantcontact"
+	"github.com/amp-labs/connectors/providers/copper"
 	"github.com/amp-labs/connectors/providers/customerapp"
 	"github.com/amp-labs/connectors/providers/dixa"
 	"github.com/amp-labs/connectors/providers/docusign"
@@ -107,6 +108,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.ClickUp:                 wrapper(newClickUpConnector),
 	providers.Close:                   wrapper(newCloseConnector),
 	providers.ConstantContact:         wrapper(newConstantContactConnector),
+	providers.Copper:                  wrapper(newCopperConnector),
 	providers.CustomerJourneysApp:     wrapper(newCustomerJourneysAppConnector),
 	providers.Dixa:                    wrapper(newDixaConnector),
 	providers.Docusign:                wrapper(newDocusignConnector),
@@ -355,6 +357,12 @@ func newConstantContactConnector(
 	return constantcontact.NewConnector(
 		constantcontact.WithAuthenticatedClient(params.AuthenticatedClient),
 	)
+}
+
+func newCopperConnector(
+	params common.ConnectorParams,
+) (*copper.Connector, error) {
+	return copper.NewConnector(params)
 }
 
 func newKeapConnector(

--- a/providers/copper.go
+++ b/providers/copper.go
@@ -6,14 +6,23 @@ func init() {
 	// Copper configuration
 	SetInfo(Copper, ProviderInfo{
 		DisplayName: "Copper",
-		AuthType:    Oauth2,
-		BaseURL:     "https://api.copper.com/developer_api",
-		Oauth2Opts: &Oauth2Opts{
-			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://app.copper.com/oauth/authorize",
-			TokenURL:                  "https://app.copper.com/oauth/token",
-			ExplicitScopesRequired:    true,
-			ExplicitWorkspaceRequired: false,
+		// AuthType:    Oauth2,
+		AuthType: ApiKey,
+		BaseURL:  "https://api.copper.com/developer_api",
+		// Oauth2Opts: &Oauth2Opts{
+		//	GrantType:                 AuthorizationCode,
+		//	AuthURL:                   "https://app.copper.com/oauth/authorize",
+		//	TokenURL:                  "https://app.copper.com/oauth/token",
+		//	ExplicitScopesRequired:    true,
+		//	ExplicitWorkspaceRequired: false,
+		// },
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://developer.copper.com/introduction/authentication.html#api-keys",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{

--- a/providers/copper/connector.go
+++ b/providers/copper/connector.go
@@ -1,0 +1,43 @@
+package copper
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/copper/internal/metadata"
+)
+
+type Connector struct {
+	*components.Connector
+	common.RequireAuthenticatedClient
+	common.RequireMetadata
+
+	components.SchemaProvider
+
+	userEmail string
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	connector, err := components.Initialize(providers.Copper, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	connector.userEmail = params.Metadata["userEmail"]
+
+	return connector, nil
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector: base,
+		RequireMetadata: common.RequireMetadata{
+			ExpectedMetadataKeys: []string{"userEmail"},
+		},
+	}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
+
+	return connector, nil
+}

--- a/providers/copper/internal/metadata/metadata.go
+++ b/providers/copper/internal/metadata/metadata.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewReader[staticschema.FieldMetadataMapV2](schemas) // nolint:gochecknoglobals
+
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/copper/internal/metadata/schemas.json
+++ b/providers/copper/internal/metadata/schemas.json
@@ -1,0 +1,957 @@
+{
+  "modules": {
+    "root": {
+      "id": "root",
+      "path": "",
+      "objects": {
+        "activities": {
+          "displayName": "Activities",
+          "path": "/activities/search",
+          "responseKey": "",
+          "fields": {
+            "activity_date": {
+              "displayName": "activity_date",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "new_value": {
+              "displayName": "new_value",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "old_value": {
+              "displayName": "old_value",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "parent": {
+              "displayName": "parent",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "user_id": {
+              "displayName": "user_id",
+              "valueType": "float",
+              "providerType": "float"
+            }
+          }
+        },
+        "activity_types": {
+          "displayName": "Activity Types",
+          "path": "/activity_types",
+          "responseKey": "user",
+          "fields": {
+            "category": {
+              "displayName": "category",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "count_as_interaction": {
+              "displayName": "count_as_interaction",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "is_disabled": {
+              "displayName": "is_disabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "companies": {
+          "displayName": "Companies",
+          "path": "/companies/search",
+          "responseKey": "",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "contact_type_id": {
+              "displayName": "contact_type_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "email_domain": {
+              "displayName": "email_domain",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "interaction_count": {
+              "displayName": "interaction_count",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phone_numbers": {
+              "displayName": "phone_numbers",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "primary_contact_id": {
+              "displayName": "primary_contact_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "socials": {
+              "displayName": "socials",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "websites": {
+              "displayName": "websites",
+              "valueType": "other",
+              "providerType": "other"
+            }
+          }
+        },
+        "contact_types": {
+          "displayName": "Contact Types",
+          "path": "/contact_types",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "customer_sources": {
+          "displayName": "Customer Sources",
+          "path": "/customer_sources",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "lead_statuses": {
+          "displayName": "Lead Statuses",
+          "path": "/lead_statuses",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "is_default": {
+              "displayName": "is_default",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "order": {
+              "displayName": "order",
+              "valueType": "float",
+              "providerType": "float"
+            }
+          }
+        },
+        "leads": {
+          "displayName": "Leads",
+          "path": "/leads/search",
+          "responseKey": "",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "company_name": {
+              "displayName": "company_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "converted_at": {
+              "displayName": "converted_at",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "converted_contact_id": {
+              "displayName": "converted_contact_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "converted_opportunity_id": {
+              "displayName": "converted_opportunity_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "customer_source_id": {
+              "displayName": "customer_source_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_last_contacted": {
+              "displayName": "date_last_contacted",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "email": {
+              "displayName": "email",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "first_name": {
+              "displayName": "first_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "interaction_count": {
+              "displayName": "interaction_count",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "last_name": {
+              "displayName": "last_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "middle_name": {
+              "displayName": "middle_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "monetary_value": {
+              "displayName": "monetary_value",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phone_numbers": {
+              "displayName": "phone_numbers",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "prefix": {
+              "displayName": "prefix",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "socials": {
+              "displayName": "socials",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status_id": {
+              "displayName": "status_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "suffix": {
+              "displayName": "suffix",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "title": {
+              "displayName": "title",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "websites": {
+              "displayName": "websites",
+              "valueType": "other",
+              "providerType": "other"
+            }
+          }
+        },
+        "loss_reasons": {
+          "displayName": "Loss Reasons",
+          "path": "/loss_reasons",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "opportunities": {
+          "displayName": "Opportunities",
+          "path": "/opportunities/search",
+          "responseKey": "",
+          "fields": {
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "close_date": {
+              "displayName": "close_date",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "company_id": {
+              "displayName": "company_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "company_name": {
+              "displayName": "company_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "customer_source_id": {
+              "displayName": "customer_source_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_last_contacted": {
+              "displayName": "date_last_contacted",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_lead_created": {
+              "displayName": "date_lead_created",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "interaction_count": {
+              "displayName": "interaction_count",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "leads_converted_from": {
+              "displayName": "leads_converted_from",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "loss_reason_id": {
+              "displayName": "loss_reason_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "monetary_value": {
+              "displayName": "monetary_value",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "pipeline_id": {
+              "displayName": "pipeline_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "pipeline_is_revenue": {
+              "displayName": "pipeline_is_revenue",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "pipeline_stage_id": {
+              "displayName": "pipeline_stage_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "pipeline_type": {
+              "displayName": "pipeline_type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primary_contact_id": {
+              "displayName": "primary_contact_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "priority": {
+              "displayName": "priority",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "win_probability": {
+              "displayName": "win_probability",
+              "valueType": "float",
+              "providerType": "float"
+            }
+          }
+        },
+        "people": {
+          "displayName": "People",
+          "path": "/people/search",
+          "responseKey": "",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "company_id": {
+              "displayName": "company_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "company_name": {
+              "displayName": "company_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "contact_type_id": {
+              "displayName": "contact_type_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_last_contacted": {
+              "displayName": "date_last_contacted",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_lead_created": {
+              "displayName": "date_lead_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "emails": {
+              "displayName": "emails",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "first_name": {
+              "displayName": "first_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "interaction_count": {
+              "displayName": "interaction_count",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "last_name": {
+              "displayName": "last_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "leads_converted_from": {
+              "displayName": "leads_converted_from",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "middle_name": {
+              "displayName": "middle_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phone_numbers": {
+              "displayName": "phone_numbers",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "prefix": {
+              "displayName": "prefix",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "socials": {
+              "displayName": "socials",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "suffix": {
+              "displayName": "suffix",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "title": {
+              "displayName": "title",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "websites": {
+              "displayName": "websites",
+              "valueType": "other",
+              "providerType": "other"
+            }
+          }
+        },
+        "pipeline_stages": {
+          "displayName": "Pipeline Stages",
+          "path": "/pipeline_stages",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "pipeline_id": {
+              "displayName": "pipeline_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "win_probability": {
+              "displayName": "win_probability",
+              "valueType": "float",
+              "providerType": "float"
+            }
+          }
+        },
+        "pipelines": {
+          "displayName": "Pipelines",
+          "path": "/pipelines",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "is_revenue": {
+              "displayName": "is_revenue",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "stages": {
+              "displayName": "stages",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "projects": {
+          "displayName": "Projects",
+          "path": "/projects/search",
+          "responseKey": "",
+          "fields": {
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "related_resource": {
+              "displayName": "related_resource",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            }
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "/tags",
+          "responseKey": "",
+          "fields": {
+            "count": {
+              "displayName": "count",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_companies": {
+              "displayName": "count_companies",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_leads": {
+              "displayName": "count_leads",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_opportunities": {
+              "displayName": "count_opportunities",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_people": {
+              "displayName": "count_people",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_projects": {
+              "displayName": "count_projects",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "count_tasks": {
+              "displayName": "count_tasks",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "tasks": {
+          "displayName": "Tasks",
+          "path": "/tasks/search",
+          "responseKey": "",
+          "fields": {
+            "assignee_id": {
+              "displayName": "assignee_id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "completed_date": {
+              "displayName": "completed_date",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "custom_fields": {
+              "displayName": "custom_fields",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "date_created": {
+              "displayName": "date_created",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "date_modified": {
+              "displayName": "date_modified",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "details": {
+              "displayName": "details",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "due_date": {
+              "displayName": "due_date",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "priority": {
+              "displayName": "priority",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "related_resource": {
+              "displayName": "related_resource",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "reminder_date": {
+              "displayName": "reminder_date",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "other"
+            }
+          }
+        },
+        "users": {
+          "displayName": "Users",
+          "path": "/users/search",
+          "responseKey": "",
+          "fields": {
+            "email": {
+              "displayName": "email",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "groups": {
+              "displayName": "groups",
+              "valueType": "other",
+              "providerType": "other"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "float",
+              "providerType": "float"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/copper/metadata_test.go
+++ b/providers/copper/metadata_test.go
@@ -1,0 +1,90 @@
+package copper
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:       "Successful metadata for Projects and Leads",
+			Input:      []string{"projects", "leads"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"projects": {
+						DisplayName: "Projects",
+						Fields: map[string]common.FieldMetadata{
+							"name": {
+								DisplayName:  "name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"status": {
+								DisplayName:  "status",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"leads": {
+						DisplayName: "Leads",
+						Fields: map[string]common.FieldMetadata{
+							"first_name": {
+								DisplayName:  "first_name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"title": {
+								DisplayName:  "title",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		common.ConnectorParams{
+			AuthenticatedClient: mockutils.NewClient(),
+			Metadata: map[string]string{
+				"userEmail": "john@test.com",
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetUnitTestBaseURL(mockutils.ReplaceURLOrigin(connector.ModuleInfo().BaseURL, serverURL))
+
+	return connector, nil
+}

--- a/scripts/schemadocs/copper/main.go
+++ b/scripts/schemadocs/copper/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	//go:embed samples.json
+	samplesData []byte
+
+	outputCopper = scrapper.NewWriter[staticschema.FieldMetadataMapV2]( // nolint:gochecknoglobals
+		fileconv.NewPath("providers/copper/internal/metadata"))
+)
+
+// Script uses object samples from Documentation https://developer.copper.com/index.html.
+// Each sample is used to extract field names to construct schema.json which will be returned via ListObjectMetadata.
+func main() {
+	var definitions []objectDefinition
+
+	err := json.Unmarshal(samplesData, &definitions)
+	goutils.MustBeNil(err)
+
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
+
+	for _, definition := range definitions {
+		for _, field := range definition.GetFields() {
+			url := strings.ReplaceAll(definition.URL, "https://api.copper.com/developer_api/v1", "")
+			schemas.Add(common.ModuleRoot, definition.Name, definition.DisplayName, url,
+				definition.ResponseKey, field, nil, nil)
+		}
+	}
+
+	goutils.MustBeNil(outputCopper.FlushSchemas(schemas))
+
+	log.Println("Completed.")
+}
+
+type objectDefinition struct {
+	Name        string         `json:"name"`
+	DisplayName string         `json:"displayName"`
+	ResponseKey string         `json:"responseKey"`
+	URL         string         `json:"url"`
+	Sample      map[string]any `json:"sample"`
+}
+
+func (d objectDefinition) GetFields() []staticschema.FieldMetadataMapV2 {
+	fields := make([]staticschema.FieldMetadataMapV2, 0)
+
+	for fieldName, value := range d.Sample {
+		primitiveType := getPrimitiveType(value)
+		fields = append(fields, staticschema.FieldMetadataMapV2{
+			fieldName: staticschema.FieldMetadata{
+				DisplayName:  fieldName,
+				ValueType:    primitiveType,
+				ProviderType: string(primitiveType),
+				ReadOnly:     false,
+				Values:       nil,
+			},
+		})
+	}
+
+	return fields
+}
+
+func getPrimitiveType(value any) common.ValueType {
+	switch value.(type) {
+	case string:
+		return common.ValueTypeString
+	case bool:
+		return common.ValueTypeBoolean
+	case float32, float64:
+		return common.ValueTypeFloat
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return common.ValueTypeInt
+	default:
+		return common.ValueTypeOther
+	}
+}

--- a/scripts/schemadocs/copper/samples.json
+++ b/scripts/schemadocs/copper/samples.json
@@ -1,0 +1,454 @@
+[
+  {
+    "name": "users",
+    "displayName": "Users",
+    "url": "https://api.copper.com/developer_api/v1/users/search",
+    "sample": {
+      "id": 137658,
+      "name": "John Doe",
+      "email": "johndoe@copper.com",
+      "groups": []
+    }
+  },
+  {
+    "name": "leads",
+    "displayName": "Leads",
+    "url": "https://api.copper.com/developer_api/v1/leads/search",
+    "sample": {
+      "id": 9150547,
+      "name": "My Contact",
+      "prefix": "",
+      "first_name": "My",
+      "last_name": "Contact",
+      "middle_name": "",
+      "suffix": "",
+      "address": null,
+      "assignee_id": null,
+      "company_name": "",
+      "customer_source_id": null,
+      "details": "",
+      "email": {
+        "email": "mycontact@noemail.com",
+        "category": "work"
+      },
+      "interaction_count": 0,
+      "monetary_value": 123,
+      "socials": [],
+      "status": "New",
+      "status_id": 208231,
+      "tags": [],
+      "title": "",
+      "websites": [],
+      "phone_numbers": [],
+      "custom_fields": [
+        {
+          "custom_field_definition_id": 100764,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 103481,
+          "value": null
+        }
+      ],
+      "date_created": 1490045162,
+      "date_modified": 1490045162,
+      "date_last_contacted": 1490045162,
+      "converted_opportunity_id": null,
+      "converted_contact_id": null,
+      "converted_at": null
+    }
+  },
+  {
+    "name": "customer_sources",
+    "displayName": "Customer Sources",
+    "url": "https://api.copper.com/developer_api/v1/customer_sources",
+    "sample": {
+      "id": 331240,
+      "name": "Email"
+    }
+  },
+  {
+    "name": "lead_statuses",
+    "displayName": "Lead Statuses",
+    "url": "https://api.copper.com/developer_api/v1/lead_statuses",
+    "sample": {
+      "id": 208231,
+      "name": "New",
+      "order": 1,
+      "is_default": true
+    }
+  },
+  {
+    "name": "people",
+    "displayName": "People",
+    "url": "https://api.copper.com/developer_api/v1/people/search",
+    "sample": {
+      "id": 7,
+      "name": "Jim Halpert",
+      "prefix": "",
+      "first_name": "Jim",
+      "middle_name": "",
+      "last_name": "Halpert",
+      "suffix": "",
+      "address": {
+        "street": "221 Main Street Suite 1350",
+        "city": "Vancouver",
+        "state": "BC",
+        "postal_code": "A1A1A1",
+        "country": "CA"
+      },
+      "assignee_id": null,
+      "company_id": 2,
+      "company_name": "ProsperWorks",
+      "contact_type_id": 8,
+      "details": "",
+      "emails": [
+        {
+          "email": "jhalpert@prosperworks.com",
+          "category": "work"
+        }
+      ],
+      "phone_numbers": [
+        {
+          "number": "4158546956",
+          "category": "work"
+        }
+      ],
+      "socials": [
+        {
+          "url": "https://www.linkedin.com/in/jimhalpert",
+          "category": "linkedin"
+        }
+      ],
+      "tags": [
+        "tag1"
+      ],
+      "title": "Business Development",
+      "websites": [
+        {
+          "url": "www.prosperworks.com",
+          "category": "work"
+        }
+      ],
+      "custom_fields": [
+        {
+          "custom_field_definition_id": 6,
+          "value": 1515744000
+        },
+        {
+          "custom_field_definition_id": 12,
+          "value": [
+            8
+          ]
+        }
+      ],
+      "date_created": 1516262400,
+      "date_modified": 1516313340,
+      "date_last_contacted": 1516313330,
+      "interaction_count": 2,
+      "leads_converted_from": [],
+      "date_lead_created": 123
+    }
+  },
+  {
+    "name": "contact_types",
+    "displayName": "Contact Types",
+    "url": "https://api.copper.com/developer_api/v1/contact_types",
+    "sample": {
+      "id": 451490,
+      "name": "Potential Customer"
+    }
+  },
+  {
+    "name": "companies",
+    "displayName": "Companies",
+    "url": "https://api.copper.com/developer_api/v1/companies/search",
+    "sample": {
+      "id": 13358412,
+      "name": "Demo Company",
+      "address": {
+        "street": "123 Main St",
+        "city": "San Francisco",
+        "state": "CA",
+        "postal_code": "94105",
+        "country": null
+      },
+      "assignee_id": null,
+      "contact_type_id": null,
+      "details": "This is a demo company",
+      "email_domain": "democompany.com",
+      "phone_numbers": [
+        {
+          "number": "415-123-45678",
+          "category": "work"
+        }
+      ],
+      "primary_contact_id": 27140361,
+      "socials": [],
+      "tags": [],
+      "websites": [
+        {
+          "url": "http://democompany.com",
+          "category": "work"
+        }
+      ],
+      "custom_fields": [
+        {
+          "custom_field_definition_id": 100764,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 103481,
+          "value": null
+        }
+      ],
+      "interaction_count": 0,
+      "date_created": 1496707930,
+      "date_modified": 1496707932
+    }
+  },
+  {
+    "name": "opportunities",
+    "displayName": "Opportunities",
+    "url": "https://api.copper.com/developer_api/v1/opportunities/search",
+    "sample": {
+      "id": 2827699,
+      "name": "25 Office Chairs (sample)",
+      "assignee_id": null,
+      "close_date": "1/16/2017",
+      "company_id": 9607580,
+      "company_name": "Dunder Mifflin (sample)",
+      "customer_source_id": 331242,
+      "details": "Opportunities are created for People and Companies that are interested in buying your products or services. Create Opportunities for People and Companies to move them through one of your Pipelines.",
+      "loss_reason_id": null,
+      "pipeline_id": 213214,
+      "pipeline_is_revenue": false,
+      "pipeline_stage_id": 987793,
+      "pipeline_type": "opportunity",
+      "primary_contact_id": null,
+      "priority": "None",
+      "status": "Open",
+      "tags": [],
+      "interaction_count": 0,
+      "monetary_value": 75000,
+      "win_probability": 40,
+      "date_last_contacted": null,
+      "leads_converted_from": [],
+      "date_lead_created": null,
+      "date_created": 1483988829,
+      "date_modified": 1489018922,
+      "custom_fields": [
+        {
+          "custom_field_definition_id": 126240,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 103481,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 100764,
+          "value": null
+        }
+      ]
+    }
+  },
+  {
+    "name": "loss_reasons",
+    "displayName": "Loss Reasons",
+    "url": "https://api.copper.com/developer_api/v1/loss_reasons",
+    "sample": {
+      "id": 308806,
+      "name": "Price"
+    }
+  },
+  {
+    "name": "pipelines",
+    "displayName": "Pipelines",
+    "url": "https://api.copper.com/developer_api/v1/pipelines",
+    "sample": {
+      "id": 213214,
+      "name": "Sales",
+      "stages": [
+        {
+          "id": 987790,
+          "name": "Qualified",
+          "win_probability": 5
+        },
+        {
+          "id": 987791,
+          "name": "Follow-up",
+          "win_probability": 10
+        },
+        {
+          "id": 987792,
+          "name": "Presentation",
+          "win_probability": 20
+        },
+        {
+          "id": 987793,
+          "name": "Contract Sent",
+          "win_probability": 40
+        },
+        {
+          "id": 987794,
+          "name": "Negotiation",
+          "win_probability": 80
+        }
+      ],
+      "type": "opportunity",
+      "is_revenue": false
+    }
+  },
+  {
+    "name": "pipeline_stages",
+    "displayName": "Pipeline Stages",
+    "url": "https://api.copper.com/developer_api/v1/pipeline_stages",
+    "sample": {
+      "id": 987790,
+      "name": "Qualified",
+      "pipeline_id": 213214,
+      "win_probability": 5
+    }
+  },
+  {
+    "name": "projects",
+    "displayName": "Projects",
+    "url": "https://api.copper.com/developer_api/v1/projects/search",
+    "sample": {
+      "id": 1,
+      "name": "Customize Your New CRM",
+      "related_resource": {
+        "id": 2,
+        "type": "company"
+      },
+      "assignee_id": 2,
+      "status": "Open",
+      "details": "Visit our settings section to discover all the ways you can customize Copper to fit your sales workflow.",
+      "tags": [
+        "tag1"
+      ],
+      "custom_fields": [
+        {
+          "custom_field_definition_id": 6,
+          "value": 1515744000
+        },
+        {
+          "custom_field_definition_id": 12,
+          "value": [
+            8
+          ]
+        },
+        {
+          "custom_field_definition_id": 8,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 11,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 9,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 7,
+          "value": false
+        },
+        {
+          "custom_field_definition_id": 3,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 4,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 10,
+          "value": null
+        },
+        {
+          "custom_field_definition_id": 5,
+          "value": null
+        }
+      ],
+      "date_created": 1515434872,
+      "date_modified": 1516819000
+    }
+  },
+  {
+    "name": "tags",
+    "displayName": "Tags",
+    "url": "https://api.copper.com/developer_api/v1/tags",
+    "sample": {
+      "name": "Apples",
+      "count": 5,
+      "count_people": 1,
+      "count_leads": 1,
+      "count_companies": 1,
+      "count_opportunities": 1,
+      "count_projects": 1,
+      "count_tasks": 0
+    }
+  },
+  {
+    "name": "tasks",
+    "displayName": "Tasks",
+    "url": "https://api.copper.com/developer_api/v1/tasks/search",
+    "sample": {
+      "id": 3726701,
+      "name": "Demo Task",
+      "related_resource": {
+        "id": null,
+        "type": null
+      },
+      "assignee_id": 137658,
+      "due_date": 123,
+      "reminder_date": 123,
+      "completed_date": null,
+      "priority": "None",
+      "status": "Open",
+      "details": "",
+      "tags": [],
+      "custom_fields": [],
+      "date_created": 1496771985,
+      "date_modified": 1496771985
+    }
+  },
+  {
+    "name": "activities",
+    "displayName": "Activities",
+    "url": "https://api.copper.com/developer_api/v1/activities/search",
+    "sample": {
+      "id": 3064242278,
+      "parent": {
+        "id": 27140359,
+        "type": "person"
+      },
+      "type": {
+        "id": 0,
+        "category": "user"
+      },
+      "user_id": 137658,
+      "details": "This is the description of this note",
+      "activity_date": 1496772355,
+      "old_value": null,
+      "new_value": null,
+      "date_created": 1496772355,
+      "date_modified": 1496772355
+    }
+  },
+  {
+    "name": "activity_types",
+    "displayName": "Activity Types",
+    "responseKey": "user",
+    "url": "https://api.copper.com/developer_api/v1/activity_types",
+    "sample": {
+      "id": 0,
+      "category": "user",
+      "name": "Note",
+      "is_disabled": false,
+      "count_as_interaction": false
+    }
+  }
+]

--- a/test/copper/connector.go
+++ b/test/copper/connector.go
@@ -1,0 +1,40 @@
+package copper
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/copper"
+	"github.com/amp-labs/connectors/test/utils"
+	testUtils "github.com/amp-labs/connectors/test/utils"
+)
+
+// nolint:gochecknoglobals
+var (
+	fieldUserEmail = credscanning.Field{
+		Name:      "userEmail",
+		PathJSON:  "metadata.userEmail",
+		SuffixENV: "USER_EMAIL",
+	}
+)
+
+func GetCopperConnector(ctx context.Context) *copper.Connector {
+	filePath := credscanning.LoadPath(providers.Copper)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false, fieldUserEmail)
+
+	conn, err := copper.NewConnector(
+		common.ConnectorParams{
+			AuthenticatedClient: utils.NewAPIKeyClient(ctx, reader, providers.Copper),
+			Metadata: map[string]string{
+				"userEmail": reader.Get(fieldUserEmail),
+			},
+		},
+	)
+	if err != nil {
+		testUtils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/copper/metadata/main.go
+++ b/test/copper/metadata/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/copper"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetCopperConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"people", "tags",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}


### PR DESCRIPTION
# Description
Sample response objects for each endpoint are coppied into one file and used to extract `schema.json`.

# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Custom fields, if not human readable names, are resolved to readable names.
   * This is not covered in this PR for simplicity
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

# Live Tests
<img width="348" height="399" alt="image" src="https://github.com/user-attachments/assets/9a9f3e2b-0df7-4ab2-8eeb-716bcf7ac50c" />