### PR TITLE
[CON-2109] feat: add Sage Inacct provider

### DIFF
--- a/providers/sageInacct.go
+++ b/providers/sageInacct.go
@@ -1,0 +1,42 @@
+package providers
+
+const SageInacct Provider = "sageInacct"
+
+func init() {
+	// Sage Inacct configuration
+	SetInfo(SageInacct, ProviderInfo{
+		DisplayName: "Sage Inacct",
+		AuthType:    Oauth2,
+		BaseURL:     "https://api.intacct.com",
+		Oauth2Opts: &Oauth2Opts{
+			AuthURL:                   "https://app.blackbaud.com/oauth/authorize",
+			TokenURL:                  "https://api.intacct.com/ia/api/v1/oauth2/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+			GrantType:                 AuthorizationCode,
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1755508463/media/sage.com_1755508463.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1755508463/media/sage.com_1755508463.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1755508405/media/sage.com_1755508404.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1755508405/media/sage.com_1755508404.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Configuration

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/external/v1/meetings
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/292ecbac-1b22-4361-9dc4-6abb293055b4" />

### GET
URL: http://localhost:4444/external/v1/teams
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/c77219a0-adb6-4d1e-be82-4bc92abaf7e0" />

### GET
URL: http://localhost:4444/external/v1/team_members
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/59d2da33-30c7-4e54-902d-4c7d0b12fd90" />

There is no POST, PUT, DELETE, or PATCH methods.

## Pagination
Fathom pagination works using a cursor.
 The server returns a fixed number of items and includes a new cursor for the next page in the response.
 The client uses this cursor to load the next set of items.


First Page
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/facee136-38b0-445e-8c5e-49de9f23d63d" />

Next Page
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/20255dd6-2446-4176-a73b-0c00d5783541" />



# Logo & Icons

Icons for both dark and regular theme
<img width="806" alt="image" src="https://github.com/user-attachments/assets/fb7c31c1-ac6a-4005-9c5d-917276933a96" />

Logo for dark theme
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/bef1a82d-d897-4182-b4d5-a22bd560a72f" />


Logo for Regular theme
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/54edd171-6de3-418c-bc96-f10d37788086" />

