### PR TITLE
fix: add recordId in drift write connector response

### DIFF
--- a/providers/drift/handlers.go
+++ b/providers/drift/handlers.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
@@ -20,6 +23,8 @@ const (
 
 	ListSuffix = "/list"
 )
+
+var ErrUnexpectedFieldId = errors.New("received unexpected data type in recordId field") //nolint: gochecknoglobals
 
 // Create a set of endpoints that require the list suffix.
 var endpointsRequiringListSuffix = datautils.NewSet(users, conversations, playbooks) //nolint: gochecknoglobals
@@ -69,7 +74,7 @@ func (c *Connector) constructReadURL(objectName string) (*urlbuilder.URL, error)
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
 	method := http.MethodPost
 
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	url, err := c.constructWriteURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -92,12 +97,25 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
+func (c *Connector) constructWriteURL(objectName string) (*urlbuilder.URL, error) {
+	lowerCaseObject := strings.ToLower(objectName)
+
+	// Check if this endpoint requires the create suffix
+	if lowerCaseObject == conversations {
+		objectName += "/new"
+	}
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
+}
+
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.WriteResult, error) {
+	logging.With(ctx, "drift connector")
+
 	body, ok := response.Body()
 	if !ok {
 		return &common.WriteResult{
@@ -115,8 +133,32 @@ func (c *Connector) parseWriteResponse(
 		return nil, err
 	}
 
+	recordId, err := retrieveRecordId(params.ObjectName, data)
+	if err != nil {
+		logging.Logger(ctx).Error("failed to retrieve the recordId from response data",
+			"object", params.ObjectName, "response", data)
+	}
+
 	return &common.WriteResult{
-		Success: true,
-		Data:    data,
+		Success:  true,
+		Data:     data,
+		RecordId: recordId,
 	}, nil
+}
+
+func retrieveRecordId(objectName string, data map[string]any) (string, error) {
+	if !recordIdFields.Has(objectName) {
+		return "", nil
+	}
+
+	fld := recordIdFields.Get(objectName)
+
+	id, ok := data[fld].(float64)
+	if !ok {
+		return "", ErrUnexpectedFieldId
+	}
+
+	recordId := strconv.Itoa(int(id))
+
+	return recordId, nil
 }

--- a/providers/drift/support.go
+++ b/providers/drift/support.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/datautils"
 )
 
 const (
@@ -14,6 +15,14 @@ const (
 	data          = "data"
 	updateAccount = "accounts/update"
 )
+
+var recordIdFields = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	"accounts":      "accountId",
+	"conversations": "id",
+	"contacts":      "id",
+}, func(k string) string {
+	return ""
+})
 
 func responseSchema(objectName string) (string, string) {
 	switch objectName {
@@ -42,7 +51,7 @@ func supportedOperations() components.EndpointRegistryInput {
 	}
 
 	writeSupport := []string{
-		"contacts", "emails/unsubscribe", "contacts/timeline", "conversations/new", "accounts/create",
+		"contacts", "emails/unsubscribe", "contacts/timeline", "conversations", "accounts/create",
 		"accounts/update", // updates do not need recordIdPath
 		"scim/Users",
 	}

--- a/test/drift/write/main.go
+++ b/test/drift/write/main.go
@@ -98,7 +98,7 @@ func testUpdateContacts(ctx context.Context, conn *dr.Connector) error {
 
 func testCreatingNewConversation(ctx context.Context, conn *dr.Connector) error {
 	params := common.WriteParams{
-		ObjectName: "conversations/new",
+		ObjectName: "conversations",
 		RecordData: map[string]any{
 			"email": "josephkarage@email.com",
 			"message": map[string]any{


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  # Context
This PR adds recordId field in drift write connector for the objects
- conversations
- contacts
- accounts

The rest do not have it.  Also fixes the `conversations` object name to align with object name used in read connector.

Live Tests:
<img width="1224" height="626" alt="Screenshot 2025-08-22 at 12 15 05" src="https://github.com/user-attachments/assets/e7493678-e704-4046-8e66-3668c6fc3637" />
