### PR TITLE
[CON-1473] feat: enable read, write drift connector

### DIFF
--- a/providers/drift.go
+++ b/providers/drift.go
@@ -26,9 +26,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1201" height="589" alt="Screenshot 2025-08-22 at 11 13 54" src="https://github.com/user-attachments/assets/c2d82619-7b8e-45c5-80a4-140e7de5897d" />

<img width="1210" height="588" alt="Screenshot 2025-08-22 at 11 14 03" src="https://github.com/user-attachments/assets/ad3ac023-3cea-41c1-ba18-486fa7e2117b" />


- [x] Insert screenshot of Svix destination.
<img width="1276" height="616" alt="Screenshot 2025-08-22 at 11 23 50" src="https://github.com/user-attachments/assets/77a069d7-26dd-4126-862e-2be5f88b3e82" />

- [x] Screenshot of operations on dashboard
<img width="971" height="589" alt="Screenshot 2025-08-22 at 11 24 51" src="https://github.com/user-attachments/assets/c051e632-82c7-4324-81b5-7193c125c89a" />


# Write
For each write object:
- [x] Insert screenshot of dashboard.
<img width="976" height="589" alt="Screenshot 2025-08-22 at 11 25 44" src="https://github.com/user-attachments/assets/d7748606-f7b8-4ca1-8eb4-b9dc1a5ce4f6" />

- [x] Insert screenshot of HTTP call.
<img width="974" height="574" alt="Screenshot 2025-08-22 at 11 25 59" src="https://github.com/user-attachments/assets/bddb85f9-db88-42df-8148-73e200409eba" />


# Examples
[Test-Data](https://github.com/amp-labs/testdata/pull/83)
