### PR TITLE
[2134] fix(teamleader): add record ID in the payload for the update operation

### DIFF
--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -141,13 +141,15 @@ func buildRequestBody(params *common.ReadParams) map[string]any {
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
 	var (
-		payload = params.RecordData
+		payload = params.RecordData.(map[string]any)
 		method  = http.MethodPost
 	)
 
 	var fullObjectName string
 	if params.RecordId != "" {
 		fullObjectName = params.ObjectName + ".update"
+		payload["id"] = params.RecordId
+
 	} else {
 		fullObjectName = writeFullObjectNames.Get(params.ObjectName)
 	}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -142,14 +143,13 @@ func buildRequestBody(params *common.ReadParams) map[string]any {
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
 	payload, ok := params.RecordData.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("invalid record data: expected map[string]any, got %T", params.RecordData)
+		return nil, errors.New("invalid record data") //nolint:goerr113
 	}
 
 	var fullObjectName string
 	if params.RecordId != "" {
 		fullObjectName = params.ObjectName + ".update"
 		payload["id"] = params.RecordId
-
 	} else {
 		fullObjectName = writeFullObjectNames.Get(params.ObjectName)
 	}

--- a/providers/teamleader/handlers.go
+++ b/providers/teamleader/handlers.go
@@ -140,10 +140,10 @@ func buildRequestBody(params *common.ReadParams) map[string]any {
 }
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
-	var (
-		payload = params.RecordData.(map[string]any)
-		method  = http.MethodPost
-	)
+	payload, ok := params.RecordData.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid record data: expected map[string]any, got %T", params.RecordData)
+	}
 
 	var fullObjectName string
 	if params.RecordId != "" {
@@ -164,7 +164,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
+	return http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonData))
 }
 
 func (c *Connector) parseWriteResponse(


### PR DESCRIPTION
## Context

Teamleader requires a record ID in the payload. This fix adds the record ID to the payload


## TEST
<img width="693" height="412" alt="image" src="https://github.com/user-attachments/assets/534f0506-a12c-42e2-b5c7-c7076c1dbbc3" />

