### PR TITLE
[CON-2064] feat: [breakcold] Enable read and write

### DIFF
--- a/providers/breakcold.go
+++ b/providers/breakcold.go
@@ -33,9 +33,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }

--- a/providers/breakcold/handlers.go
+++ b/providers/breakcold/handlers.go
@@ -173,7 +173,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 
 	method := http.MethodPost
 
-	if len(params.RecordId) > 0 {
+	if params.RecordId != "" {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err

--- a/providers/breakcold/support.go
+++ b/providers/breakcold/support.go
@@ -34,7 +34,6 @@ func supportedOperations() components.EndpointRegistryInput {
 	deleteSupport := []string{
 		"status",
 		"lead",
-		"leads/add-list",
 		"tags",
 		"lists",
 		"notes",


### PR DESCRIPTION
# Installation
<img width="1856" height="897" alt="image" src="https://github.com/user-attachments/assets/d7ad515e-4ba7-4ac6-a0b9-3cd5da9b41e9" />

# Conventions
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1856" height="897" alt="image" src="https://github.com/user-attachments/assets/66fcb342-d4ff-41ba-ae60-8a9277624f56" />

- [x] Insert screenshot of Svix destination.
- [x] Screenshot of operations on dashboard

**For leads object**

<img width="1870" height="888" alt="image" src="https://github.com/user-attachments/assets/ce496226-57d4-4f06-8e12-49f27a66a7c4" />

**For tags object**

<img width="1870" height="902" alt="image" src="https://github.com/user-attachments/assets/10af55a7-3ad7-4da6-88b8-6ae796123502" />

**For reminders object**

<img width="1865" height="891" alt="image" src="https://github.com/user-attachments/assets/81f2da81-f883-4625-8324-7c0833a3aceb" />

<img width="1604" height="274" alt="image" src="https://github.com/user-attachments/assets/4c5171bb-6ace-4f6e-b6ad-5cb40313483b" />

# Write
For each write object:
- [x] Insert screenshot of dashboard.
- [x] Insert screenshot of HTTP call.

**For notes object**

<img width="1665" height="836" alt="image" src="https://github.com/user-attachments/assets/ec9eb541-37ef-4e53-9db8-c2e42e725466" />

<img width="1598" height="566" alt="image" src="https://github.com/user-attachments/assets/2a83069e-d8ad-46cd-9ebf-103b76d4e117" />

<img width="1669" height="828" alt="image" src="https://github.com/user-attachments/assets/fa4a6ceb-4b5c-4f73-8e17-e9cfc6c08097" />

<img width="1601" height="629" alt="image" src="https://github.com/user-attachments/assets/23ef5621-e5e9-4ea9-b626-fa7c29c13c50" />

**For reminders object**

<img width="1760" height="824" alt="image" src="https://github.com/user-attachments/assets/adfc00d4-c915-411c-8259-2da1e129484c" />

<img width="1607" height="575" alt="image" src="https://github.com/user-attachments/assets/b91b6e2d-0851-41a5-b30f-63d31ef431b8" />

<img width="1674" height="886" alt="image" src="https://github.com/user-attachments/assets/a4a22fad-00d1-4c5f-8b82-61e8827f5914" />

<img width="1598" height="632" alt="image" src="https://github.com/user-attachments/assets/ccd1b2bc-982a-41c7-9f1e-fd7285604909" />

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata/pull/84
