### PR TITLE
[CON-1341] feat(sellsy): Read

### DIFF
--- a/providers/sellsy/connector.go
+++ b/providers/sellsy/connector.go
@@ -2,17 +2,24 @@ package sellsy
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/sellsy/internal/metadata"
 )
+
+const apiVersion = "v2"
 
 type Connector struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
 
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -26,5 +33,29 @@ func constructor(base *components.Connector) (*Connector, error) {
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
 	return connector, nil
+}
+
+func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
+	objectPath, err := metadata.Schemas.FindURLPath(common.ModuleRoot, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.ModuleInfo().BaseURL, apiVersion, objectPath)
 }

--- a/providers/sellsy/errors.go
+++ b/providers/sellsy/errors.go
@@ -1,0 +1,31 @@
+package sellsy
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	Error ErrorDetails `json:"error"`
+}
+
+type ErrorDetails struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Details any    `json:"details"`
+	Context any    `json:"context"`
+}
+
+func (e ResponseError) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, e.Error.Message)
+}

--- a/providers/sellsy/handlers.go
+++ b/providers/sellsy/handlers.go
@@ -1,0 +1,118 @@
+package sellsy
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/sellsy/internal/metadata"
+	"github.com/spyzhov/ajson"
+)
+
+// Every request has a page limit in range [0,100].
+// https://docs.sellsy.com/api/v2/#operation/get-contacts
+const defaultPageSize = "100"
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	readURL, err := c.getReadURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointURL := params.NextPage.String()
+
+	if params.NextPage == "" {
+		// This is the first, initial page for the object.
+		// Page size query parameters:
+		// https://docs.sellsy.com/api/v2/#operation/get-contacts
+		readURL.WithQueryParam("limit", defaultPageSize)
+
+		endpointURL = readURL.String()
+	}
+
+	method, jsonData, err := createReadOperation(readURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpointURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module(), params.ObjectName)
+
+	return common.ParseResultFiltered(params, resp,
+		common.MakeRecordsFunc(responseFieldName),
+		makeFilterFunc(params, request),
+		common.MakeMarshaledDataFunc(nil),
+		params.Fields,
+	)
+}
+
+/*
+Pagination uses cursor pagination which in Sellsy documentation is referred to as "Seek" Method.
+https://docs.sellsy.com/api/v2/#section/Pagination-on-list-and-search-requests
+
+When number of records is less than the max page size this signifies that we can ignore making the next page request.
+
+Read Response format:
+
+	{
+	  ...
+	  "pagination": {
+		"limit": 2,
+		"count": 2,
+		"total": 32,
+		"offset": "WyI0Il0="
+	  }
+	}
+*/
+func makeNextRecordsURL(requestURL *url.URL) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		seekOffset, err := jsonquery.New(node, "pagination").StrWithDefault("offset", "")
+		if err != nil {
+			return "", err
+		}
+
+		if seekOffset == "" {
+			// Next page doesn't exist.
+			return "", nil
+		}
+
+		counter, _ := jsonquery.New(node, "pagination").IntegerWithDefault("count", 0)
+		limit, _ := jsonquery.New(node, "pagination").IntegerWithDefault("limit", 0)
+
+		if counter < limit {
+			// This is the last page.
+			// The next page cannot contain more records, so stop here.
+			return "", nil
+		}
+
+		nextURL, err := urlbuilder.FromRawURL(requestURL)
+		if err != nil {
+			return "", err
+		}
+
+		nextURL.WithQueryParam("offset", seekOffset)
+
+		return nextURL.String(), nil
+	}
+}

--- a/providers/sellsy/incremental.go
+++ b/providers/sellsy/incremental.go
@@ -1,0 +1,256 @@
+package sellsy
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// createReadOperation determines the HTTP method and request payload for reading an object.
+// For search endpoints, it includes time-based filters when supported.
+// For other endpoints, it defaults to a GET without a payload. These endpoints have no filtering options.
+//
+// Behavior:
+//   - Uses POST with a JSON payload for endpoints ending in `/search`.
+//   - Uses GET without a payload for all other endpoints.
+//
+// Background:
+//
+//	Incremental reads in Sellsy are inconsistent across endpoints. Each
+//	"search" resource may support different filter fields (e.g., "created",
+//	"updated", "updated_at"), or expose different timestamp fields in
+//	their responses. Some objects do not support timestamp filtering at all.
+//
+// Common cases:
+//   - Some objects can be filtered by "updated" and include that field in response.
+//   - Some can only be filtered by "created" but return "updated" (requiring client-side filtering).
+//   - Others expose no filterable timestamp field, though they may include "created" in responses.
+//   - A few lack both filterable parameters and usable timestamps entirely.
+func createReadOperation(
+	url *urlbuilder.URL, params common.ReadParams,
+) (method string, payload []byte, err error) {
+	if !strings.HasSuffix(url.Path(), "/search") {
+		return http.MethodGet, nil, nil
+	}
+
+	filter := readFilter{}
+	if !params.Since.IsZero() {
+		filter.Start = datautils.Time.FormatRFC3339inUTC(params.Since)
+	}
+
+	if !params.Until.IsZero() {
+		filter.End = datautils.Time.FormatRFC3339inUTC(params.Until)
+	}
+
+	objectTimeSpec := objectsFilterParam.Get(params.ObjectName)
+
+	searchPayload := &readSearchPayload{
+		Filters: newReadSearchFilters(objectTimeSpec.RequestBy, filter),
+	}
+
+	payload, err = json.Marshal(searchPayload)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return http.MethodPost, payload, nil
+}
+
+// makeFilterFunc returns a filtering function that respects the Since and Until parameters specified in ReadParams.
+//
+// If the object does not expose a suitable timestamp field for filtering,
+// the function returns an identity filter (passing all records unchanged).
+//
+// Note:
+//
+//	Even if the HTTP method (GET or POST) does not support server-side time filtering,
+//	the client still applies local filtering to exclude records outside the specified time window.
+func makeFilterFunc(params common.ReadParams, request *http.Request) common.RecordsFilterFunc {
+	timeSpec := objectsFilterParam.Get(params.ObjectName)
+	if timeSpec.ResponseAt == "" {
+		// No timestamp field available; return all records unfiltered.
+		return readhelper.MakeIdentityFilterFunc(makeNextRecordsURL(request.URL))
+	}
+
+	// Client side filtering.
+	return readhelper.MakeTimeFilterFunc(
+		readhelper.ChronologicalOrder,
+		readhelper.NewTimeBoundary(),
+		timeSpec.ResponseAt, time.RFC3339,
+		makeNextRecordsURL(request.URL))
+}
+
+// objectsFilterParam defines which timestamp fields and filters apply to
+// each Sellsy object for incremental reads.
+//
+// Structure:
+//   - RequestBy: the time filter parameter accepted by the Sellsy API (if any).
+//   - ResponseAt: the timestamp field to use when advancing the incremental read.
+//
+// Notes:
+//   - Some objects can be queried by "created" but should advance based on "updated".
+//   - Some support no query filters but still expose a timestamp usable for client-side filtering.
+//   - If both are unavailable, RequestBy = filterNone and ResponseAt = "".
+//
+// References:
+//
+//	Each object entry includes a link to its API documentation for clarity.
+var objectsFilterParam = datautils.NewDefaultMap(map[string]timeFieldSpec{ // nolint:gochecknoglobals
+	// -----------------------------------------------------------------------------
+	// (1) Objects with UPDATED field
+	// -----------------------------------------------------------------------------
+	// comments: https://docs.sellsy.com/api/v2/#operation/search-comments
+	"comments": {RequestBy: filterByUpdated, ResponseAt: "updated"},
+	// contacts: https://docs.sellsy.com/api/v2/#operation/search-contacts
+	"contacts": {RequestBy: filterByUpdated, ResponseAt: "updated"},
+	// phone-calls: https://docs.sellsy.com/api/v2/#operation/search-phone-calls
+	"phone-calls": {RequestBy: filterByCreated, ResponseAt: "updated"},
+	// tasks: https://docs.sellsy.com/api/v2/#operation/search-tasks
+	"tasks": {RequestBy: filterByCreated, ResponseAt: "updated"},
+	// calendar-events: https://docs.sellsy.com/api/v2/#operation/search-calendar-events
+	"calendar-events": {RequestBy: filterByDate, ResponseAt: "updated"},
+	// custom-activities: https://docs.sellsy.com/api/v2/#operation/post-custom-activities-search
+	"custom-activities": {RequestBy: filterByDate, ResponseAt: "updated"},
+	// custom-activity-types: https://docs.sellsy.com/api/v2/#operation/get-custom-activity-types
+	"custom-activity-types": {RequestBy: filterNone, ResponseAt: "updated"},
+	// webhooks: https://docs.sellsy.com/api/v2/#operation/search-webhooks
+	"webhooks": {RequestBy: filterNone, ResponseAt: "updated"},
+	// -----------------------------------------------------------------------------
+	// (2) Objects with CREATED field
+	// -----------------------------------------------------------------------------
+	// deposit-invoices: https://docs.sellsy.com/api/v2/#operation/search-deposit-invoices
+	"deposit-invoices": {RequestBy: filterByCreated, ResponseAt: "created"},
+	// documents/models: https://docs.sellsy.com/api/v2/#operation/search-models
+	"documents/models": {RequestBy: filterByCreated, ResponseAt: "created"},
+	// estimates: https://docs.sellsy.com/api/v2/#operation/search-estimates
+	"estimates": {RequestBy: filterByCreated, ResponseAt: "created"},
+	// invoices: https://docs.sellsy.com/api/v2/#operation/search-invoices
+	"invoices": {RequestBy: filterByCreated, ResponseAt: "created"},
+	// opportunities: https://docs.sellsy.com/api/v2/#operation/search-opportunities
+	"opportunities": {RequestBy: filterByCreated, ResponseAt: "created"},
+	// credit-notes: https://docs.sellsy.com/api/v2/#operation/search-credit-notes
+	"credit-notes": {RequestBy: filterNone, ResponseAt: "created"},
+	// notifications: https://docs.sellsy.com/api/v2/#operation/search-notifications
+	"notifications": {RequestBy: filterNone, ResponseAt: "created"},
+	// orders: https://docs.sellsy.com/api/v2/#operation/search-orders
+	"orders": {RequestBy: filterNone, ResponseAt: "created"},
+	// staffs: https://docs.sellsy.com/api/v2/#operation/search-staffs
+	"staffs": {RequestBy: filterNone, ResponseAt: "created"},
+	// subscriptions: https://docs.sellsy.com/api/v2/#operation/search-subscriptions
+	"subscriptions": {RequestBy: filterNone, ResponseAt: "created"},
+	// -----------------------------------------------------------------------------
+	// (3) Objects with UPDATED_AT field
+	// -----------------------------------------------------------------------------
+	// companies: https://docs.sellsy.com/api/v2/#operation/search-companies
+	"companies": {RequestBy: filterByUpdatedAt, ResponseAt: "updated_at"},
+	// individuals: https://docs.sellsy.com/api/v2/#operation/search-individuals
+	"individuals": {RequestBy: filterByUpdatedAt, ResponseAt: "updated_at"},
+	// -----------------------------------------------------------------------------
+	// (4) Objects with CREATED_AT field:
+	// -----------------------------------------------------------------------------
+	// pur-invoice: https://docs.sellsy.com/api/v2/#operation/search-ocr-pur-invoice
+	"pur-invoice": {RequestBy: filterNone, ResponseAt: "created_at"},
+}, func(objectName string) timeFieldSpec {
+	// Default case: no time-based filter or response field available.
+	return timeFieldSpec{
+		RequestBy:  filterNone,
+		ResponseAt: "",
+	}
+})
+
+// timeFieldSpec defines which Sellsy API parameters and response fields are
+// associated with time-based filtering for incremental reads.
+//
+// Example: request records created after a certain time, but advance incrementally based on their "updated" timestamp.
+//
+//	timeFieldSpec{
+//	    RequestBy:  filterByCreated,
+//	    ResponseAt: "updated",
+//	}
+type timeFieldSpec struct {
+	// RequestBy specifies the query parameter accepted by the API (if any).
+	RequestBy filterParameterType
+	// ResponseAt specifies the timestamp field available in the response used
+	// to advance the incremental cursor.
+	ResponseAt string
+}
+
+// readSearchPayload represents the JSON payload for a Sellsy search request.
+type readSearchPayload struct {
+	Filters readSearchFilters `json:"filters,omitempty"`
+}
+
+// readSearchFilters defines the supported time-based filters accepted in Sellsy
+// search request payloads.
+//
+// Note: These filters control query parameters only — they are not guaranteed to
+// directly correspond to timestamp fields in the response. For example, an endpoint
+// might accept a `date` filter but return `created` or `updated` fields instead.
+//
+// Sellsy's API is inconsistent in how it names and expects these filters across
+// different objects. Using an unsupported parameter results in a 400 Bad Request.
+type readSearchFilters struct {
+	// Date is used by endpoints that filter results by a general "date" range.
+	// Despite the name, this parameter effectively filters by creation time.
+	// Some endpoints expose both `created` and `updated` timestamps in responses,
+	// but still expect `date` as the filter parameter.
+	Date *readFilter `json:"date,omitempty"`
+
+	// Created filters results by record creation time.
+	// Common for resources that explicitly expose `created` in their payloads
+	// but do not support an `updated` timestamp.
+	// However, it doesn't mean response won't have `updated` field!
+	Created *readFilter `json:"created,omitempty"`
+
+	// Updated filters results using the `updated` timestamp field.
+	// This parameter is supported by only a few endpoints.
+	Updated *readFilter `json:"updated,omitempty"`
+
+	// UpdatedAt exists because some endpoints expect `updated_at` instead of `updated`
+	// as their time filter parameter. Functionally identical to `updated`, it reflects
+	// Sellsy’s inconsistent naming conventions across objects.
+	UpdatedAt *readFilter `json:"updated_at,omitempty"`
+}
+
+type readFilter struct {
+	Start string `json:"start,omitempty"`
+	End   string `json:"end,omitempty"`
+}
+
+// newReadSearchFilters constructs a readSearchFilters struct with the appropriate time filter based on filter type.
+func newReadSearchFilters(parameter filterParameterType, filter readFilter) readSearchFilters {
+	filters := readSearchFilters{}
+
+	switch parameter {
+	case filterByDate:
+		filters.Date = &filter
+	case filterByCreated:
+		filters.Created = &filter
+	case filterByUpdated:
+		filters.Updated = &filter
+	case filterByUpdatedAt:
+		filters.UpdatedAt = &filter
+	case filterNone:
+		fallthrough
+	default:
+		return filters // no-op, empty filters.
+	}
+
+	return filters
+}
+
+type filterParameterType int
+
+const (
+	filterNone filterParameterType = iota
+	filterByDate
+	filterByCreated
+	filterByUpdated
+	filterByUpdatedAt
+)

--- a/providers/sellsy/read_test.go
+++ b/providers/sellsy/read_test.go
@@ -1,0 +1,253 @@
+package sellsy
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	errorBadRequest := testutils.DataFromFile(t, "read/err-bad-request.json")
+	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts/1-first-page.json")
+	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts/2-last-page.json")
+	responseContactsEmptyPage := testutils.DataFromFile(t, "read/contacts/empty.json")
+	responseTasksLabelsFirstPage := testutils.DataFromFile(t, "read/tasks-labels/1-first-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "contacts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:  "Error invalid params",
+			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("last_name")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, errorBadRequest),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Le contenu de la requête est invalide: le champ 'filters' est manquant."), // nolint:goerr113,lll
+			},
+		},
+		{
+			Name: "Read contacts first page via search endpoint with payload",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("last_name"),
+				Since:      time.Date(2025, 8, 22, 8, 22, 56, 0, time.UTC),
+				Until:      time.Date(2025, 8, 25, 8, 32, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/contacts/search"),
+					mockcond.Body(`{
+						"filters": {
+							"updated": {
+								"start":"2025-08-22T08:22:56Z",
+								"end":"2025-08-25T08:32:00Z"
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsFirstPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"last_name": "Blanc",
+					},
+					Raw: map[string]any{
+						"civility":      "mr",
+						"first_name":    "Antoine",
+						"email":         "antoine@sellsy-mail.com",
+						"mobile_number": "+33612345678",
+					},
+				}, {
+					Fields: map[string]any{
+						"last_name": "Leduc",
+					},
+					Raw: map[string]any{
+						"civility":      "mrs",
+						"first_name":    "Marie",
+						"email":         "marie@sellsy-mail.com",
+						"mobile_number": "+33612345678",
+					},
+				}},
+				NextPage: testroutines.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read contacts second page via search endpoint using next page token",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("last_name"),
+				NextPage:   testroutines.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
+				Since:      time.Date(2025, 8, 22, 8, 22, 56, 0, time.UTC),
+				Until:      time.Date(2025, 8, 25, 8, 32, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/contacts/search"),
+					mockcond.QueryParam("limit", "100"),
+					mockcond.QueryParam("offset", "WyI0Il0="),
+					mockcond.Body(`{
+						"filters": {
+							"updated": {
+								"start":"2025-08-22T08:22:56Z",
+								"end":"2025-08-25T08:32:00Z"
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsLastPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"last_name": "Durand",
+					},
+					Raw: map[string]any{
+						"civility":      "mr",
+						"first_name":    "Michel",
+						"email":         "michel@sellsy-enchante.fr",
+						"mobile_number": "+33612345678",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read contacts empty page does not produce next page token",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("last_name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/contacts/search"),
+					mockcond.Body(`{
+						"filters": {
+							"updated": {}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsEmptyPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     0,
+				Data:     []common.ReadResultRow{},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read task labels via usual get endpoint",
+			Input: common.ReadParams{
+				ObjectName: "tasks/labels",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v2/tasks/labels"),
+					mockcond.BodyBytes(nil),
+				},
+				Then: mockserver.Response(http.StatusOK, responseTasksLabelsFirstPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "📞 Relance téléphonique",
+					},
+					Raw: map[string]any{
+						"id":        float64(3),
+						"name":      "📞 Relance téléphonique",
+						"color":     "FAE60C",
+						"is_active": true,
+						"rank":      float64(0),
+					},
+				}},
+				NextPage: testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read task labels last page via usual get endpoint",
+			Input: common.ReadParams{
+				ObjectName: "tasks/labels",
+				Fields:     connectors.Fields("name"),
+				NextPage:   testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v2/tasks/labels"),
+					mockcond.QueryParam("limit", "100"),
+					mockcond.QueryParam("offset", "WyIwIiwiMyJd"),
+					mockcond.BodyBytes(nil),
+				},
+				// Response doesn't matter for second page, reuse first page output.
+				Then: mockserver.Response(http.StatusOK, responseTasksLabelsFirstPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Data:     []common.ReadResultRow{},
+				NextPage: testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/sellsy/test/read/contacts/1-first-page.json
+++ b/providers/sellsy/test/read/contacts/1-first-page.json
@@ -1,0 +1,108 @@
+{
+  "data": [
+    {
+      "id": 3,
+      "civility": "mr",
+      "first_name": "Antoine",
+      "last_name": "Blanc",
+      "email": "antoine@sellsy-mail.com",
+      "website": null,
+      "phone_number": null,
+      "mobile_number": "+33612345678",
+      "fax_number": null,
+      "position": null,
+      "avatar": null,
+      "note": "",
+      "birth_date": null,
+      "invoicing_address_id": null,
+      "delivery_address_id": null,
+      "is_archived": false,
+      "created": "2025-08-22T21:37:04+02:00",
+      "updated": "2025-08-22T21:37:04+02:00",
+      "social": {
+        "twitter": null,
+        "facebook": null,
+        "linkedin": null,
+        "viadeo": null
+      },
+      "sync": {
+        "mailchimp": true,
+        "mailjet": true,
+        "simplemail": true
+      },
+      "owner": {
+        "id": 602301,
+        "type": "staff"
+      },
+      "marketing_campaigns_subscriptions": [
+        "email",
+        "sms",
+        "phone",
+        "postal_mail",
+        "custom"
+      ],
+      "rgpd_consent": {
+        "email": true,
+        "sms": true,
+        "phone": true,
+        "postal_mail": true,
+        "custom": true
+      }
+    },
+    {
+      "id": 4,
+      "civility": "mrs",
+      "first_name": "Marie",
+      "last_name": "Leduc",
+      "email": "marie@sellsy-mail.com",
+      "website": null,
+      "phone_number": null,
+      "mobile_number": "+33612345678",
+      "fax_number": null,
+      "position": null,
+      "avatar": null,
+      "note": "",
+      "birth_date": null,
+      "invoicing_address_id": null,
+      "delivery_address_id": null,
+      "is_archived": false,
+      "created": "2025-08-22T21:37:04+02:00",
+      "updated": "2025-08-22T21:37:04+02:00",
+      "social": {
+        "twitter": null,
+        "facebook": null,
+        "linkedin": null,
+        "viadeo": null
+      },
+      "sync": {
+        "mailchimp": true,
+        "mailjet": true,
+        "simplemail": true
+      },
+      "owner": {
+        "id": 602301,
+        "type": "staff"
+      },
+      "marketing_campaigns_subscriptions": [
+        "email",
+        "sms",
+        "phone",
+        "postal_mail",
+        "custom"
+      ],
+      "rgpd_consent": {
+        "email": true,
+        "sms": true,
+        "phone": true,
+        "postal_mail": true,
+        "custom": true
+      }
+    }
+  ],
+  "pagination": {
+    "limit": 2,
+    "count": 2,
+    "total": 32,
+    "offset": "WyI0Il0="
+  }
+}

--- a/providers/sellsy/test/read/contacts/2-last-page.json
+++ b/providers/sellsy/test/read/contacts/2-last-page.json
@@ -1,0 +1,59 @@
+{
+  "data": [
+    {
+      "id": 5,
+      "civility": "mr",
+      "first_name": "Michel",
+      "last_name": "Durand",
+      "email": "michel@sellsy-enchante.fr",
+      "website": null,
+      "phone_number": null,
+      "mobile_number": "+33612345678",
+      "fax_number": null,
+      "position": "Dirigeant",
+      "avatar": null,
+      "note": "",
+      "birth_date": null,
+      "invoicing_address_id": null,
+      "delivery_address_id": null,
+      "is_archived": false,
+      "created": "2025-08-22T21:37:04+02:00",
+      "updated": "2025-08-22T21:37:04+02:00",
+      "social": {
+        "twitter": null,
+        "facebook": null,
+        "linkedin": null,
+        "viadeo": null
+      },
+      "sync": {
+        "mailchimp": true,
+        "mailjet": true,
+        "simplemail": true
+      },
+      "owner": {
+        "id": 602301,
+        "type": "staff"
+      },
+      "marketing_campaigns_subscriptions": [
+        "email",
+        "sms",
+        "phone",
+        "postal_mail",
+        "custom"
+      ],
+      "rgpd_consent": {
+        "email": true,
+        "sms": true,
+        "phone": true,
+        "postal_mail": true,
+        "custom": true
+      }
+    }
+  ],
+  "pagination": {
+    "limit": 100,
+    "count": 30,
+    "total": 32,
+    "offset": "WyIzNCJd"
+  }
+}

--- a/providers/sellsy/test/read/contacts/empty.json
+++ b/providers/sellsy/test/read/contacts/empty.json
@@ -1,0 +1,9 @@
+{
+  "data": [],
+  "pagination": {
+    "limit": 100,
+    "count": 0,
+    "total": 32,
+    "offset": "WyIzNCJd"
+  }
+}

--- a/providers/sellsy/test/read/err-bad-request.json
+++ b/providers/sellsy/test/read/err-bad-request.json
@@ -1,0 +1,10 @@
+{
+  "error": {
+    "code": 400,
+    "message": "Le contenu de la requ\u00eate est invalide: le champ \u0027filters\u0027 est manquant.",
+    "details": {
+      "filters": "Ce champ est manquant"
+    },
+    "context": null
+  }
+}

--- a/providers/sellsy/test/read/tasks-labels/1-first-page.json
+++ b/providers/sellsy/test/read/tasks-labels/1-first-page.json
@@ -1,0 +1,17 @@
+{
+  "data": [
+    {
+      "id": 3,
+      "name": "📞 Relance téléphonique",
+      "color": "FAE60C",
+      "is_active": true,
+      "rank": 0
+    }
+  ],
+  "pagination": {
+    "limit": 1,
+    "count": 1,
+    "total": 9,
+    "offset": "WyIwIiwiMyJd"
+  }
+}

--- a/test/sellsy/read/contacts/main.go
+++ b/test/sellsy/read/contacts/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/sellsy"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSellsyConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		// Incremental reading is supported. Response has "updated" field.
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("first_name", "last_name", "updated"),
+		// Since:      time.Now().Add(-1 * time.Minute * 12),
+		// Until:      time.Now().Add(-1 * time.Minute * 9),
+		// NextPage: "https://api.sellsy.com/v2/contacts/search?limit=36&offset=WyIzOCJd",
+		Since: timestamp("2025-10-21T23:01:30+02:00"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func timestamp(timeText string) time.Time {
+	result, err := time.Parse(time.RFC3339, timeText)
+	if err != nil {
+		utils.Fail("bad timestamp", "error", err)
+	}
+
+	return result
+}

--- a/test/sellsy/read/custom-activities/main.go
+++ b/test/sellsy/read/custom-activities/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/sellsy"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSellsyConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		// Incremental read is supported: the request uses the "date" parameter,
+		// while the response timestamp is provided in the "updated" field.
+		// This is an example where the request and response fields differ.
+		ObjectName: "custom-activities",
+		Fields:     connectors.Fields("action", "updated"),
+		Since:      timestamp("2025-10-21T23:01:30+02:00"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func timestamp(timeText string) time.Time {
+	result, err := time.Parse(time.RFC3339, timeText)
+	if err != nil {
+		utils.Fail("bad timestamp", "error", err)
+	}
+
+	return result
+}

--- a/test/sellsy/read/items/main.go
+++ b/test/sellsy/read/items/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/sellsy"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSellsyConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		// Incremental reading is not supported by either the provider or the client.
+		ObjectName: "items",
+		Fields:     connectors.Fields("name", "reference", "currency"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/sellsy/read/staffs/main.go
+++ b/test/sellsy/read/staffs/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/sellsy"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSellsyConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		// Incremental read is supported only on the client side.
+		ObjectName: "staffs",
+		Fields:     connectors.Fields("firstname", "created"),
+		Since:      timestamp("2025-10-21T23:01:23+02:00"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func timestamp(timeText string) time.Time {
+	result, err := time.Parse(time.RFC3339, timeText)
+	if err != nil {
+		utils.Fail("bad timestamp", "error", err)
+	}
+
+	return result
+}


### PR DESCRIPTION
# Desription

- [x] Connector uses `internal/components`
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
  * dedicated follow up PR will be created, but it is possible. 
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

## Incremental Read
Filtering is applied on the **connector side** in addition to the provider's own filtering.
When possible, the connector uses more **accurate response fields** for filtering, and it performs filtering even when the provider does not offer such parameters.

To match the behavior of Sellsy's search endpoints, both `Since` and `Until` filters are inclusive.
<img width="374" height="160" alt="image" src="https://github.com/user-attachments/assets/97ac0e86-9394-425f-ae61-7bd536265d1f" />
To validate the connector-side filtering logic, the request mechanism was **temporarily disabled to fetch all available records**.
The results produced by the connector's internal filtering **matched those returned by the Sellsy API**, confirming that both approaches yield consistent outcomes.

# Live Tests
## Contacts
First, we request contacts since _a specific date_.
In the response, we search for records that have that exact timestamp.

As shown below, there are **34 contacts** older than or equal to `2025-10-21T23:01:30+02:00`.
When searching for an **exact match** in the IDE, there are **7 records** with that timestamp.

This confirms that the implementation correctly uses a **"greater than or equal to" comparison**, matching the provider's behavior.
<img width="736" height="622" alt="image" src="https://github.com/user-attachments/assets/e5628ef9-8525-45b9-b9d0-23fc9a1506f2" />

Next, we request records with both `Since` and `Until` set to the same timestamp.
Logically, this means we're asking for records that are **"greater than or equal to"** and **"less than or equal to"** the same date — effectively returning only records **equal to that timestamp**, which we already know to be **7 records**:
<img width="669" height="619" alt="image" src="https://github.com/user-attachments/assets/0a39c954-9416-43b4-a824-7e2f08703321" />

## Custom Activities
<img width="708" height="464" alt="image" src="https://github.com/user-attachments/assets/f4cc3593-5651-4a9e-8bbf-a0ff31ec4c30" />

## Items
<img width="806" height="463" alt="image" src="https://github.com/user-attachments/assets/04d82461-c338-4154-b87b-e0302bead754" />

## Staffs
<img width="630" height="447" alt="image" src="https://github.com/user-attachments/assets/4440b332-c201-4038-bc8c-58983f3a1bef" />
