### PR TITLE
[CON-2140] feat: add Pylon connector

### DIFF
--- a/providers/pylon.go
+++ b/providers/pylon.go
@@ -1,0 +1,42 @@
+package providers
+
+const Pylon Provider = "pylon"
+
+func init() {
+	// Pylon configuration
+	SetInfo(Pylon, ProviderInfo{
+		DisplayName: "Pylon",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.usepylon.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://docs.usepylon.com/pylon-docs/developer/api",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}

--- a/providers/pylon.go
+++ b/providers/pylon.go
@@ -19,10 +19,10 @@ func init() {
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png",
 			},
 		},


### PR DESCRIPTION
# Configuration

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/accounts
<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/18530bf3-ef42-4ebb-bed7-cce35b455c64" />


### POST
URL: http://localhost:4444/tags
<img width="1278" height="526" alt="image" src="https://github.com/user-attachments/assets/7301af4c-9d7f-45fc-81c8-f31380eafe92" />


### PATCH
URL: http://localhost:4444/tags/10c78695-9246-4e0c-874d-8c2654783de7
<img width="1285" height="548" alt="image" src="https://github.com/user-attachments/assets/e7679f47-0994-4787-8341-93b95ab28cfb" />


### DELETE
URL: http://localhost:4444/tags/10c78695-9246-4e0c-874d-8c2654783de7
<img width="1278" height="399" alt="image" src="https://github.com/user-attachments/assets/45a49a0a-e7a4-44ad-a44b-307c5e16b5d1" />


## Pagination
Pylon pagination works with a cursor and a limit. The response object contains the cursor for the next page, and the limit query specifies the number of results per page.

First Page
<img width="1276" height="979" alt="image" src="https://github.com/user-attachments/assets/67e832be-f716-4f8e-ac27-7d605d23012b" />


Next Page
<img width="1275" height="972" alt="image" src="https://github.com/user-attachments/assets/07a51200-2b51-4cdd-a365-e54b7b502ae7" />




# Logo & Icons
Icon and logo are the same.

Icon and logo for dark theme
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1756274754/media/usepylon.com_1756274753.jpg" />

Icon and logo for regular theme
<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1756274730/media/usepylon.com_1756274729.png" />

