### PR TITLE
[CON-2133] fix: Add recordId, record data in zoho CRM write connector

### DIFF
--- a/providers/zohocrm/write.go
+++ b/providers/zohocrm/write.go
@@ -107,8 +107,16 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 			errs = append(errs, r)
 		}
 
+		details, ok := r["details"].(map[string]any)
+		if !ok {
+			logging.Logger(ctx).Error("failed to retrieve details in response data", "object", config.ObjectName,
+				"response", response)
+
+			return &common.WriteResult{Success: true}, nil
+		}
+
 		// Extract record ID from successful responses
-		if id, ok := r["id"].(string); ok && id != "" {
+		if id, ok := details["id"].(string); ok && id != "" {
 			recordId = id
 		} else {
 			logging.Logger(ctx).Error("failed to construct recordId from response",

--- a/providers/zohocrm/write_test.go
+++ b/providers/zohocrm/write_test.go
@@ -69,7 +69,20 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Then:  mockserver.Response(http.StatusOK, leadsWriteResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
-				Success: true,
+				Success:  true,
+				RecordId: "6493490000001504003",
+				Data: map[string]any{
+					"code": "SUCCESS",
+					"details": map[string]any{
+						"Modified_Time": "2025-01-10T13:09:14+03:00",
+						"Modified_By":   map[string]any{"name": "Joseph Karage", "id": "6493490000000486001"},
+						"Created_Time":  "2025-01-10T13:09:14+03:00",
+						"id":            "6493490000001504003",
+						"Created_By":    map[string]any{"name": "Joseph Karage", "id": "6493490000000486001"},
+					},
+					"message": "record added",
+					"status":  "success",
+				},
 			},
 			ExpectedErrs: nil,
 		},
@@ -88,7 +101,20 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Then:  mockserver.Response(http.StatusOK, updateContactsResponse),
 			}.Server(),
 			Expected: &common.WriteResult{
-				Success: true,
+				Success:  true,
+				RecordId: "6493490000001291001",
+				Data: map[string]any{
+					"code": "SUCCESS",
+					"details": map[string]any{
+						"Modified_Time": "2025-01-10T13:22:08+03:00",
+						"Modified_By":   map[string]any{"name": "Joseph Karage", "id": "6493490000000486001"},
+						"Created_Time":  "2024-12-20T10:09:52+03:00",
+						"id":            "6493490000001291001",
+						"Created_By":    map[string]any{"name": "Joseph Karage", "id": "6493490000000486001"},
+					},
+					"message": "record updated",
+					"status":  "success",
+				},
 			},
 			ExpectedErrs: nil,
 		},

--- a/test/zohocrm/write/write.go
+++ b/test/zohocrm/write/write.go
@@ -97,7 +97,7 @@ func createLeads(ctx context.Context, conn *zohocrm.Connector) error {
 func updateContacts(ctx context.Context, conn *zohocrm.Connector) error {
 	config := common.WriteParams{
 		ObjectName: "contacts",
-		RecordId:   "6493490000001291001",
+		RecordId:   "6172731000000472189",
 		RecordData: map[string]any{
 			"First_Name": "Ryan",
 			"Phone":      "+12343678910",


### PR DESCRIPTION
Updates the WriteResults data, to add recordId + plus record data. 

Live Read tests:
<img width="1991" height="1003" alt="Screenshot 2025-08-15 at 21 50 47" src="https://github.com/user-attachments/assets/899659df-e67e-4cda-b0f6-9be1ecbdb9ec" />
