### PR TITLE
fix: add recordId in zendeskChat write connector

### DIFF
--- a/providers/zendeskchat/handlers.go
+++ b/providers/zendeskchat/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
@@ -17,6 +18,7 @@ const (
 	bans            = "bans"
 	account         = "account"
 	chats           = "chats"
+	id              = "id"
 	defaultPageSize = 1000
 )
 
@@ -178,6 +180,19 @@ func (c *Connector) buildWriteRequest(
 	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
+func retrieveRecordId(data map[string]any) string {
+	switch v := data["id"].(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.Itoa(int(v))
+	case int:
+		return strconv.Itoa(v)
+	}
+
+	return ""
+}
+
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
@@ -196,8 +211,11 @@ func (c *Connector) parseWriteResponse(
 		return nil, err
 	}
 
+	recordId := retrieveRecordId(data)
+
 	return &common.WriteResult{
-		Success: true,
-		Data:    data,
+		Success:  true,
+		RecordId: recordId,
+		Data:     data,
 	}, nil
 }

--- a/test/zendeskchat/write/main.go
+++ b/test/zendeskchat/write/main.go
@@ -71,7 +71,7 @@ func testCreatingTriggers(ctx context.Context, conn *zc.Connector) error {
 	params := common.WriteParams{
 		ObjectName: "triggers",
 		RecordData: map[string]any{
-			"name":        "Test Trigger Z",
+			"name":        "Test Trigger ABC",
 			"enabled":     1,
 			"description": "Visitor requested chat",
 		},


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  Context:
  - Adds recordId in write connector result.
  
  Live Tests:
  
<img width="1227" height="629" alt="Screenshot 2025-08-22 at 13 33 05" src="https://github.com/user-attachments/assets/4e6d8fd0-65be-4877-af59-056a4f9d8eaa" />
