### PR TITLE
fix: add recordId gitlab write connector

### DIFF
--- a/providers/gitlab/handlers.go
+++ b/providers/gitlab/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -166,6 +167,19 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
+func retrieveRecordId(data map[string]any) string {
+	switch v := data["id"].(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.Itoa(int(v))
+	case int:
+		return strconv.Itoa(v)
+	}
+
+	return ""
+}
+
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
@@ -189,8 +203,11 @@ func (c *Connector) parseWriteResponse(
 		return nil, err
 	}
 
+	recordId := retrieveRecordId(data)
+
 	return &common.WriteResult{
-		Success: true,
-		Data:    data,
+		Success:  true,
+		Data:     data,
+		RecordId: recordId,
 	}, nil
 }

--- a/providers/gitlab/handlers.go
+++ b/providers/gitlab/handlers.go
@@ -167,7 +167,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
-func retrieveRecordId(data map[string]any) string {
+func parseRecordId(data map[string]any) string {
 	switch v := data["id"].(type) {
 	case string:
 		return v
@@ -203,7 +203,7 @@ func (c *Connector) parseWriteResponse(
 		return nil, err
 	}
 
-	recordId := retrieveRecordId(data)
+	recordId := parseRecordId(data)
 
 	return &common.WriteResult{
 		Success:  true,

--- a/test/gitlab/write/main.go
+++ b/test/gitlab/write/main.go
@@ -39,7 +39,7 @@ func testCreatingProjects(ctx context.Context, conn *gl.Connector) error {
 	params := common.WriteParams{
 		ObjectName: "projects",
 		RecordData: map[string]any{
-			"name": "Test Project",
+			"name": "Test Project AB",
 		},
 	}
 
@@ -64,13 +64,13 @@ func testCreatingSnippets(ctx context.Context, conn *gl.Connector) error {
 	params := common.WriteParams{
 		ObjectName: "snippets",
 		RecordData: map[string]any{
-			"title":       "This is a snippet",
-			"description": "Hello World snippet",
+			"title":       "This is a snippet A",
+			"description": "Hello World snippet A",
 			"visibility":  "public",
 			"files": []map[string]string{
 				{
 					"content":   "Hello world",
-					"file_path": "test.txt",
+					"file_path": "testA.txt",
 				},
 			},
 		},


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  ## Context
  Adds recordId value in the write connector result.
  
  ## Live Test
<img width="1226" height="625" alt="Screenshot 2025-08-22 at 14 02 59" src="https://github.com/user-attachments/assets/7c24fcee-73f4-4792-81a9-639c7367d6ea" />
