### PR TITLE
[CON-2179] feat(google/mail): Metadata

### DIFF
--- a/providers/google.go
+++ b/providers/google.go
@@ -8,9 +8,14 @@ const (
 
 const (
 	// ModuleGoogleCalendar is the module used for listing user calendars.
+	// https://developers.google.com/workspace/calendar/api/v3/reference
 	ModuleGoogleCalendar common.ModuleID = "calendar"
 	// ModuleGoogleContacts is the module used for listing contacts from People API.
+	// https://developers.google.com/people
 	ModuleGoogleContacts common.ModuleID = "contacts"
+	// ModuleGoogleMail is the module used for listing emails from Gmail API.
+	// https://developers.google.com/workspace/gmail/api/reference/rest
+	ModuleGoogleMail common.ModuleID = "mail"
 )
 
 //nolint:funlen
@@ -44,6 +49,15 @@ func init() {
 			ModuleGoogleContacts: {
 				BaseURL:     "https://people.googleapis.com",
 				DisplayName: "Google Contacts",
+				Support: Support{
+					Read:      false,
+					Subscribe: false,
+					Write:     false,
+				},
+			},
+			ModuleGoogleMail: {
+				BaseURL:     "https://gmail.googleapis.com/gmail",
+				DisplayName: "Google Mail (Gmail)",
 				Support: Support{
 					Read:      false,
 					Subscribe: false,

--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/google/internal/calendar"
 	"github.com/amp-labs/connectors/providers/google/internal/contacts"
+	"github.com/amp-labs/connectors/providers/google/internal/mail"
 )
 
 // Connector for Google provider.
@@ -20,6 +21,7 @@ type Connector struct {
 
 	Calendar *calendar.Adapter
 	Contacts *contacts.Adapter
+	Mail     *mail.Adapter
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -50,6 +52,15 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 		connector.Contacts = adapter
 	}
 
+	if connector.Module() == providers.ModuleGoogleMail {
+		adapter, err := mail.NewAdapter(params)
+		if err != nil {
+			return nil, err
+		}
+
+		connector.Mail = adapter
+	}
+
 	return connector, nil
 }
 
@@ -62,6 +73,10 @@ func (c Connector) ListObjectMetadata(
 
 	if c.Contacts != nil {
 		return c.Contacts.ListObjectMetadata(ctx, objectNames)
+	}
+
+	if c.Mail != nil {
+		return c.Mail.ListObjectMetadata(ctx, objectNames)
 	}
 
 	return nil, common.ErrNotImplemented
@@ -110,5 +125,9 @@ func (c Connector) setUnitTestBaseURL(url string) {
 
 	if c.Contacts != nil {
 		c.Contacts.SetUnitTestBaseURL(url)
+	}
+
+	if c.Mail != nil {
+		c.Mail.SetUnitTestBaseURL(url)
 	}
 }

--- a/providers/google/internal/mail/adapter.go
+++ b/providers/google/internal/mail/adapter.go
@@ -1,0 +1,27 @@
+package mail
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Adapter struct {
+	*components.Connector
+	components.SchemaProvider
+}
+
+func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
+	return components.Initialize(providers.Google, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Adapter, error) {
+	adapter := &Adapter{
+		Connector: base,
+	}
+
+	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(adapter.ProviderContext.Module(), Schemas)
+
+	return adapter, nil
+}

--- a/providers/google/internal/mail/metadata.go
+++ b/providers/google/internal/mail/metadata.go
@@ -1,0 +1,19 @@
+package mail
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// nolint:gochecknoglobals
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas []byte
+
+	// Schemas is cached data.
+	Schemas = scrapper.NewReader[staticschema.FieldMetadataMapV2](schemas).MustLoadSchemas()
+)

--- a/providers/google/internal/mail/schemas.json
+++ b/providers/google/internal/mail/schemas.json
@@ -1,0 +1,435 @@
+{
+  "modules": {
+    "mail": {
+      "id": "mail",
+      "path": "",
+      "objects": {
+        "delegates": {
+          "displayName": "Delegates",
+          "path": "/users/me/settings/delegates",
+          "responseKey": "delegates",
+          "fields": {
+            "delegateEmail": {
+              "displayName": "Delegate Email",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "verificationStatus": {
+              "displayName": "Verification Status",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "drafts": {
+          "displayName": "Drafts",
+          "path": "/users/me/drafts",
+          "responseKey": "drafts",
+          "fields": {
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "message": {
+              "displayName": "Message",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            }
+          }
+        },
+        "filters": {
+          "displayName": "Filters",
+          "path": "/users/me/settings/filters",
+          "responseKey": "filter",
+          "fields": {
+            "action": {
+              "displayName": "Action",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            },
+            "criteria": {
+              "displayName": "Criteria",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "forwardingAddresses": {
+          "displayName": "Forwarding Addresses",
+          "path": "/users/me/settings/forwardingAddresses",
+          "responseKey": "forwardingAddresses",
+          "fields": {
+            "forwardingEmail": {
+              "displayName": "Forwarding Email",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "verificationStatus": {
+              "displayName": "Verification Status",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "history": {
+          "displayName": "History",
+          "path": "/users/me/history",
+          "responseKey": "history",
+          "fields": {
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "labelsAdded": {
+              "displayName": "Labels Added",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "labelsRemoved": {
+              "displayName": "Labels Removed",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "messages": {
+              "displayName": "Messages",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "messagesAdded": {
+              "displayName": "Messages Added",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "messagesDeleted": {
+              "displayName": "Messages Deleted",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            }
+          }
+        },
+        "identities": {
+          "displayName": "Identities",
+          "path": "/users/me/settings/cse/identities",
+          "responseKey": "cseIdentities",
+          "fields": {
+            "emailAddress": {
+              "displayName": "Email Address",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "primaryKeyPairId": {
+              "displayName": "Primary Key Pair Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "signAndEncryptKeyPairs": {
+              "displayName": "Sign And Encrypt Key Pairs",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            }
+          }
+        },
+        "keypairs": {
+          "displayName": "Keypairs",
+          "path": "/users/me/settings/cse/keypairs",
+          "responseKey": "cseKeyPairs",
+          "fields": {
+            "disableTime": {
+              "displayName": "Disable Time",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "enablementState": {
+              "displayName": "Enablement State",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "keyPairId": {
+              "displayName": "Key Pair Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "pem": {
+              "displayName": "Pem",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "pkcs7": {
+              "displayName": "Pkcs 7",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "privateKeyMetadata": {
+              "displayName": "Private Key Metadata",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "subjectEmailAddresses": {
+              "displayName": "Subject Email Addresses",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            }
+          }
+        },
+        "labels": {
+          "displayName": "Labels",
+          "path": "/users/me/labels",
+          "responseKey": "labels",
+          "fields": {
+            "color": {
+              "displayName": "Color",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "labelListVisibility": {
+              "displayName": "Label List Visibility",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "messageListVisibility": {
+              "displayName": "Message List Visibility",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "messagesTotal": {
+              "displayName": "Messages Total",
+              "valueType": "int",
+              "providerType": "integer",
+              "readOnly": false
+            },
+            "messagesUnread": {
+              "displayName": "Messages Unread",
+              "valueType": "int",
+              "providerType": "integer",
+              "readOnly": false
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "threadsTotal": {
+              "displayName": "Threads Total",
+              "valueType": "int",
+              "providerType": "integer",
+              "readOnly": false
+            },
+            "threadsUnread": {
+              "displayName": "Threads Unread",
+              "valueType": "int",
+              "providerType": "integer",
+              "readOnly": false
+            },
+            "type": {
+              "displayName": "Type",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "messages": {
+          "displayName": "Messages",
+          "path": "/users/me/messages",
+          "responseKey": "messages",
+          "fields": {
+            "classificationLabelValues": {
+              "displayName": "Classification Label Values",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "historyId": {
+              "displayName": "History Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "internalDate": {
+              "displayName": "Internal Date",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "labelIds": {
+              "displayName": "Label Ids",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "payload": {
+              "displayName": "Payload",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            },
+            "raw": {
+              "displayName": "Raw",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "sizeEstimate": {
+              "displayName": "Size Estimate",
+              "valueType": "int",
+              "providerType": "integer",
+              "readOnly": false
+            },
+            "snippet": {
+              "displayName": "Snippet",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "threadId": {
+              "displayName": "Thread Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "sendAs": {
+          "displayName": "Send As",
+          "path": "/users/me/settings/sendAs",
+          "responseKey": "sendAs",
+          "fields": {
+            "displayName": {
+              "displayName": "Display Name",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "isDefault": {
+              "displayName": "Is Default",
+              "valueType": "boolean",
+              "providerType": "boolean",
+              "readOnly": false
+            },
+            "isPrimary": {
+              "displayName": "Is Primary",
+              "valueType": "boolean",
+              "providerType": "boolean",
+              "readOnly": false
+            },
+            "replyToAddress": {
+              "displayName": "Reply To Address",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "sendAsEmail": {
+              "displayName": "Send As Email",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "signature": {
+              "displayName": "Signature",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "smtpMsa": {
+              "displayName": "Smtp Msa",
+              "valueType": "other",
+              "providerType": "object",
+              "readOnly": false
+            },
+            "treatAsAlias": {
+              "displayName": "Treat As Alias",
+              "valueType": "boolean",
+              "providerType": "boolean",
+              "readOnly": false
+            },
+            "verificationStatus": {
+              "displayName": "Verification Status",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        },
+        "threads": {
+          "displayName": "Threads",
+          "path": "/users/me/threads",
+          "responseKey": "threads",
+          "fields": {
+            "historyId": {
+              "displayName": "History Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            },
+            "messages": {
+              "displayName": "Messages",
+              "valueType": "other",
+              "providerType": "array",
+              "readOnly": false
+            },
+            "snippet": {
+              "displayName": "Snippet",
+              "valueType": "string",
+              "providerType": "string",
+              "readOnly": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/google/metadata_test.go
+++ b/providers/google/metadata_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -153,12 +154,74 @@ func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 	}
 }
 
+func TestMailListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Metadata{
+		{
+			Name:       "Successful metadata for messages and drafts",
+			Input:      []string{"messages", "drafts"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"messages": {
+						DisplayName: "Messages",
+						Fields: map[string]common.FieldMetadata{
+							"threadId": {
+								DisplayName:  "Thread Id",
+								ValueType:    "string",
+								ProviderType: "string",
+								ReadOnly:     goutils.Pointer(false),
+							},
+						},
+					},
+					"drafts": {
+						DisplayName: "Drafts",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Id",
+								ValueType:    "string",
+								ProviderType: "string",
+								ReadOnly:     goutils.Pointer(false),
+							},
+							"message": {
+								DisplayName:  "Message",
+								ValueType:    "other",
+								ProviderType: "object",
+								ReadOnly:     goutils.Pointer(false),
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestMailConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
 func constructTestCalendarConnector(serverURL string) (*Connector, error) {
 	return constructTestConnector(serverURL, providers.ModuleGoogleCalendar)
 }
 
 func constructTestContactsConnector(serverURL string) (*Connector, error) {
 	return constructTestConnector(serverURL, providers.ModuleGoogleContacts)
+}
+
+func constructTestMailConnector(serverURL string) (*Connector, error) {
+	return constructTestConnector(serverURL, providers.ModuleGoogleMail)
 }
 
 func constructTestConnector(serverURL string, moduleID common.ModuleID) (*Connector, error) {

--- a/scripts/openapi/google/internal/files/file.go
+++ b/scripts/openapi/google/internal/files/file.go
@@ -16,6 +16,8 @@ var (
 	calendarAPI []byte
 	//go:embed people.json
 	peopleAPI []byte
+	//go:embed mail.json
+	mailAPI []byte
 
 	InputCalendar  = api3.NewOpenapiFileManager[any](calendarAPI)
 	OutputCalendar = scrapper.NewWriter[staticschema.FieldMetadataMapV2](
@@ -23,4 +25,7 @@ var (
 	InputContacts  = api3.NewOpenapiFileManager[any](peopleAPI)
 	OutputContacts = scrapper.NewWriter[staticschema.FieldMetadataMapV2](
 		fileconv.NewPath("providers/google/internal/contacts"))
+	InputMail  = api3.NewOpenapiFileManager[any](mailAPI)
+	OutputMail = scrapper.NewWriter[staticschema.FieldMetadataMapV2](
+		fileconv.NewPath("providers/google/internal/mail"))
 )

--- a/scripts/openapi/google/internal/files/mail.json
+++ b/scripts/openapi/google/internal/files/mail.json
@@ -1,0 +1,9138 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Gmail API",
+    "description": "The Gmail API lets you view and manage Gmail mailbox data like threads, messages, and labels.",
+    "contact": {
+      "name": "Google",
+      "url": "https://google.com"
+    },
+    "version": "v1",
+    "license": {
+      "name": "Creative Commons Attribution 3.0",
+      "url": "http://creativecommons.org/licenses/by/3.0/"
+    },
+    "termsOfService": "https://developers.google.com/terms/"
+  },
+  "servers": [
+    {
+      "url": "https://gmail.googleapis.com/"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "AutoForwarding": {
+        "description": "Auto-forwarding settings for an account.",
+        "properties": {
+          "disposition": {
+            "description": "The state that a message should be left in after it has been forwarded.",
+            "enum": [
+              "dispositionUnspecified",
+              "leaveInInbox",
+              "archive",
+              "trash",
+              "markRead"
+            ],
+            "type": "string"
+          },
+          "emailAddress": {
+            "description": "Email address to which all incoming messages are forwarded. This email address must be a verified member of the forwarding addresses.",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Whether all incoming mail is automatically forwarded to another address.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "BatchDeleteMessagesRequest": {
+        "properties": {
+          "ids": {
+            "description": "The IDs of the messages to delete.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "BatchModifyMessagesRequest": {
+        "properties": {
+          "addLabelIds": {
+            "description": "A list of label IDs to add to messages.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ids": {
+            "description": "The IDs of the messages to modify. There is a limit of 1000 ids per request.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "removeLabelIds": {
+            "description": "A list of label IDs to remove from messages.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ClassificationLabelFieldValue": {
+        "description": "Field values for a classification label.",
+        "properties": {
+          "fieldId": {
+            "description": "Required. The field ID for the Classification Label Value. Maps to the ID field of the Google Drive `Label.Field` object.",
+            "type": "string"
+          },
+          "selection": {
+            "description": "Selection choice ID for the selection option. Should only be set if the field type is `SELECTION` in the Google Drive `Label.Field` object. Maps to the id field of the Google Drive `Label.Field.SelectionOptions` resource.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ClassificationLabelValue": {
+        "description": "Classification Labels applied to the email message. Classification Labels are different from Gmail inbox labels. Only used for Google Workspace accounts. [Learn more about classification labels](https://support.google.com/a/answer/9292382).",
+        "properties": {
+          "fields": {
+            "description": "Field values for the given classification label ID.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationLabelFieldValue"
+            },
+            "type": "array"
+          },
+          "labelId": {
+            "description": "Required. The canonical or raw alphanumeric classification label ID. Maps to the ID field of the Google Drive Label resource.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CseIdentity": {
+        "description": "The client-side encryption (CSE) configuration for the email address of an authenticated user. Gmail uses CSE configurations to save drafts of client-side encrypted email messages, and to sign and send encrypted email messages. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "properties": {
+          "emailAddress": {
+            "description": "The email address for the sending identity. The email address must be the primary email address of the authenticated user.",
+            "type": "string"
+          },
+          "primaryKeyPairId": {
+            "description": "If a key pair is associated, the ID of the key pair, CseKeyPair.",
+            "type": "string"
+          },
+          "signAndEncryptKeyPairs": {
+            "$ref": "#/components/schemas/SignAndEncryptKeyPairs",
+            "description": "The configuration of a CSE identity that uses different key pairs for signing and encryption."
+          }
+        },
+        "type": "object"
+      },
+      "CseKeyPair": {
+        "description": "A client-side encryption S/MIME key pair, which is comprised of a public key, its certificate chain, and metadata for its paired private key. Gmail uses the key pair to complete the following tasks: - Sign outgoing client-side encrypted messages. - Save and reopen drafts of client-side encrypted messages. - Save and reopen sent messages. - Decrypt incoming or archived S/MIME messages. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "properties": {
+          "disableTime": {
+            "description": "Output only. If a key pair is set to `DISABLED`, the time that the key pair's state changed from `ENABLED` to `DISABLED`. This field is present only when the key pair is in state `DISABLED`.",
+            "format": "google-datetime",
+            "readOnly": true,
+            "type": "string"
+          },
+          "enablementState": {
+            "description": "Output only. The current state of the key pair.",
+            "enum": [
+              "stateUnspecified",
+              "enabled",
+              "disabled"
+            ],
+            "readOnly": true,
+            "type": "string"
+          },
+          "keyPairId": {
+            "description": "Output only. The immutable ID for the client-side encryption S/MIME key pair.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "pem": {
+            "description": "Output only. The public key and its certificate chain, in [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) format.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "pkcs7": {
+            "description": "Input only. The public key and its certificate chain. The chain must be in [PKCS#7](https://en.wikipedia.org/wiki/PKCS_7) format and use PEM encoding and ASCII armor.",
+            "type": "string"
+          },
+          "privateKeyMetadata": {
+            "description": "Metadata for instances of this key pair's private key.",
+            "items": {
+              "$ref": "#/components/schemas/CsePrivateKeyMetadata"
+            },
+            "type": "array"
+          },
+          "subjectEmailAddresses": {
+            "description": "Output only. The email address identities that are specified on the leaf certificate.",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CsePrivateKeyMetadata": {
+        "description": "Metadata for a private key instance.",
+        "properties": {
+          "hardwareKeyMetadata": {
+            "$ref": "#/components/schemas/HardwareKeyMetadata",
+            "description": "Metadata for hardware keys."
+          },
+          "kaclsKeyMetadata": {
+            "$ref": "#/components/schemas/KaclsKeyMetadata",
+            "description": "Metadata for a private key instance managed by an external key access control list service."
+          },
+          "privateKeyMetadataId": {
+            "description": "Output only. The immutable ID for the private key metadata instance.",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Delegate": {
+        "description": "Settings for a delegate. Delegates can read, send, and delete messages, as well as view and add contacts, for the delegator's account. See \"Set up mail delegation\" for more information about delegates.",
+        "properties": {
+          "delegateEmail": {
+            "description": "The email address of the delegate.",
+            "type": "string"
+          },
+          "verificationStatus": {
+            "description": "Indicates whether this address has been verified and can act as a delegate for the account. Read-only.",
+            "enum": [
+              "verificationStatusUnspecified",
+              "accepted",
+              "pending",
+              "rejected",
+              "expired"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DisableCseKeyPairRequest": {
+        "description": "Requests to turn off a client-side encryption key pair.",
+        "properties": {},
+        "type": "object"
+      },
+      "Draft": {
+        "description": "A draft email in the user's mailbox.",
+        "properties": {
+          "id": {
+            "description": "The immutable ID of the draft.",
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/Message",
+            "description": "The message content of the draft."
+          }
+        },
+        "type": "object"
+      },
+      "EnableCseKeyPairRequest": {
+        "description": "Requests to turn on a client-side encryption key pair.",
+        "properties": {},
+        "type": "object"
+      },
+      "Filter": {
+        "description": "Resource definition for Gmail filters. Filters apply to specific messages instead of an entire email thread.",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/FilterAction",
+            "description": "Action that the filter performs."
+          },
+          "criteria": {
+            "$ref": "#/components/schemas/FilterCriteria",
+            "description": "Matching criteria for the filter."
+          },
+          "id": {
+            "description": "The server assigned ID of the filter.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "FilterAction": {
+        "description": "A set of actions to perform on a message.",
+        "properties": {
+          "addLabelIds": {
+            "description": "List of labels to add to the message.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "forward": {
+            "description": "Email address that the message should be forwarded to.",
+            "type": "string"
+          },
+          "removeLabelIds": {
+            "description": "List of labels to remove from the message.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "FilterCriteria": {
+        "description": "Message matching criteria.",
+        "properties": {
+          "excludeChats": {
+            "description": "Whether the response should exclude chats.",
+            "type": "boolean"
+          },
+          "from": {
+            "description": "The sender's display name or email address.",
+            "type": "string"
+          },
+          "hasAttachment": {
+            "description": "Whether the message has any attachment.",
+            "type": "boolean"
+          },
+          "negatedQuery": {
+            "description": "Only return messages not matching the specified query. Supports the same query format as the Gmail search box. For example, `\"from:someuser@example.com rfc822msgid: is:unread\"`.",
+            "type": "string"
+          },
+          "query": {
+            "description": "Only return messages matching the specified query. Supports the same query format as the Gmail search box. For example, `\"from:someuser@example.com rfc822msgid: is:unread\"`.",
+            "type": "string"
+          },
+          "size": {
+            "description": "The size of the entire RFC822 message in bytes, including all headers and attachments.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "sizeComparison": {
+            "description": "How the message size in bytes should be in relation to the size field.",
+            "enum": [
+              "unspecified",
+              "smaller",
+              "larger"
+            ],
+            "type": "string"
+          },
+          "subject": {
+            "description": "Case-insensitive phrase found in the message's subject. Trailing and leading whitespace are be trimmed and adjacent spaces are collapsed.",
+            "type": "string"
+          },
+          "to": {
+            "description": "The recipient's display name or email address. Includes recipients in the \"to\", \"cc\", and \"bcc\" header fields. You can use simply the local part of the email address. For example, \"example\" and \"example@\" both match \"example@gmail.com\". This field is case-insensitive.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ForwardingAddress": {
+        "description": "Settings for a forwarding address.",
+        "properties": {
+          "forwardingEmail": {
+            "description": "An email address to which messages can be forwarded.",
+            "type": "string"
+          },
+          "verificationStatus": {
+            "description": "Indicates whether this address has been verified and is usable for forwarding. Read-only.",
+            "enum": [
+              "verificationStatusUnspecified",
+              "accepted",
+              "pending"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "HardwareKeyMetadata": {
+        "description": "Metadata for hardware keys. If [hardware key encryption](https://support.google.com/a/answer/14153163) is set up for the Google Workspace organization, users can optionally store their private key on their smart card and use it to sign and decrypt email messages in Gmail by inserting their smart card into a reader attached to their Windows device.",
+        "properties": {
+          "description": {
+            "description": "Description about the hardware key.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "History": {
+        "description": "A record of a change to the user's mailbox. Each history change may affect multiple messages in multiple ways.",
+        "properties": {
+          "id": {
+            "description": "The mailbox sequence ID.",
+            "format": "uint64",
+            "type": "string"
+          },
+          "labelsAdded": {
+            "description": "Labels added to messages in this history record.",
+            "items": {
+              "$ref": "#/components/schemas/HistoryLabelAdded"
+            },
+            "type": "array"
+          },
+          "labelsRemoved": {
+            "description": "Labels removed from messages in this history record.",
+            "items": {
+              "$ref": "#/components/schemas/HistoryLabelRemoved"
+            },
+            "type": "array"
+          },
+          "messages": {
+            "description": "List of messages changed in this history record. The fields for specific change types, such as `messagesAdded` may duplicate messages in this field. We recommend using the specific change-type fields instead of this.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "type": "array"
+          },
+          "messagesAdded": {
+            "description": "Messages added to the mailbox in this history record.",
+            "items": {
+              "$ref": "#/components/schemas/HistoryMessageAdded"
+            },
+            "type": "array"
+          },
+          "messagesDeleted": {
+            "description": "Messages deleted (not Trashed) from the mailbox in this history record.",
+            "items": {
+              "$ref": "#/components/schemas/HistoryMessageDeleted"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "HistoryLabelAdded": {
+        "properties": {
+          "labelIds": {
+            "description": "Label IDs added to the message.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          }
+        },
+        "type": "object"
+      },
+      "HistoryLabelRemoved": {
+        "properties": {
+          "labelIds": {
+            "description": "Label IDs removed from the message.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          }
+        },
+        "type": "object"
+      },
+      "HistoryMessageAdded": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          }
+        },
+        "type": "object"
+      },
+      "HistoryMessageDeleted": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          }
+        },
+        "type": "object"
+      },
+      "ImapSettings": {
+        "description": "IMAP settings for an account.",
+        "properties": {
+          "autoExpunge": {
+            "description": "If this value is true, Gmail will immediately expunge a message when it is marked as deleted in IMAP. Otherwise, Gmail will wait for an update from the client before expunging messages marked as deleted.",
+            "type": "boolean"
+          },
+          "enabled": {
+            "description": "Whether IMAP is enabled for the account.",
+            "type": "boolean"
+          },
+          "expungeBehavior": {
+            "description": "The action that will be executed on a message when it is marked as deleted and expunged from the last visible IMAP folder.",
+            "enum": [
+              "expungeBehaviorUnspecified",
+              "archive",
+              "trash",
+              "deleteForever"
+            ],
+            "type": "string"
+          },
+          "maxFolderSize": {
+            "description": "An optional limit on the number of messages that an IMAP folder may contain. Legal values are 0, 1000, 2000, 5000 or 10000. A value of zero is interpreted to mean that there is no limit.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "KaclsKeyMetadata": {
+        "description": "Metadata for private keys managed by an external key access control list service. For details about managing key access, see [Google Workspace CSE API Reference](https://developers.google.com/workspace/cse/reference).",
+        "properties": {
+          "kaclsData": {
+            "description": "Opaque data generated and used by the key access control list service. Maximum size: 8 KiB.",
+            "type": "string"
+          },
+          "kaclsUri": {
+            "description": "The URI of the key access control list service that manages the private key.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Label": {
+        "description": "Labels are used to categorize messages and threads within the user's mailbox. The maximum number of labels supported for a user's mailbox is 10,000.",
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/LabelColor",
+            "description": "The color to assign to the label. Color is only available for labels that have their `type` set to `user`."
+          },
+          "id": {
+            "description": "The immutable ID of the label.",
+            "type": "string"
+          },
+          "labelListVisibility": {
+            "description": "The visibility of the label in the label list in the Gmail web interface.",
+            "enum": [
+              "labelShow",
+              "labelShowIfUnread",
+              "labelHide"
+            ],
+            "type": "string"
+          },
+          "messageListVisibility": {
+            "description": "The visibility of messages with this label in the message list in the Gmail web interface.",
+            "enum": [
+              "show",
+              "hide"
+            ],
+            "type": "string"
+          },
+          "messagesTotal": {
+            "description": "The total number of messages with the label.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "messagesUnread": {
+            "description": "The number of unread messages with the label.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The display name of the label.",
+            "type": "string"
+          },
+          "threadsTotal": {
+            "description": "The total number of threads with the label.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "threadsUnread": {
+            "description": "The number of unread threads with the label.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The owner type for the label. User labels are created by the user and can be modified and deleted by the user and can be applied to any message or thread. System labels are internally created and cannot be added, modified, or deleted. System labels may be able to be applied to or removed from messages and threads under some circumstances but this is not guaranteed. For example, users can apply and remove the `INBOX` and `UNREAD` labels from messages and threads, but cannot apply or remove the `DRAFTS` or `SENT` labels from messages or threads.",
+            "enum": [
+              "system",
+              "user"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LabelColor": {
+        "properties": {
+          "backgroundColor": {
+            "description": "The background color represented as hex string #RRGGBB (ex #000000). This field is required in order to set the color of a label. Only the following predefined set of color values are allowed: \\#000000, #434343, #666666, #999999, #cccccc, #efefef, #f3f3f3, #ffffff, \\#fb4c2f, #ffad47, #fad165, #16a766, #43d692, #4a86e8, #a479e2, #f691b3, \\#f6c5be, #ffe6c7, #fef1d1, #b9e4d0, #c6f3de, #c9daf8, #e4d7f5, #fcdee8, \\#efa093, #ffd6a2, #fce8b3, #89d3b2, #a0eac9, #a4c2f4, #d0bcf1, #fbc8d9, \\#e66550, #ffbc6b, #fcda83, #44b984, #68dfa9, #6d9eeb, #b694e8, #f7a7c0, \\#cc3a21, #eaa041, #f2c960, #149e60, #3dc789, #3c78d8, #8e63ce, #e07798, \\#ac2b16, #cf8933, #d5ae49, #0b804b, #2a9c68, #285bac, #653e9b, #b65775, \\#822111, #a46a21, #aa8831, #076239, #1a764d, #1c4587, #41236d, #83334c \\#464646, #e7e7e7, #0d3472, #b6cff5, #0d3b44, #98d7e4, #3d188e, #e3d7ff, \\#711a36, #fbd3e0, #8a1c0a, #f2b2a8, #7a2e0b, #ffc8af, #7a4706, #ffdeb5, \\#594c05, #fbe983, #684e07, #fdedc1, #0b4f30, #b3efd3, #04502e, #a2dcc1, \\#c2c2c2, #4986e7, #2da2bb, #b99aff, #994a64, #f691b2, #ff7537, #ffad46, \\#662e37, #ebdbde, #cca6ac, #094228, #42d692, #16a765",
+            "type": "string"
+          },
+          "textColor": {
+            "description": "The text color of the label, represented as hex string. This field is required in order to set the color of a label. Only the following predefined set of color values are allowed: \\#000000, #434343, #666666, #999999, #cccccc, #efefef, #f3f3f3, #ffffff, \\#fb4c2f, #ffad47, #fad165, #16a766, #43d692, #4a86e8, #a479e2, #f691b3, \\#f6c5be, #ffe6c7, #fef1d1, #b9e4d0, #c6f3de, #c9daf8, #e4d7f5, #fcdee8, \\#efa093, #ffd6a2, #fce8b3, #89d3b2, #a0eac9, #a4c2f4, #d0bcf1, #fbc8d9, \\#e66550, #ffbc6b, #fcda83, #44b984, #68dfa9, #6d9eeb, #b694e8, #f7a7c0, \\#cc3a21, #eaa041, #f2c960, #149e60, #3dc789, #3c78d8, #8e63ce, #e07798, \\#ac2b16, #cf8933, #d5ae49, #0b804b, #2a9c68, #285bac, #653e9b, #b65775, \\#822111, #a46a21, #aa8831, #076239, #1a764d, #1c4587, #41236d, #83334c \\#464646, #e7e7e7, #0d3472, #b6cff5, #0d3b44, #98d7e4, #3d188e, #e3d7ff, \\#711a36, #fbd3e0, #8a1c0a, #f2b2a8, #7a2e0b, #ffc8af, #7a4706, #ffdeb5, \\#594c05, #fbe983, #684e07, #fdedc1, #0b4f30, #b3efd3, #04502e, #a2dcc1, \\#c2c2c2, #4986e7, #2da2bb, #b99aff, #994a64, #f691b2, #ff7537, #ffad46, \\#662e37, #ebdbde, #cca6ac, #094228, #42d692, #16a765",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LanguageSettings": {
+        "description": "Language settings for an account. These settings correspond to the \"Language settings\" feature in the web interface.",
+        "properties": {
+          "displayLanguage": {
+            "description": "The language to display Gmail in, formatted as an RFC 3066 Language Tag (for example `en-GB`, `fr` or `ja` for British English, French, or Japanese respectively). The set of languages supported by Gmail evolves over time, so please refer to the \"Language\" dropdown in the Gmail settings for all available options, as described in the language settings help article. For a table of sample values, see [Manage language settings](https://developers.google.com/workspace/gmail/api/guides/language-settings). Not all Gmail clients can display the same set of languages. In the case that a user's display language is not available for use on a particular client, said client automatically chooses to display in the closest supported variant (or a reasonable default).",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ListCseIdentitiesResponse": {
+        "properties": {
+          "cseIdentities": {
+            "description": "One page of the list of CSE identities configured for the user.",
+            "items": {
+              "$ref": "#/components/schemas/CseIdentity"
+            },
+            "type": "array"
+          },
+          "nextPageToken": {
+            "description": "Pagination token to be passed to a subsequent ListCseIdentities call in order to retrieve the next page of identities. If this value is not returned or is the empty string, then no further pages remain.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ListCseKeyPairsResponse": {
+        "properties": {
+          "cseKeyPairs": {
+            "description": "One page of the list of CSE key pairs installed for the user.",
+            "items": {
+              "$ref": "#/components/schemas/CseKeyPair"
+            },
+            "type": "array"
+          },
+          "nextPageToken": {
+            "description": "Pagination token to be passed to a subsequent ListCseKeyPairs call in order to retrieve the next page of key pairs. If this value is not returned, then no further pages remain.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ListDelegatesResponse": {
+        "description": "Response for the ListDelegates method.",
+        "properties": {
+          "delegates": {
+            "description": "List of the user's delegates (with any verification status). If an account doesn't have delegates, this field doesn't appear.",
+            "items": {
+              "$ref": "#/components/schemas/Delegate"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListDraftsResponse": {
+        "properties": {
+          "drafts": {
+            "description": "List of drafts. Note that the `Message` property in each `Draft` resource only contains an `id` and a `threadId`. The [`messages.get`](https://developers.google.com/workspace/gmail/api/v1/reference/users/messages/get) method can fetch additional message details.",
+            "items": {
+              "$ref": "#/components/schemas/Draft"
+            },
+            "type": "array"
+          },
+          "nextPageToken": {
+            "description": "Token to retrieve the next page of results in the list.",
+            "type": "string"
+          },
+          "resultSizeEstimate": {
+            "description": "Estimated total number of results.",
+            "format": "uint32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListFiltersResponse": {
+        "description": "Response for the ListFilters method.",
+        "properties": {
+          "filter": {
+            "description": "List of a user's filters.",
+            "items": {
+              "$ref": "#/components/schemas/Filter"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListForwardingAddressesResponse": {
+        "description": "Response for the ListForwardingAddresses method.",
+        "properties": {
+          "forwardingAddresses": {
+            "description": "List of addresses that may be used for forwarding.",
+            "items": {
+              "$ref": "#/components/schemas/ForwardingAddress"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListHistoryResponse": {
+        "properties": {
+          "history": {
+            "description": "List of history records. Any `messages` contained in the response will typically only have `id` and `threadId` fields populated.",
+            "items": {
+              "$ref": "#/components/schemas/History"
+            },
+            "type": "array"
+          },
+          "historyId": {
+            "description": "The ID of the mailbox's current history record.",
+            "format": "uint64",
+            "type": "string"
+          },
+          "nextPageToken": {
+            "description": "Page token to retrieve the next page of results in the list.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ListLabelsResponse": {
+        "properties": {
+          "labels": {
+            "description": "List of labels. Note that each label resource only contains an `id`, `name`, `messageListVisibility`, `labelListVisibility`, and `type`. The [`labels.get`](https://developers.google.com/workspace/gmail/api/v1/reference/users/labels/get) method can fetch additional label details.",
+            "items": {
+              "$ref": "#/components/schemas/Label"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListMessagesResponse": {
+        "properties": {
+          "messages": {
+            "description": "List of messages. Note that each message resource contains only an `id` and a `threadId`. Additional message details can be fetched using the messages.get method.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "type": "array"
+          },
+          "nextPageToken": {
+            "description": "Token to retrieve the next page of results in the list.",
+            "type": "string"
+          },
+          "resultSizeEstimate": {
+            "description": "Estimated total number of results.",
+            "format": "uint32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListSendAsResponse": {
+        "description": "Response for the ListSendAs method.",
+        "properties": {
+          "sendAs": {
+            "description": "List of send-as aliases.",
+            "items": {
+              "$ref": "#/components/schemas/SendAs"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListSmimeInfoResponse": {
+        "properties": {
+          "smimeInfo": {
+            "description": "List of SmimeInfo.",
+            "items": {
+              "$ref": "#/components/schemas/SmimeInfo"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListThreadsResponse": {
+        "properties": {
+          "nextPageToken": {
+            "description": "Page token to retrieve the next page of results in the list.",
+            "type": "string"
+          },
+          "resultSizeEstimate": {
+            "description": "Estimated total number of results.",
+            "format": "uint32",
+            "type": "integer"
+          },
+          "threads": {
+            "description": "List of threads. Note that each thread resource does not contain a list of `messages`. The list of `messages` for a given thread can be fetched using the [`threads.get`](https://developers.google.com/workspace/gmail/api/v1/reference/users/threads/get) method.",
+            "items": {
+              "$ref": "#/components/schemas/Thread"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Message": {
+        "description": "An email message.",
+        "properties": {
+          "classificationLabelValues": {
+            "description": "Classification Label values on the message. Available Classification Label schemas can be queried using the Google Drive Labels API. Each classification label ID must be unique. If duplicate IDs are provided, only one will be retained, and the selection is arbitrary. Only used for Google Workspace accounts.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationLabelValue"
+            },
+            "type": "array"
+          },
+          "historyId": {
+            "description": "The ID of the last history record that modified this message.",
+            "format": "uint64",
+            "type": "string"
+          },
+          "id": {
+            "description": "The immutable ID of the message.",
+            "type": "string"
+          },
+          "internalDate": {
+            "description": "The internal message creation timestamp (epoch ms), which determines ordering in the inbox. For normal SMTP-received email, this represents the time the message was originally accepted by Google, which is more reliable than the `Date` header. However, for API-migrated mail, it can be configured by client to be based on the `Date` header.",
+            "format": "int64",
+            "type": "string"
+          },
+          "labelIds": {
+            "description": "List of IDs of labels applied to this message.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/MessagePart",
+            "description": "The parsed email structure in the message parts."
+          },
+          "raw": {
+            "description": "The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.",
+            "format": "byte",
+            "type": "string"
+          },
+          "sizeEstimate": {
+            "description": "Estimated size in bytes of the message.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "snippet": {
+            "description": "A short part of the message text.",
+            "type": "string"
+          },
+          "threadId": {
+            "description": "The ID of the thread the message belongs to. To add a message or draft to a thread, the following criteria must be met: 1. The requested `threadId` must be specified on the `Message` or `Draft.Message` you supply with your request. 2. The `References` and `In-Reply-To` headers must be set in compliance with the [RFC 2822](https://tools.ietf.org/html/rfc2822) standard. 3. The `Subject` headers must match. ",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MessagePart": {
+        "description": "A single MIME message part.",
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/MessagePartBody",
+            "description": "The message part body for this part, which may be empty for container MIME message parts."
+          },
+          "filename": {
+            "description": "The filename of the attachment. Only present if this message part represents an attachment.",
+            "type": "string"
+          },
+          "headers": {
+            "description": "List of headers on this message part. For the top-level message part, representing the entire message payload, it will contain the standard RFC 2822 email headers such as `To`, `From`, and `Subject`.",
+            "items": {
+              "$ref": "#/components/schemas/MessagePartHeader"
+            },
+            "type": "array"
+          },
+          "mimeType": {
+            "description": "The MIME type of the message part.",
+            "type": "string"
+          },
+          "partId": {
+            "description": "The immutable ID of the message part.",
+            "type": "string"
+          },
+          "parts": {
+            "description": "The child MIME message parts of this part. This only applies to container MIME message parts, for example `multipart/*`. For non- container MIME message part types, such as `text/plain`, this field is empty. For more information, see RFC 1521.",
+            "items": {
+              "$ref": "#/components/schemas/MessagePart"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MessagePartBody": {
+        "description": "The body of a single MIME message part.",
+        "properties": {
+          "attachmentId": {
+            "description": "When present, contains the ID of an external attachment that can be retrieved in a separate `messages.attachments.get` request. When not present, the entire content of the message part body is contained in the data field.",
+            "type": "string"
+          },
+          "data": {
+            "description": "The body data of a MIME message part as a base64url encoded string. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.",
+            "format": "byte",
+            "type": "string"
+          },
+          "size": {
+            "description": "Number of bytes for the message part data (encoding notwithstanding).",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "MessagePartHeader": {
+        "properties": {
+          "name": {
+            "description": "The name of the header before the `:` separator. For example, `To`.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the header after the `:` separator. For example, `someuser@example.com`.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ModifyMessageRequest": {
+        "properties": {
+          "addLabelIds": {
+            "description": "A list of IDs of labels to add to this message. You can add up to 100 labels with each update.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "removeLabelIds": {
+            "description": "A list IDs of labels to remove from this message. You can remove up to 100 labels with each update.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ModifyThreadRequest": {
+        "properties": {
+          "addLabelIds": {
+            "description": "A list of IDs of labels to add to this thread. You can add up to 100 labels with each update.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "removeLabelIds": {
+            "description": "A list of IDs of labels to remove from this thread. You can remove up to 100 labels with each update.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ObliterateCseKeyPairRequest": {
+        "description": "Request to obliterate a CSE key pair.",
+        "properties": {},
+        "type": "object"
+      },
+      "PopSettings": {
+        "description": "POP settings for an account.",
+        "properties": {
+          "accessWindow": {
+            "description": "The range of messages which are accessible via POP.",
+            "enum": [
+              "accessWindowUnspecified",
+              "disabled",
+              "fromNowOn",
+              "allMail"
+            ],
+            "type": "string"
+          },
+          "disposition": {
+            "description": "The action that will be executed on a message after it has been fetched via POP.",
+            "enum": [
+              "dispositionUnspecified",
+              "leaveInInbox",
+              "archive",
+              "trash",
+              "markRead"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Profile": {
+        "description": "Profile for a Gmail user.",
+        "properties": {
+          "emailAddress": {
+            "description": "The user's email address.",
+            "type": "string"
+          },
+          "historyId": {
+            "description": "The ID of the mailbox's current history record.",
+            "format": "uint64",
+            "type": "string"
+          },
+          "messagesTotal": {
+            "description": "The total number of messages in the mailbox.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "threadsTotal": {
+            "description": "The total number of threads in the mailbox.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SendAs": {
+        "description": "Settings associated with a send-as alias, which can be either the primary login address associated with the account or a custom \"from\" address. Send-as aliases correspond to the \"Send Mail As\" feature in the web interface.",
+        "properties": {
+          "displayName": {
+            "description": "A name that appears in the \"From:\" header for mail sent using this alias. For custom \"from\" addresses, when this is empty, Gmail will populate the \"From:\" header with the name that is used for the primary address associated with the account. If the admin has disabled the ability for users to update their name format, requests to update this field for the primary login will silently fail.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Whether this address is selected as the default \"From:\" address in situations such as composing a new message or sending a vacation auto-reply. Every Gmail account has exactly one default send-as address, so the only legal value that clients may write to this field is `true`. Changing this from `false` to `true` for an address will result in this field becoming `false` for the other previous default address.",
+            "type": "boolean"
+          },
+          "isPrimary": {
+            "description": "Whether this address is the primary address used to login to the account. Every Gmail account has exactly one primary address, and it cannot be deleted from the collection of send-as aliases. This field is read-only.",
+            "type": "boolean"
+          },
+          "replyToAddress": {
+            "description": "An optional email address that is included in a \"Reply-To:\" header for mail sent using this alias. If this is empty, Gmail will not generate a \"Reply-To:\" header.",
+            "type": "string"
+          },
+          "sendAsEmail": {
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias. This is read-only for all operations except create.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "An optional HTML signature that is included in messages composed with this alias in the Gmail web UI. This signature is added to new emails only.",
+            "type": "string"
+          },
+          "smtpMsa": {
+            "$ref": "#/components/schemas/SmtpMsa",
+            "description": "An optional SMTP service that will be used as an outbound relay for mail sent using this alias. If this is empty, outbound mail will be sent directly from Gmail's servers to the destination SMTP service. This setting only applies to custom \"from\" aliases."
+          },
+          "treatAsAlias": {
+            "description": "Whether Gmail should treat this address as an alias for the user's primary email address. This setting only applies to custom \"from\" aliases.",
+            "type": "boolean"
+          },
+          "verificationStatus": {
+            "description": "Indicates whether this address has been verified for use as a send-as alias. Read-only. This setting only applies to custom \"from\" aliases.",
+            "enum": [
+              "verificationStatusUnspecified",
+              "accepted",
+              "pending"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SignAndEncryptKeyPairs": {
+        "description": "The configuration of a CSE identity that uses different key pairs for signing and encryption.",
+        "properties": {
+          "encryptionKeyPairId": {
+            "description": "The ID of the CseKeyPair that encrypts signed outgoing mail.",
+            "type": "string"
+          },
+          "signingKeyPairId": {
+            "description": "The ID of the CseKeyPair that signs outgoing mail.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SmimeInfo": {
+        "description": "An S/MIME email config.",
+        "properties": {
+          "encryptedKeyPassword": {
+            "description": "Encrypted key password, when key is encrypted.",
+            "type": "string"
+          },
+          "expiration": {
+            "description": "When the certificate expires (in milliseconds since epoch).",
+            "format": "int64",
+            "type": "string"
+          },
+          "id": {
+            "description": "The immutable ID for the SmimeInfo.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Whether this SmimeInfo is the default one for this user's send-as address.",
+            "type": "boolean"
+          },
+          "issuerCn": {
+            "description": "The S/MIME certificate issuer's common name.",
+            "type": "string"
+          },
+          "pem": {
+            "description": "PEM formatted X509 concatenated certificate string (standard base64 encoding). Format used for returning key, which includes public key as well as certificate chain (not private key).",
+            "type": "string"
+          },
+          "pkcs12": {
+            "description": "PKCS#12 format containing a single private/public key pair and certificate chain. This format is only accepted from client for creating a new SmimeInfo and is never returned, because the private key is not intended to be exported. PKCS#12 may be encrypted, in which case encryptedKeyPassword should be set appropriately.",
+            "format": "byte",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SmtpMsa": {
+        "description": "Configuration for communication with an SMTP service.",
+        "properties": {
+          "host": {
+            "description": "The hostname of the SMTP service. Required.",
+            "type": "string"
+          },
+          "password": {
+            "description": "The password that will be used for authentication with the SMTP service. This is a write-only field that can be specified in requests to create or update SendAs settings; it is never populated in responses.",
+            "type": "string"
+          },
+          "port": {
+            "description": "The port of the SMTP service. Required.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "securityMode": {
+            "description": "The protocol that will be used to secure communication with the SMTP service. Required.",
+            "enum": [
+              "securityModeUnspecified",
+              "none",
+              "ssl",
+              "starttls"
+            ],
+            "type": "string"
+          },
+          "username": {
+            "description": "The username that will be used for authentication with the SMTP service. This is a write-only field that can be specified in requests to create or update SendAs settings; it is never populated in responses.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Thread": {
+        "description": "A collection of messages representing a conversation.",
+        "properties": {
+          "historyId": {
+            "description": "The ID of the last history record that modified this thread.",
+            "format": "uint64",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique ID of the thread.",
+            "type": "string"
+          },
+          "messages": {
+            "description": "The list of messages in the thread.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "type": "array"
+          },
+          "snippet": {
+            "description": "A short part of the message text.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "VacationSettings": {
+        "description": "Vacation auto-reply settings for an account. These settings correspond to the \"Vacation responder\" feature in the web interface.",
+        "properties": {
+          "enableAutoReply": {
+            "description": "Flag that controls whether Gmail automatically replies to messages.",
+            "type": "boolean"
+          },
+          "endTime": {
+            "description": "An optional end time for sending auto-replies (epoch ms). When this is specified, Gmail will automatically reply only to messages that it receives before the end time. If both `startTime` and `endTime` are specified, `startTime` must precede `endTime`.",
+            "format": "int64",
+            "type": "string"
+          },
+          "responseBodyHtml": {
+            "description": "Response body in HTML format. Gmail will sanitize the HTML before storing it. If both `response_body_plain_text` and `response_body_html` are specified, `response_body_html` will be used.",
+            "type": "string"
+          },
+          "responseBodyPlainText": {
+            "description": "Response body in plain text format. If both `response_body_plain_text` and `response_body_html` are specified, `response_body_html` will be used.",
+            "type": "string"
+          },
+          "responseSubject": {
+            "description": "Optional text to prepend to the subject line in vacation responses. In order to enable auto-replies, either the response subject or the response body must be nonempty.",
+            "type": "string"
+          },
+          "restrictToContacts": {
+            "description": "Flag that determines whether responses are sent to recipients who are not in the user's list of contacts.",
+            "type": "boolean"
+          },
+          "restrictToDomain": {
+            "description": "Flag that determines whether responses are sent to recipients who are outside of the user's domain. This feature is only available for Google Workspace users.",
+            "type": "boolean"
+          },
+          "startTime": {
+            "description": "An optional start time for sending auto-replies (epoch ms). When this is specified, Gmail will automatically reply only to messages that it receives after the start time. If both `startTime` and `endTime` are specified, `startTime` must precede `endTime`.",
+            "format": "int64",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WatchRequest": {
+        "description": "Set up or update a new push notification watch on this user's mailbox.",
+        "properties": {
+          "labelFilterAction": {
+            "deprecated": true,
+            "description": "Filtering behavior of `labelIds list` specified. This field is deprecated because it caused incorrect behavior in some cases; use `label_filter_behavior` instead.",
+            "enum": [
+              "include",
+              "exclude"
+            ],
+            "type": "string"
+          },
+          "labelFilterBehavior": {
+            "description": "Filtering behavior of `labelIds list` specified. This field replaces `label_filter_action`; if set, `label_filter_action` is ignored.",
+            "enum": [
+              "include",
+              "exclude"
+            ],
+            "type": "string"
+          },
+          "labelIds": {
+            "description": "List of label_ids to restrict notifications about. By default, if unspecified, all changes are pushed out. If specified then dictates which labels are required for a push notification to be generated.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "topicName": {
+            "description": "A fully qualified Google Cloud Pub/Sub API topic name to publish the events to. This topic name **must** already exist in Cloud Pub/Sub and you **must** have already granted gmail \"publish\" permission on it. For example, \"projects/my-project-identifier/topics/my-topic-name\" (using the Cloud Pub/Sub \"v1\" topic naming format). Note that the \"my-project-identifier\" portion must exactly match your Google developer project id (the one executing this watch request).",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WatchResponse": {
+        "description": "Push notification watch response.",
+        "properties": {
+          "expiration": {
+            "description": "When Gmail will stop sending notifications for mailbox updates (epoch millis). Call `watch` again before this time to renew the watch.",
+            "format": "int64",
+            "type": "string"
+          },
+          "historyId": {
+            "description": "The ID of the mailbox's current history record.",
+            "format": "uint64",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "parameters": {
+      "_.xgafv": {
+        "name": "$.xgafv",
+        "in": "query",
+        "description": "V1 error format.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "1",
+            "2"
+          ]
+        }
+      },
+      "access_token": {
+        "name": "access_token",
+        "in": "query",
+        "description": "OAuth access token.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "alt": {
+        "name": "alt",
+        "in": "query",
+        "description": "Data format for response.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "json",
+            "media",
+            "proto"
+          ]
+        }
+      },
+      "callback": {
+        "name": "callback",
+        "in": "query",
+        "description": "JSONP",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "fields": {
+        "name": "fields",
+        "in": "query",
+        "description": "Selector specifying which fields to include in a partial response.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "key": {
+        "name": "key",
+        "in": "query",
+        "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "oauth_token": {
+        "name": "oauth_token",
+        "in": "query",
+        "description": "OAuth 2.0 token for the current user.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "prettyPrint": {
+        "name": "prettyPrint",
+        "in": "query",
+        "description": "Returns response with indentations and line breaks.",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "quotaUser": {
+        "name": "quotaUser",
+        "in": "query",
+        "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "upload_protocol": {
+        "name": "upload_protocol",
+        "in": "query",
+        "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "uploadType": {
+        "name": "uploadType",
+        "in": "query",
+        "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "securitySchemes": {
+      "Oauth2": {
+        "type": "oauth2",
+        "description": "Oauth 2.0 implicit authentication",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
+            "scopes": {
+              "https://mail.google.com/": "Read, compose, send, and permanently delete all your email from Gmail",
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose": "Manage drafts and send emails when you interact with the add-on",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action": "View your email messages when you interact with the add-on",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata": "View your email message metadata when the add-on is running",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly": "View your email messages when the add-on is running",
+              "https://www.googleapis.com/auth/gmail.compose": "Manage drafts and send emails",
+              "https://www.googleapis.com/auth/gmail.insert": "Add emails into your Gmail mailbox",
+              "https://www.googleapis.com/auth/gmail.labels": "See and edit your email labels",
+              "https://www.googleapis.com/auth/gmail.metadata": "View your email message metadata such as labels and headers, but not the email body",
+              "https://www.googleapis.com/auth/gmail.modify": "Read, compose, and send emails from your Gmail account",
+              "https://www.googleapis.com/auth/gmail.readonly": "View your email messages and settings",
+              "https://www.googleapis.com/auth/gmail.send": "Send email on your behalf",
+              "https://www.googleapis.com/auth/gmail.settings.basic": "See, edit, create, or change your email settings and filters in Gmail",
+              "https://www.googleapis.com/auth/gmail.settings.sharing": "Manage your sensitive mail settings, including who can manage your mail"
+            }
+          }
+        }
+      },
+      "Oauth2c": {
+        "type": "oauth2",
+        "description": "Oauth 2.0 authorizationCode authentication",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
+            "tokenUrl": "https://accounts.google.com/o/oauth2/token",
+            "scopes": {
+              "https://mail.google.com/": "Read, compose, send, and permanently delete all your email from Gmail",
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose": "Manage drafts and send emails when you interact with the add-on",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action": "View your email messages when you interact with the add-on",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata": "View your email message metadata when the add-on is running",
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly": "View your email messages when the add-on is running",
+              "https://www.googleapis.com/auth/gmail.compose": "Manage drafts and send emails",
+              "https://www.googleapis.com/auth/gmail.insert": "Add emails into your Gmail mailbox",
+              "https://www.googleapis.com/auth/gmail.labels": "See and edit your email labels",
+              "https://www.googleapis.com/auth/gmail.metadata": "View your email message metadata such as labels and headers, but not the email body",
+              "https://www.googleapis.com/auth/gmail.modify": "Read, compose, and send emails from your Gmail account",
+              "https://www.googleapis.com/auth/gmail.readonly": "View your email messages and settings",
+              "https://www.googleapis.com/auth/gmail.send": "Send email on your behalf",
+              "https://www.googleapis.com/auth/gmail.settings.basic": "See, edit, create, or change your email settings and filters in Gmail",
+              "https://www.googleapis.com/auth/gmail.settings.sharing": "Manage your sensitive mail settings, including who can manage your mail"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/gmail/v1/users/{userId}/profile": {
+      "get": {
+        "description": "Gets the current user's Gmail profile.",
+        "operationId": "gmail.users.getProfile",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Profile"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/stop": {
+      "post": {
+        "description": "Stop receiving push notifications for the given user mailbox.",
+        "operationId": "gmail.users.stop",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/watch": {
+      "post": {
+        "description": "Set up or update a push notification watch on the given user mailbox.",
+        "operationId": "gmail.users.watch",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WatchRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/drafts": {
+      "post": {
+        "description": "Creates a new draft with the `DRAFT` label.",
+        "operationId": "gmail.users.drafts.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the drafts in the user's mailbox.",
+        "operationId": "gmail.users.drafts.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDraftsResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSpamTrash",
+            "in": "query",
+            "description": "Include drafts from `SPAM` and `TRASH` in the results.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "Maximum number of drafts to return. This field defaults to 100. The maximum allowed value for this field is 500.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Page token to retrieve a specific page of results in the list.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Only return draft messages matching the specified query. Supports the same query format as the Gmail search box. For example, `\"from:someuser@example.com rfc822msgid: is:unread\"`.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/drafts/{id}": {
+      "delete": {
+        "description": "Immediately and permanently deletes the specified draft. Does not simply trash it.",
+        "operationId": "gmail.users.drafts.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the draft to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified draft.",
+        "operationId": "gmail.users.drafts.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the draft to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "The format to return the draft in.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "minimal",
+                "full",
+                "raw",
+                "metadata"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Replaces a draft's content.",
+        "operationId": "gmail.users.drafts.update",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the draft to update.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/drafts/send": {
+      "post": {
+        "description": "Sends the specified, existing draft to the recipients in the `To`, `Cc`, and `Bcc` headers.",
+        "operationId": "gmail.users.drafts.send",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Draft"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/history": {
+      "get": {
+        "description": "Lists the history of all changes to the given mailbox. History results are returned in chronological order (increasing `historyId`).",
+        "operationId": "gmail.users.history.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListHistoryResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "historyTypes",
+            "in": "query",
+            "description": "History types to be returned by the function",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "messageAdded",
+                  "messageDeleted",
+                  "labelAdded",
+                  "labelRemoved"
+                ]
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "labelId",
+            "in": "query",
+            "description": "Only return messages with a label matching the ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "Maximum number of history records to return. This field defaults to 100. The maximum allowed value for this field is 500.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Page token to retrieve a specific page of results in the list.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "startHistoryId",
+            "in": "query",
+            "description": "Required. Returns history records after the specified `startHistoryId`. The supplied `startHistoryId` should be obtained from the `historyId` of a message, thread, or previous `list` response. History IDs increase chronologically but are not contiguous with random gaps in between valid IDs. Supplying an invalid or out of date `startHistoryId` typically returns an `HTTP 404` error code. A `historyId` is typically valid for at least a week, but in some rare circumstances may be valid for only a few hours. If you receive an `HTTP 404` error response, your application should perform a full sync. If you receive no `nextPageToken` in the response, there are no updates to retrieve and you can store the returned `historyId` for a future request.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/labels": {
+      "post": {
+        "description": "Creates a new label.",
+        "operationId": "gmail.users.labels.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Label"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Label"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists all labels in the user's mailbox.",
+        "operationId": "gmail.users.labels.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLabelsResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/labels/{id}": {
+      "delete": {
+        "description": "Immediately and permanently deletes the specified label and removes it from any messages and threads that it is applied to.",
+        "operationId": "gmail.users.labels.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the label to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified label.",
+        "operationId": "gmail.users.labels.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Label"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the label to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "patch": {
+        "description": "Patch the specified label.",
+        "operationId": "gmail.users.labels.patch",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Label"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Label"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the label to update.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates the specified label.",
+        "operationId": "gmail.users.labels.update",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Label"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Label"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the label to update.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.labels"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/batchDelete": {
+      "post": {
+        "description": "Deletes many messages by message ID. Provides no guarantees that messages were not already deleted or even existed at all.",
+        "operationId": "gmail.users.messages.batchDelete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchDeleteMessagesRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/batchModify": {
+      "post": {
+        "description": "Modifies the labels on the specified messages.",
+        "operationId": "gmail.users.messages.batchModify",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchModifyMessagesRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/{id}": {
+      "delete": {
+        "description": "Immediately and permanently deletes the specified message. This operation cannot be undone. Prefer `messages.trash` instead.",
+        "operationId": "gmail.users.messages.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the message to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified message.",
+        "operationId": "gmail.users.messages.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the message to retrieve. This ID is usually retrieved using `messages.list`. The ID is also contained in the result when a message is inserted (`messages.insert`) or imported (`messages.import`).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "The format to return the message in.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "minimal",
+                "full",
+                "raw",
+                "metadata"
+              ]
+            }
+          },
+          {
+            "name": "metadataHeaders",
+            "in": "query",
+            "description": "When given and format is `METADATA`, only include headers specified.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/import": {
+      "post": {
+        "description": "Imports a message into only this user's mailbox, with standard email delivery scanning and classification similar to receiving via SMTP. This method doesn't perform SPF checks, so it might not work for some spam messages, such as those attempting to perform domain spoofing. This method does not send a message. Note that the maximum size of the message is 150MB.",
+        "operationId": "gmail.users.messages.import",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "description": "Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a Vault administrator. Only used for Google Workspace accounts.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "internalDateSource",
+            "in": "query",
+            "description": "Source for Gmail's internal date of the message.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "receivedTime",
+                "dateHeader"
+              ]
+            }
+          },
+          {
+            "name": "neverMarkSpam",
+            "in": "query",
+            "description": "Ignore the Gmail spam classifier decision and never mark this email as SPAM in the mailbox.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "processForCalendar",
+            "in": "query",
+            "description": "Process calendar invites in the email and add any extracted meetings to the Google Calendar for this user.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.insert"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.insert"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages": {
+      "post": {
+        "description": "Directly inserts a message into only this user's mailbox similar to `IMAP APPEND`, bypassing most scanning and classification. Does not send a message.",
+        "operationId": "gmail.users.messages.insert",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "description": "Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a Vault administrator. Only used for Google Workspace accounts.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "internalDateSource",
+            "in": "query",
+            "description": "Source for Gmail's internal date of the message.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "receivedTime",
+                "dateHeader"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.insert"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.insert"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the messages in the user's mailbox. For example usage, see [List Gmail messages](https://developers.google.com/workspace/gmail/api/guides/list-messages).",
+        "operationId": "gmail.users.messages.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMessagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSpamTrash",
+            "in": "query",
+            "description": "Include messages from `SPAM` and `TRASH` in the results.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "labelIds",
+            "in": "query",
+            "description": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have. To learn more, see [Manage labels on messages and threads](https://developers.google.com/workspace/gmail/api/guides/labels#manage_labels_on_messages_threads).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "Maximum number of messages to return. This field defaults to 100. The maximum allowed value for this field is 500.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Page token to retrieve a specific page of results in the list.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Only return messages matching the specified query. Supports the same query format as the Gmail search box. For example, `\"from:someuser@example.com rfc822msgid: is:unread\"`. Parameter cannot be used when accessing the api using the gmail.metadata scope.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/{id}/modify": {
+      "post": {
+        "description": "Modifies the labels on the specified message.",
+        "operationId": "gmail.users.messages.modify",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyMessageRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the message to modify.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/send": {
+      "post": {
+        "description": "Sends the specified message to the recipients in the `To`, `Cc`, and `Bcc` headers. For example usage, see [Sending email](https://developers.google.com/workspace/gmail/api/guides/sending).",
+        "operationId": "gmail.users.messages.send",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "message/cpim": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/external-body": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/feedback-report": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-delivery-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-disposition-notification": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/global-headers": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/imdn+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/news": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/partial": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/rfc822": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/s-http": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sip": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/sipfrag": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/tracking-status": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.si.simp": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "message/vnd.wfa.wsc": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.action.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.compose"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.send"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.send"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/{id}/trash": {
+      "post": {
+        "description": "Moves the specified message to the trash.",
+        "operationId": "gmail.users.messages.trash",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the message to Trash.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/{id}/untrash": {
+      "post": {
+        "description": "Removes the specified message from the trash.",
+        "operationId": "gmail.users.messages.untrash",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the message to remove from Trash.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/messages/{messageId}/attachments/{id}": {
+      "get": {
+        "description": "Gets the specified message attachment.",
+        "operationId": "gmail.users.messages.attachments.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessagePartBody"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "messageId",
+            "in": "path",
+            "description": "The ID of the message containing the attachment.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the attachment.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/autoForwarding": {
+      "get": {
+        "description": "Gets the auto-forwarding setting for the specified account.",
+        "operationId": "gmail.users.settings.getAutoForwarding",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoForwarding"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates the auto-forwarding setting for the specified account. A verified forwarding address must be specified when auto-forwarding is enabled. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.updateAutoForwarding",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoForwarding"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoForwarding"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/imap": {
+      "get": {
+        "description": "Gets IMAP settings.",
+        "operationId": "gmail.users.settings.getImap",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImapSettings"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates IMAP settings.",
+        "operationId": "gmail.users.settings.updateImap",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImapSettings"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImapSettings"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/language": {
+      "get": {
+        "description": "Gets language settings.",
+        "operationId": "gmail.users.settings.getLanguage",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageSettings"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates language settings. If successful, the return object contains the `displayLanguage` that was saved for the user, which may differ from the value passed into the request. This is because the requested `displayLanguage` may not be directly supported by Gmail but have a close variant that is, and so the variant may be chosen and saved instead.",
+        "operationId": "gmail.users.settings.updateLanguage",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageSettings"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageSettings"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/pop": {
+      "get": {
+        "description": "Gets POP settings.",
+        "operationId": "gmail.users.settings.getPop",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PopSettings"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates POP settings.",
+        "operationId": "gmail.users.settings.updatePop",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PopSettings"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PopSettings"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/vacation": {
+      "get": {
+        "description": "Gets vacation responder settings.",
+        "operationId": "gmail.users.settings.getVacation",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VacationSettings"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates vacation responder settings.",
+        "operationId": "gmail.users.settings.updateVacation",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VacationSettings"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VacationSettings"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/identities": {
+      "post": {
+        "description": "Creates and configures a client-side encryption identity that's authorized to send mail from the user account. Google publishes the S/MIME certificate to a shared domain-wide directory so that people within a Google Workspace organization can encrypt and send mail to the identity. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.identities.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseIdentity"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CseIdentity"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the client-side encrypted identities for an authenticated user. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.identities.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCseIdentitiesResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of identities to return. If not provided, the page size will default to 20 entries.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Pagination token indicating which page of identities to return. If the token is not supplied, then the API will return the first page of results.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}": {
+      "delete": {
+        "description": "Deletes a client-side encryption identity. The authenticated user can no longer use the identity to send encrypted messages. You cannot restore the identity after you delete it. Instead, use the CreateCseIdentity method to create another identity with the same configuration. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.identities.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cseEmailAddress",
+            "in": "path",
+            "description": "The primary email address associated with the client-side encryption identity configuration that's removed.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Retrieves a client-side encryption identity configuration. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.identities.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseIdentity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cseEmailAddress",
+            "in": "path",
+            "description": "The primary email address associated with the client-side encryption identity configuration that's retrieved.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/identities/{emailAddress}": {
+      "patch": {
+        "description": "Associates a different key pair with an existing client-side encryption identity. The updated key pair must validate against Google's [S/MIME certificate profiles](https://support.google.com/a/answer/7300887). For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.identities.patch",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseIdentity"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CseIdentity"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "emailAddress",
+            "in": "path",
+            "description": "The email address of the client-side encryption identity to update.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/keypairs": {
+      "post": {
+        "description": "Creates and uploads a client-side encryption S/MIME public key certificate chain and private key metadata for the authenticated user. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseKeyPair"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CseKeyPair"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists client-side encryption key pairs for an authenticated user. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCseKeyPairsResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of key pairs to return. If not provided, the page size will default to 20 entries.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Pagination token indicating which page of key pairs to return. If the token is not supplied, then the API will return the first page of results.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable": {
+      "post": {
+        "description": "Turns off a client-side encryption key pair. The authenticated user can no longer use the key pair to decrypt incoming CSE message texts or sign outgoing CSE mail. To regain access, use the EnableCseKeyPair to turn on the key pair. After 30 days, you can permanently delete the key pair by using the ObliterateCseKeyPair method. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.disable",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseKeyPair"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableCseKeyPairRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keyPairId",
+            "in": "path",
+            "description": "The identifier of the key pair to turn off.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable": {
+      "post": {
+        "description": "Turns on a client-side encryption key pair that was turned off. The key pair becomes active again for any associated client-side encryption identities. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.enable",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseKeyPair"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnableCseKeyPairRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keyPairId",
+            "in": "path",
+            "description": "The identifier of the key pair to turn on.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}": {
+      "get": {
+        "description": "Retrieves an existing client-side encryption key pair. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CseKeyPair"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keyPairId",
+            "in": "path",
+            "description": "The identifier of the key pair to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate": {
+      "post": {
+        "description": "Deletes a client-side encryption key pair permanently and immediately. You can only permanently delete key pairs that have been turned off for more than 30 days. To turn off a key pair, use the DisableCseKeyPair method. Gmail can't restore or decrypt any messages that were encrypted by an obliterated key. Authenticated users and Google Workspace administrators lose access to reading the encrypted messages. For administrators managing identities and keypairs for users in their organization, requests require authorization with a [service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount) that has [domain-wide delegation authority](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority) to impersonate users with the `https://www.googleapis.com/auth/gmail.settings.basic` scope. For users managing their own identities and keypairs, requests require [hardware key encryption](https://support.google.com/a/answer/14153163) turned on and configured.",
+        "operationId": "gmail.users.settings.cse.keypairs.obliterate",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObliterateCseKeyPairRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The requester's primary email address. To indicate the authenticated user, you can use the special value `me`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keyPairId",
+            "in": "path",
+            "description": "The identifier of the key pair to obliterate.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/delegates": {
+      "post": {
+        "description": "Adds a delegate with its verification status set directly to `accepted`, without sending any verification email. The delegate user must be a member of the same Google Workspace organization as the delegator user. Gmail imposes limitations on the number of delegates and delegators each user in a Google Workspace organization can have. These limits depend on your organization, but in general each user can have up to 25 delegates and up to 10 delegators. Note that a delegate user must be referred to by their primary email address, and not an email alias. Also note that when a new delegate is created, there may be up to a one minute delay before the new delegate is available for use. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.delegates.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Delegate"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Delegate"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the delegates for the specified account. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.delegates.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDelegatesResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/delegates/{delegateEmail}": {
+      "delete": {
+        "description": "Removes the specified delegate (which can be of any verification status), and revokes any verification that may have been required for using it. Note that a delegate user must be referred to by their primary email address, and not an email alias. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.delegates.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "delegateEmail",
+            "in": "path",
+            "description": "The email address of the user to be removed as a delegate.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified delegate. Note that a delegate user must be referred to by their primary email address, and not an email alias. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.delegates.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Delegate"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "delegateEmail",
+            "in": "path",
+            "description": "The email address of the user whose delegate relationship is to be retrieved.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/filters": {
+      "post": {
+        "description": "Creates a filter. Note: you can only create a maximum of 1,000 filters.",
+        "operationId": "gmail.users.settings.filters.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Filter"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Filter"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the message filters of a Gmail user.",
+        "operationId": "gmail.users.settings.filters.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFiltersResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/filters/{id}": {
+      "delete": {
+        "description": "Immediately and permanently deletes the specified filter.",
+        "operationId": "gmail.users.settings.filters.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the filter to be deleted.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets a filter.",
+        "operationId": "gmail.users.settings.filters.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Filter"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the filter to be fetched.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/forwardingAddresses": {
+      "post": {
+        "description": "Creates a forwarding address. If ownership verification is required, a message will be sent to the recipient and the resource's verification status will be set to `pending`; otherwise, the resource will be created with verification status set to `accepted`. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.forwardingAddresses.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForwardingAddress"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForwardingAddress"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the forwarding addresses for the specified account.",
+        "operationId": "gmail.users.settings.forwardingAddresses.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListForwardingAddressesResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}": {
+      "delete": {
+        "description": "Deletes the specified forwarding address and revokes any verification that may have been required. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.forwardingAddresses.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "forwardingEmail",
+            "in": "path",
+            "description": "The forwarding address to be deleted.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified forwarding address.",
+        "operationId": "gmail.users.settings.forwardingAddresses.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForwardingAddress"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "forwardingEmail",
+            "in": "path",
+            "description": "The forwarding address to be retrieved.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs": {
+      "post": {
+        "description": "Creates a custom \"from\" send-as alias. If an SMTP MSA is specified, Gmail will attempt to connect to the SMTP service to validate the configuration before creating the alias. If ownership verification is required for the alias, a message will be sent to the email address and the resource's verification status will be set to `pending`; otherwise, the resource will be created with verification status set to `accepted`. If a signature is provided, Gmail will sanitize the HTML before saving it with the alias. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.sendAs.create",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendAs"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendAs"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists the send-as aliases for the specified account. The result includes the primary send-as address associated with the account as well as any custom \"from\" aliases.",
+        "operationId": "gmail.users.settings.sendAs.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSendAsResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}": {
+      "delete": {
+        "description": "Deletes the specified send-as alias. Revokes any verification that may have been required for using it. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.sendAs.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The send-as alias to be deleted.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified send-as alias. Fails with an HTTP 404 error if the specified address is not a member of the collection.",
+        "operationId": "gmail.users.settings.sendAs.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendAs"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The send-as alias to be retrieved.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "patch": {
+        "description": "Patch the specified send-as alias.",
+        "operationId": "gmail.users.settings.sendAs.patch",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendAs"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendAs"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The send-as alias to be updated.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Updates a send-as alias. If a signature is provided, Gmail will sanitize the HTML before saving it with the alias. Addresses other than the primary address for the account can only be updated by service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.sendAs.update",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendAs"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendAs"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The send-as alias to be updated.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify": {
+      "post": {
+        "description": "Sends a verification email to the specified send-as alias address. The verification status must be `pending`. This method is only available to service account clients that have been delegated domain-wide authority.",
+        "operationId": "gmail.users.settings.sendAs.verify",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "User's email address. The special value \"me\" can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The send-as alias to be verified.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}": {
+      "delete": {
+        "description": "Deletes the specified S/MIME config for the specified send-as alias.",
+        "operationId": "gmail.users.settings.sendAs.smimeInfo.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The immutable ID for the SmimeInfo.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified S/MIME config for the specified send-as alias.",
+        "operationId": "gmail.users.settings.sendAs.smimeInfo.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SmimeInfo"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The immutable ID for the SmimeInfo.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo": {
+      "post": {
+        "description": "Insert (upload) the given S/MIME config for the specified send-as alias. Note that pkcs12 format is required for the key.",
+        "operationId": "gmail.users.settings.sendAs.smimeInfo.insert",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SmimeInfo"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SmimeInfo"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Lists S/MIME configs for the specified send-as alias.",
+        "operationId": "gmail.users.settings.sendAs.smimeInfo.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSmimeInfoResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault": {
+      "post": {
+        "description": "Sets the default S/MIME config for the specified send-as alias.",
+        "operationId": "gmail.users.settings.sendAs.smimeInfo.setDefault",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sendAsEmail",
+            "in": "path",
+            "description": "The email address that appears in the \"From:\" header for mail sent using this alias.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The immutable ID for the SmimeInfo.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.basic"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.settings.sharing"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/threads/{id}": {
+      "delete": {
+        "description": "Immediately and permanently deletes the specified thread. Any messages that belong to the thread are also deleted. This operation cannot be undone. Prefer `threads.trash` instead.",
+        "operationId": "gmail.users.threads.delete",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the Thread to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "get": {
+        "description": "Gets the specified thread.",
+        "operationId": "gmail.users.threads.get",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the thread to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "The format to return the messages in.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "full",
+                "metadata",
+                "minimal"
+              ]
+            }
+          },
+          {
+            "name": "metadataHeaders",
+            "in": "query",
+            "description": "When given and format is METADATA, only include headers specified.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.action"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.addons.current.message.readonly"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/threads": {
+      "get": {
+        "description": "Lists the threads in the user's mailbox.",
+        "operationId": "gmail.users.threads.list",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListThreadsResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeSpamTrash",
+            "in": "query",
+            "description": "Include threads from `SPAM` and `TRASH` in the results.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "labelIds",
+            "in": "query",
+            "description": "Only return threads with labels that match all of the specified label IDs.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "description": "Maximum number of threads to return. This field defaults to 100. The maximum allowed value for this field is 500.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "description": "Page token to retrieve a specific page of results in the list.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Only return threads matching the specified query. Supports the same query format as the Gmail search box. For example, `\"from:someuser@example.com rfc822msgid: is:unread\"`. Parameter cannot be used when accessing the api using the gmail.metadata scope.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.metadata"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.readonly"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/threads/{id}/modify": {
+      "post": {
+        "description": "Modifies the labels applied to the thread. This applies to all messages in the thread.",
+        "operationId": "gmail.users.threads.modify",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyThreadRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the thread to modify.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/threads/{id}/trash": {
+      "post": {
+        "description": "Moves the specified thread to the trash. Any messages that belong to the thread are also moved to the trash.",
+        "operationId": "gmail.users.threads.trash",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the thread to Trash.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    },
+    "/gmail/v1/users/{userId}/threads/{id}/untrash": {
+      "post": {
+        "description": "Removes the specified thread from the trash. Any messages that belong to the thread are also removed from the trash.",
+        "operationId": "gmail.users.threads.untrash",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user's email address. The special value `me` can be used to indicate the authenticated user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the thread to remove from Trash.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "Oauth2": [
+              "https://mail.google.com/"
+            ],
+            "Oauth2c": [
+              "https://mail.google.com/"
+            ]
+          },
+          {
+            "Oauth2": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ],
+            "Oauth2c": [
+              "https://www.googleapis.com/auth/gmail.modify"
+            ]
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        },
+        {
+          "$ref": "#/components/parameters/access_token"
+        },
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/fields"
+        },
+        {
+          "$ref": "#/components/parameters/key"
+        },
+        {
+          "$ref": "#/components/parameters/oauth_token"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/quotaUser"
+        },
+        {
+          "$ref": "#/components/parameters/upload_protocol"
+        },
+        {
+          "$ref": "#/components/parameters/uploadType"
+        }
+      ]
+    }
+  },
+  "tags": [
+    {
+      "name": "users"
+    }
+  ],
+  "externalDocs": {
+    "url": "https://developers.google.com/workspace/gmail/api/"
+  },
+  "x-hasEquivalentPaths": true
+}

--- a/scripts/openapi/google/mail/main.go
+++ b/scripts/openapi/google/mail/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/scripts/openapi/google/internal/files"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// nolint:gochecknoglobals
+var (
+	ignoreEndpoints = []string{
+		// Endpoints to ignore because they return single configuration objects,
+		// not resource collections. Our schema extraction targets collection-based
+		// resources (list/create/update flows), so singleton "settings/profile"
+		// endpoints are applicable and therefore excluded.
+		"/gmail/v1/users/{userId}/settings/autoForwarding",
+		"/gmail/v1/users/{userId}/settings/language",
+		"/gmail/v1/users/{userId}/profile",
+		"/gmail/v1/users/{userId}/settings/vacation",
+		"/gmail/v1/users/{userId}/settings/pop",
+		"/gmail/v1/users/{userId}/settings/imap",
+	}
+)
+
+func main() {
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
+	registry := datautils.NamedLists[string]{}
+
+	for _, object := range Objects() {
+		urlPath, _ := strings.CutPrefix(object.URLPath, "/gmail/v1")
+		// All Gmail endpoints require user identifier.
+		// Luckily we can reference current user using an alias "me".
+		urlPath = strings.ReplaceAll(urlPath, "{userId}", "me")
+
+		objectName := object.ObjectName
+
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", objectName,
+				"error", object.Problem,
+			)
+		}
+
+		for _, field := range object.Fields {
+			fieldMetadataMap := staticschema.FieldMetadataMapV2{
+				field.Name: staticschema.FieldMetadata{
+					DisplayName:  fieldNameConvertToDisplayName(field.Name),
+					ValueType:    providerTypeConvertToValueType(field.Type),
+					ProviderType: field.Type,
+					ReadOnly:     goutils.Pointer(false),
+					Values:       nil,
+				},
+			}
+
+			schemas.Add(providers.ModuleGoogleMail, objectName, object.DisplayName, urlPath,
+				object.ResponseKey, fieldMetadataMap, nil, object.Custom)
+		}
+
+		for _, queryParam := range object.QueryParams {
+			registry.Add(queryParam, object.ObjectName)
+		}
+	}
+
+	goutils.MustBeNil(files.OutputMail.FlushSchemas(schemas))
+	goutils.MustBeNil(files.OutputMail.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
+
+	slog.Info("Completed.")
+}
+
+func Objects() []metadatadef.Schema {
+	explorer, err := files.InputMail.GetExplorer(
+		api3.WithDisplayNamePostProcessors(
+			api3.CamelCaseToSpaceSeparated,
+			api3.CapitalizeFirstLetterEveryWord,
+		),
+		api3.WithArrayItemAutoSelection(),
+	)
+	goutils.MustBeNil(err)
+
+	objects, err := explorer.ReadObjects(
+		http.MethodGet,
+		api3.AndPathMatcher{
+			api3.NestedIDPathIgnorer{},
+			api3.NewDenyPathStrategy(ignoreEndpoints),
+		},
+		nil, nil,
+		func(objectName, fieldName string) bool {
+			return false
+		},
+	)
+	goutils.MustBeNil(err)
+
+	return objects
+}
+
+func fieldNameConvertToDisplayName(fieldName string) string {
+	return api3.CapitalizeFirstLetterEveryWord(
+		api3.CamelCaseToSpaceSeparated(fieldName),
+	)
+}
+
+func providerTypeConvertToValueType(providerType string) common.ValueType {
+	switch providerType {
+	case "integer":
+		return common.ValueTypeInt
+	case "string":
+		return common.ValueTypeString
+	case "boolean":
+		return common.ValueTypeBoolean
+	default:
+		// Ex: object, array
+		return common.ValueTypeOther
+	}
+}

--- a/test/google/connector.go
+++ b/test/google/connector.go
@@ -19,6 +19,10 @@ func GetGoogleContactsConnector(ctx context.Context) *google.Connector {
 	return getGoogleConnector(ctx, providers.ModuleGoogleContacts)
 }
 
+func GetGoogleMailConnector(ctx context.Context) *google.Connector {
+	return getGoogleConnector(ctx, providers.ModuleGoogleMail)
+}
+
 func getGoogleConnector(ctx context.Context, moduleID common.ModuleID) *google.Connector {
 	filePath := credscanning.LoadPath(providers.Google)
 	reader := utils.MustCreateProvCredJSON(filePath, true)

--- a/test/google/mail/metadata/messages/main.go
+++ b/test/google/mail/metadata/messages/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/google"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetGoogleMailConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"messages",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/tools/fileconv/api3/strategy.go
+++ b/tools/fileconv/api3/strategy.go
@@ -150,12 +150,20 @@ func (IDPathIgnorer) IsPathMatching(path string) bool {
 
 type NestedIDPathIgnorer struct{}
 
+// IsPathMatching returns true when there is more than one URI part as ID.
 func (NestedIDPathIgnorer) IsPathMatching(path string) bool {
-	// Remove the last URL part.
-	parts := strings.Split(path, "/")
-	parts = parts[:len(parts)-1]
-	path = strings.Join(parts, "/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	idCounter := 0
 
-	// We get the large prefix which may have variate parts. It shouldn't.
-	return !strings.Contains(path, "{")
+	for _, p := range parts {
+		if strings.Contains(p, "{") && strings.Contains(p, "}") {
+			idCounter += 1
+
+			if idCounter > 1 {
+				return false
+			}
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
# Description

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [x] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [x] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Live Tests
<img width="367" height="441" alt="image" src="https://github.com/user-attachments/assets/6620e9b5-3476-4ab6-b5ae-218a91fd444d" />
