### PR TITLE
fix: add support to reading user meetings drift connector

### DIFF
--- a/providers/drift/handlers.go
+++ b/providers/drift/handlers.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -17,6 +19,7 @@ const (
 	users         = "users"
 	conversations = "conversations"
 	playbooks     = "playbooks"
+	userMeetings  = "users/meetings/org"
 
 	ListSuffix = "/list"
 )
@@ -35,6 +38,24 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if params.ObjectName == userMeetings {
+		// For this object, we need both min_start_time and max_start_time values.
+		// which correspond to Since and Until, respectively.
+		minTime := time.Now().Add(-30 * 24 * time.Hour) // Default: 30 days ago
+		if !params.Since.IsZero() {
+			minTime = params.Since
+		}
+
+		url.WithQueryParam("min_start_time", strconv.FormatInt(minTime.UnixMilli(), 10))
+
+		maxTime := time.Now()
+		if !params.Until.IsZero() {
+			maxTime = params.Until
+		}
+
+		url.WithQueryParam("max_start_time", strconv.FormatInt(maxTime.UnixMilli(), 10))
 	}
 
 	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)

--- a/test/drift/read/main.go
+++ b/test/drift/read/main.go
@@ -37,6 +37,10 @@ func main() {
 	if err := testRead(ctx, conn, "scim/Users", []string{"Resources", "schemas", "id"}); err != nil {
 		slog.Error(err.Error())
 	}
+
+	if err := testRead(ctx, conn, "users/meetings/org", []string{"orgId", "conversationId", "agentId"}); err != nil {
+		slog.Error(err.Error())
+	}
 }
 
 func testRead(ctx context.Context, conn *dr.Connector, objectName string, fields []string) error {


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)


Adds support for reading incremental sync for the object `users/meetings/org`

Live Tests:
<img width="1987" height="868" alt="Screenshot 2025-09-04 at 11 58 07" src="https://github.com/user-attachments/assets/ba0f1dda-b3e0-44f9-97e8-d1fcbf0a64cd" />
