### PR TITLE
[CON-1316] feat(nutshell): Metadata

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -60,6 +60,7 @@ import (
 	"github.com/amp-labs/connectors/providers/mixmax"
 	"github.com/amp-labs/connectors/providers/monday"
 	"github.com/amp-labs/connectors/providers/netsuite"
+	"github.com/amp-labs/connectors/providers/nutshell"
 	"github.com/amp-labs/connectors/providers/outreach"
 	"github.com/amp-labs/connectors/providers/pinterest"
 	"github.com/amp-labs/connectors/providers/pipedrive"
@@ -143,6 +144,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Mixmax:                  wrapper(newMixmaxConnector),
 	providers.Monday:                  wrapper(newMondayConnector),
 	providers.Netsuite:                wrapper(newNetsuiteConnector),
+	providers.Nutshell:                wrapper(newNutshellConnector),
 	providers.Outreach:                wrapper(newOutreachConnector),
 	providers.Pinterest:               wrapper(newPinterestConnector),
 	providers.Pipedrive:               wrapper(newPipedriveConnector),
@@ -447,6 +449,12 @@ func newMondayConnector(
 	params common.ConnectorParams,
 ) (*monday.Connector, error) {
 	return monday.NewConnector(params)
+}
+
+func newNutshellConnector(
+	params common.ConnectorParams,
+) (*nutshell.Connector, error) {
+	return nutshell.NewConnector(params)
 }
 
 func newHeyReachConnector(

--- a/providers/nutshell/connector.go
+++ b/providers/nutshell/connector.go
@@ -1,0 +1,30 @@
+package nutshell
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/nutshell/internal/metadata"
+)
+
+type Connector struct {
+	*components.Connector
+	common.RequireAuthenticatedClient
+
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Initialize(providers.Nutshell, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector: base,
+	}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
+
+	return connector, nil
+}

--- a/providers/nutshell/internal/metadata/metadata.go
+++ b/providers/nutshell/internal/metadata/metadata.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	FileManager = scrapper.NewReader[staticschema.FieldMetadataMapV2](schemas) // nolint:gochecknoglobals
+
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/nutshell/internal/metadata/schemas.json
+++ b/providers/nutshell/internal/metadata/schemas.json
@@ -1,0 +1,1541 @@
+{
+  "modules": {
+    "root": {
+      "id": "root",
+      "path": "",
+      "objects": {
+        "accounts": {
+          "displayName": "Accounts",
+          "path": "/accounts",
+          "responseKey": "accounts",
+          "fields": {
+            "addresses": {
+              "displayName": "addresses",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "emails": {
+              "displayName": "emails",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "employeeCount": {
+              "displayName": "employeeCount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phones": {
+              "displayName": "phones",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "revenue": {
+              "displayName": "revenue",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "urls": {
+              "displayName": "urls",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "accounts/list": {
+          "displayName": "Accounts List",
+          "path": "/accounts/list",
+          "responseKey": "listItems",
+          "fields": {
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "fields": {
+              "displayName": "fields",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isDeleted": {
+              "displayName": "isDeleted",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "latlon": {
+              "displayName": "latlon",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "mapUrl": {
+              "displayName": "mapUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryAccount": {
+              "displayName": "primaryAccount",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryContact": {
+              "displayName": "primaryContact",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryInfo": {
+              "displayName": "primaryInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryName": {
+              "displayName": "primaryName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedInfo": {
+              "displayName": "relatedInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedName": {
+              "displayName": "relatedName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedType": {
+              "displayName": "relatedType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrl": {
+              "displayName": "relatedUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrlPath": {
+              "displayName": "relatedUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "accounttypes": {
+          "displayName": "Account Types",
+          "path": "/accounttypes",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "activities": {
+          "displayName": "Activities",
+          "path": "/activities",
+          "responseKey": "activities",
+          "fields": {
+            "agenda": {
+              "displayName": "agenda",
+              "valueType": "other"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "endTime": {
+              "displayName": "endTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isAllDay": {
+              "displayName": "isAllDay",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isCancelled": {
+              "displayName": "isCancelled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isEditable": {
+              "displayName": "isEditable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isFlagged": {
+              "displayName": "isFlagged",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isLogged": {
+              "displayName": "isLogged",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isMediaLogged": {
+              "displayName": "isMediaLogged",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isOverdue": {
+              "displayName": "isOverdue",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "loggedTime": {
+              "displayName": "loggedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "startTime": {
+              "displayName": "startTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "transcription": {
+              "displayName": "transcription",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "activitytypes": {
+          "displayName": "Activity Types",
+          "path": "/activitytypes",
+          "responseKey": "activityTypes",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isBenchmarkable": {
+              "displayName": "isBenchmarkable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "audiences": {
+          "displayName": "Audiences",
+          "path": "/audiences",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isWebFX": {
+              "displayName": "isWebFX",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "competitormaps": {
+          "displayName": "Competitor Maps",
+          "path": "/competitormaps",
+          "responseKey": "competitorMaps",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relationship": {
+              "displayName": "relationship",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "potential",
+                  "displayValue": "potential"
+                },
+                {
+                  "value": "stole",
+                  "displayValue": "stole"
+                },
+                {
+                  "value": "beat",
+                  "displayValue": "beat"
+                }
+              ]
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "competitors": {
+          "displayName": "Competitors",
+          "path": "/competitors",
+          "responseKey": "competitors",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "contacts": {
+          "displayName": "Contacts",
+          "path": "/contacts",
+          "responseKey": "contacts",
+          "fields": {
+            "addresses": {
+              "displayName": "addresses",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "emails": {
+              "displayName": "emails",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "firstName": {
+              "displayName": "firstName",
+              "valueType": "other"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "jobTitle": {
+              "displayName": "jobTitle",
+              "valueType": "other"
+            },
+            "lastName": {
+              "displayName": "lastName",
+              "valueType": "other"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phones": {
+              "displayName": "phones",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "urls": {
+              "displayName": "urls",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "contacts/list": {
+          "displayName": "Contacts List",
+          "path": "/contacts/list",
+          "responseKey": "listItems",
+          "fields": {
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "fields": {
+              "displayName": "fields",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isDeleted": {
+              "displayName": "isDeleted",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "latlon": {
+              "displayName": "latlon",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "mapUrl": {
+              "displayName": "mapUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryAccount": {
+              "displayName": "primaryAccount",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryContact": {
+              "displayName": "primaryContact",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryInfo": {
+              "displayName": "primaryInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryName": {
+              "displayName": "primaryName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedInfo": {
+              "displayName": "relatedInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedName": {
+              "displayName": "relatedName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedType": {
+              "displayName": "relatedType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrl": {
+              "displayName": "relatedUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrlPath": {
+              "displayName": "relatedUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "deleted": {
+          "displayName": "Deleted",
+          "path": "/events/deleted",
+          "responseKey": "events",
+          "fields": {
+            "action": {
+              "displayName": "action",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "actorType": {
+              "displayName": "actorType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "changes": {
+              "displayName": "changes",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "count": {
+              "displayName": "count",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "payloadType": {
+              "displayName": "payloadType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "events": {
+          "displayName": "Events",
+          "path": "/events",
+          "responseKey": "events",
+          "fields": {
+            "action": {
+              "displayName": "action",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "actorType": {
+              "displayName": "actorType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "changes": {
+              "displayName": "changes",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "count": {
+              "displayName": "count",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "payloadType": {
+              "displayName": "payloadType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "forms": {
+          "displayName": "Forms",
+          "path": "/forms",
+          "responseKey": "wfForms",
+          "fields": {
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "industries": {
+          "displayName": "Industries",
+          "path": "/industries",
+          "responseKey": "",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "leads": {
+          "displayName": "Leads",
+          "path": "/leads",
+          "responseKey": "leads",
+          "fields": {
+            "anticipatedClosedTime": {
+              "displayName": "anticipatedClosedTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "closedTime": {
+              "displayName": "closedTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "confidence": {
+              "displayName": "confidence",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "dueTime": {
+              "displayName": "dueTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isCurrentUserWatching": {
+              "displayName": "isCurrentUserWatching",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isOverdue": {
+              "displayName": "isOverdue",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "lastContactedTime": {
+              "displayName": "lastContactedTime",
+              "valueType": "other"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "number": {
+              "displayName": "number",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "overdueTime": {
+              "displayName": "overdueTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "ownerType": {
+              "displayName": "ownerType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "pieState": {
+              "displayName": "pieState",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "priority": {
+              "displayName": "priority",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "value": {
+              "displayName": "value",
+              "valueType": "other",
+              "providerType": "object"
+            }
+          }
+        },
+        "leads/list": {
+          "displayName": "Leads List",
+          "path": "/leads/list",
+          "responseKey": "listItems",
+          "fields": {
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "fields": {
+              "displayName": "fields",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "htmlUrl": {
+              "displayName": "htmlUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "htmlUrlPath": {
+              "displayName": "htmlUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isDeleted": {
+              "displayName": "isDeleted",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "latlon": {
+              "displayName": "latlon",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "mapUrl": {
+              "displayName": "mapUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryAccount": {
+              "displayName": "primaryAccount",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryContact": {
+              "displayName": "primaryContact",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryInfo": {
+              "displayName": "primaryInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primaryName": {
+              "displayName": "primaryName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedInfo": {
+              "displayName": "relatedInfo",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedName": {
+              "displayName": "relatedName",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedType": {
+              "displayName": "relatedType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrl": {
+              "displayName": "relatedUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "relatedUrlPath": {
+              "displayName": "relatedUrlPath",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "notes": {
+          "displayName": "Notes",
+          "path": "/notes",
+          "responseKey": "notes",
+          "fields": {
+            "body": {
+              "displayName": "body",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "bodyHtml": {
+              "displayName": "bodyHtml",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "bodyMarkup": {
+              "displayName": "bodyMarkup",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdTime": {
+              "displayName": "createdTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isEditable": {
+              "displayName": "isEditable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "parentType": {
+              "displayName": "parentType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "productmaps": {
+          "displayName": "Product Maps",
+          "path": "/productmaps",
+          "responseKey": "productMaps",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "price": {
+              "displayName": "price",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "productType": {
+              "displayName": "productType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "quantity": {
+              "displayName": "quantity",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "relationship": {
+              "displayName": "relationship",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "unit": {
+              "displayName": "unit",
+              "valueType": "other"
+            }
+          }
+        },
+        "products": {
+          "displayName": "Products",
+          "path": "/products",
+          "responseKey": "products",
+          "fields": {
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "other"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "price": {
+              "displayName": "price",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "prices": {
+              "displayName": "prices",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "productType": {
+              "displayName": "productType",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "report": {
+          "displayName": "Report",
+          "path": "/leads/report",
+          "responseKey": "reports",
+          "fields": {
+            "report": {
+              "displayName": "report",
+              "valueType": "other"
+            }
+          }
+        },
+        "sources": {
+          "displayName": "Sources",
+          "path": "/sources",
+          "responseKey": "sources",
+          "fields": {
+            "channel": {
+              "displayName": "channel",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "stages": {
+          "displayName": "Stages",
+          "path": "/stages",
+          "responseKey": "",
+          "fields": {
+            "activeAvatarUrl": {
+              "displayName": "activeAvatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "canAdvanceStage": {
+              "displayName": "canAdvanceStage",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "completeAvatarUrl": {
+              "displayName": "completeAvatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "incompleteAvatarUrl": {
+              "displayName": "incompleteAvatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "links": {
+              "displayName": "links",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "numSteps": {
+              "displayName": "numSteps",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "overdueAvatarUrl": {
+              "displayName": "overdueAvatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "position": {
+              "displayName": "position",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "stagesets": {
+          "displayName": "Stage Sets",
+          "path": "/stagesets",
+          "responseKey": "",
+          "fields": {
+            "canAccess": {
+              "displayName": "canAccess",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "default": {
+              "displayName": "default",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "/tags",
+          "responseKey": "tags",
+          "fields": {
+            "colorType": {
+              "displayName": "colorType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "count": {
+              "displayName": "count",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "deletedTime": {
+              "displayName": "deletedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tagType": {
+              "displayName": "tagType",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "territories": {
+          "displayName": "Territories",
+          "path": "/territories",
+          "responseKey": "",
+          "fields": {
+            "href": {
+              "displayName": "href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "users": {
+          "displayName": "Users",
+          "path": "/users",
+          "responseKey": "users",
+          "fields": {
+            "avatarUrl": {
+              "displayName": "avatarUrl",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "canAccessEmailMarketing": {
+              "displayName": "canAccessEmailMarketing",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "emails": {
+              "displayName": "emails",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "firstName": {
+              "displayName": "firstName",
+              "valueType": "other"
+            },
+            "hasSetPassword": {
+              "displayName": "hasSetPassword",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initials": {
+              "displayName": "initials",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "isAdministrator": {
+              "displayName": "isAdministrator",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isEnabled": {
+              "displayName": "isEnabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isHiddenFromFilters": {
+              "displayName": "isHiddenFromFilters",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "isViewingRestricted": {
+              "displayName": "isViewingRestricted",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "modifiedTime": {
+              "displayName": "modifiedTime",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "other"
+            },
+            "permissions": {
+              "displayName": "permissions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "phonecallerType": {
+              "displayName": "phonecallerType",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "other"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/nutshell/metadata_test.go
+++ b/providers/nutshell/metadata_test.go
@@ -1,0 +1,109 @@
+package nutshell
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:       "Successful metadata for CalendarList and Settings",
+			Input:      []string{"competitormaps", "contacts", "products"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"competitormaps": {
+						DisplayName: "Competitor Maps",
+						Fields: map[string]common.FieldMetadata{
+							"name": {
+								DisplayName:  "name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"status": {
+								DisplayName:  "status",
+								ValueType:    "singleSelect",
+								ProviderType: "string",
+								Values: []common.FieldValue{{
+									Value:        "potential",
+									DisplayValue: "potential",
+								}, {
+									Value:        "stole",
+									DisplayValue: "stole",
+								}, {
+									Value:        "beat",
+									DisplayValue: "beat",
+								}},
+							},
+						},
+					},
+					"contacts": {
+						DisplayName: "Contacts",
+						Fields: map[string]common.FieldMetadata{
+							"firstName": {
+								DisplayName: "firstName",
+								ValueType:   "other",
+							},
+							"href": {
+								DisplayName:  "href",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"products": {
+						DisplayName: "Products",
+						Fields: map[string]common.FieldMetadata{
+							"name": {
+								DisplayName: "name",
+								ValueType:   "other",
+							},
+							"price": {
+								DisplayName:  "price",
+								ValueType:    "other",
+								ProviderType: "object",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		common.ConnectorParams{
+			AuthenticatedClient: mockutils.NewClient(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetUnitTestBaseURL(mockutils.ReplaceURLOrigin(connector.ModuleInfo().BaseURL, serverURL))
+
+	return connector, nil
+}

--- a/scripts/openapi/nutshell/internal/files/README.md
+++ b/scripts/openapi/nutshell/internal/files/README.md
@@ -1,0 +1,20 @@
+# OpenAPI
+
+## Obtain file
+
+You can download the file from: https://developers.nutshell.com/reference/get_accounts-id.
+
+To understand how this was discovered:
+1. Navigate to [Nutshell API Docs](https://developers.nutshell.com/reference/get_accounts-id).
+2. Open browser network tab
+3. Reload the page, and locate the request that retrieves the `get_accounts-id?json=on`.
+
+## Modify the File
+From the obtained JSON response, locate the `oasDefinition` field, which contains the OpenAPI file as its value.
+Extract this data and save it as `openapi.json`.
+
+You can then use the script to extract `schemas.json` from the acquired `openapi.json`.
+
+# Changelog
+OpenAPI file was changed to fix Notes response. Note schema is wrapped in NoteResponse similar
+to LeadResponse or any other object for that matter.

--- a/scripts/openapi/nutshell/internal/files/file.go
+++ b/scripts/openapi/nutshell/internal/files/file.go
@@ -1,0 +1,21 @@
+package files
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// nolint:gochecknoglobals
+var (
+	// Static file containing openapi spec.
+	//go:embed openapi.json
+	openapiAPI []byte
+
+	InputNutshell  = api3.NewOpenapiFileManager[any](openapiAPI)
+	OutputNutshell = scrapper.NewWriter[staticschema.FieldMetadataMapV2](
+		fileconv.NewPath("providers/nutshell/internal/metadata"))
+)

--- a/scripts/openapi/nutshell/internal/files/openapi.json
+++ b/scripts/openapi/nutshell/internal/files/openapi.json
@@ -1,0 +1,7299 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Nutshell API",
+    "description": "The most powerful API in the world",
+    "version": "1.0.1"
+  },
+  "paths": {
+    "/accounts/{id}": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get an account",
+        "description": "Get an account by ID. Accounts are companies or organizations that you do business with, and are referred to as 'Companies' in the Nutshell UI.  <br> <br> The returned arrays creators, owners, origins, contacts, accountTypes, and industries contain additional information corresponding to the requested accounts. ",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "API ids are of the form 'n-accounts', where n is an integer. Ids can be listed in a comma-separated format to retrieve multiple accounts.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "account",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/accountResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Delete an account",
+        "description": "Delete an account by ID. Deleted accounts are removed from the companies tab, and can be restored from the trash within 30 days of deletion via the undelete endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-accounts', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/accountResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Update an account",
+        "description": "Update an account by id. <br><br> op is the operation to be performed, and path specifies what resource to patch. <br><br> Use the path accounts/0/fieldName to update fields that are user-entered for this resource, i.e. name, description, etc. <br> <br> Use the path accounts/0/links/fieldName to update this account's links to other resources within Nutshell, i.e. contacts, owner, territory, etc. When performing an 'add', include a /- at the end of the path, i.e. accounts/0/links/fieldName/- .  <br><br> When using the remove operation, include the id at the end of the path (i.e. accounts/0/links/contacts/1-contacts) - no need to include a value. <br><br> Value can alternatively be a list of objects, which can be used with the replace operation and the path accounts/0/urls, accounts/0/addresses, accounts/0/phones, or accounts/0/phones to replace the existing list with a list of new objects. Visit <a href='https://developers.nutshell.com/reference/get_accounts-id'>the account docs</a> for more detail on the structure of these objects.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-accounts', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patchInput"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/{id}/customfields": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get custom fields",
+        "description": "Get a list of custom field values for an account by ID. Custom fields are user-defined fields that can be added to accounts.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-accounts', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "customFields": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FullCustomField"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/customfields/attributes": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get a list of custom fields",
+        "description": "Get a list of all account custom fields in your Nutshell instance. Custom fields are user-defined fields that can be added to accounts.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "customFields": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CustomField"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/customfield": {
+      "post": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Create a custom field",
+        "description": "Creates a custom field to use for accounts.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CustomFieldCreateInput"
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/list": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get list items for all accounts",
+        "description": "Get a list of all accounts and associated data in your Nutshell Instance, in a list item format. List items have additional fields attached to them for filtering purposes.",
+        "parameters": [
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter results by name. Visit the filters guide for more information on how to filter by other terms. ",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info on an entity. Returns all entities that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order. ",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "-accountType",
+                  "-createdTime",
+                  "-industry",
+                  "-lastContactedTime",
+                  "-name",
+                  "-numberOfContacts",
+                  "-owner",
+                  "-phone",
+                  "-postalCode",
+                  "-territory",
+                  "accountType",
+                  "createdTime",
+                  "industry",
+                  "lastContactedTime",
+                  "name",
+                  "numberOfContacts",
+                  "owner",
+                  "phone",
+                  "postalCode",
+                  "territory"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "accounts list",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "count": {
+                              "description": "The number of returned accounts",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "total": {
+                              "description": "The total number of accounts in your Nutshell instance",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "facets": {
+                              "description": "Contains an AccountType object, which lists the id and count for each account type in your instance",
+                              "properties": {
+                                "AccountType": {
+                                  "properties": {
+                                    "n-accountTypes": {
+                                      "description": "The number of accounts with the account type id n-accountTypes, where n is an integer",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/meta"
+                        }
+                      ]
+                    },
+                    "listItems": {
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/ListItemAccount"
+                          },
+                          {
+                            "$ref": "#/components/schemas/HtmlLinkable"
+                          },
+                          {
+                            "$ref": "#/components/schemas/Avatarable"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get a list of accounts",
+        "description": "Get all accounts and associated data in your Nutshell instance. Accounts are companies or organizations that you do business with, and are referred to as 'Companies' in the Nutshell UI.",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "description": "query for accounts associated with a specific email address",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info on an entity. Returns all entities that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[contacts][]",
+            "in": "query",
+            "description": "Filter by accounts that have a specific contact (person) associated with them. The value should be the id of the contact, in the form 'n-contacts', where n is an integer. <br><br> Visit the filtering guide for more information on the usage of filters and the different filter terms that are available.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order. ",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "-accountType",
+                  "-createdTime",
+                  "-industry",
+                  "-lastContactedTime",
+                  "-name",
+                  "-numberOfContacts",
+                  "-owner",
+                  "-phone",
+                  "-postalCode",
+                  "-territory",
+                  "accountType",
+                  "createdTime",
+                  "industry",
+                  "lastContactedTime",
+                  "name",
+                  "numberOfContacts",
+                  "owner",
+                  "phone",
+                  "postalCode",
+                  "territory"
+                ]
+              }
+            }
+          },
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "Limit the number of results returned, for pagination.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[page]",
+            "in": "query",
+            "description": "Request a specific page of results, for pagination. Used in conjunction with the page[limit] parameter. Indexing is 0-based.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "accounts",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "count": {
+                              "description": "The number of returned accounts",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "total": {
+                              "description": "The total number of accounts in your Nutshell instance",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "facets": {
+                              "description": "Contains an AccountType object, which lists the id and count for each account type in your instance",
+                              "properties": {
+                                "AccountType": {
+                                  "properties": {
+                                    "n-accountTypes": {
+                                      "description": "The number of accounts with the account type id n-accountTypes, where n is an integer",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/meta"
+                        }
+                      ]
+                    },
+                    "accounts": {
+                      "description": "An array of returned accounts.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Account"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Create an account",
+        "description": "Create a new account. Accounts are companies or organizations that you do business with, and are referred to as 'Companies' in the Nutshell UI.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "accounts": {
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "phones": {
+                          "type": "array",
+                          "items": {
+                            "properties": {
+                              "isPrimary": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string",
+                                "example": "123-456-7890"
+                              }
+                            }
+                          }
+                        },
+                        "emails": {
+                          "type": "array",
+                          "items": {
+                            "properties": {
+                              "value": {
+                                "type": "string",
+                                "example": "support@nutshell.com"
+                              }
+                            }
+                          }
+                        },
+                        "urls": {
+                          "type": "array",
+                          "items": {
+                            "properties": {
+                              "value": {
+                                "type": "string",
+                                "example": "http://www.nutshell.com"
+                              }
+                            }
+                          }
+                        },
+                        "addresses": {
+                          "type": "array",
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "isPrimary": {
+                                "type": "boolean"
+                              },
+                              "value": {
+                                "properties": {
+                                  "address_1": {
+                                    "description": "Street address",
+                                    "type": "string",
+                                    "example": "123 Main St"
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "example": "Ann Arbor"
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "example": "MI"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            }
+                          }
+                        },
+                        "links": {
+                          "description": "Links to other resources within Nutshell. Key is the type of resource being linked, value is the id of that resource.",
+                          "type": "object"
+                        },
+                        "customFields": {
+                          "description": "Custom fields to add to the Account.",
+                          "type": "object",
+                          "example": {
+                            "Favorite Number": "12"
+                          },
+                          "additionalProperties": {
+                            "$ref": "#/components/schemas/CustomFieldInput"
+                          }
+                        }
+                      },
+                      "type": "object"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "At least one of the following fields is required: name, phone, email, address, or url. All other fields are optional.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Undelete an account",
+        "description": "Undelete an account by id.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-accounts', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/accounttypes": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get a list of account types",
+        "description": "Get a list of all account types in a Nutshell instance.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/activities": {
+      "get": {
+        "tags": [
+          "Activities"
+        ],
+        "summary": "Get activities",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "String search",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many activities to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filter[participant][]",
+            "in": "query",
+            "description": "Which participant to get activities related to",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "filter[status][]",
+            "in": "query",
+            "description": "Which activities to get based on status",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "scheduled",
+                  "logged",
+                  "cancelled"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[leadPriority][]",
+            "in": "query",
+            "description": "Whether to only return activities related to hot leads",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hot"
+              ]
+            }
+          },
+          {
+            "name": "filter[activityType]",
+            "in": "query",
+            "description": "Which types of activities to get",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "name": "filter[flagged]",
+            "in": "query",
+            "description": "Only return flagged activities",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "filter[isImportant]",
+            "in": "query",
+            "description": "Only return activities marked as important",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "filter[dateMin]",
+            "in": "query",
+            "description": "The earliest activity to return",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "filter[dateMax]",
+            "in": "query",
+            "description": "The latest activity to return",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Activities"
+        ],
+        "summary": "Create an activity",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/activityPostInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/activities/{id}": {
+      "get": {
+        "tags": [
+          "Activities"
+        ],
+        "summary": "Get an activity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Activity ID of the format {integer}-activities",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/activitytypes": {
+      "get": {
+        "tags": [
+          "Activities"
+        ],
+        "summary": "Get activity types",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityTypeResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/audiences": {
+      "get": {
+        "tags": [
+          "Audiences"
+        ],
+        "summary": "Get a list of audiences",
+        "description": "Returns a list of all email marketing audiences in a Nutshell instance.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Audience"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Audiences"
+        ],
+        "summary": "Create an audience",
+        "description": "Create an audience. Audiences are used to organize leads, contacts, and accounts into groups for marketing.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "emAudiences": {
+                    "description": "The name of the audience to be created.",
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "Your Audience"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "The name of the audience to be created.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "emAudiences": {
+                      "description": "Properties of the created audience",
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "1-emAudiences"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "emAudiences"
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Your Audience"
+                          },
+                          "isWebFX": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        },
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/competitors": {
+      "get": {
+        "tags": [
+          "Competitors"
+        ],
+        "summary": "Get a list of competitors",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "String to search for in competitor name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of competitors",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompetitorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/competitors/{id}": {
+      "get": {
+        "tags": [
+          "Competitors"
+        ],
+        "summary": "Get a competitor",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the competitor",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single competitor",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompetitorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/competitormaps/{id}": {
+      "get": {
+        "tags": [
+          "Competitors",
+          "Leads"
+        ],
+        "summary": "Get a lead-competitor relationship",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the lead-competitor relationship",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of lead-competitor relationships",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadCompetitorMapResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Competitors",
+          "Leads"
+        ],
+        "summary": "Delete a lead-competitor relationship",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the lead-competitor relationship",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Competitors",
+          "Leads"
+        ],
+        "summary": "Update a lead-competitor relationship",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the lead-competitor relationship",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/patchInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/competitormaps": {
+      "get": {
+        "tags": [
+          "Competitors",
+          "Leads"
+        ],
+        "summary": "Get a list of lead-competitor relationships",
+        "responses": {
+          "200": {
+            "description": "A list of lead-competitor relationships",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadCompetitorMapResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/{id}": {
+      "get": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Get a contact",
+        "description": "Returns a single contact based on the provided ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Contact ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Delete a contact",
+        "description": "Deletes a contact from Nutshell. Can be recovered by posting to /contacts/{id}/undelete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Contact ID",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Update a contact",
+        "description": "Update a contact by id. <br><br> op is the operation to be performed, and path specifies what resource to patch. <br><br> Use the path contacts/0/fieldName to update fields that are user-entered for this resource, i.e. name, description, etc. <br> <br> Use the path contacts/0/links/fieldName to update this contact's links to other resources within Nutshell, i.e. accounts, owner, territory, emAudiences, etc. When performing an 'add', include a /- at the end of the path, i.e. contacts/0/links/fieldName/- .  <br><br> When using the remove operation, include the id at the end of the path (i.e. contacts/0/links/accounts/1-accounts) - no need to include a value. <br><br> Value can alternatively be a list of objects, which can be used with the replace operation and the path contacts/0/urls, contacts/0/addresses, contacts/0/phones, contacts/0/phones, contacts/0/links/emAudiences, or contacts/0/links/accounts to replace the existing list with a list of new objects. For certain replace operations like accounts and emAudiences, provide an array of strings as the value. <br><br> Visit <a href='https://developers.nutshell.com/reference/get_contacts-id-3'>the contact docs</a> for more detail on the structure of these objects. ",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-contacts', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patchInput"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/{id}/customfields": {
+      "get": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Get contact custom fields",
+        "description": "Returns a list of custom fields for a contact.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Contact ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom Fields",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomField"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/customfields/attributes": {
+      "get": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Get applicable custom fields",
+        "description": "Get a list of all custom fields that can be applied to any contact.",
+        "responses": {
+          "200": {
+            "description": "Custom Fields",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomField"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/customfield": {
+      "post": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Create a custom field",
+        "description": "Creates a custom field to use for contacts.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CustomFieldCreateInput"
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts": {
+      "get": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Get a list of contacts",
+        "description": "Returns a number of contacts which is filterable based on their basic information.",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "description": "Returns contacts with the provided email address.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Returns contacts with a piece of information similar to the provided string, such as name, email, location, etc.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "What criteria to order the returned list of results.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "accountType",
+                "-accountType",
+                "accounts",
+                "-accounts",
+                "createdTime",
+                "-createdTime",
+                "email",
+                "-email",
+                "industry",
+                "-industry",
+                "lastContactedTime",
+                "-lastContactedTime",
+                "name",
+                "-name",
+                "owner",
+                "-owner",
+                "phone",
+                "-phone",
+                "postalCode",
+                "-postalCode",
+                "territory",
+                "-territory"
+              ]
+            }
+          },
+          {
+            "name": "filter[leads][]",
+            "in": "query",
+            "description": "Of the format '?filter[accounts][]=1-accounts,2-accounts', where 'accounts' can be any entity. See the guide on Filters for more details.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[page]",
+            "in": "query",
+            "description": "The page of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "How many results to return per page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Create a contact",
+        "description": "Create a new contact, also known as a person, in Nutshell. Only one contact may be created at a time.",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/contactPostInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Contact",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Undelete a contact",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Contact ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/contacts/list": {
+      "get": {
+        "tags": [
+          "Contacts (People)"
+        ],
+        "summary": "Get list items for all contacts",
+        "description": "Get a list of all contacts and associated data in your Nutshell Instance, in a list item format. List items have additional fields attached to them for filtering purposes. Contacts are people that you do business with, and are referred to as 'People' in the Nutshell UI.",
+        "parameters": [
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter results by name. Visit the filters guide for more information on how to filter by other terms. ",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info on an entity. Returns all entities that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order.",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "-accountType",
+                  "-accounts",
+                  "-createdTime",
+                  "-industry",
+                  "-lastContactedTime",
+                  "-owner",
+                  "-phone",
+                  "-postalCode",
+                  "-territory",
+                  "accountType",
+                  "accounts",
+                  "createdTime",
+                  "industry",
+                  "lastContactedTime",
+                  "owner",
+                  "phone",
+                  "postalCode",
+                  "territory"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "contacts list",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "count": {
+                              "description": "The number of returned contacts",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "total": {
+                              "description": "The total number of contacts in your Nutshell instance",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/meta"
+                        }
+                      ]
+                    },
+                    "listItems": {
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/ListItemContact"
+                          },
+                          {
+                            "$ref": "#/components/schemas/HtmlLinkable"
+                          },
+                          {
+                            "$ref": "#/components/schemas/Avatarable"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/events": {
+      "get": {
+        "tags": [
+          "Events (Timeline)"
+        ],
+        "summary": "Get a list of events",
+        "description": "Retrieve a feed of events. Events, also known as change logs, are a record of everything that happened in Nutshell. They're used to power notifications and timelines among other things.",
+        "parameters": [
+          {
+            "name": "max_id",
+            "in": "query",
+            "description": "Retrieve a feed of events with an ID less than or equal to than the specified ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "since_id",
+            "in": "query",
+            "description": "Retrieve a feed of events with an ID greater than the specified ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "max_time",
+            "in": "query",
+            "description": "Retrieve a feed of events that occurred before the specified time",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "since_time",
+            "in": "query",
+            "description": "Retrieve a feed of events that occurred after the specified time",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "description": "Retrieve a feed of events related to a specific entity",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of events to return",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "events",
+            "in": "query",
+            "description": "Opt in to additional event types: comments, mailchimp, followup, constantContact, emailInteraction, assignments, formSubmissions",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "comments",
+                  "mailchimp",
+                  "followup",
+                  "constantContact",
+                  "emailInteraction",
+                  "assignments",
+                  "formSubmissions"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filters[payload][]",
+            "in": "query",
+            "description": "Retrieve a feed of events related to a type of entity",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "accounts",
+                  "activities",
+                  "assignments",
+                  "chats",
+                  "companyEnrichment",
+                  "constantContact",
+                  "contacts",
+                  "emails",
+                  "emailInteraction",
+                  "formSubmissions",
+                  "inbox_threads",
+                  "leadUpdates",
+                  "leads",
+                  "marketingEmails",
+                  "mcfxSessions",
+                  "notes",
+                  "queued",
+                  "ticketMessages",
+                  "undelivered",
+                  "unshared"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filters[creator][]",
+            "in": "query",
+            "description": "Retrieve a feed of events caused by a specific user or team",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "filters[emailEntityType][]",
+            "in": "query",
+            "description": "Whether to receive email sent or received events. Requires a creator filter",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "sender",
+                  "recipient"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of events",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/events/deleted": {
+      "get": {
+        "tags": [
+          "Events (Timeline)"
+        ],
+        "summary": "Get deletion events",
+        "description": "Retrieve a feed of every time an entity was deleted.",
+        "parameters": [
+          {
+            "name": "filter[types]",
+            "in": "query",
+            "description": "Retrieve a feed of events related to a type of entity",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "accounts",
+                "activities",
+                "assignments",
+                "chats",
+                "companyEnrichment",
+                "constantContact",
+                "contacts",
+                "emails",
+                "emailInteraction",
+                "formSubmissions",
+                "inbox_threads",
+                "leadUpdates",
+                "leads",
+                "marketingEmails",
+                "mcfxSessions",
+                "notes",
+                "queued",
+                "ticketMessages",
+                "undelivered",
+                "unshared"
+              ]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Reverse the order of returned results",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "-change_time"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of events",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/filters": {
+      "get": {
+        "tags": [
+          "Filter"
+        ],
+        "summary": "Get saved filters",
+        "description": "Get saved filters",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "The user ID to get saved filters for",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "reportType",
+            "in": "query",
+            "description": "The report type to get saved filters for",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter options",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/forms": {
+      "get": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "Get all forms",
+        "description": "Get all non-archived nutshell forms along with the IDs of the fields used in each form.",
+        "responses": {
+          "200": {
+            "description": "Forms",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/forms/{id}": {
+      "get": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "Get a form",
+        "description": "Get a single form by the ID provided. The fields used in the form are also returned in the response.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Form ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Form",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/FormResponse"
+                    },
+                    {
+                      "properties": {
+                        "wfFields": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Field"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/forms/{fieldId}": {
+      "get": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "Get a form field",
+        "description": "Get a single form field by the ID provided.",
+        "parameters": [
+          {
+            "name": "fieldId",
+            "in": "path",
+            "description": "Field Id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Form Field",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "wfFields": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Field"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/industries": {
+      "get": {
+        "tags": [
+          "Accounts (Companies)"
+        ],
+        "summary": "Get a list of industries",
+        "description": "Retreives the list of valid industries to describe companies as belonging to.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Industry"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/customfields": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get a lead's custom fields",
+        "description": "Get a list of custom fields that are applied to a lead.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom Fields",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FullCustomField"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/customfields/attributes": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get applicable custom fields for leads",
+        "description": "Get a list of custom fields that can be applied to leads.",
+        "responses": {
+          "200": {
+            "description": "Custom Fields",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomField"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/customfield": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Create a custom field",
+        "description": "Creates a custom field to use for leads.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CustomFieldCreateInput"
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get a lead",
+        "description": "Get a single lead by the ID provided.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Delete a lead.",
+        "description": "Delete a lead by the ID provided. Can be restored with the undelete endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Update a lead",
+        "description": "Update a lead by id. <br><br> op is the operation to be performed, and path specifies what resource to patch. <br><br> Use the path leads/0/fieldName to update fields that are user-entered for this resource, i.e. name, description, etc. <br> <br> Use the path leads/0/links/fieldName to update this lead's links to other resources within Nutshell, i.e. contacts, owner, tags, etc. When performing an 'add', include a /- at the end of the path, i.e. leads/0/links/fieldName/- .  <br><br> When using the remove operation, include the id at the end of the path (i.e. leads/0/links/contacts/1-contacts) - no need to include a value.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/patchInput"
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "No patches sent"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/list": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get list items for all leads",
+        "description": "Get a list of all leads and associated data in your Nutshell Instance, in a list item format. List items have additional fields attached to them for filtering purposes.",
+        "parameters": [
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter results by name. Visit the filters guide for more information on how to filter by other terms.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info on an entity. Returns all entities that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order.",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "-age",
+                  "-value",
+                  "-milestone",
+                  "-confidence",
+                  "-name",
+                  "-closedTime",
+                  "-owner",
+                  "-sources",
+                  "age",
+                  "value",
+                  "milestone",
+                  "confidence",
+                  "name",
+                  "closedTime",
+                  "owner",
+                  "sources"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leads list",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "count": {
+                              "description": "The number of returned leads",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "total": {
+                              "description": "The total number of leads in your Nutshell instance",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/meta"
+                        }
+                      ]
+                    },
+                    "listItems": {
+                      "type": "array",
+                      "items": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/ListItemLead"
+                          },
+                          {
+                            "$ref": "#/components/schemas/HtmlLinkable"
+                          },
+                          {
+                            "$ref": "#/components/schemas/Avatarable"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get a list of leads",
+        "description": "Get a list of all leads and associated data in your Nutshell Instance.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info on an entity. Returns all entities that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order.",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "-age",
+                  "-value",
+                  "-milestone",
+                  "-confidence",
+                  "-name",
+                  "-closedTime",
+                  "-owner",
+                  "-sources",
+                  "age",
+                  "value",
+                  "milestone",
+                  "confidence",
+                  "name",
+                  "closedTime",
+                  "owner",
+                  "sources"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter[number]",
+            "in": "query",
+            "description": "Of the format '?filter[number]=1000', where 'number' can be any valid filter type. See the guide on Filters for more details.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[page]",
+            "in": "query",
+            "description": "The page of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "How many results to return per page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leads",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Create a lead",
+        "description": "Create a new lead. Only one lead can be created at a time.",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "properties": {
+                  "leads": {
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "description": {
+                          "description": "Description of the lead, which is also set as the name of the lead",
+                          "type": "string",
+                          "example": "Car Wash Inc."
+                        },
+                        "dueTime": {
+                          "$ref": "#/components/schemas/dueTime"
+                        },
+                        "customFields": {
+                          "description": "Custom fields to add to the Lead.",
+                          "type": "object",
+                          "example": {
+                            "Favorite Number": "12"
+                          },
+                          "additionalProperties": {
+                            "$ref": "#/components/schemas/CustomFieldInput"
+                          }
+                        },
+                        "links": {
+                          "properties": {
+                            "accounts": {
+                              "description": "This can either be the IDs of the accounts the lead should be associated with, or an account object",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "example": "1-accounts"
+                              }
+                            },
+                            "contacts": {
+                              "description": "This can either be the IDs of the contacts the lead should be associated with, or a contact object",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "example": "1-contacts"
+                              }
+                            },
+                            "owner": {
+                              "description": "The ID of the user the lead is assigned to",
+                              "type": "string",
+                              "example": "1-users"
+                            },
+                            "sources": {
+                              "description": "The IDs of the sources the lead should be associated with",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "example": "1-sources"
+                              }
+                            },
+                            "tags": {
+                              "description": "The tags to attach to the lead",
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "example": "1-tags"
+                              }
+                            },
+                            "productMaps": {
+                              "description": "The products to attach to the lead. You need to specify a product ID and under links to map the product to the lead. When specifying the price, quantity, or other root level productMap properties, you need to specify the type and productType as well",
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/LeadProductMap"
+                              }
+                            },
+                            "competitorMaps": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/report": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get reports for a lead",
+        "parameters": [
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter results by lead name. Visit the filters guide for more information on how to filter by other terms.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to search all related info. Returns all reports that are similar to the query term.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort the returned list by a chosen field. Use a '-' before the field name to sort in descending order.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "csv",
+                "pdf",
+                "png",
+                "html"
+              ]
+            }
+          },
+          {
+            "name": "gap",
+            "in": "query",
+            "description": "The bucket size of the report",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "d",
+                "w",
+                "m",
+                "y",
+                "q"
+              ]
+            }
+          },
+          {
+            "name": "groupByField",
+            "in": "query",
+            "description": "The field to group leads by",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pivotFacet",
+            "in": "query",
+            "description": "The facet to sort values on.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "reportType",
+            "in": "query",
+            "description": "The type of report to generate.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "segmentByField",
+            "in": "query",
+            "description": "Fields to segment the groupByField by.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "useConfidence",
+            "in": "query",
+            "description": "When calculating lead values, use their weight confidence value or not",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reports",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "reports": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "report": {
+                            "$ref": "#/components/schemas/NutReportOnDemandReport"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/stages": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Get all stages associated with lead",
+        "description": "Get all stages associated with a lead by the ID provided, including information like amount of time spent in each stage.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stages",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "description": "Get all stages associated with lead",
+                      "properties": {
+                        "stageset": {
+                          "$ref": "#/components/schemas/Stageset"
+                        }
+                      },
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/meta"
+                        },
+                        {
+                          "properties": {
+                            "timeSpent": {
+                              "description": "Array of time spent in each stage",
+                              "type": "array",
+                              "items": {
+                                "properties": {
+                                  "formatted": {
+                                    "description": "Formatted value",
+                                    "type": "string"
+                                  },
+                                  "prefix": {
+                                    "description": "Prefix to add to value",
+                                    "type": "string"
+                                  },
+                                  "suffix": {
+                                    "description": "Suffix to add to value",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Actual value",
+                                    "type": "number"
+                                  },
+                                  "unit": {
+                                    "description": "Unit of time",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "stages": {
+                      "description": "Get all stages associated with lead",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Stage"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/reopen": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Reopen a lead",
+        "description": "Reopen a lead that was previously closed.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/status": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Update the status of a lead.",
+        "description": "Update the status of a lead, for example, close a lead as won or lost. Also allows for setting the outcome of the lead, and competitor and product maps.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the lead to update the status of",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "outcomeId": {
+                    "description": "ID of the outcome to set for the lead",
+                    "type": "string",
+                    "example": "1-outcomes"
+                  },
+                  "competitorMaps": {
+                    "description": "Array of competitor maps ids",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": "1-competitorMaps"
+                    }
+                  },
+                  "productMaps": {
+                    "description": "Array of product maps. You need to specify a product ID and under links to map the product to the lead. When specifying the price, quantity, or other root level productMap properties, you need to specify the type and productType as well",
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LeadProductMap"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/stageset": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Set the pipeline for a lead",
+        "description": "Pipelines are also known as stagesets.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "stageset": {
+                    "description": "ID of the stageset to set",
+                    "type": "string",
+                    "example": "1-stagesets"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/watch": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Watch a lead",
+        "description": "Watch/unwatch a lead to receive (or stop receiving) notifications about it. The user this change is made for is the authenticated user when making the api call.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/leads/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Undelete a lead",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Lead ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lead",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullLead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/notes/{id}": {
+      "get": {
+        "tags": [
+          "Notes"
+        ],
+        "summary": "Get a note",
+        "description": "Get a single note by the ID provided.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Notes"
+        ],
+        "summary": "Delete a note.",
+        "description": "Delete a note by the ID provided. Can be restored with the undelete endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/notes/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Notes"
+        ],
+        "summary": "Undelete a note.",
+        "description": "Undelete a note by the ID provided.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/notes": {
+      "get": {
+        "tags": [
+          "Notes"
+        ],
+        "summary": "Get a list of notes",
+        "description": "Get a list of notes.",
+        "parameters": [
+          {
+            "name": "page[limit]",
+            "in": "query",
+            "description": "Limit the number of results returned, for pagination.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[page]",
+            "in": "query",
+            "description": "Request a specific page of results, for pagination. Used in conjunction with the page[limit] parameter. Indexing is 0-based.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Notes"
+        ],
+        "summary": "Create a note",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/notePostInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/products/{id}": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Get a product",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Delete a product",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/products/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Undelete a product",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/products": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "List all products",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Filter for matching name or sku",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "-name",
+                "sku",
+                "-sku"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of products",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/productmaps/{id}": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Get lead product",
+        "description": "A product map is an instance of a product attached to a lead, including quantity and custom pricing information. This endpoint returns a single mapping between a particular product and lead.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ProductMap ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadProductMapResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Update a lead's product information.",
+        "description": "A product map is an instance of a product attached to a lead, including quantity and custom pricing information which this endpoint allows you to modify.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ProductMap ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/productMapPatchInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/productMaps/{id}": {
+      "delete": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Delete a product on a lead",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadProductMapResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/productmaps": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Get lead products",
+        "description": "A product map is an instance of a product attached to a lead, including quantity and custom pricing information. This endpoint returns all mappings between products and leads.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadProductMapResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/sources/{id}": {
+      "delete": {
+        "tags": [
+          "Sources"
+        ],
+        "summary": "Delete a Source",
+        "description": "Delete a source by ID. Deleted sources are removed from the sources tab, and can be restored from the trash within 30 days of deletion via the undelete endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-sources', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "description": "Returns the deleted source",
+                  "properties": {
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Source"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/sources/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Sources"
+        ],
+        "summary": "Undelete a Source",
+        "description": "Undelete a source by id.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Ids are of the form 'n-sources', where n is an integer.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "description": "Returns the undeleted source",
+                  "properties": {
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Source"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/sources": {
+      "get": {
+        "tags": [
+          "Sources"
+        ],
+        "summary": "Get a list of sources",
+        "description": "Returns a list of all possible sources for leads in your Nutshell instance.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Query for sources that match a specific string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Source"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Sources"
+        ],
+        "summary": "Create a new source",
+        "description": "Create a new source for leads in your Nutshell instance. Sources are used to track how leads arrive at your website and learn about your business.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sources": {
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "description": "The name of the source",
+                          "type": "string"
+                        },
+                        "channel": {
+                          "description": "The channel of the source. 0 = no channel, 1 = organic search, 2 = paid search, 3 = organic social, 4 = paid social, 5 = email, 6 = referrer, 7 = traditional, 8 = direct to website",
+                          "type": "integer",
+                          "enum": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Source"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/stages": {
+      "get": {
+        "tags": [
+          "Stagesets (Pipelines)"
+        ],
+        "summary": "Get a list of stages",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Stage"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/stagesets": {
+      "get": {
+        "tags": [
+          "Stagesets (Pipelines)"
+        ],
+        "summary": "Get a list of pipelines",
+        "description": "Gets a list of pipelines that leads can be assigned to. Pipelines are also known as stagesets.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Stageset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/stagesets/{id}/export": {
+      "get": {
+        "tags": [
+          "Stagesets (Pipelines)"
+        ],
+        "summary": "Get a CSV export of lead movements through a pipeline",
+        "description": "Get a CSV export of lead movements through a pipeline",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Stageset ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/tags/{id}": {
+      "delete": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Delete a tag",
+        "description": "Delete a tag by id. Deleted tags are removed from the list of tags, and can be restored from the trash within 30 days of deletion via the undelete endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id of the form n-tags, where n is an integer.<br><br> Ids can be listed in a comma-separated format to delete multiple tags at once.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "tags": {
+                      "description": "Contains the deleted tags",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tag"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/tags": {
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Get a list of tags",
+        "description": "Get a list of all tags in a Nutshell instance.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Used to query for tags that match a specific string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[tagType]",
+            "in": "query",
+            "description": "Used to get tags of a specific type",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "leads",
+                "contacts",
+                "accounts"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tag"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Create a tag",
+        "description": "Create a tag. Tags are used to organize leads, contacts, and accounts into groups.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "Enterprise"
+                        },
+                        "colorType": {
+                          "description": "Use '1' for default, '2' for grey, '3' for red, '4' for light red, '5' for orange, '6' for light orange, '7' for yellow, '8' for light yellow, '9' for blue, '10' for light blue, '11' for green, '12' for light green, '13' for purple, '14' for light purple",
+                          "type": "string",
+                          "enum": [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5",
+                            "6",
+                            "7",
+                            "8",
+                            "9",
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                            "14"
+                          ]
+                        },
+                        "tagType": {
+                          "description": "Use '1' for leads, '2' for contacts, '3' for accounts",
+                          "type": "string",
+                          "enum": [
+                            "1",
+                            "2",
+                            "3"
+                          ]
+                        },
+                        "links": {
+                          "description": "Array of entity IDs to link the tag to",
+                          "properties": {
+                            "entities": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Name and tagType are required.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "tags": {
+                      "description": "Contains the created tag",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tag"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/tags/{id}/undelete": {
+      "post": {
+        "tags": [
+          "Tags"
+        ],
+        "summary": "Undelete a tag",
+        "description": "Undelete a tag by id. Tags can be restored from the trash within 30 days of deletion.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id in the form n-tags, where n is an integer",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "properties": {
+                    "tags": {
+                      "description": "Contains the undeleted tag",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tag"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/territories": {
+      "get": {
+        "tags": [
+          "Territories"
+        ],
+        "summary": "Get a list of territories",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Territory"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get a list of users",
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get a user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://app.nutshell.com/rest"
+    }
+  ],
+  "components": {
+    "requestBodies": {
+      "CustomFieldCreateInput": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CustomFieldCreateInput"
+            }
+          }
+        },
+        "required": true
+      },
+      "patchInput": {
+        "content": {
+          "application/json-patch+json": {
+            "schema": {
+              "$ref": "#/components/schemas/patchInput"
+            }
+          }
+        },
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "description": "email:apiKey",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "accountResponse": {
+        "description": "A full response object for an account-related endpoint.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "accounts": {
+            "description": "An array of returned accounts.",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Account"
+                },
+                {
+                  "$ref": "#/components/schemas/HtmlLinkable"
+                },
+                {
+                  "$ref": "#/components/schemas/Avatarable"
+                }
+              ]
+            }
+          },
+          "creators": {
+            "description": "An array of creators for the accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "owners": {
+            "description": "An array of owners for the accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "origins": {
+            "description": "An array of origins for the accounts",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Origin"
+                },
+                {
+                  "$ref": "#/components/schemas/HtmlLinkable"
+                },
+                {
+                  "$ref": "#/components/schemas/Avatarable"
+                }
+              ]
+            }
+          },
+          "contacts": {
+            "description": "An array of contacts for the accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Contact"
+            }
+          },
+          "accountTypes": {
+            "description": "An array of account types for the accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccountType"
+            }
+          },
+          "industries": {
+            "description": "An array of industries for the accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Industry"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "activityPostInput": {
+        "properties": {
+          "activities": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "The name of the activity",
+                  "type": "string",
+                  "example": "Call with Andy Fowler"
+                },
+                "description": {
+                  "description": "The agenda for the activity",
+                  "type": "string",
+                  "example": "Discuss the new feature set"
+                },
+                "note": {
+                  "description": "An internal note about the activity",
+                  "type": "string",
+                  "example": "Andy was very excited about the new feature set"
+                },
+                "location": {
+                  "description": "Where the activity will take place",
+                  "type": "string",
+                  "example": "Andy's office"
+                },
+                "activityType": {
+                  "description": "See GET /activitytypes",
+                  "type": "string",
+                  "example": "1-activityTypes"
+                },
+                "startTime": {
+                  "description": "Unix timestamp",
+                  "type": "integer"
+                },
+                "endTime": {
+                  "description": "Unix timestamp",
+                  "type": "integer"
+                },
+                "transcription": {
+                  "description": "The transcription of the activity",
+                  "type": "string",
+                  "example": "Speaker 1: Hello.\\n Speaker 2: Good morning!"
+                },
+                "isFlagged": {
+                  "description": "Whether the activity is marked as important or not",
+                  "type": "boolean",
+                  "example": false
+                },
+                "isLogged": {
+                  "description": "Whether the activity has occurred yet or not",
+                  "type": "boolean",
+                  "example": true
+                },
+                "isAllDay": {
+                  "description": "Whether the activity is an all-day event",
+                  "type": "boolean",
+                  "example": false
+                },
+                "links": {
+                  "description": "The entity IDs of activity participants",
+                  "properties": {
+                    "participants": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "contactPostInput": {
+        "description": "The fields to be updated",
+        "properties": {
+          "contacts": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "The new full name of the contact.",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "The new description of the contact, which appears under their name.",
+                  "type": "string"
+                },
+                "phones": {
+                  "$ref": "#/components/schemas/phones"
+                },
+                "emails": {
+                  "$ref": "#/components/schemas/emails"
+                },
+                "urls": {
+                  "$ref": "#/components/schemas/urls"
+                },
+                "addresses": {
+                  "$ref": "#/components/schemas/addresses"
+                },
+                "customFields": {
+                  "description": "Custom fields to add to the Contact.",
+                  "type": "object",
+                  "example": {
+                    "Favorite Number": "12"
+                  },
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/CustomFieldInput"
+                  }
+                },
+                "links": {
+                  "description": "Enter API IDs to link to the contact.",
+                  "properties": {
+                    "accounts": {
+                      "description": "Enter an array of API IDs for each account to associate with the contact. Including an empty array will clear all associated accounts.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "territory": {
+                      "description": "Enter an API ID for the territory to associate with the contact.",
+                      "type": "string"
+                    },
+                    "owner": {
+                      "description": "Enter an API ID for the owner to associate with the contact.",
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "Enter an array of API IDs for each tag to associate with the contact.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "emAudiences": {
+                      "description": "Enter an array of API IDs ({id}-emAudiences) for each audience to associate with the contact.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "dueTime": {
+        "description": "When the lead is due.",
+        "properties": {
+          "absoluteLocalizedString": {
+            "description": "The value formatted as a string",
+            "type": "string",
+            "example": "May 28, 2024"
+          },
+          "timestamp": {
+            "type": "number",
+            "example": "1234567890"
+          },
+          "value": {
+            "description": "The value to be formatted",
+            "type": "string",
+            "example": "May 28, 2024"
+          }
+        },
+        "type": "object"
+      },
+      "notePostInput": {
+        "properties": {
+          "data": {
+            "properties": {
+              "body": {
+                "description": "The text to display on the note",
+                "type": "string",
+                "example": "Hello World!"
+              },
+              "links": {
+                "description": "The entity to attach the note to",
+                "properties": {
+                  "parent": {
+                    "description": "The entity to attach the note to",
+                    "type": "string",
+                    "example": "3-contacts"
+                  }
+                },
+                "type": "object",
+                "example": "3-contacts"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "productMapPatchInput": {
+        "type": "array",
+        "items": {
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "replace"
+              ]
+            },
+            "path": {
+              "description": "The path to the value you want to update",
+              "type": "string",
+              "enum": [
+                "/productMaps/0/quantity",
+                "/productMaps/0/price"
+              ]
+            },
+            "value": {
+              "description": "The updated value",
+              "type": "string",
+              "example": "7"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "patchInput": {
+        "type": "array",
+        "items": {
+          "properties": {
+            "op": {
+              "description": "The operation to perform",
+              "type": "string",
+              "enum": [
+                "add",
+                "remove",
+                "replace",
+                "move",
+                "copy"
+              ],
+              "example": "add"
+            },
+            "path": {
+              "description": "The path to the attribute to patch. Can be used to update custom fields as well, such as using /leads/0/{customFieldName}",
+              "type": "string",
+              "example": "/leads/0/links/accounts/337-accounts"
+            },
+            "value": {
+              "description": "The value to set, can be various types, please refer to our guide on JSON Patch for more information",
+              "type": "string",
+              "example": "337-accounts"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "commentLinkIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "Account": {
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "revenue": {
+            "properties": {
+              "amount": {
+                "type": "string",
+                "example": "8675309.00"
+              },
+              "formatted": {
+                "type": "string",
+                "example": "$8,675,309.00"
+              }
+            },
+            "type": "object"
+          },
+          "employeeCount": {
+            "type": "integer"
+          },
+          "name": {
+            "description": "The entity's full name.",
+            "type": "string",
+            "example": "Andy Nutshell"
+          },
+          "description": {
+            "description": "A brief explanation of this entity which appears under their name.",
+            "type": "string",
+            "example": "CEO / cofounder @ Nutshell. Building growth software, wrangling beagles 🐶"
+          },
+          "createdTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletedTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "emails": {
+            "$ref": "#/components/schemas/emails"
+          },
+          "addresses": {
+            "$ref": "#/components/schemas/addresses"
+          },
+          "phones": {
+            "$ref": "#/components/schemas/phones"
+          },
+          "urls": {
+            "$ref": "#/components/schemas/urls"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "accountLinks": {
+        "properties": {
+          "accounts.creator": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.owner": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.territory": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.tags": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.origin": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.mergedWith": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.files": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.relatedFiles": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.followup": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.recurringTask": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.contacts": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.accountType": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "accounts.industry": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "AccountType": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "ActivityResponse": {
+        "description": "A full response object for a activity-related endpoint",
+        "properties": {
+          "activities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FullActivity"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "FullActivity": {
+        "description": "An individual activity with all fields",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Activity"
+          },
+          {
+            "$ref": "#/components/schemas/HtmlLinkable"
+          }
+        ]
+      },
+      "Activity": {
+        "properties": {
+          "agenda": {
+            "description": "The list of things to accomplish in the activity",
+            "example": "Sign a contract with Andy"
+          },
+          "createdTime": {
+            "type": "integer"
+          },
+          "endTime": {
+            "type": "integer"
+          },
+          "deletedTime": {
+            "type": "integer"
+          },
+          "href": {
+            "description": "The URL to fetch this contact.",
+            "type": "string",
+            "example": "https://app.nutshell.com/rest/contacts/3-contacts"
+          },
+          "isAllDay": {
+            "description": "Whether the activity is an all-day event",
+            "type": "boolean",
+            "example": "false"
+          },
+          "isEditable": {
+            "description": "Whether the activity can still be modified",
+            "type": "boolean",
+            "example": "true"
+          },
+          "isCancelled": {
+            "description": "Whether the activity occurred as planned or not",
+            "type": "boolean",
+            "example": "false"
+          },
+          "isFlagged": {
+            "description": "Whether the activity is marked as important or not",
+            "type": "boolean",
+            "example": "false"
+          },
+          "isLogged": {
+            "description": "Whether the activity has occurred yet or not",
+            "type": "boolean",
+            "example": "true"
+          },
+          "isOverdue": {
+            "description": "Whether the activity was supposed to be logged by now or not",
+            "type": "boolean",
+            "example": "false"
+          },
+          "loggedTime": {
+            "type": "integer"
+          },
+          "modifiedTime": {
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the activity",
+            "type": "string",
+            "example": "Meeting with Andy"
+          },
+          "startTime": {
+            "type": "integer"
+          },
+          "isMediaLogged": {
+            "type": "boolean"
+          },
+          "transcription": {
+            "description": "The transcription on the activity",
+            "type": "string",
+            "example": "Speaker 1: Hello.\\n Speaker 2: Good morning!"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "ActivityTypeResponse": {
+        "description": "A full response object for an activity type-related endpoint.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "activityTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityType"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "ActivityType": {
+        "properties": {
+          "name": {},
+          "modifiedTime": {
+            "type": "integer"
+          },
+          "isBenchmarkable": {
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "EventResponse": {
+        "description": "A full response object for an event-related endpoint.",
+        "properties": {
+          "meta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/meta"
+              },
+              {
+                "properties": {
+                  "previous": {
+                    "description": "The URL to the previous page of results",
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "next": {
+                    "description": "The URL to the next page of results",
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeLogEntry"
+                },
+                {
+                  "properties": {
+                    "links": {
+                      "$ref": "#/components/schemas/eventLinkIds"
+                    }
+                  },
+                  "type": "object"
+                }
+              ]
+            }
+          }
+        },
+        "type": "object"
+      },
+      "ChangeLogEntry": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "integer"
+          },
+          "actorType": {
+            "description": "The type of entity that performed the action.",
+            "type": "string",
+            "example": "users"
+          },
+          "payloadType": {
+            "description": "The type of entity that was changed",
+            "type": "string",
+            "example": "contacts"
+          },
+          "action": {
+            "description": "What type of change took place",
+            "type": "string",
+            "example": "create"
+          },
+          "changes": {
+            "$ref": "#/components/schemas/changes"
+          },
+          "count": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "eventLinkIds": {
+        "properties": {
+          "actor": {
+            "type": "string"
+          },
+          "payloads": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "comments": {
+            "$ref": "#/components/schemas/commentLinkIds"
+          }
+        },
+        "type": "object"
+      },
+      "changeLogChange": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "changes": {
+        "description": "The changed values associated with the event",
+        "type": "array",
+        "items": {
+          "properties": {
+            "attribute": {
+              "description": "What value of the entity was changed",
+              "type": "string",
+              "example": "value"
+            },
+            "oldValue": {
+              "$ref": "#/components/schemas/changeLogChange"
+            },
+            "newValue": {
+              "$ref": "#/components/schemas/changeLogChange"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "CompetitorResponse": {
+        "description": "A competitor response object",
+        "properties": {
+          "competitors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Competitor"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "Competitor": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "ContactResponse": {
+        "description": "A full response object for a contact-related endpoint.",
+        "properties": {
+          "links": {
+            "description": "Where to get related entities.",
+            "type": "object"
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FullContact"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "FullContact": {
+        "description": "An individual contact with all fields.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Contact"
+          },
+          {
+            "$ref": "#/components/schemas/HtmlLinkable"
+          },
+          {
+            "$ref": "#/components/schemas/Avatarable"
+          },
+          {
+            "properties": {
+              "links": {
+                "description": "The entity IDs of related entities.",
+                "type": "object"
+              }
+            }
+          }
+        ]
+      },
+      "Contact": {
+        "properties": {
+          "jobTitle": {
+            "description": "The person's role at their company.",
+            "example": "CEO"
+          },
+          "firstName": {
+            "description": "The person's given name.",
+            "example": "Andy"
+          },
+          "lastName": {
+            "description": "The person's family name.",
+            "example": "Fowler"
+          },
+          "href": {
+            "description": "The URL to fetch this contact.",
+            "type": "string",
+            "example": "https://app.nutshell.com/rest/contacts/3-contacts"
+          },
+          "name": {
+            "description": "The entity's full name.",
+            "type": "string",
+            "example": "Andy Nutshell"
+          },
+          "description": {
+            "description": "A brief explanation of this entity which appears under their name.",
+            "type": "string",
+            "example": "CEO / cofounder @ Nutshell. Building growth software, wrangling beagles 🐶"
+          },
+          "createdTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletedTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "emails": {
+            "$ref": "#/components/schemas/emails"
+          },
+          "addresses": {
+            "$ref": "#/components/schemas/addresses"
+          },
+          "phones": {
+            "$ref": "#/components/schemas/phones"
+          },
+          "urls": {
+            "$ref": "#/components/schemas/urls"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "contactLinkIds": {
+        "description": "A collection of IDs for entities associated with a contact. Use the paths in the 'links' object to retrieve the full entity.",
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "creator": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "territory": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "origin": {
+            "type": "string"
+          },
+          "mergedWith": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "relatedFiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "followup": {
+            "type": "string"
+          },
+          "recurringTask": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "contactLinks": {
+        "description": "A collection of paths for entities associated with a contact. Use the IDs in a contact's 'links' object to retrieve the full entity.",
+        "properties": {
+          "contacts.accounts": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.creator": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.owner": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.territory": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.tags": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.origin": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.mergedWith": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.files": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.relatedFiles": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.followup": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contacts.recurringTask": {
+            "properties": {
+              "href": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "CustomFieldCreateInput": {
+        "properties": {
+          "name": {
+            "description": "The name of the custom fields",
+            "type": "string",
+            "example": "My custom field"
+          },
+          "type": {
+            "description": "Email, location, phone, and URL are only applicable to leads.",
+            "type": "string",
+            "enum": [
+              "String",
+              "Text",
+              "Date",
+              "Currency",
+              "Enum",
+              "Email",
+              "Location",
+              "Phone",
+              "Url"
+            ],
+            "example": "String"
+          },
+          "choices": {
+            "description": "For enums only. The possible values for the custom field.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Option 1",
+              "Option 2"
+            ]
+          },
+          "isMultiple": {
+            "description": "For enums only. Whether the custom field can have multiple values",
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "type": "object"
+      },
+      "CustomFieldInput": {
+        "description": "The key-value pair for the custom field.",
+        "type": "string"
+      },
+      "FullCustomField": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CustomField"
+          },
+          {
+            "properties": {
+              "value": {
+                "description": "Custom fields can be many different types, see the guide on Custom Fields for more info.",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "CustomField": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "example": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "example": "Custom Field Title"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "Industry": {
+        "properties": {
+          "name": {
+            "description": "The type of industry.",
+            "example": "Software"
+          },
+          "modifiedTime": {
+            "type": "integer"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "LeadResponse": {
+        "description": "A full response object for a lead-related endpoint.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "type": "object"
+          },
+          "leads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FullLead"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "FullLead": {
+        "description": "A fully-fleshed lead.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Lead"
+          },
+          {
+            "$ref": "#/components/schemas/HtmlLinkable"
+          },
+          {
+            "$ref": "#/components/schemas/Avatarable"
+          }
+        ]
+      },
+      "Lead": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "example": "leads"
+          },
+          "deletedTime": {
+            "type": "string"
+          },
+          "name": {
+            "description": "The full name of the lead",
+            "type": "string",
+            "example": "John Doe"
+          },
+          "value": {
+            "$ref": "#/components/schemas/value"
+          },
+          "number": {
+            "type": "integer",
+            "format": "int64",
+            "example": "1234"
+          },
+          "description": {
+            "type": "string",
+            "example": "This is a description"
+          },
+          "createdTime": {
+            "$ref": "#/components/schemas/createdTime"
+          },
+          "closedTime": {
+            "type": "string"
+          },
+          "dueTime": {
+            "type": "string"
+          },
+          "anticipatedClosedTime": {
+            "type": "string"
+          },
+          "ownerType": {
+            "type": "string",
+            "example": "users"
+          },
+          "status": {
+            "description": "The current status of the lead",
+            "type": "string",
+            "example": "open"
+          },
+          "lastContactedTime": {
+            "description": "When the lead was last contacted.",
+            "format": "string"
+          },
+          "pieState": {
+            "type": "string"
+          },
+          "isOverdue": {
+            "description": "Whether the lead is overdue to have a final outcome set",
+            "type": "boolean",
+            "example": "false"
+          },
+          "overdueTime": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "confidence": {
+            "description": "How confident, as a percentage, that the lead will close",
+            "type": "integer",
+            "example": 25
+          },
+          "priority": {
+            "description": "Whether a lead is marked as hot (1) or not (0)",
+            "type": "integer",
+            "example": 0
+          },
+          "isCurrentUserWatching": {
+            "description": "Whether the current authenticated user is subscribed to receive notifications about this lead",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "value": {
+        "properties": {
+          "formatted": {
+            "description": "The value formatted as a string",
+            "type": "string",
+            "example": "$100.00"
+          },
+          "amount": {
+            "description": "The value as a number",
+            "type": "string",
+            "example": "100.00"
+          },
+          "currency": {
+            "description": "The currency code",
+            "type": "string",
+            "example": "USD"
+          }
+        },
+        "type": "object"
+      },
+      "createdTime": {
+        "description": "When the lead was created.",
+        "properties": {
+          "absoluteLocalizedString": {
+            "description": "The value formatted as a string",
+            "type": "string",
+            "example": "May 28, 2024"
+          },
+          "timestamp": {
+            "type": "number",
+            "example": "1234567890"
+          },
+          "value": {
+            "description": "The value to be formatted",
+            "type": "string",
+            "example": "May 28, 2024"
+          }
+        },
+        "type": "object"
+      },
+      "LeadCompetitorMapResponse": {
+        "properties": {
+          "competitorMaps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LeadCompetitorMap"
+            }
+          },
+          "leads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Lead"
+            }
+          },
+          "competitors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Competitor"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "LeadCompetitorMap": {
+        "description": "A competitor relationship on a lead represents an entity that you may be competing with for this lead",
+        "properties": {
+          "relationship": {
+            "type": "string"
+          },
+          "name": {
+            "description": "A shortcut to the name of the competitor",
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "potential",
+              "stole",
+              "beat",
+              null
+            ]
+          },
+          "links": {
+            "properties": {
+              "lead": {
+                "type": "string"
+              },
+              "competitor": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "LeadProductMapResponse": {
+        "description": "A full response object for a lead product map.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "productMaps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LeadProductMap"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "LeadProductMap": {
+        "properties": {
+          "relationship": {},
+          "price": {
+            "$ref": "#/components/schemas/value"
+          },
+          "name": {},
+          "unit": {},
+          "quantity": {
+            "type": "integer"
+          },
+          "productType": {
+            "type": "string",
+            "example": "product"
+          },
+          "type": {
+            "type": "string",
+            "example": "productMaps"
+          },
+          "links": {
+            "properties": {
+              "product": {
+                "description": "The product this map is for",
+                "type": "string",
+                "example": "1-products"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "ListItem": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "primaryName": {
+            "type": "string"
+          },
+          "primaryInfo": {
+            "type": "string"
+          },
+          "relatedName": {
+            "type": "string"
+          },
+          "relatedInfo": {
+            "type": "string"
+          },
+          "relatedType": {
+            "type": "string"
+          },
+          "relatedUrl": {
+            "type": "string"
+          },
+          "relatedUrlPath": {
+            "type": "string"
+          },
+          "primaryContact": {
+            "type": "string"
+          },
+          "primaryAccount": {
+            "type": "string"
+          },
+          "latlon": {
+            "type": "string"
+          },
+          "mapUrl": {
+            "type": "string"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "fields": {
+            "description": "Various additional fields for the list item. View the example response for more details.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "creator": {
+        "properties": {
+          "value": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "avatarUrl": {
+                "type": "string"
+              },
+              "initials": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "origin": {
+        "properties": {
+          "value": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "avatarUrl": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type": "object"
+      },
+      "tags": {
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "emailOpenRate": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "emailClickRate": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "openedEmailSequenceTemplates": {
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "clickedEmailSequenceTemplates": {
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "ctctNumberOfEmailsSent": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctBounceRate": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctClickRate": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctOpenRate": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctEngagementRating": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctLists": {
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "ctctStatus": {
+        "properties": {
+          "value": {
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ctctLastOpenTime": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctLastClickTime": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ctctEmailAddress": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "lastContactedTime": {
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "url": {
+        "properties": {
+          "value": {
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ListItemAccount": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "primaryName": {
+            "type": "string"
+          },
+          "primaryInfo": {
+            "type": "string"
+          },
+          "relatedName": {
+            "type": "string"
+          },
+          "relatedInfo": {
+            "type": "string"
+          },
+          "relatedType": {
+            "type": "string"
+          },
+          "relatedUrl": {
+            "type": "string"
+          },
+          "relatedUrlPath": {
+            "type": "string"
+          },
+          "primaryContact": {
+            "type": "string"
+          },
+          "primaryAccount": {
+            "type": "string"
+          },
+          "latlon": {
+            "type": "string"
+          },
+          "mapUrl": {
+            "type": "string"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "fields": {
+            "description": "Various additional fields for the list item. View the example response for more details.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ListItemContact": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "primaryName": {
+            "type": "string"
+          },
+          "primaryInfo": {
+            "type": "string"
+          },
+          "relatedName": {
+            "type": "string"
+          },
+          "relatedInfo": {
+            "type": "string"
+          },
+          "relatedType": {
+            "type": "string"
+          },
+          "relatedUrl": {
+            "type": "string"
+          },
+          "relatedUrlPath": {
+            "type": "string"
+          },
+          "primaryContact": {
+            "type": "string"
+          },
+          "primaryAccount": {
+            "type": "string"
+          },
+          "latlon": {
+            "type": "string"
+          },
+          "mapUrl": {
+            "type": "string"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "fields": {
+            "description": "Various additional fields for the list item. View the example response for more details.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ListItemLead": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "primaryName": {
+            "type": "string"
+          },
+          "primaryInfo": {
+            "type": "string"
+          },
+          "relatedName": {
+            "type": "string"
+          },
+          "relatedInfo": {
+            "type": "string"
+          },
+          "relatedType": {
+            "type": "string"
+          },
+          "relatedUrl": {
+            "type": "string"
+          },
+          "relatedUrlPath": {
+            "type": "string"
+          },
+          "primaryContact": {
+            "type": "string"
+          },
+          "primaryAccount": {
+            "type": "string"
+          },
+          "latlon": {
+            "type": "string"
+          },
+          "mapUrl": {
+            "type": "string"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "fields": {
+            "description": "Various additional fields for the list item. View the example response for more details.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "Note": {
+        "properties": {
+          "createdTime": {
+            "type": "string"
+          },
+          "deletedTime": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyHtml": {
+            "type": "string"
+          },
+          "bodyMarkup": {
+            "type": "string"
+          },
+          "isEditable": {
+            "type": "boolean"
+          },
+          "parentType": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "NoteResponse": {
+        "description": "A full response object for a lead-related endpoint.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "type": "object"
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Note"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "NutReportOnDemandReport": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "example": "reports"
+          },
+          "key": {
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "bucket": {
+                  "$ref": "#/components/schemas/ReportBucket"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/ReportBucket"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "ReportCount": {
+        "description": "Count of the report",
+        "properties": {
+          "formatted": {
+            "description": "The formatted value after applying the prefix and suffix",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "The prefix to apply to the value",
+            "type": "string",
+            "example": "$"
+          },
+          "suffix": {
+            "description": "The suffix to apply to the value",
+            "type": "string"
+          },
+          "value": {
+            "description": "The raw value to be formatted",
+            "type": "number",
+            "example": 100
+          }
+        },
+        "type": "object"
+      },
+      "ReportBucket": {
+        "description": "Bucket of the report",
+        "properties": {
+          "bucket": {
+            "description": "The name of the bucket",
+            "type": "string",
+            "example": "best bucket"
+          },
+          "count": {
+            "$ref": "#/components/schemas/ReportCount"
+          },
+          "total": {
+            "$ref": "#/components/schemas/ReportCount"
+          },
+          "bucketType": {
+            "type": "string"
+          },
+          "bucketSubtype": {
+            "type": "string"
+          },
+          "filters": {
+            "description": "The filters applied to the report",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "Origin": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastseenTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "originType": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "Peep": {
+        "properties": {
+          "name": {
+            "description": "The entity's full name.",
+            "type": "string",
+            "example": "Andy Nutshell"
+          },
+          "description": {
+            "description": "A brief explanation of this entity which appears under their name.",
+            "type": "string",
+            "example": "CEO / cofounder @ Nutshell. Building growth software, wrangling beagles 🐶"
+          },
+          "createdTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletedTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int64"
+          },
+          "emails": {
+            "$ref": "#/components/schemas/emails"
+          },
+          "addresses": {
+            "$ref": "#/components/schemas/addresses"
+          },
+          "phones": {
+            "$ref": "#/components/schemas/phones"
+          },
+          "urls": {
+            "$ref": "#/components/schemas/urls"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "emails": {
+        "description": "All email addresses associated with an entity.",
+        "type": "array",
+        "items": {
+          "properties": {
+            "isPrimary": {
+              "description": "If entity has multiple email addresses, which should be used as the primary point of contact.",
+              "type": "boolean",
+              "example": true
+            },
+            "name": {
+              "description": "A label for the email address, e.g. 'work', 'personal', 'support'.",
+              "type": "string",
+              "example": "personal"
+            },
+            "value": {
+              "description": "The email address itself.",
+              "type": "string",
+              "example": "andy@nutshell.com"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "addresses": {
+        "description": "All addresses associated with an entity.",
+        "type": "array",
+        "items": {
+          "properties": {
+            "isPrimary": {
+              "description": "Should this address be used if there are multiple",
+              "type": "boolean",
+              "example": true
+            },
+            "name": {
+              "description": "A label for the address, e.g. 'work', 'home', 'shipping'.",
+              "type": "string",
+              "example": "address"
+            },
+            "value": {
+              "description": "The geographic coordinates for the address.",
+              "properties": {
+                "location": {
+                  "properties": {
+                    "longitude": {
+                      "type": "number",
+                      "example": -83.732124
+                    },
+                    "latitude": {
+                      "type": "number",
+                      "example": 42.279594
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "locationAccuracy": {
+              "description": "How specific the address is. 8 is an exact street address, 1 is only a country.",
+              "type": "string",
+              "example": "8"
+            },
+            "address_1": {
+              "description": "Primary street address",
+              "type": "string",
+              "example": "206 E Huron St"
+            },
+            "address_2": {
+              "description": "Secondary street address, such as a suite or apartment number",
+              "type": "string",
+              "example": "Suite 200"
+            },
+            "address_3": {
+              "type": "string"
+            },
+            "city": {
+              "description": "City or town",
+              "type": "string",
+              "example": "Ann Arbor"
+            },
+            "state": {
+              "description": "State or province",
+              "type": "string",
+              "example": "MI"
+            },
+            "postalCode": {
+              "description": "ZIP or postal code",
+              "type": "string",
+              "example": "48103"
+            },
+            "country": {
+              "description": "Country code",
+              "type": "string",
+              "example": "US"
+            },
+            "timezone": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "phones": {
+        "type": "array",
+        "items": {
+          "properties": {
+            "isOptedOut": {
+              "description": "If this number has opted out of receiving SMS messages",
+              "type": "boolean",
+              "example": true
+            },
+            "isPrimary": {
+              "description": "Should this phone number be used if there are multiple",
+              "type": "boolean",
+              "example": true
+            },
+            "name": {
+              "description": "A label for the phone number, e.g. 'work', 'home', 'mobile'.",
+              "type": "string",
+              "example": "phone"
+            },
+            "value": {
+              "properties": {
+                "countryCode": {
+                  "description": "Phone number prefix for calling individuals in other countries",
+                  "type": "string",
+                  "example": "1"
+                },
+                "number": {
+                  "description": "The unformatted phone number with only digits",
+                  "type": "string",
+                  "example": "7341234567"
+                },
+                "extension": {
+                  "description": "An additional code to reach a specific person or department which share a number",
+                  "type": "string",
+                  "example": "123"
+                },
+                "numberFormatted": {
+                  "description": "The phone number formatted for human readability",
+                  "type": "string",
+                  "example": "734-123-4567"
+                },
+                "E164": {
+                  "description": "The phone number formatted for international use; a common programatic standard for working with phone numbers",
+                  "type": "string",
+                  "example": "+17341234567"
+                },
+                "countryCodeAndNumber": {
+                  "description": "The phone number formatted for human readability with the country code",
+                  "type": "string",
+                  "example": "+1 734-123-4567"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "urls": {
+        "type": "array",
+        "items": {
+          "properties": {
+            "isPrimary": {
+              "description": "Should this URL be used if there are multiple",
+              "type": "boolean",
+              "example": true
+            },
+            "name": {
+              "description": "A label for the URL, e.g. 'LinkedIn', 'Facebook', 'personal website'.",
+              "type": "string",
+              "example": "LinkedIn"
+            },
+            "value": {
+              "description": "The URL itself",
+              "type": "string",
+              "example": "https://www.linkedin.com"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "ProductResponse": {
+        "description": "A full response object for a product-related endpoint.",
+        "properties": {
+          "products": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Product"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "Product": {
+        "properties": {
+          "name": {},
+          "href": {},
+          "modifiedTime": {
+            "type": "integer"
+          },
+          "deletedTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "productType": {},
+          "prices": {
+            "properties": {
+              "1-markets": {
+                "$ref": "#/components/schemas/productPrice"
+              }
+            },
+            "type": "object"
+          },
+          "price": {
+            "$ref": "#/components/schemas/productPrice"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "productPrice": {
+        "properties": {
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "formatted": {
+            "type": "string"
+          },
+          "currencySymbol": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Source": {
+        "properties": {
+          "name": {
+            "example": "Google"
+          },
+          "href": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "description": "Unix Timestamp",
+            "type": "integer",
+            "format": "int64",
+            "example": 1704774720
+          },
+          "channel": {
+            "description": "Channels group sources into broader groups.",
+            "properties": {
+              "value": {
+                "type": "integer",
+                "example": 1
+              },
+              "display": {
+                "type": "string",
+                "example": "Organic search"
+              }
+            },
+            "type": "object"
+          },
+          "deletedTime": {
+            "description": "Unix Timestamp",
+            "type": "integer",
+            "format": "int64",
+            "example": 1704774720
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "Stage": {
+        "properties": {
+          "name": {
+            "description": "The name of the stage",
+            "type": "string",
+            "example": "Prospecting"
+          },
+          "description": {
+            "description": "The purpose of the stage",
+            "type": "string",
+            "example": "Identify and qualify potential customers"
+          },
+          "position": {
+            "description": "The order in which this stage appears in the pipeline",
+            "type": "integer",
+            "example": 1
+          },
+          "type": {
+            "type": "string",
+            "example": "stages"
+          },
+          "activeAvatarUrl": {
+            "type": "string"
+          },
+          "completeAvatarUrl": {
+            "type": "string"
+          },
+          "incompleteAvatarUrl": {
+            "type": "string"
+          },
+          "overdueAvatarUrl": {
+            "type": "string"
+          },
+          "numSteps": {
+            "description": "The number of steps in this stage to move on to the next stage",
+            "type": "number",
+            "example": 3
+          },
+          "canAdvanceStage": {
+            "description": "Can we advance the lead to this stage?",
+            "type": "boolean",
+            "example": true
+          },
+          "links": {
+            "description": "A list of related entity IDs",
+            "type": "array",
+            "items": {
+              "properties": {
+                "stageset": {
+                  "type": "string",
+                  "example": "1-stagesets"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "Stageset": {
+        "properties": {
+          "name": {
+            "description": "The name of the pipeline",
+            "example": "Preimum Prospects Pipeline"
+          },
+          "default": {
+            "description": "Whether this is the default pipeline for new leads.",
+            "type": "boolean",
+            "example": true
+          },
+          "canAccess": {
+            "description": "Whether the user can access the stageset based on the current Nutshell plan.",
+            "type": "boolean",
+            "example": true
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "Tag": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Enterprise"
+          },
+          "href": {
+            "type": "string",
+            "example": "https://app.nutshell.com/rest/tags/1-tags"
+          },
+          "modifiedTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int32",
+            "example": 31536000
+          },
+          "deletedTime": {
+            "description": "Unix timestamp",
+            "type": "integer",
+            "format": "int32",
+            "example": 31536000
+          },
+          "tagType": {
+            "description": "The type of entity the tag corresponds to",
+            "type": "string",
+            "example": "leads"
+          },
+          "count": {
+            "description": "The number of entities with this tag",
+            "type": "integer",
+            "format": "int32",
+            "example": "1"
+          },
+          "colorType": {
+            "description": "The color or the tag, returned as a string",
+            "type": "string",
+            "example": "COLOR_ORANGE"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "Territory": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string",
+            "example": "territories"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "UserResponse": {
+        "description": "A full response object for a user-related endpoint.",
+        "properties": {
+          "meta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/meta"
+              },
+              {
+                "properties": {
+                  "next": {
+                    "description": "The URL to the next page of results",
+                    "type": "string"
+                  },
+                  "previous": {
+                    "description": "The URL to the previous page of results",
+                    "type": "string"
+                  },
+                  "total": {
+                    "type": "integer"
+                  }
+                }
+              }
+            ]
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/User"
+                },
+                {
+                  "$ref": "#/components/schemas/Avatarable"
+                }
+              ]
+            }
+          }
+        },
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "name": {},
+          "firstName": {},
+          "modifiedTime": {
+            "type": "integer"
+          },
+          "type": {},
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "hasSetPassword": {
+            "type": "boolean"
+          },
+          "isAdministrator": {
+            "type": "boolean"
+          },
+          "isViewingRestricted": {
+            "type": "boolean"
+          },
+          "isHiddenFromFilters": {
+            "type": "boolean"
+          },
+          "canAccessEmailMarketing": {
+            "type": "boolean"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/permissions"
+          },
+          "emails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "phonecallerType": {},
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "permissions": {
+        "properties": {
+          "canAccessSetup": {
+            "type": "boolean"
+          },
+          "canAccessMarketing": {
+            "type": "boolean"
+          },
+          "canBulkEdit": {
+            "type": "boolean"
+          },
+          "canExport": {
+            "type": "boolean"
+          },
+          "canViewSharedEmails": {
+            "type": "boolean"
+          },
+          "canImport": {
+            "type": "boolean"
+          },
+          "canMergeEntities": {
+            "type": "boolean"
+          },
+          "canDeleteEntities": {
+            "type": "boolean"
+          },
+          "canAssignEntities": {
+            "type": "boolean"
+          },
+          "canAccessBilling": {
+            "type": "boolean"
+          },
+          "canManageEmailTemplates": {
+            "type": "boolean"
+          },
+          "canAccessCrm": {
+            "type": "boolean"
+          },
+          "canAccessFullCampaigns": {
+            "type": "boolean"
+          },
+          "canUsePeopleIQ": {
+            "type": "boolean"
+          },
+          "canUseInbox": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "Audience": {
+        "properties": {
+          "id": {
+            "description": "The API id of the audience",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isWebFX": {
+            "description": "Whether the audience is a WebFX audience",
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "Field": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "1-wfFields"
+          },
+          "label": {
+            "type": "string",
+            "example": "Full Name"
+          },
+          "fieldName": {
+            "type": "string",
+            "example": "name"
+          },
+          "fieldType": {
+            "type": "string",
+            "example": "textfield"
+          },
+          "entityName": {
+            "type": "string",
+            "example": "Contacts"
+          },
+          "type": {
+            "description": "The type of this entity, e.g. 'contacts', 'leads'.",
+            "type": "string",
+            "example": "contacts"
+          }
+        }
+      },
+      "FormResponse": {
+        "description": "A full response object for a form-related endpoint.",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "type": "object"
+          },
+          "wfForms": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Form"
+                },
+                {
+                  "$ref": "#/components/schemas/FormLinks"
+                }
+              ]
+            }
+          }
+        },
+        "type": "object"
+      },
+      "FormLinks": {
+        "properties": {
+          "links": {
+            "description": "The IDs of the fields in the form",
+            "properties": {
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "1-wfFields"
+                }
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "Form": {
+        "properties": {
+          "name": {
+            "description": "The name of the form",
+            "type": "string",
+            "example": "Client Questionnaire"
+          },
+          "href": {
+            "type": "string"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "description": "The API ID of this entity, formatted {integer}-{entityType}",
+            "type": "string",
+            "example": "3-contacts"
+          }
+        }
+      },
+      "Avatarable": {
+        "properties": {
+          "avatarUrl": {
+            "description": "The URL of the entity's avatar image.",
+            "type": "string",
+            "example": "https://app.nutshell.com/avatars/contacts/1006/{path}"
+          },
+          "initials": {
+            "description": "The initials of the entity, used as a fallback for the avatar image.",
+            "type": "string",
+            "example": "AF"
+          }
+        }
+      },
+      "HtmlLinkable": {
+        "properties": {
+          "htmlUrl": {
+            "description": "The link to the entity within the app.",
+            "type": "string",
+            "example": "https://app.nutshell.com/lead/1006"
+          },
+          "htmlUrlPath": {
+            "description": "The path to the entity within the app.",
+            "type": "string",
+            "example": "/lead/1006"
+          }
+        }
+      },
+      "meta": {
+        "description": "Information about the Nutshell instance making the request",
+        "properties": {
+          "instanceId": {
+            "description": "The Nutshell instance ID",
+            "type": "string",
+            "example": "12345"
+          },
+          "siteId": {
+            "description": "Site ID for WebFX customers",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "x-readme": {
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "_id": "66e88d63358431003dd273c9"
+}

--- a/scripts/openapi/nutshell/metadata/main.go
+++ b/scripts/openapi/nutshell/metadata/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/scripts/openapi/nutshell/internal/files"
+	utilsopenapi "github.com/amp-labs/connectors/scripts/openapi/utils"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// nolint:gochecknoglobals
+var (
+	ignoreEndpoints = []string{
+		// Accounts, contacts, leads custom fields.
+		"*/customfields/attributes",
+	}
+	displayNameOverride = map[string]string{
+		"accounttypes":   "Account Types",
+		"activitytypes":  "Activity Types",
+		"competitormaps": "Competitor Maps",
+		"productmaps":    "Product Maps",
+		"stagesets":      "Stage Sets",
+	}
+)
+
+func main() {
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
+	registry := datautils.NamedLists[string]{}
+
+	for _, object := range Objects() {
+		urlPath := object.URLPath
+		objectName := object.ObjectName
+
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", objectName,
+				"error", object.Problem,
+			)
+		}
+
+		for _, field := range object.Fields {
+			schemas.Add(common.ModuleRoot, objectName, object.DisplayName, urlPath, object.ResponseKey,
+				utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, object.Custom)
+		}
+
+		for _, queryParam := range object.QueryParams {
+			registry.Add(queryParam, objectName)
+		}
+	}
+
+	goutils.MustBeNil(files.OutputNutshell.FlushSchemas(schemas))
+	goutils.MustBeNil(files.OutputNutshell.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
+
+	slog.Info("Completed.")
+}
+
+func Objects() []metadatadef.Schema {
+	explorer, err := files.InputNutshell.GetExplorer(
+		api3.WithDisplayNamePostProcessors(
+			api3.SlashesToSpaceSeparated,
+			api3.CapitalizeFirstLetterEveryWord,
+		),
+		api3.WithArrayItemAutoSelection(),
+	)
+	goutils.MustBeNil(err)
+
+	objects, err := explorer.ReadObjectsGet(
+		api3.NewDenyPathStrategy(ignoreEndpoints),
+		nil, displayNameOverride,
+		func(objectName, fieldName string) bool {
+			if objectName == "competitormaps" {
+				return fieldName == "competitorMaps"
+			}
+
+			slog.Warn("don't know how to find array property")
+
+			return false
+		},
+	)
+	goutils.MustBeNil(err)
+
+	return objects
+}

--- a/test/nutshell/connector.go
+++ b/test/nutshell/connector.go
@@ -1,0 +1,28 @@
+package nutshell
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/nutshell"
+	"github.com/amp-labs/connectors/test/utils"
+	testUtils "github.com/amp-labs/connectors/test/utils"
+)
+
+func GetNutshellConnector(ctx context.Context) *nutshell.Connector {
+	filePath := credscanning.LoadPath(providers.Nutshell)
+	reader := testUtils.MustCreateProvCredJSON(filePath, false)
+
+	conn, err := nutshell.NewConnector(
+		common.ConnectorParams{
+			AuthenticatedClient: utils.NewBasicAuthClient(ctx, reader),
+		},
+	)
+	if err != nil {
+		testUtils.Fail("error creating connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/nutshell/metadata/main.go
+++ b/test/nutshell/metadata/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/nutshell"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetNutshellConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"accounts", "products", "tags",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -60,6 +60,11 @@ func CamelCaseToSpaceSeparated(displayName string) string {
 	return strcase.ToDelimited(displayName, ' ')
 }
 
+// SlashesToSpaceSeparated replaces URL slashes with spaces.
+func SlashesToSpaceSeparated(displayName string) string {
+	return strings.ReplaceAll(displayName, "/", " ")
+}
+
 // Pluralize will apply pluralization to the display name.
 func Pluralize(displayName string) string {
 	return naming.NewPluralString(displayName).String()


### PR DESCRIPTION
# Installation
Mailmonkey using API key/Oauth2 with scopes/Password, etc.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [ ] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [ ] Insert screenshot of metadata fields from read object installation.
Ex: ![image](https://github.com/user-attachments/assets/ebc027fb-b82b-4505-ac71-f2b61209fa4d)
- [ ] Insert screenshot of Svix destination.
- [ ] Screenshot of operations on dashboard

# Write
For each write object:
- [ ] Insert screenshot of dashboard.
- [ ] Insert screenshot of HTTP call.

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata
