### PR TITLE
[CON-2022] feat: [Highlevel] Enable read and write

### DIFF
--- a/providers/highlevel.go
+++ b/providers/highlevel.go
@@ -31,9 +31,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
@@ -79,9 +79,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/providers/highlevelstandard/README.md
+++ b/providers/highlevelstandard/README.md
@@ -36,17 +36,18 @@ Below is an exhaustive list of objects & methods supported on the objects
 | proposals/document              | proposals/document              | read         |
 | proposals/templates             | proposals/templates             | read         |
 | store/shipping-zone             | store/shipping-zone             | read, write  |
-| store/shipping-carrier          | store/shipping-carrier          | read         |
+| store/shipping-carrier          | store/shipping-carrier          | read, write  |
 | store/store-setting             | store/store-setting             | read         |
 | surveys                         | surveys                         | read         |
 | users                           | users                           | read, write  |
 | workflows                       | workflows                       | read         |
 | locations/search                | locations/search                | read         |
 | custom-menus                    | custom-menus                    | read, write  |
+| marketplace/billing/charges     | marketplace/billing/charges     | read         |
 | calendars/events/appointments   | calendars/events/appointments   | write        |
 | calendars/events/block-slots    | calendars/events/block-slots    | write        |
 | contacts                        | contacts                        | write        |
-| objects                         | objects                         | write        |
+| objects                         | objects                         | read, write  |
 | associations                    | associations                    | write        |
 | associations/relations          | associations/relations          | write        |
 | custom-fields                   | custom-fields                   | write        |

--- a/providers/highlevelstandard/support.go
+++ b/providers/highlevelstandard/support.go
@@ -43,12 +43,12 @@ func supportedOperations() components.EndpointRegistryInput {
 		"store/shipping-zone",
 		"store/shipping-carrier",
 		"store/store-setting",
-		"snapshots",
 		"surveys",
 		"users",
 		"workflows",
 		"locations/search",
 		"custom-menus",
+		"marketplace/billing/charges",
 	}
 
 	writeSupport := []string{
@@ -86,6 +86,8 @@ func supportedOperations() components.EndpointRegistryInput {
 		"products",
 		"products/collections",
 		"store/shipping-zone",
+		"store/shipping-carrier",
+		"store/store-setting",
 	}
 
 	deleteSupport := []string{
@@ -96,21 +98,10 @@ func supportedOperations() components.EndpointRegistryInput {
 		"calendars/groups",
 		"contacts",
 		"associations",
-		"associations/relations",
 		"custom-fields",
-		"custom-fields/folder",
 		"conversations",
-		"invoices",
-		"invoices/template",
-		"invoices/schedule",
-		"invoices/estimate",
-		"invoices/estimate/template",
 		"links",
-		"funnels/lookup/redirect",
 		"opportunities",
-		"payments/coupon",
-		"products",
-		"store/shipping-zone",
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/highlevelstandard/support.go
+++ b/providers/highlevelstandard/support.go
@@ -98,10 +98,20 @@ func supportedOperations() components.EndpointRegistryInput {
 		"calendars/groups",
 		"contacts",
 		"associations",
+		"associations/relations",
 		"custom-fields",
+		"custom-fields/folder",
 		"conversations",
+		"invoices",
+		"invoices/template",
+		"invoices/schedule",
+		"invoices/estimate",
+		"invoices/estimate/template",
+		"funnels/lookup/redirect",
 		"links",
 		"opportunities",
+		"products/collections",
+		"store/shipping-zone",
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/highlevelstandard/utils.go
+++ b/providers/highlevelstandard/utils.go
@@ -34,6 +34,7 @@ var objectsWithLocationIdInParam = datautils.NewSet( //nolint:gochecknoglobals
 	"surveys",
 	"users",
 	"workflows",
+	"objects",
 )
 
 var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
@@ -47,7 +48,7 @@ var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
 	"blogs/categories",
 	"funnels/lookup/redirect/list",
 	"funnels/funnel/list",
-	"payment/orders",
+	"payments/orders",
 	"payments/transactions",
 	"payments/subscriptions",
 	"payments/coupon/list",
@@ -58,6 +59,11 @@ var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
 	"store/shipping-zone",
 	"locations/search",
 	"custom-menus",
+	"surveys",
+	"proposals/document",
+	"proposals/templates",
+	"marketplace/billing/charges",
+	"forms",
 )
 
 var objectWithAltTypeAndIdQueryParam = datautils.NewSet( //nolint:gochecknoglobals
@@ -85,6 +91,7 @@ var objectWithSkipQueryParam = datautils.NewSet( //nolint:gochecknoglobals
 	"proposals/templates",
 	"surveys",
 	"invoices",
+	"marketplace/billing/charges",
 )
 
 // Ref for nodePath https://highlevel.stoplight.io/docs/integrations/a8db8afcbe0a3-get-businesses-by-location.
@@ -108,7 +115,7 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	"funnels/lookup/redirect/list": "data",
 	"funnels/funnel/list":          "funnels",
 	"opportunities/pipelines":      "pipelines",
-	"payment/orders":               "data",
+	"payments/orders":              "data",
 	"payments/transactions":        "data",
 	"payments/subscriptions":       "data",
 	"payments/coupon/list":         "data",
@@ -121,12 +128,13 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	"store/shipping-zone":          "data",
 	"store/shipping-carrier":       "data",
 	"store/store-setting":          "data",
-	"snapshots":                    "snapshots",
 	"surveys":                      "surveys",
 	"users":                        "users ",
 	"workflows":                    "workflows",
 	"locations/search":             "locations",
 	"custom-menus":                 "customMenus",
+	"marketplace/billing/charges":  "charges",
+	"objects":                      "objects",
 }, func(objectName string) string {
 	return "id"
 },
@@ -168,7 +176,7 @@ var writeObjectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:g
 	"invoices":                        "",
 	"invoices/template":               "",
 	"invoices/schedule":               "",
-	"invoices/text2pay":               "",
+	"invoices/text2pay":               "invoice",
 	"invoices/estimate":               "",
 	"invoices/estimate/template":      "",
 	"links":                           "link",
@@ -180,6 +188,8 @@ var writeObjectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:g
 	"products":                        "",
 	"products/collections":            "data",
 	"store/shipping-zone":             "data",
+	"store/shipping-carrier":          "data",
+	"store/store-setting":             "data",
 }, func(objectName string) string {
 	return "id"
 })
@@ -217,4 +227,6 @@ var writeObjectsWithUnderscoreIdField = datautils.NewSet( //nolint:gochecknoglob
 	"products",
 	"products/collections",
 	"store/shipping-zone",
+	"store/shipping-carrier",
+	"store/store-setting",
 )

--- a/providers/highlevelstandard/utils.go
+++ b/providers/highlevelstandard/utils.go
@@ -230,3 +230,14 @@ var writeObjectsWithUnderscoreIdField = datautils.NewSet( //nolint:gochecknoglob
 	"store/shipping-carrier",
 	"store/store-setting",
 )
+
+var deleteObjectWithLocationIdQueryParam = datautils.NewSet( //nolint:gochecknoglobals
+	"associations/relations",
+	"custom-fields/folder",
+	"funnels/lookup/redirect",
+)
+
+var objectWithAltTypeAndIdBodyParam = datautils.NewSet( //nolint:gochecknoglobals
+	"invoices/estimate",
+	"invoices/estimate/template",
+)

--- a/providers/highlevelwhitelabel/README.md
+++ b/providers/highlevelwhitelabel/README.md
@@ -36,17 +36,18 @@ Below is an exhaustive list of objects & methods supported on the objects
 | proposals/document              | proposals/document              | read         |
 | proposals/templates             | proposals/templates             | read         |
 | store/shipping-zone             | store/shipping-zone             | read, write  |
-| store/shipping-carrier          | store/shipping-carrier          | read         |
+| store/shipping-carrier          | store/shipping-carrier          | read, write  |
 | store/store-setting             | store/store-setting             | read         |
 | surveys                         | surveys                         | read         |
 | users                           | users                           | read, write  |
 | workflows                       | workflows                       | read         |
 | locations/search                | locations/search                | read         |
 | custom-menus                    | custom-menus                    | read, write  |
+| marketplace/billing/charges     | marketplace/billing/charges     | read         |
 | calendars/events/appointments   | calendars/events/appointments   | write        |
 | calendars/events/block-slots    | calendars/events/block-slots    | write        |
 | contacts                        | contacts                        | write        |
-| objects                         | objects                         | write        |
+| objects                         | objects                         | read, write  |
 | associations                    | associations                    | write        |
 | associations/relations          | associations/relations          | write        |
 | custom-fields                   | custom-fields                   | write        |

--- a/providers/highlevelwhitelabel/support.go
+++ b/providers/highlevelwhitelabel/support.go
@@ -43,12 +43,12 @@ func supportedOperations() components.EndpointRegistryInput {
 		"store/shipping-zone",
 		"store/shipping-carrier",
 		"store/store-setting",
-		"snapshots",
 		"surveys",
 		"users",
 		"workflows",
 		"locations/search",
 		"custom-menus",
+		"marketplace/billing/charges",
 	}
 
 	writeSupport := []string{
@@ -86,6 +86,8 @@ func supportedOperations() components.EndpointRegistryInput {
 		"products",
 		"products/collections",
 		"store/shipping-zone",
+		"store/shipping-carrier",
+		"store/store-setting",
 	}
 
 	deleteSupport := []string{
@@ -96,21 +98,10 @@ func supportedOperations() components.EndpointRegistryInput {
 		"calendars/groups",
 		"contacts",
 		"associations",
-		"associations/relations",
 		"custom-fields",
-		"custom-fields/folder",
 		"conversations",
-		"invoices",
-		"invoices/template",
-		"invoices/schedule",
-		"invoices/estimate",
-		"invoices/estimate/template",
 		"links",
-		"funnels/lookup/redirect",
 		"opportunities",
-		"payments/coupon",
-		"products",
-		"store/shipping-zone",
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/highlevelwhitelabel/support.go
+++ b/providers/highlevelwhitelabel/support.go
@@ -98,10 +98,20 @@ func supportedOperations() components.EndpointRegistryInput {
 		"calendars/groups",
 		"contacts",
 		"associations",
+		"associations/relations",
 		"custom-fields",
+		"custom-fields/folder",
 		"conversations",
+		"invoices",
+		"invoices/template",
+		"invoices/schedule",
+		"invoices/estimate",
+		"invoices/estimate/template",
+		"funnels/lookup/redirect",
 		"links",
 		"opportunities",
+		"products/collections",
+		"store/shipping-zone",
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/highlevelwhitelabel/utils.go
+++ b/providers/highlevelwhitelabel/utils.go
@@ -34,6 +34,7 @@ var objectsWithLocationIdInParam = datautils.NewSet( //nolint:gochecknoglobals
 	"surveys",
 	"users",
 	"workflows",
+	"objects",
 )
 
 var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
@@ -47,7 +48,7 @@ var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
 	"blogs/categories",
 	"funnels/lookup/redirect/list",
 	"funnels/funnel/list",
-	"payment/orders",
+	"payments/orders",
 	"payments/transactions",
 	"payments/subscriptions",
 	"payments/coupon/list",
@@ -58,6 +59,11 @@ var paginationObjects = datautils.NewSet( //nolint:gochecknoglobals
 	"store/shipping-zone",
 	"locations/search",
 	"custom-menus",
+	"surveys",
+	"proposals/document",
+	"proposals/templates",
+	"marketplace/billing/charges",
+	"forms",
 )
 
 var objectWithAltTypeAndIdQueryParam = datautils.NewSet( //nolint:gochecknoglobals
@@ -85,6 +91,7 @@ var objectWithSkipQueryParam = datautils.NewSet( //nolint:gochecknoglobals
 	"proposals/templates",
 	"surveys",
 	"invoices",
+	"marketplace/billing/charges",
 )
 
 // Ref for nodePath https://highlevel.stoplight.io/docs/integrations/a8db8afcbe0a3-get-businesses-by-location.
@@ -108,7 +115,7 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	"funnels/lookup/redirect/list": "data",
 	"funnels/funnel/list":          "funnels",
 	"opportunities/pipelines":      "pipelines",
-	"payment/orders":               "data",
+	"payments/orders":              "data",
 	"payments/transactions":        "data",
 	"payments/subscriptions":       "data",
 	"payments/coupon/list":         "data",
@@ -121,12 +128,13 @@ var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochec
 	"store/shipping-zone":          "data",
 	"store/shipping-carrier":       "data",
 	"store/store-setting":          "data",
-	"snapshots":                    "snapshots",
 	"surveys":                      "surveys",
 	"users":                        "users ",
 	"workflows":                    "workflows",
 	"locations/search":             "locations",
 	"custom-menus":                 "customMenus",
+	"marketplace/billing/charges":  "charges",
+	"objects":                      "objects",
 }, func(objectName string) string {
 	return "id"
 },
@@ -168,7 +176,7 @@ var writeObjectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:g
 	"invoices":                        "",
 	"invoices/template":               "",
 	"invoices/schedule":               "",
-	"invoices/text2pay":               "",
+	"invoices/text2pay":               "invoice",
 	"invoices/estimate":               "",
 	"invoices/estimate/template":      "",
 	"links":                           "link",
@@ -180,6 +188,8 @@ var writeObjectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:g
 	"products":                        "",
 	"products/collections":            "data",
 	"store/shipping-zone":             "data",
+	"store/shipping-carrier":          "data",
+	"store/store-setting":             "data",
 }, func(objectName string) string {
 	return "id"
 })
@@ -217,4 +227,6 @@ var writeObjectsWithUnderscoreIdField = datautils.NewSet( //nolint:gochecknoglob
 	"products",
 	"products/collections",
 	"store/shipping-zone",
+	"store/shipping-carrier",
+	"store/store-setting",
 )

--- a/providers/highlevelwhitelabel/utils.go
+++ b/providers/highlevelwhitelabel/utils.go
@@ -230,3 +230,14 @@ var writeObjectsWithUnderscoreIdField = datautils.NewSet( //nolint:gochecknoglob
 	"store/shipping-carrier",
 	"store/store-setting",
 )
+
+var deleteObjectWithLocationIdQueryParam = datautils.NewSet( //nolint:gochecknoglobals
+	"associations/relations",
+	"custom-fields/folder",
+	"funnels/lookup/redirect",
+)
+
+var objectWithAltTypeAndIdBodyParam = datautils.NewSet( //nolint:gochecknoglobals
+	"invoices/estimate",
+	"invoices/estimate/template",
+)


### PR DESCRIPTION
# Installation
# For HighLevelStandard Connector
<img width="1851" height="835" alt="image" src="https://github.com/user-attachments/assets/326223f1-4cf0-4754-8343-e22ddc21bbff" />

<img width="1806" height="894" alt="image" src="https://github.com/user-attachments/assets/13f46f67-204f-4c07-95fe-b936b16b9628" />

# For HighLevelWhiteLabel Connector
<img width="1857" height="800" alt="image" src="https://github.com/user-attachments/assets/56b8bd30-1383-40fe-89d8-87bdc8915b97" />

<img width="1535" height="895" alt="image" src="https://github.com/user-attachments/assets/72785f64-73f9-4bc4-a6e0-5a56e6a443cf" />

# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# For HighLevelStandard Connector
# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1849" height="874" alt="image" src="https://github.com/user-attachments/assets/840f8642-5708-4995-8337-8aa788344b4e" />

- [x] Insert screenshot of Svix destination.
- [x] Screenshot of operations on dashboard
<img width="1863" height="905" alt="image" src="https://github.com/user-attachments/assets/9336cff2-e656-4c8c-9be3-834c5a0b43ba" />

<img width="1882" height="912" alt="image" src="https://github.com/user-attachments/assets/0cbe7763-1962-4c13-bb9b-47155c85dc3e" />

<img width="1865" height="912" alt="image" src="https://github.com/user-attachments/assets/e8184f44-5a41-4cab-b2bf-ac64654128c0" />

<img width="1595" height="391" alt="image" src="https://github.com/user-attachments/assets/7231a72c-f7d6-4487-bb06-13e59c978549" />

# Write
For each write object:
- [x] Insert screenshot of dashboard.
- [x] Insert screenshot of HTTP call.

<img width="1758" height="869" alt="image" src="https://github.com/user-attachments/assets/df72bcaa-63b5-409c-a3a4-ae848376cce5" />
<img width="1602" height="653" alt="image" src="https://github.com/user-attachments/assets/122defc2-8f39-4cae-b589-25c258204b93" />

<img width="1766" height="885" alt="image" src="https://github.com/user-attachments/assets/856fe619-4ead-44ab-9b2c-0542317ba13d" />
<img width="1601" height="574" alt="image" src="https://github.com/user-attachments/assets/94a01cf9-ab91-43fe-a44f-4f68d4a3b61f" />

<img width="1782" height="905" alt="image" src="https://github.com/user-attachments/assets/597ae74e-112c-48f1-a22e-1ffe0b453a74" />
<img width="1603" height="588" alt="image" src="https://github.com/user-attachments/assets/73a03b24-4513-4e39-9be2-3bdc44ec8d8b" />

<img width="1632" height="884" alt="image" src="https://github.com/user-attachments/assets/0819235c-6719-473e-b3b4-4ef9f6287aee" />
<img width="1605" height="569" alt="image" src="https://github.com/user-attachments/assets/ce491d9e-e464-4bfb-9a72-a265a4a43bbc" />

# For HighLevelWhiteLabel Connector
# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1544" height="883" alt="image" src="https://github.com/user-attachments/assets/f391282c-b88f-49e0-b43a-55d27dd2f790" />

- [x] Insert screenshot of Svix destination.
- [x] Screenshot of operations on dashboard

<img width="1589" height="914" alt="image" src="https://github.com/user-attachments/assets/199b7620-161e-4ce8-942e-17776ec94143" />

<img width="1588" height="906" alt="image" src="https://github.com/user-attachments/assets/0ce78228-deb2-4e32-accb-ededa829a714" />

<img width="1589" height="914" alt="image" src="https://github.com/user-attachments/assets/85dc945f-537c-4bdf-8ac7-163dd75b54f1" />

<img width="1599" height="578" alt="image" src="https://github.com/user-attachments/assets/7f31495a-3353-404a-901f-73d415362860" />

# Write
For each write object:
- [x] Insert screenshot of dashboard.
- [x] Insert screenshot of HTTP call.

<img width="1795" height="873" alt="image" src="https://github.com/user-attachments/assets/7068ef8d-5f8e-4531-87bb-8474cbce3d6a" />
<img width="1609" height="595" alt="image" src="https://github.com/user-attachments/assets/2174205d-2609-461f-811a-801f756730a7" />

<img width="1772" height="873" alt="image" src="https://github.com/user-attachments/assets/b4799f8e-bb47-4eb8-a304-fb09b0599e30" />
<img width="1602" height="569" alt="image" src="https://github.com/user-attachments/assets/1d514999-44fd-4e34-ab51-11c501e4b486" />

<img width="1770" height="883" alt="image" src="https://github.com/user-attachments/assets/d7d4123b-a81a-4e8c-bac5-6cf68df549f1" />
<img width="1600" height="569" alt="image" src="https://github.com/user-attachments/assets/8881539d-1b06-4f3f-8d3e-6a5ca7372709" />

# Examples
Link pull request to testdata repo which contains installation file: https://github.com/amp-labs/testdata/pull/87

**Note:**
In this PR, I have added support for some read and write endpoints, and removed certain delete endpoints because they require query parameters or body parameters in the request. 
And also chekced all this and tested it.