### PR TITLE
[CON-1970] feat(xero): add ListMetadata

### DIFF
--- a/providers/xero/connector.go
+++ b/providers/xero/connector.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -17,6 +19,8 @@ type Connector struct {
 	common.PostAuthInfo
 
 	tenantId string // Tenant ID for Xero
+
+	components.SchemaProvider
 }
 
 // NewConnector.
@@ -27,6 +31,15 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
 
 	return connector, nil
 }

--- a/providers/xero/handlers.go
+++ b/providers/xero/handlers.go
@@ -34,7 +34,6 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ObjectMetadata, error) {
-
 	objectMetadata := common.ObjectMetadata{
 		Fields:      make(map[string]common.FieldMetadata),
 		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),

--- a/providers/xero/utils.go
+++ b/providers/xero/utils.go
@@ -6,7 +6,6 @@ import (
 )
 
 func (c *Connector) constructURL(objName string) (*urlbuilder.URL, error) {
-
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiBasePath, naming.CapitalizeFirstLetter(objName))
 	if err != nil {
 		return nil, err

--- a/providers/xero/utils.go
+++ b/providers/xero/utils.go
@@ -1,0 +1,16 @@
+package xero
+
+import (
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+func (c *Connector) constructURL(objName string) (*urlbuilder.URL, error) {
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiBasePath, naming.CapitalizeFirstLetter(objName))
+	if err != nil {
+		return nil, err
+	}
+
+	return url, nil
+}

--- a/test/xero/metadata/main.go
+++ b/test/xero/metadata/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/xero"
+)
+
+func main() {
+	ctx := context.Background()
+	connector := xero.GetXeroConnector(ctx)
+
+	_, err := connector.GetPostAuthInfo(ctx)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	m, err := connector.ListObjectMetadata(ctx, []string{"contacts", "accounts"})
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	// Print the results
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/xero/metadata/main.go
+++ b/test/xero/metadata/main.go
@@ -17,7 +17,7 @@ func main() {
 		utils.Fail(err.Error())
 	}
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"contacts", "accounts"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"contacts", "accounts", "Budgets"})
 	if err != nil {
 		utils.Fail(err.Error())
 	}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Metadata Response
<img width="578" height="714" alt="image" src="https://github.com/user-attachments/assets/8b4d951f-693b-438a-8366-d6c152b5b580" />
<img width="570" height="963" alt="image" src="https://github.com/user-attachments/assets/6369153b-6571-47fe-9580-1bdac66c875e" />
<img width="784" height="1045" alt="image" src="https://github.com/user-attachments/assets/f40fc615-e5ea-4bf8-a8b8-d39a1616fb6e" />



## Sample Testcase Result



