### PR TITLE
[CON-1478] feat: add calendly write connector

### DIFF
--- a/providers/calendly/connector.go
+++ b/providers/calendly/connector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/tools/fileconv"
@@ -36,6 +37,7 @@ type Connector struct {
 	// Supported operations
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 
 	userURI string
 	orgURI  string
@@ -64,6 +66,18 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	// Set the write provider for the connector
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		registry,
+		common.ModuleRoot,
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/calendly/support.go
+++ b/providers/calendly/support.go
@@ -22,15 +22,19 @@ var (
 )
 
 func supportedOperations() components.EndpointRegistryInput {
-	readSupport := []string{
-		"*",
-	}
+	readSupport := []string{"*"}
+
+	writeSupport := []string{"*"}
 
 	return components.EndpointRegistryInput{
 		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,
+			},
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
+				Support:  components.WriteSupport,
 			},
 		},
 	}

--- a/test/calendly/write/main.go
+++ b/test/calendly/write/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	cl "github.com/amp-labs/connectors/providers/calendly"
+	"github.com/amp-labs/connectors/test/calendly"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+	conn := calendly.GetCalendlyConnector(ctx)
+
+	err := testCreatingSchedulingLink(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	err = testCreatingEventTypes(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testCreatingSchedulingLink(ctx context.Context, conn *cl.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "scheduling_links",
+		RecordData: map[string]any{
+			"max_event_count": 1,
+			"owner":           "https://api.calendly.com/event_types/4a2abc24-beca-487f-8bcc-dcdbc20cb370",
+			"owner_type":      "EventType",
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testCreatingEventTypes(ctx context.Context, conn *cl.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "one_off_event_types",
+		RecordData: map[string]any{
+			"name":     "My Meeting Test 1",
+			"host":     "https://api.calendly.com/users/42687819-a60c-446a-b42f-0d84ce589f0e",
+			"duration": 30,
+			"timezone": "Africa/Dar_es_Salaam",
+			"date_setting": map[string]string{
+				"type":       "date_range",
+				"start_date": "2025-09-07",
+				"end_date":   "2025-10-07",
+			},
+			"location": map[string]string{
+				"kind":           "physical",
+				"location":       "Main Office",
+				"additonal_info": "string",
+			},
+		},
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}

--- a/test/zoom/metadata/metadata.go
+++ b/test/zoom/metadata/metadata.go
@@ -22,6 +22,7 @@ func main() {
 	defer utils.Close(conn)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{"users", "groups"})
+
 	if err != nil {
 		utils.Fail("error listing metadata for zoom", "error", err)
 	}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  Write Live Tests:
  
<img width="1225" height="625" alt="Screenshot 2025-08-19 at 16 29 54" src="https://github.com/user-attachments/assets/5483b90e-cfae-4894-ad05-368e5c6e195f" />
