### PR TITLE
[CON-1266,CON-1267] feat(copper): Custom fields

### DIFF
--- a/internal/datautils/set.go
+++ b/internal/datautils/set.go
@@ -1,5 +1,10 @@
 package datautils
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // NewStringSet and StringSet are Aliases.
 var NewStringSet = NewSet[string] // nolint:gochecknoglobals
 type StringSet = Set[string]
@@ -105,4 +110,19 @@ func (s Set[T]) Remove(key T) {
 
 func (s Set[T]) IsEmpty() bool {
 	return len(s) == 0
+}
+
+func (s Set[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.List())
+}
+
+func (s *Set[T]) UnmarshalJSON(bytes []byte) error {
+	var items []T
+	if err := json.Unmarshal(bytes, &items); err != nil {
+		return fmt.Errorf("Set[T] unmarshal error: %w", err)
+	}
+
+	*s = NewSetFromList(items)
+
+	return nil
 }

--- a/providers/copper/connector.go
+++ b/providers/copper/connector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
-	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/copper/internal/metadata"
@@ -28,7 +27,6 @@ type Connector struct {
 	common.RequireAuthenticatedClient
 	common.RequireMetadata
 
-	components.SchemaProvider
 	components.Reader
 	components.Writer
 	components.Deleter
@@ -58,8 +56,6 @@ func constructor(base *components.Connector) (*Connector, error) {
 	errorHandler := interpreter.ErrorHandler{
 		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
 	}.Handle
-
-	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
 	connector.Reader = reader.NewHTTPReader(
 		connector.HTTPClient().Client,
@@ -109,6 +105,10 @@ func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
 
 func (c *Connector) getWriteURL(objectName string, id string) (*urlbuilder.URL, error) {
 	return urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, objectName, id)
+}
+
+func (c *Connector) getCustomFieldsURL() (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, "custom_field_definitions")
 }
 
 // emailHeader is required for all REST API calls.

--- a/providers/copper/custom.go
+++ b/providers/copper/custom.go
@@ -1,0 +1,151 @@
+package copper
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// Custom Field Definitions.
+// https://developer.copper.com/custom-fields/general/list-custom-field-definitions.html
+type customFieldsRegistry map[int]customFieldResponse
+
+type customFieldsResponse []customFieldResponse
+
+// nolint:tagliatelle
+type customFieldResponse struct {
+	ID           int                 `json:"id"`
+	DisplayName  string              `json:"name"`
+	DataType     string              `json:"data_type"`
+	AvailableOn  datautils.StringSet `json:"available_on"`
+	IsFilterable bool                `json:"is_filterable"`
+	Options      []customFieldOption `json:"options,omitempty"`
+	ConnectedId  int                 `json:"connected_id,omitempty"`
+	Currency     string              `json:"currency,omitempty"`
+}
+
+type customFieldOption struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+	Rank int    `json:"rank"`
+}
+
+func (r customFieldsResponse) FilterByObjectName(objectName string) customFieldsResponse {
+	filtered := make([]customFieldResponse, 0)
+
+	for _, field := range r {
+		if field.BelongsToObject(objectName) {
+			filtered = append(filtered, field)
+		}
+	}
+
+	return filtered
+}
+
+func (r customFieldsResponse) CreateRegistry() customFieldsRegistry {
+	registry := make(customFieldsRegistry)
+
+	for _, fields := range r {
+		registry[fields.ID] = fields
+	}
+
+	return registry
+}
+
+func (c customFieldResponse) Name() string {
+	// In-house format for custom field.
+	return "custom_field_" + strings.ToLower(strings.ReplaceAll(c.DisplayName, " ", "_"))
+}
+
+func (c customFieldResponse) BelongsToObject(objectName string) bool {
+	return c.AvailableOn.Has(
+		naming.NewSingularString(objectName).String(),
+	)
+}
+
+func (c customFieldResponse) getValues() []common.FieldValue {
+	fields := make([]common.FieldValue, 0)
+
+	for _, option := range c.Options {
+		fields = append(fields, common.FieldValue{
+			Value:        strconv.Itoa(option.Id),
+			DisplayValue: option.Name,
+		})
+	}
+
+	if len(fields) == 0 {
+		return nil
+	}
+
+	return fields
+}
+
+func (c *Connector) fetchCustomFields(ctx context.Context) (*customFieldsResponse, error) {
+	url, err := c.getCustomFieldsURL()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.JSONHTTPClient().Get(ctx, url.String(), c.emailHeader(), applicationHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	customFields, err := common.UnmarshalJSON[customFieldsResponse](res)
+	if err != nil {
+		return nil, err
+	}
+
+	return customFields, nil
+}
+
+func (c *Connector) attachReadCustomFields(customFields *customFieldsResponse) common.RecordTransformer {
+	return func(node *ajson.Node) (map[string]any, error) {
+		if customFields == nil || len(*customFields) == 0 {
+			// No custom fields, no-op, return as is.
+			return jsonquery.Convertor.ObjectToMap(node)
+		}
+
+		return enhanceObjectsWithCustomFieldNames(node, customFields.CreateRegistry())
+	}
+}
+
+func enhanceObjectsWithCustomFieldNames(
+	node *ajson.Node, fieldsRegistry customFieldsRegistry,
+) (map[string]any, error) {
+	object, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := jsonquery.ParseNode[readCustomFieldsResponse](node)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace identifiers with human-readable field names which were found by making a call to "/model".
+	for _, field := range resp.CustomFields {
+		if fieldDefinition, ok := fieldsRegistry[field.ID]; ok {
+			object[fieldDefinition.Name()] = field.Value
+		}
+	}
+
+	return object, nil
+}
+
+// nolint:tagliatelle
+type readCustomFieldsResponse struct {
+	CustomFields []readCustomField `json:"custom_fields"`
+}
+
+// nolint:tagliatelle
+type readCustomField struct {
+	ID    int `json:"custom_field_definition_id"`
+	Value any `json:"value"`
+}

--- a/providers/copper/metadata.go
+++ b/providers/copper/metadata.go
@@ -1,0 +1,65 @@
+package copper
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/copper/internal/metadata"
+)
+
+func (c *Connector) ListObjectMetadata(ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	allExistingCustomFields, err := c.fetchCustomFields(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	data := common.NewListObjectMetadataResult()
+
+	for _, objectName := range objectNames {
+		objectMetadata, err := metadata.Schemas.SelectOne(c.Module(), objectName)
+		if err != nil {
+			data.AppendError(objectName, err)
+
+			continue
+		}
+
+		for _, field := range allExistingCustomFields.FilterByObjectName(objectName) {
+			objectMetadata.AddFieldMetadata(field.Name(), common.FieldMetadata{
+				DisplayName:  field.DisplayName,
+				ValueType:    getFieldValueType(field),
+				ProviderType: field.DataType,
+				ReadOnly:     false,
+				Values:       field.getValues(),
+			})
+		}
+
+		data.Result[objectName] = *objectMetadata
+	}
+
+	return data, nil
+}
+
+func getFieldValueType(field customFieldResponse) common.ValueType {
+	switch field.DataType {
+	case "String", "Text", "URL":
+		return common.ValueTypeString
+	case "Currency", "Float", "Percentage":
+		return common.ValueTypeFloat
+	case "Checkbox":
+		return common.ValueTypeBoolean
+	case "Date":
+		return common.ValueTypeDateTime
+	case "Dropdown":
+		return common.ValueTypeSingleSelect
+	case "MultiSelect":
+		return common.ValueTypeMultiSelect
+	default:
+		return common.ValueTypeOther
+	}
+}

--- a/providers/copper/metadata_test.go
+++ b/providers/copper/metadata_test.go
@@ -1,23 +1,37 @@
 package copper
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
+	responseCustomFields := testutils.DataFromFile(t, "custom/fields.json")
+
 	tests := []testroutines.Metadata{
 		{
-			Name:       "Successful metadata for Projects and Leads",
-			Input:      []string{"projects", "leads"},
-			Server:     mockserver.Dummy(),
+			Name:  "Successful metadata for Projects and Leads",
+			Input: []string{"projects", "leads", "companies"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/developer_api/v1/custom_field_definitions"),
+					mockcond.Header(http.Header{"X-PW-Application": []string{"developer_api"}}),
+					mockcond.Header(http.Header{"X-PW-UserEmail": []string{"john@test.com"}}),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCustomFields),
+			}.Server(),
 			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
@@ -48,6 +62,111 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								DisplayName:  "title",
 								ValueType:    "string",
 								ProviderType: "string",
+							},
+							"custom_field_fruits": {
+								DisplayName:  "Fruits",
+								ValueType:    common.ValueTypeSingleSelect,
+								ProviderType: "Dropdown",
+								ReadOnly:     false,
+								Values: []common.FieldValue{{
+									Value:        "2082340",
+									DisplayValue: "Banana",
+								}, {
+									Value:        "2082341",
+									DisplayValue: "Strawberries",
+								}},
+							},
+						},
+					},
+					"companies": {
+						DisplayName: "Companies",
+						Fields: map[string]common.FieldMetadata{
+							"custom_field_birthday": {
+								DisplayName:  "Birthday",
+								ValueType:    "datetime",
+								ProviderType: "Date",
+								ReadOnly:     false,
+							},
+							"custom_field_child_of": {
+								DisplayName:  "Child of",
+								ValueType:    "other",
+								ProviderType: "Connect",
+							},
+							"custom_field_favnum": {
+								DisplayName:  "FavNum",
+								ValueType:    "float",
+								ProviderType: "Float",
+							},
+							"custom_field_fruits": {
+								DisplayName:  "Fruits",
+								ValueType:    "singleSelect",
+								ProviderType: "Dropdown",
+								ReadOnly:     false,
+								Values: []common.FieldValue{{
+									Value:        "2082340",
+									DisplayValue: "Banana",
+								}, {
+									Value:        "2082341",
+									DisplayValue: "Strawberries",
+								}},
+							},
+							"custom_field_hryvnia": {
+								DisplayName:  "Hryvnia",
+								ValueType:    "float",
+								ProviderType: "Currency",
+							},
+							"custom_field_isbouillonsoup": {
+								DisplayName:  "IsBouillonSoup",
+								ValueType:    "boolean",
+								ProviderType: "Checkbox",
+							},
+							"custom_field_many": {
+								DisplayName:  "Many",
+								ValueType:    "multiSelect",
+								ProviderType: "MultiSelect",
+								ReadOnly:     false,
+								Values: []common.FieldValue{{
+									Value:        "2082480",
+									DisplayValue: "Option 1",
+								}, {
+									Value:        "2082481",
+									DisplayValue: "Option 2",
+								}},
+							},
+							"custom_field_mywebsite": {
+								DisplayName:  "MyWebsite",
+								ValueType:    "string",
+								ProviderType: "URL",
+							},
+							"custom_field_parent_of": {
+								DisplayName:  "Parent of",
+								ValueType:    "other",
+								ProviderType: "Connect",
+							},
+							"custom_field_progression": {
+								DisplayName:  "Progression",
+								ValueType:    "float",
+								ProviderType: "Percentage",
+							},
+							"custom_field_story": {
+								DisplayName:  "Story",
+								ValueType:    "string",
+								ProviderType: "Text",
+							},
+							"custom_field_textentry": {
+								DisplayName:  "TextEntry",
+								ValueType:    "string",
+								ProviderType: "String",
+							},
+							"custom_fields": {
+								DisplayName:  "custom_fields",
+								ValueType:    "other",
+								ProviderType: "other",
+							},
+							"date_created": {
+								DisplayName:  "date_created",
+								ValueType:    "float",
+								ProviderType: "float",
 							},
 						},
 					},

--- a/providers/copper/test/custom/fields.json
+++ b/providers/copper/test/custom/fields.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": 705303,
+    "name": "Fruits",
+    "data_type": "Dropdown",
+    "available_on": [
+      "company",
+      "lead",
+      "person"
+    ],
+    "is_filterable": false,
+    "options": [
+      {
+        "id": 2082340,
+        "name": "Banana",
+        "rank": 0
+      },
+      {
+        "id": 2082341,
+        "name": "Strawberries",
+        "rank": 1
+      }
+    ]
+  },
+  {
+    "id": 705393,
+    "name": "Parent of",
+    "data_type": "Connect",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": false,
+    "connected_id": 705394
+  },
+  {
+    "id": 705394,
+    "name": "Child of",
+    "data_type": "Connect",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": false,
+    "connected_id": 705393
+  },
+  {
+    "id": 705396,
+    "name": "Hryvnia",
+    "data_type": "Currency",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": false,
+    "currency": "UAH"
+  },
+  {
+    "id": 705399,
+    "name": "Birthday",
+    "data_type": "Date",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705401,
+    "name": "Many",
+    "data_type": "MultiSelect",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true,
+    "options": [
+      {
+        "id": 2082480,
+        "name": "Option 1",
+        "rank": 0
+      },
+      {
+        "id": 2082481,
+        "name": "Option 2",
+        "rank": 1
+      }
+    ]
+  },
+  {
+    "id": 705402,
+    "name": "FavNum",
+    "data_type": "Float",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705403,
+    "name": "Story",
+    "data_type": "Text",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705404,
+    "name": "MyWebsite",
+    "data_type": "URL",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705407,
+    "name": "IsBouillonSoup",
+    "data_type": "Checkbox",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705452,
+    "name": "TextEntry",
+    "data_type": "String",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  },
+  {
+    "id": 705453,
+    "name": "Progression",
+    "data_type": "Percentage",
+    "available_on": [
+      "company"
+    ],
+    "is_filterable": true
+  }
+]

--- a/providers/copper/test/read/companies/with-custom-fields.json
+++ b/providers/copper/test/read/companies/with-custom-fields.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": 73616517,
+    "name": "Demo Company",
+    "address": null,
+    "assignee_id": null,
+    "contact_type_id": null,
+    "details": "This is a demo company",
+    "email_domain": null,
+    "phone_numbers": [],
+    "primary_contact_id": null,
+    "socials": [],
+    "tags": [],
+    "websites": [],
+    "custom_fields": [
+      {
+        "custom_field_definition_id": 705303,
+        "value": 2082340
+      },
+      {
+        "custom_field_definition_id": 705396,
+        "value": 2.0
+      },
+      {
+        "custom_field_definition_id": 705399,
+        "value": 1754031600
+      },
+      {
+        "custom_field_definition_id": 705401,
+        "value": [
+          2082480,
+          2082481
+        ]
+      },
+      {
+        "custom_field_definition_id": 705402,
+        "value": 3.0
+      },
+      {
+        "custom_field_definition_id": 705403,
+        "value": "The lore of the company creation."
+      },
+      {
+        "custom_field_definition_id": 705404,
+        "value": "https://test.com"
+      },
+      {
+        "custom_field_definition_id": 705407,
+        "value": true
+      },
+      {
+        "custom_field_definition_id": 705452,
+        "value": "Cake"
+      },
+      {
+        "custom_field_definition_id": 705453,
+        "value": 95
+      },
+      {
+        "custom_field_definition_id": 705393,
+        "value": []
+      },
+      {
+        "custom_field_definition_id": 705394,
+        "value": []
+      }
+    ],
+    "interaction_count": 0,
+    "date_created": 1754516346,
+    "date_modified": 1754598988
+  }
+]

--- a/test/copper/read/companies/main.go
+++ b/test/copper/read/companies/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
 	connTest "github.com/amp-labs/connectors/test/copper"
 	"github.com/amp-labs/connectors/test/utils"
 )
@@ -21,13 +23,14 @@ func main() {
 
 	conn := connTest.GetCopperConnector(ctx)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		"companies", "people", "tags",
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "companies",
+		Fields:     connectors.Fields("name", "custom_field_story", "custom_field_many"),
 	})
 	if err != nil {
-		utils.Fail("error listing metadata", "error", err)
+		utils.Fail("error reading from connector", "error", err)
 	}
 
-	fmt.Println("Metadata...")
-	utils.DumpJSON(metadata, os.Stdout)
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
 }

--- a/test/utils/mockutils/mockcond/request.go
+++ b/test/utils/mockutils/mockcond/request.go
@@ -20,6 +20,10 @@ func Method(methodName string) Check {
 	}
 }
 
+func MethodGET() Check {
+	return Method("GET")
+}
+
 func MethodPOST() Check {
 	return Method("POST")
 }


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [ ] Connector uses `internal/components`
   * Metadata is implemented directly without the helper because of custom field resolution.
   * Read still uses `internal/components`
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
  * Custom fields are artifically added to the read with `custom_field_` prefix.

# Live Tests
## Metadata
### Companies
<img width="368" height="990" alt="image" src="https://github.com/user-attachments/assets/d3c35c9c-04d0-42b6-b324-5a1cd0accec9" />

## Read
### Companies
<img width="527" height="448" alt="image" src="https://github.com/user-attachments/assets/076677e5-7ee1-453d-924d-6c61eeeed775" />
<img width="426" height="332" alt="image" src="https://github.com/user-attachments/assets/a085da90-cd7c-4b17-92cb-3724e14d5b21" />
