### PR TITLE
[CON-2032] feat: [loxo] Add loxo connector

### DIFF
--- a/providers/loxo.go
+++ b/providers/loxo.go
@@ -1,0 +1,54 @@
+package providers
+
+const Loxo Provider = "loxo"
+
+//nolint:lll
+func init() {
+	// Loxo configuration
+	SetInfo(Loxo, ProviderInfo{
+		DisplayName: "Loxo",
+		AuthType:    ApiKey,
+		BaseURL:     "https://pod4.app.loxo.co/api/integration-user-loxo-withampersand-com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://help.loxo.co/en/articles/446640-loxo-s-open-api#h_668904ffbd",
+		}, Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://static.intercomassets.com/avatars/988166/square_128/custom_avatar-1664218549.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756216233/media/loxo.co_1756216238.jpg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://static.intercomassets.com/avatars/988166/square_128/custom_avatar-1664218549.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756216216/media/loxo.co_1756216221.png",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "domain",
+					DisplayName: "Full Domain",
+				},
+				{
+					Name:        "agency_slug",
+					DisplayName: "Agency Slug",
+				},
+			},
+		},
+	})
+}

--- a/providers/loxo.go
+++ b/providers/loxo.go
@@ -8,7 +8,7 @@ func init() {
 	SetInfo(Loxo, ProviderInfo{
 		DisplayName: "Loxo",
 		AuthType:    ApiKey,
-		BaseURL:     "https://pod4.app.loxo.co/api/integration-user-loxo-withampersand-com",
+		BaseURL:     "https://{{.domain}}/api/{{.agency_slug}}",
 		ApiKeyOpts: &ApiKeyOpts{
 			AttachmentType: Header,
 			Header: &ApiKeyOptsHeader{


### PR DESCRIPTION
# Conventions
- [ ] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/people
<img width="1483" height="655" alt="image" src="https://github.com/user-attachments/assets/f9ca9b48-fec1-444c-b08e-a8604d668800" />

### GET by Id
URL: http://localhost:4444/people/1388693
<img width="1493" height="810" alt="image" src="https://github.com/user-attachments/assets/347149e3-b6b3-421a-ae58-f32a15ea1676" />

### POST
URL: http://localhost:4444/people
<img width="1475" height="812" alt="image" src="https://github.com/user-attachments/assets/1acbc470-b9c5-4280-8a0d-a97aa5178171" />

### UPDATE
URL: http://localhost:4444/people/1388693
<img width="1483" height="803" alt="image" src="https://github.com/user-attachments/assets/22a7f7b4-6353-4ece-ad75-7cd473ead782" />

## Pagination
Request the list of people paginated results by using **per_page** to limit the response.
URL:  http://localhost:4444/people?per_page=1
<img width="1491" height="793" alt="image" src="https://github.com/user-attachments/assets/cb2b53f4-1cf0-4fd2-9c08-0d847fd02c82" />

Request the next paginated result by using **scroll_id**  in the response and use the value on the **scroll_id**  query param.
URL: http://localhost:4444/people?per_page=1&scroll_id=5B313735363230393730353637302C302E302C313338383337315D
<img width="1471" height="681" alt="image" src="https://github.com/user-attachments/assets/543bf496-56dc-46e9-87f5-08c38761dde8" />

# Logo & Icons
Logo for light mode
<img width="788" height="778" alt="image" src="https://github.com/user-attachments/assets/d433a133-c882-4c4a-a18d-bcf2fec8a8e0" />

Logo for dark mode
<img width="711" height="570" alt="image" src="https://github.com/user-attachments/assets/7e01fa43-7fa0-47f7-a66b-17c2512f96e8" />

Icon for light & dark mode
<img width="1156" height="785" alt="image" src="https://github.com/user-attachments/assets/1e91deef-3ac5-41e2-82d1-5ecc5b8550df" />



