### PR TITLE
[CON-1268] feat(copper): Write

### DIFF
--- a/providers/copper/connector.go
+++ b/providers/copper/connector.go
@@ -5,9 +5,11 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/copper/internal/metadata"
 )
@@ -27,6 +29,8 @@ type Connector struct {
 
 	components.SchemaProvider
 	components.Reader
+	components.Writer
+	components.Deleter
 
 	userEmail string
 }
@@ -67,6 +71,29 @@ func constructor(base *components.Connector) (*Connector, error) {
 		},
 	)
 
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
+	// Set the deleter for the connector
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
 	return connector, nil
 }
 
@@ -77,6 +104,10 @@ func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
 	}
 
 	return urlbuilder.New(c.ModuleInfo().BaseURL, apiVersion, objectPath)
+}
+
+func (c *Connector) getWriteURL(objectName string, id string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, objectName, id)
 }
 
 // https://developer.copper.com/introduction/requests.html#headers

--- a/providers/copper/delete_test.go
+++ b/providers/copper/delete_test.go
@@ -1,0 +1,73 @@
+package copper
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "projects"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name:  "Remove Company",
+			Input: common.DeleteParams{ObjectName: "companies", RecordId: "73615382"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodDELETE(),
+					mockcond.Path("/developer_api/v1/companies/73615382"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Remove Project",
+			Input: common.DeleteParams{ObjectName: "projects", RecordId: "1621193"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodDELETE(),
+					mockcond.Path("/developer_api/v1/projects/1621193"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/copper/handlers.go
+++ b/providers/copper/handlers.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/providers/copper/internal/metadata"
 	"github.com/spyzhov/ajson"
 )
@@ -117,4 +119,90 @@ func makeNextRecordsURL(params common.ReadParams) common.NextPageFunc {
 
 		return strconv.Itoa(pageNum), nil
 	}
+}
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	url, err := c.getWriteURL(params.ObjectName, params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	method := http.MethodPost
+	if len(params.RecordId) != 0 {
+		method = http.MethodPut
+	}
+
+	jsonData, err := json.Marshal(params.RecordData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal record data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	applicationHeader.ApplyToRequest(req)
+	c.emailHeader().ApplyToRequest(req)
+
+	return req, nil
+}
+
+func (c *Connector) parseWriteResponse(ctx context.Context, params common.WriteParams,
+	request *http.Request, response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		// it is unlikely to have no payload
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	recordID, err := jsonquery.New(body).TextWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Errors:   nil,
+		Data:     data,
+	}, nil
+}
+
+func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	url, err := c.getWriteURL(params.ObjectName, params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	applicationHeader.ApplyToRequest(req)
+	c.emailHeader().ApplyToRequest(req)
+
+	return req, nil
+}
+
+func (c *Connector) parseDeleteResponse(ctx context.Context, params common.DeleteParams,
+	request *http.Request, response *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	if response.Code != http.StatusOK && response.Code != http.StatusNoContent {
+		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, response.Code)
+	}
+
+	// Response body is not used.
+	return &common.DeleteResult{
+		Success: true,
+	}, nil
 }

--- a/providers/copper/internal/metadata/README.md
+++ b/providers/copper/internal/metadata/README.md
@@ -1,0 +1,43 @@
+# Write
+
+### activities
+POST https://api.copper.com/developer_api/v1/activities
+PUT  https://api.copper.com/developer_api/v1/activities/{{update_activity_id}}
+https://developer.copper.com/activities/create-a-new-activity.html
+https://developer.copper.com/activities/update-an-activity.html
+
+### companies
+POST https://api.copper.com/developer_api/v1/companies
+PUT  https://api.copper.com/developer_api/v1/companies/{{example_company_id}}
+https://developer.copper.com/companies/create-a-new-company.html
+https://developer.copper.com/companies/update-a-company.html
+
+### leads
+POST https://api.copper.com/developer_api/v1/leads
+PUT  https://api.copper.com/developer_api/v1/leads/{{example_lead_id}}
+https://developer.copper.com/leads/create-a-new-lead.html
+https://developer.copper.com/leads/update-a-lead.html
+
+### opportunities
+POST https://api.copper.com/developer_api/v1/opportunities
+PUT  https://api.copper.com/developer_api/v1/opportunities/{{example_opportunity_id}}
+https://developer.copper.com/opportunities/create-a-new-opportunity.html
+https://developer.copper.com/opportunities/update-an-opportunity.html
+
+### people
+POST https://api.copper.com/developer_api/v1/people
+PUT  https://api.copper.com/developer_api/v1/people/{{example_person_id}}
+https://developer.copper.com/people/create-a-new-person.html
+https://developer.copper.com/people/update-a-person.html
+
+### projects
+POST https://api.copper.com/developer_api/v1/projects
+PUT  https://api.copper.com/developer_api/v1/projects/{{example_project_id}}
+https://developer.copper.com/projects/create-a-new-project.html
+https://developer.copper.com/projects/update-a-project.html
+
+### tasks
+POST https://api.copper.com/developer_api/v1/tasks
+PUT  https://api.copper.com/developer_api/v1/tasks/{{example_task_id}}
+https://developer.copper.com/tasks/create-a-new-task.html
+https://developer.copper.com/tasks/update-a-task.html

--- a/providers/copper/test/write/companies/new.json
+++ b/providers/copper/test/write/companies/new.json
@@ -1,0 +1,18 @@
+{
+  "id": 73615382,
+  "name": "Demo Company",
+  "address": null,
+  "assignee_id": null,
+  "contact_type_id": null,
+  "details": null,
+  "email_domain": null,
+  "phone_numbers": [],
+  "primary_contact_id": null,
+  "socials": [],
+  "tags": [],
+  "websites": [],
+  "custom_fields": [],
+  "interaction_count": 0,
+  "date_created": 1754503301,
+  "date_modified": 1754503301
+}

--- a/providers/copper/test/write/projects/new.json
+++ b/providers/copper/test/write/projects/new.json
@@ -1,0 +1,12 @@
+{
+  "id": 1621193,
+  "name": "Great project",
+  "related_resource": null,
+  "assignee_id": null,
+  "status": "Open",
+  "details": null,
+  "tags": [],
+  "custom_fields": [],
+  "date_created": 1754503153,
+  "date_modified": 1754503153
+}

--- a/providers/copper/test/write/unprocessable-entity.json
+++ b/providers/copper/test/write/unprocessable-entity.json
@@ -1,0 +1,5 @@
+{
+  "success": false,
+  "status": 422,
+  "message": "Invalid input: Validation errors: Name: can't be blank"
+}

--- a/providers/copper/write_test.go
+++ b/providers/copper/write_test.go
@@ -1,0 +1,154 @@
+package copper
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	responseUnprocessableEntity := testutils.DataFromFile(t, "write/unprocessable-entity.json")
+	responseCompanies := testutils.DataFromFile(t, "write/companies/new.json")
+	responseProjects := testutils.DataFromFile(t, "write/projects/new.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Error unprocessable entity",
+			Input: common.WriteParams{ObjectName: "companies", RecordData: map[string]any{}},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, responseUnprocessableEntity),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Invalid input: Validation errors: Name: can't be blank"), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Create company via POST",
+			Input: common.WriteParams{ObjectName: "companies", RecordData: "dummy"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/developer_api/v1/companies"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCompanies),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "73615382",
+				Errors:   nil,
+				Data: map[string]any{
+					"name":          "Demo Company",
+					"date_created":  float64(1754503301),
+					"date_modified": float64(1754503301),
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Update company via PUT",
+			Input: common.WriteParams{ObjectName: "companies", RecordId: "73615382", RecordData: "dummy"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPUT(),
+					mockcond.Path("/developer_api/v1/companies/73615382"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCompanies),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "73615382",
+				Errors:   nil,
+				Data: map[string]any{
+					"name":          "Demo Company",
+					"date_created":  float64(1754503301),
+					"date_modified": float64(1754503301),
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Create project via POST",
+			Input: common.WriteParams{ObjectName: "projects", RecordData: "dummy"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/developer_api/v1/projects"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK, responseProjects),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "1621193",
+				Errors:   nil,
+				Data: map[string]any{
+					"name":   "Great project",
+					"status": "Open",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Update project via PUT",
+			Input: common.WriteParams{ObjectName: "projects", RecordData: "dummy", RecordId: "1621193"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPUT(),
+					mockcond.Path("/developer_api/v1/projects/1621193"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK, responseProjects),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "1621193",
+				Errors:   nil,
+				Data: map[string]any{
+					"name":   "Great project",
+					"status": "Open",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/copper/write-delete/companies/main.go
+++ b/test/copper/write-delete/companies/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/copper"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type companyPayload struct {
+	Name    string `json:"name"`
+	Details string `json:"details"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetCopperConnector(ctx)
+
+	name := gofakeit.Name()
+	updatedName := gofakeit.Name()
+	details := gofakeit.Name()
+	updatedDetails := gofakeit.Name()
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"companies",
+		companyPayload{
+			Name:    name,
+			Details: details,
+		},
+		companyPayload{
+			Name:    updatedName,
+			Details: updatedDetails,
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields:       datautils.NewSet("id", "name", "details"),
+			WaitBeforeSearch: 40 * time.Second,
+			SearchBy: testscenario.Property{
+				Key:   "name",
+				Value: name,
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"name":    updatedName,
+				"details": updatedDetails,
+			},
+		},
+	)
+}

--- a/test/copper/write-delete/projects/main.go
+++ b/test/copper/write-delete/projects/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/copper"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type projectPayload struct {
+	Name string `json:"name"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetCopperConnector(ctx)
+
+	name := gofakeit.Name()
+	updatedName := gofakeit.Name()
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"projects",
+		projectPayload{
+			Name: name,
+		},
+		projectPayload{
+			Name: updatedName,
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields:       datautils.NewSet("id", "name"),
+			WaitBeforeSearch: 40 * time.Second,
+			SearchBy: testscenario.Property{
+				Key:   "name",
+				Value: name,
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"name": updatedName,
+			},
+		},
+	)
+}


### PR DESCRIPTION
# Installation
Mailmonkey using API key/Oauth2 with scopes/Password, etc.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [ ] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [ ] Insert screenshot of metadata fields from read object installation.
Ex: ![image](https://github.com/user-attachments/assets/ebc027fb-b82b-4505-ac71-f2b61209fa4d)
- [ ] Insert screenshot of Svix destination.
- [ ] Screenshot of operations on dashboard

# Write
For each write object:
- [ ] Insert screenshot of dashboard.
- [ ] Insert screenshot of HTTP call.

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata
