### PR TITLE
fix: Add recordId in dixa connector writeResults

### DIFF
--- a/providers/dixa/handlers.go
+++ b/providers/dixa/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -122,14 +123,29 @@ func (c *Connector) parseWriteResponse(
 }
 
 func parseRecordId(data map[string]any) string {
-	switch v := data["id"].(type) {
+	v := getID(data)
+	if v == nil {
+		return ""
+	}
+
+	switch v := v.(type) {
 	case string:
 		return v
 	case float64:
 		return strconv.Itoa(int(v))
 	case int:
 		return strconv.Itoa(v)
+	default:
+		return ""
+	}
+}
+
+func getID(data map[string]any) any {
+	for key, value := range data {
+		if strings.EqualFold(key, "id") {
+			return value
+		}
 	}
 
-	return ""
+	return nil
 }

--- a/providers/dixa/handlers.go
+++ b/providers/dixa/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -111,8 +112,24 @@ func (c *Connector) parseWriteResponse(
 		return nil, err
 	}
 
+	recordId := parseRecordId(data)
+
 	return &common.WriteResult{
-		Success: true,
-		Data:    data,
+		Success:  true,
+		Data:     data,
+		RecordId: recordId,
 	}, nil
+}
+
+func parseRecordId(data map[string]any) string {
+	switch v := data["id"].(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.Itoa(int(v))
+	case int:
+		return strconv.Itoa(v)
+	}
+
+	return ""
 }


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  Live Tests:
  
<img width="1986" height="900" alt="Screenshot 2025-08-26 at 13 15 27" src="https://github.com/user-attachments/assets/a4a892d3-71c2-4f67-885c-4fdbd9fe2737" />
