### PR TITLE
[CON-2111] feat(SageIntacct): enable proxy support

### DIFF
--- a/providers/sageIntacct.go
+++ b/providers/sageIntacct.go
@@ -33,7 +33,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Testing

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

### GET
URL: https://proxy.withampersand.com/ia/api/v1/objects/company-config/contact
<img width="1358" height="977" alt="image" src="https://github.com/user-attachments/assets/91f1743d-b7d3-42a6-8f96-38041797086b" />



### POST
URL: https://proxy.withampersand.com/ia/api/v1/objects/company-config/contact
<img width="1359" height="733" alt="image" src="https://github.com/user-attachments/assets/42d4291c-371c-4977-b5fb-0e64a84918f4" />



### PATCH
URL: https://proxy.withampersand.com/ia/api/v1/objects/company-config/contact/284
<img width="1365" height="618" alt="image" src="https://github.com/user-attachments/assets/84f5332d-f604-4d57-a8cd-e37f157ad9bb" />



### DELETE
URL: https://proxy.withampersand.com/ia/api/v1/objects/company-config/contact/284
<img width="1356" height="355" alt="image" src="https://github.com/user-attachments/assets/ae4fce23-236c-454a-8b46-3f2c8cfbb5aa" />




## Pagination
Sage Intacct uses start and size key for pagination, and it Is added to the request body payload.

First Page
<img width="1350" height="885" alt="image" src="https://github.com/user-attachments/assets/91dccad4-911c-4a42-bedb-c4c27af02db6" />



Next Page
<img width="1361" height="907" alt="image" src="https://github.com/user-attachments/assets/89d58b2c-7750-4eac-abe6-c121d784d990" />





## Invalid requests
Invalid payload
<img width="1360" height="899" alt="image" src="https://github.com/user-attachments/assets/c2f0ebec-d633-4938-b718-ad9476482fa0" />

Invalid path 
<img width="1366" height="647" alt="image" src="https://github.com/user-attachments/assets/c942fa25-e5db-4980-aef5-1d883b0a0108" />




## Successful console operation (operation & events)
<img width="1499" height="833" alt="image" src="https://github.com/user-attachments/assets/262da640-d748-49c0-87a9-7b00148748be" />
<img width="1493" height="798" alt="image" src="https://github.com/user-attachments/assets/44f65784-af4c-4f80-a4cf-7dd933b48fb4" />


## Failed console operation (operation & events)
<img width="1502" height="877" alt="image" src="https://github.com/user-attachments/assets/da17dda2-0f5d-4619-8757-d6591e50d8d0" />

<img width="1497" height="779" alt="image" src="https://github.com/user-attachments/assets/1e813f16-d8ab-4aff-aa90-8e62f03a8150" />

