### PR TITLE
fix: add recordId mixmax  write results

### DIFF
--- a/providers/mixmax/handlers.go
+++ b/providers/mixmax/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
@@ -163,21 +164,12 @@ func (c *Connector) parseWriteResponse(
 }
 
 func parseRecordId(data map[string]any) string {
-	// id fields in the response can be either in _id or id
-	// we check which one exists and use that
-	var idField string
-
-	if _, exists := data["id"]; exists {
-		idField = "id"
-	} else if _, exists := data["_id"]; exists {
-		idField = "_id"
-	}
-
-	if idField == "" {
+	val := getID(data)
+	if val == nil {
 		return ""
 	}
 
-	switch v := data[idField].(type) {
+	switch v := val.(type) {
 	case string:
 		return v
 	case float64:
@@ -187,4 +179,18 @@ func parseRecordId(data map[string]any) string {
 	}
 
 	return ""
+}
+
+func getID(data map[string]any) any {
+	for key, value := range data {
+		if strings.EqualFold(key, "id") {
+			return value
+		}
+
+		if strings.EqualFold(key, "_id") {
+			return value
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination 
- [ ] Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  LIve Tests:
  
<img width="1995" height="905" alt="Screenshot 2025-08-27 at 11 08 46" src="https://github.com/user-attachments/assets/d5e77351-3933-4b25-9328-19c4e9a8dee1" />
