### PR TITLE
feat: Add UserURI and OrgURI metadata in calendly connector

### DIFF
--- a/providers/calendly.go
+++ b/providers/calendly.go
@@ -23,7 +23,6 @@ func init() {
 			ExplicitWorkspaceRequired: false,
 		},
 
-		PostAuthInfoNeeded: true,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722346654/media/calendly_1722346653.svg",

--- a/providers/calendly.go
+++ b/providers/calendly.go
@@ -22,6 +22,8 @@ func init() {
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
+
+		PostAuthInfoNeeded: true,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722346654/media/calendly_1722346653.svg",

--- a/providers/calendly.go
+++ b/providers/calendly.go
@@ -22,7 +22,6 @@ func init() {
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
-
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722346654/media/calendly_1722346653.svg",

--- a/providers/calendly.go
+++ b/providers/calendly.go
@@ -22,7 +22,6 @@ func init() {
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
-
 		PostAuthInfoNeeded: true,
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
@@ -45,6 +44,16 @@ func init() {
 			Read:      false,
 			Subscribe: false,
 			Write:     false,
+		},
+		Metadata: &ProviderMetadata{
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "UserURI",
+				},
+				{
+					Name: "OrganizationURI",
+				},
+			},
 		},
 	})
 }

--- a/providers/calendly/authmetadata.go
+++ b/providers/calendly/authmetadata.go
@@ -1,0 +1,81 @@
+package calendly
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	userInfoEndpoint = "users/me"
+)
+
+var (
+	ErrUnexpectedUserURI = errors.New("malformed response: user URI missing or invalid type")
+	ErrUnexpectedOrgURI  = errors.New("malformed response: organization URI missing or invalid type")
+)
+
+type UserResponse struct {
+	Resource map[string]any `json:"resource"`
+}
+
+func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
+	userURI, orgURI, rawResp, err := c.retrieveURIs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.userURI = userURI
+	c.orgURI = orgURI
+
+	cv := map[string]string{
+		"userURI":         userURI,
+		"organizationURI": orgURI,
+	}
+
+	return &common.PostAuthInfo{
+		CatalogVars: &cv,
+		RawResponse: rawResp,
+	}, nil
+}
+
+// retrieveURIs fetches the authenticated user's URI and their current organization URI
+// from the user info endpoint. These URIs are used to identify the user's context
+// since a user can only belong to one organization at a time.
+//
+// Returns:
+//   - userURI: The unique identifier URI for the authenticated user
+//   - orgURI: The unique identifier URI for the user's current organization
+//   - error: Any error that occurred during the request or parsing
+func (c *Connector) retrieveURIs(ctx context.Context) (string, string, *common.JSONHTTPResponse, error) {
+	// Build the full user info endpoint URL
+	fullURL, err := urlbuilder.New(c.ModuleInfo().BaseURL, userInfoEndpoint)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to build user info URL: %w", err)
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, fullURL.String())
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to fetch user info: %w", err)
+	}
+
+	res, err := common.UnmarshalJSON[UserResponse](resp)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to parse user info response: %w", err)
+	}
+
+	userURI, ok := res.Resource["uri"].(string)
+	if !ok {
+		return "", "", nil, ErrUnexpectedUserURI
+	}
+
+	orgURI, ok := res.Resource["current_organization"].(string)
+	if !ok {
+		return "", "", nil, ErrUnexpectedOrgURI
+	}
+
+	return userURI, orgURI, resp, nil
+}

--- a/providers/calendly/authmetadatamodel.go
+++ b/providers/calendly/authmetadatamodel.go
@@ -1,0 +1,21 @@
+package calendly
+
+type AuthMetadataVars struct {
+	UserURI         string
+	OrganizationURI string
+}
+
+// NewAuthMetadataVars parses map into the model.
+func NewAuthMetadataVars(data map[string]string) *AuthMetadataVars {
+	return &AuthMetadataVars{
+		UserURI:         data["userURI"],
+		OrganizationURI: data["organizationURI"],
+	}
+}
+
+func (v AuthMetadataVars) AsMap() *map[string]string {
+	return &map[string]string{
+		"userURI":         v.UserURI,
+		"organizationURI": v.OrganizationURI,
+	}
+}

--- a/providers/calendly/connector.go
+++ b/providers/calendly/connector.go
@@ -29,9 +29,13 @@ type Connector struct {
 
 	// Require authenticated client
 	common.RequireAuthenticatedClient
+	common.PostAuthInfo
 
 	// Supported operations
 	components.SchemaProvider
+
+	userURI string
+	orgURI  string
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {

--- a/providers/calendly/handlers.go
+++ b/providers/calendly/handlers.go
@@ -1,0 +1,1 @@
+package calendly

--- a/test/calendly/auth-metadata/main.go
+++ b/test/calendly/auth-metadata/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/providers/calendly"
+	connTest "github.com/amp-labs/connectors/test/calendly"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetCalendlyConnector(ctx)
+
+	info, err := conn.GetPostAuthInfo(ctx)
+	if err != nil || info.CatalogVars == nil {
+		utils.Fail("error obtaining auth info", "error", err)
+	}
+
+	userURI := calendly.NewAuthMetadataVars(*info.CatalogVars).UserURI
+	orgURI := calendly.NewAuthMetadataVars(*info.CatalogVars).OrganizationURI
+
+	// Log the retrieved tenant ID.
+	slog.Info("retrieved auth metadata", "userURI", userURI)
+	slog.Info("retrieved auth metadata", "orgURI", orgURI)
+}

--- a/test/zoom/metadata/metadata.go
+++ b/test/zoom/metadata/metadata.go
@@ -21,8 +21,7 @@ func main() {
 	conn := connTest.GetZoomConnector(ctx)
 	defer utils.Close(conn)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "groups"})
-
+	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "group"})
 	if err != nil {
 		utils.Fail("error listing metadata for zoom", "error", err)
 	}

--- a/test/zoom/metadata/metadata.go
+++ b/test/zoom/metadata/metadata.go
@@ -21,7 +21,7 @@ func main() {
 	conn := connTest.GetZoomConnector(ctx)
 	defer utils.Close(conn)
 
-	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "group"})
+	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "groups"})
 	if err != nil {
 		utils.Fail("error listing metadata for zoom", "error", err)
 	}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

This adds these metadata to the calendly connector:
 - userURI 
 - orgURI
 
 these will be used in most of the calls when reading different calendly objects, as will be shown in the read connector PR. This is possible as one account can only be associated with 1 organization at a time. [Link](https://community.calendly.com/how-do-i-40/one-user-multiple-organizations-1514)
 
 Ideas have been taken from [here](https://github.com/amp-labs/connectors/pull/1871)
 
 Live tests:
<img width="1211" height="369" alt="Screenshot 2025-08-18 at 12 11 32" src="https://github.com/user-attachments/assets/fb8e50af-f664-4c7f-baf8-d95bb6bc8990" />
