### PR TITLE
fix: update object naming drift connector

### DIFF
--- a/providers/drift/handlers.go
+++ b/providers/drift/handlers.go
@@ -11,13 +11,14 @@ import (
 	"github.com/amp-labs/connectors/internal/jsonquery"
 )
 
-func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
-	var (
-		url *urlbuilder.URL
-		err error
-	)
+const (
+	users         = "users"
+	conversations = "conversations"
+	playbooks     = "playbooks"
+)
 
-	url, err = urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := c.constructReadURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +46,14 @@ func (c *Connector) parseReadResponse(
 		common.GetMarshaledData,
 		params.Fields,
 	)
+}
+
+func (c *Connector) constructReadURL(objectName string) (*urlbuilder.URL, error) {
+	if objectName == users || objectName == playbooks || objectName == conversations {
+		objectName += "/list"
+	}
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
 }
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {

--- a/providers/drift/schemas.json
+++ b/providers/drift/schemas.json
@@ -4,7 +4,7 @@
       "id": "root",
       "path": "",
       "objects": {
-        "users/list": {
+        "users": {
           "displayName": "Users",
           "path": "/users/list",
           "docs": "https://devdocs.drift.com/docs/listing-users",
@@ -26,7 +26,7 @@
             "updatedAt": "updatedAt"
           }
         },
-        "conversations/list": {
+        "conversations": {
           "displayName": "Conversations List",
           "path": "/conversations/list",
           "docs": "https://devdocs.drift.com/docs/list-conversations",
@@ -88,7 +88,7 @@
             "isPrivate": "isPrivate"
           }
         },
-        "playbooks/list": {
+        "playbooks": {
           "displayName": "Playbooks Lists",
           "path": "/playbooks/list",
           "docs": "https://devdocs.drift.com/docs/get-playbooks",

--- a/providers/drift/support.go
+++ b/providers/drift/support.go
@@ -17,9 +17,9 @@ const (
 
 func responseSchema(objectName string) (string, string) {
 	switch objectName {
-	case "users/list", "conversations/list", "teams/org", "users/meetings/org":
+	case "users", "conversations", "teams/org", "users/meetings/org":
 		return object, data
-	case "playbooks/list", "playbooks/clp":
+	case "playbooks", "playbooks/clp":
 		return list, ""
 	default:
 		return object, ""
@@ -37,8 +37,8 @@ func writeResponseField(objectName string) string {
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{
-		"users/list", "conversations/list", "teams/org", "users/meetings/org",
-		"playbooks/list", "playbooks/clp", "conversations/stats", "scim/Users",
+		"users", "conversations", "teams/org", "users/meetings/org",
+		"playbooks", "playbooks/clp", "conversations/stats", "scim/Users",
 	}
 
 	writeSupport := []string{

--- a/test/drift/metadata/main.go
+++ b/test/drift/metadata/main.go
@@ -18,7 +18,7 @@ func run() error {
 	ctx := context.Background()
 	connector := drift.GetConnector(ctx)
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"users/list", "conversations/stats", "conversations/list", "teams/org"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"users", "conversations/stats", "conversations", "teams/org"})
 	if err != nil {
 		return err
 	}

--- a/test/drift/read/main.go
+++ b/test/drift/read/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	conn := drift.GetConnector(ctx)
 
-	if err := testRead(ctx, conn, "users/list", []string{"id", "name", "email"}); err != nil {
+	if err := testRead(ctx, conn, "users", []string{"id", "name", "email"}); err != nil {
 		slog.Error(err.Error())
 	}
 


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

This updates object namings, we previously had `users/list`, `conversations/list`, `playbooks/list` now we can use  `users`, `conversations` and `playbooks`

Live Metadata Tests:
<img width="1227" height="207" alt="Screenshot 2025-08-14 at 12 40 20" src="https://github.com/user-attachments/assets/85405d0e-ba2b-4947-a175-fedeed14bf94" />


Live Read Tests:
<img width="1022" height="670" alt="Screenshot 2025-08-14 at 12 38 05" src="https://github.com/user-attachments/assets/a7efd6a1-b70e-457c-a620-d0728aeb2302" />
