### PR TITLE
[CON-2157] feat(hubspot): Custom fields - auto create group

### DIFF
--- a/common/metadata.go
+++ b/common/metadata.go
@@ -157,21 +157,6 @@ type FieldDefinition struct {
 	NumericOptions *NumericFieldOptions `json:"numericOptions,omitempty"`
 	// Association defines association/relationship information for the field (if any).
 	Association *AssociationDefinition `json:"association,omitempty"`
-	// UniqueProperties are fields unique to some providers.
-	UniqueProperties UniqueProperties `json:"specialFields"`
-}
-
-// nolint:lll
-// UniqueProperties is a list of special properties unique to providers.
-type UniqueProperties struct {
-	// HubspotGroupName identifies the HubSpot property group that a custom
-	// field belongs to. This is required when creating or updating fields in HubSpot.
-	// https://developers.hubspot.com/docs/api-reference/crm-properties-v3/properties/post-crm-properties-v3-objectType#body-group-name
-	//
-	// In Hubspot you can create property groups which act as tags/folders for the properties.
-	// See API example for company:
-	// https://developers.hubspot.com/docs/api-reference/legacy/crm-properties-v1-companies/post-properties-v1-companies-groups#create-a-company-property-group
-	HubspotGroupName string `json:"hubspotGroupName"`
 }
 
 // NumericFieldOptions contains additional options for numeric fields.

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -49,6 +49,8 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	}
 
 	conn.Client.HTTPClient.Base = conn.providerInfo.BaseURL
+	// Note: error handler must return common.HTTPError.
+	// Check method in the internal package "custom", method "readGroupName" which relies on error casting.
 	conn.Client.HTTPClient.ErrorHandler = conn.interpretError
 	conn.moduleInfo = conn.providerInfo.ReadModuleInfo(conn.moduleID)
 

--- a/providers/hubspot/internal/custom/adapter.go
+++ b/providers/hubspot/internal/custom/adapter.go
@@ -6,9 +6,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 )
 
-const (
-	ModuleCRMVersion = "v3"
-)
+const ModuleCRMVersion = "v3"
 
 type Adapter struct {
 	Client     *common.JSONHTTPClient
@@ -32,4 +30,16 @@ func (a *Adapter) getPropertyBatchCreateURL(objectName string) (*urlbuilder.URL,
 // https://developers.hubspot.com/docs/api-reference/crm-properties-v3/properties/patch-crm-properties-v3-objectType-propertyName
 func (a *Adapter) getPropertyUpdateURL(objectName, propertyName string) (*urlbuilder.URL, error) {
 	return urlbuilder.New(a.moduleInfo.BaseURL, "properties", ModuleCRMVersion, objectName, propertyName)
+}
+
+// nolint:lll
+// https://developers.hubspot.com/docs/api-reference/crm-properties-v3/groups/get-crm-v3-properties-objectType-groups-groupName
+func (a *Adapter) getPropertyGroupNameURL(objectName, groupName string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(a.moduleInfo.BaseURL, "properties", ModuleCRMVersion, objectName, "groups", groupName)
+}
+
+// nolint:lll
+// https://developers.hubspot.com/docs/api-reference/crm-properties-v3/groups/post-crm-v3-properties-objectType-groups
+func (a *Adapter) getPropertyGroupNameCreationURL(objectName string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(a.moduleInfo.BaseURL, "properties", ModuleCRMVersion, objectName, "groups")
 }

--- a/providers/hubspot/internal/custom/create.go
+++ b/providers/hubspot/internal/custom/create.go
@@ -11,15 +11,16 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
-func (a *Adapter) createCustomFields(ctx context.Context, objectName string, definitions []common.FieldDefinition,
-	fields map[string]common.FieldUpsertResult,
+func (a *Adapter) createCustomFields(
+	ctx context.Context, objectName string, groupName string,
+	definitions []common.FieldDefinition, fields map[string]common.FieldUpsertResult,
 ) ([]string, error) {
 	url, err := a.getPropertyBatchCreateURL(objectName)
 	if err != nil {
 		return nil, err
 	}
 
-	payload, err := newBatchPayload(definitions)
+	payload, err := newBatchPayload(groupName, definitions)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/hubspot/internal/custom/metadata.go
+++ b/providers/hubspot/internal/custom/metadata.go
@@ -2,6 +2,8 @@ package custom
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -24,7 +26,13 @@ func (a *Adapter) UpsertMetadata(
 	}
 
 	for objectName, fieldDefinitions := range params.Fields {
-		fields, err := a.upsertCustomFields(ctx, objectName, fieldDefinitions)
+		// Each object has a list of groups to organize fields.
+		groupName, err := a.getOrCreateGroupName(ctx, objectName)
+		if err != nil {
+			return nil, err
+		}
+
+		fields, err := a.upsertCustomFields(ctx, objectName, groupName, fieldDefinitions)
 		if err != nil {
 			return nil, err
 		}
@@ -44,13 +52,13 @@ func (a *Adapter) UpsertMetadata(
 //  3. Update the marked fields.
 //  4. Return a map of results for all created and updated fields.
 func (a *Adapter) upsertCustomFields(
-	ctx context.Context, objectName string, definitions []common.FieldDefinition,
+	ctx context.Context, objectName string, groupName string, definitions []common.FieldDefinition,
 ) (map[string]common.FieldUpsertResult, error) {
 	fields := make(map[string]common.FieldUpsertResult)
 
 	// Step 1: Attempt to create every field.
 	// Existing fields are returned for update.
-	fieldsForUpdate, err := a.createCustomFields(ctx, objectName, definitions, fields)
+	fieldsForUpdate, err := a.createCustomFields(ctx, objectName, groupName, definitions, fields)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +71,106 @@ func (a *Adapter) upsertCustomFields(
 
 	// Step 3: Update the fields that already exist.
 	// Any failed response here cannot be resolved and therefore will be surfaced.
-	err = a.updateCustomFields(ctx, objectName, definitionsForUpdate, fields)
+	err = a.updateCustomFields(ctx, objectName, groupName, definitionsForUpdate, fields)
 	if err != nil {
 		return nil, err
 	}
 
 	// Step 4: Return the complete set of results (created + updated).
 	return fields, nil
+}
+
+const (
+	defaultGroupNameID          = "integrationcreatedproperties"
+	defaultGroupNameDisplayName = "Integration Created Properties"
+)
+
+// getOrCreateGroup returns the property group name for a custom field in HubSpot.
+// If the group already exists, it is returned; otherwise, it is created automatically.
+// A property group can be thought of as a folder or tag that organizes related properties.
+// HubSpot requires a group when creating or updating fields, so this helper ensures one exists.
+func (a *Adapter) getOrCreateGroupName(ctx context.Context, objectName string) (string, error) {
+	groupName, err := a.fetchGroupName(ctx, objectName)
+	if err != nil {
+		return "", err
+	}
+
+	if groupName == nil {
+		return a.createGroupName(ctx, objectName)
+	}
+
+	return *groupName, nil
+}
+
+// fetchGroupName retrieves the default group for the given object.
+// Returns nil if the group does not exist.
+func (a *Adapter) fetchGroupName(ctx context.Context, objectName string) (*string, error) {
+	url, err := a.getPropertyGroupNameURL(objectName, defaultGroupNameID)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := a.Client.Get(ctx, url.String())
+	if err != nil {
+		// Check that record was not found.
+		// It is not considered an error but a valid exist path.
+		var httpError *common.HTTPError
+		if errors.As(err, &httpError) {
+			if httpError.Status == http.StatusNotFound {
+				return nil, nil // nolint:nilnil
+			}
+		}
+
+		return nil, err
+	}
+
+	groupNameObject, err := common.UnmarshalJSON[GroupNameModel](response)
+	if err != nil {
+		return nil, err
+	}
+
+	if groupNameObject == nil {
+		return nil, common.ErrEmptyJSONHTTPResponse
+	}
+
+	return &groupNameObject.Name, nil
+}
+
+// createGroupName creates a new default property group for the given object.
+// Returns the name of the newly created group.
+func (a *Adapter) createGroupName(ctx context.Context, objectName string) (string, error) {
+	url, err := a.getPropertyGroupNameCreationURL(objectName)
+	if err != nil {
+		return "", err
+	}
+
+	response, err := a.Client.Post(ctx, url.String(), &GroupNameModel{
+		Name:         defaultGroupNameID,
+		Label:        defaultGroupNameDisplayName,
+		DisplayOrder: 0,
+		Archived:     false,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	groupNameObject, err := common.UnmarshalJSON[GroupNameModel](response)
+	if err != nil {
+		return "", err
+	}
+
+	if groupNameObject == nil {
+		return "", common.ErrEmptyJSONHTTPResponse
+	}
+
+	return groupNameObject.Name, nil
+}
+
+// GroupNameModel represents a HubSpot property group.
+// It is used for both request payloads and API responses.
+type GroupNameModel struct {
+	Name         string `json:"name,omitempty"`
+	Label        string `json:"label,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+	Archived     bool   `json:"archived,omitempty"`
 }

--- a/providers/hubspot/internal/custom/payload.go
+++ b/providers/hubspot/internal/custom/payload.go
@@ -8,11 +8,11 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
-func newBatchPayload(fieldDefinitions []common.FieldDefinition) (*BatchPayload, error) {
+func newBatchPayload(groupName string, fieldDefinitions []common.FieldDefinition) (*BatchPayload, error) {
 	payloads := make([]Payload, len(fieldDefinitions))
 
 	for index, definition := range fieldDefinitions {
-		payload, err := newPayload(definition)
+		payload, err := newPayload(groupName, definition)
 		if err != nil {
 			return nil, err
 		}
@@ -25,7 +25,7 @@ func newBatchPayload(fieldDefinitions []common.FieldDefinition) (*BatchPayload, 
 	}, nil
 }
 
-func newPayload(definition common.FieldDefinition) (*Payload, error) {
+func newPayload(groupName string, definition common.FieldDefinition) (*Payload, error) {
 	theType, err := matchType(definition)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func newPayload(definition common.FieldDefinition) (*Payload, error) {
 	return &Payload{
 		Name:            definition.FieldName,
 		Label:           definition.DisplayName,
-		GroupName:       definition.UniqueProperties.HubspotGroupName,
+		GroupName:       groupName,
 		Type:            theType,
 		FieldType:       fieldType,
 		Hidden:          false,

--- a/providers/hubspot/internal/custom/update.go
+++ b/providers/hubspot/internal/custom/update.go
@@ -7,12 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common/urlbuilder"
 )
 
-func (a *Adapter) updateCustomFields(ctx context.Context, objectName string, definitions []common.FieldDefinition,
-	fields map[string]common.FieldUpsertResult,
+func (a *Adapter) updateCustomFields(
+	ctx context.Context, objectName string, groupName string,
+	definitions []common.FieldDefinition, fields map[string]common.FieldUpsertResult,
 ) error {
 	// There is no batch update, therefore for each definition we have to make a dedicated call.
 	for _, definition := range definitions {
-		if err := a.updateCustomField(ctx, objectName, definition, fields); err != nil {
+		if err := a.updateCustomField(ctx, objectName, groupName, definition, fields); err != nil {
 			return err
 		}
 	}
@@ -21,15 +22,15 @@ func (a *Adapter) updateCustomFields(ctx context.Context, objectName string, def
 }
 
 func (a *Adapter) updateCustomField(
-	ctx context.Context, objectName string, definition common.FieldDefinition,
-	fields map[string]common.FieldUpsertResult,
+	ctx context.Context, objectName string, groupName string,
+	definition common.FieldDefinition, fields map[string]common.FieldUpsertResult,
 ) error {
 	url, err := a.getPropertyUpdateURL(objectName, definition.FieldName)
 	if err != nil {
 		return err
 	}
 
-	payload, err := newPayload(definition)
+	payload, err := newPayload(groupName, definition)
 	if err != nil {
 		return err
 	}

--- a/test/hubspot/metadata/write/many/main.go
+++ b/test/hubspot/metadata/write/many/main.go
@@ -35,9 +35,6 @@ func main() {
 					Description: "Your hobby description",
 					ValueType:   common.ValueTypeString,
 					Unique:      true,
-					UniqueProperties: common.UniqueProperties{
-						HubspotGroupName: "contactinformation",
-					},
 				},
 				{
 					FieldName:   "age__c",
@@ -45,9 +42,6 @@ func main() {
 					Description: "How many years you lived.",
 					ValueType:   common.ValueTypeInt,
 					Unique:      false,
-					UniqueProperties: common.UniqueProperties{
-						HubspotGroupName: "contactinformation",
-					},
 				},
 				{
 					FieldName:   "interests__c",
@@ -58,9 +52,6 @@ func main() {
 					StringOptions: &common.StringFieldOptions{
 						Values: []string{"art", "travel", "swimming"},
 					},
-					UniqueProperties: common.UniqueProperties{
-						HubspotGroupName: "contactinformation",
-					},
 				},
 				{
 					FieldName:   "isready__c",
@@ -68,9 +59,6 @@ func main() {
 					Description: "Indicates the readiness for next steps.",
 					ValueType:   common.ValueTypeBoolean,
 					Unique:      false,
-					UniqueProperties: common.UniqueProperties{
-						HubspotGroupName: "contactinformation",
-					},
 				},
 			},
 		},


### PR DESCRIPTION
# Description
Auto create group name uses group id: `integrationcreatedproperties` and its display name is `Integration Created Properties`.
The auto get-create is applied for each object only once.

# Live Tests / Dashboard
After running the live `test` script the properties were "moved" to a new group. 
As you can see the group exists with valid display name:

<img width="854" height="552" alt="image" src="https://github.com/user-attachments/assets/fab077d4-b1b9-4eb9-a2ad-3cef630ed1ba" />

Note: I had removed some fields and ran the script again to see that create & update work as expected:
<img width="507" height="92" alt="image" src="https://github.com/user-attachments/assets/fc0bf342-186b-418b-b675-3ccd1415a774" />
