### PR TITLE
[CON-1342] feat(sellsy): Write

### DIFF
--- a/providers/sellsy/delete_test.go
+++ b/providers/sellsy/delete_test.go
@@ -1,0 +1,68 @@
+package sellsy
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestDelete(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseNotFound := testutils.DataFromFile(t, "delete/err-not-found.json")
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "contacts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name:  "Error invalid payload",
+			Input: common.DeleteParams{ObjectName: "contacts", RecordId: "39"},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseNotFound),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("bad request: not found: Not Found"), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Remove contact",
+			Input: common.DeleteParams{ObjectName: "contacts", RecordId: "39"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/sellsy/handlers.go
+++ b/providers/sellsy/handlers.go
@@ -3,6 +3,8 @@ package sellsy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -115,4 +117,84 @@ func makeNextRecordsURL(requestURL *url.URL) common.NextPageFunc {
 
 		return nextURL.String(), nil
 	}
+}
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	writeURL, err := c.getWriteURL(params.ObjectName, params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	method := http.MethodPost
+	if len(params.RecordId) != 0 {
+		method = http.MethodPut
+	}
+
+	jsonData, err := json.Marshal(params.RecordData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal record data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, writeURL.String(), bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseWriteResponse(ctx context.Context, params common.WriteParams,
+	request *http.Request, response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		// it is unlikely to have no payload
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	recordID, err := jsonquery.New(body).TextWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Errors:   nil,
+		Data:     data,
+	}, nil
+}
+
+func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	deleteURL, err := c.getWriteURL(params.ObjectName, params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deleteURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseDeleteResponse(ctx context.Context, params common.DeleteParams,
+	request *http.Request, response *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	if response.Code != http.StatusOK && response.Code != http.StatusNoContent {
+		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, response.Code)
+	}
+
+	// Response body is not used.
+	return &common.DeleteResult{
+		Success: true,
+	}, nil
 }

--- a/providers/sellsy/test/delete/err-not-found.json
+++ b/providers/sellsy/test/delete/err-not-found.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "code": 404,
+    "message": "Not Found",
+    "details": [],
+    "context": null
+  }
+}

--- a/providers/sellsy/test/write/contacts/err-bad-request.json
+++ b/providers/sellsy/test/write/contacts/err-bad-request.json
@@ -1,0 +1,10 @@
+{
+  "error": {
+    "code": 400,
+    "message": "Le contenu de la requête est invalide: le champ 'last_name' est manquant.",
+    "details": {
+      "last_name": "Ce champ est manquant"
+    },
+    "context": null
+  }
+}

--- a/providers/sellsy/test/write/contacts/new.json
+++ b/providers/sellsy/test/write/contacts/new.json
@@ -1,0 +1,29 @@
+{
+  "id": 39,
+  "first_name": "Waldo",
+  "last_name": "Vazquez",
+  "note": "",
+  "is_archived": false,
+  "created": "2025-09-16T23:47:09+02:00",
+  "updated": "2025-09-16T23:47:09+02:00",
+  "social": {
+    "viadeo": null
+  },
+  "sync": {
+    "mailchimp": true,
+    "mailjet": true,
+    "simplemail": true
+  },
+  "owner": {
+    "id": 605352,
+    "type": "staff"
+  },
+  "marketing_campaigns_subscriptions": [],
+  "rgpd_consent": {
+    "email": false,
+    "sms": false,
+    "phone": false,
+    "postal_mail": false,
+    "custom": false
+  }
+}

--- a/providers/sellsy/write_test.go
+++ b/providers/sellsy/write_test.go
@@ -1,0 +1,101 @@
+package sellsy
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	responseBadRequest := testutils.DataFromFile(t, "write/contacts/err-bad-request.json")
+	responseContacts := testutils.DataFromFile(t, "write/contacts/new.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Error invalid payload",
+			Input: common.WriteParams{ObjectName: "contacts", RecordData: map[string]any{}},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, responseBadRequest),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				errors.New("Le contenu de la requête est invalide: le champ 'last_name' est manquant."), // nolint:goerr113
+			},
+		},
+		{
+			Name:  "Create contact via POST",
+			Input: common.WriteParams{ObjectName: "contacts", RecordData: "dummy"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/contacts"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "39",
+				Errors:   nil,
+				Data: map[string]any{
+					"first_name": "Waldo",
+					"last_name":  "Vazquez",
+					"created":    "2025-09-16T23:47:09+02:00",
+					"updated":    "2025-09-16T23:47:09+02:00",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Update contact via PUT",
+			Input: common.WriteParams{ObjectName: "contacts", RecordData: "dummy", RecordId: "39"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPUT(),
+					mockcond.Path("/v2/contacts/39"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "39",
+				Errors:   nil,
+				Data: map[string]any{
+					"first_name": "Waldo",
+					"last_name":  "Vazquez",
+					"created":    "2025-09-16T23:47:09+02:00",
+					"updated":    "2025-09-16T23:47:09+02:00",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/sellsy/write-delete/contacts/main.go
+++ b/test/sellsy/write-delete/contacts/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/sellsy"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type payload struct {
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSellsyConnector(ctx)
+
+	firstName := gofakeit.Name()
+	updatedFirstName := gofakeit.Name()
+	lastName := gofakeit.Name()
+	updatedLastName := gofakeit.Name()
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"contacts",
+		payload{
+			FirstName: firstName,
+			LastName:  lastName,
+		},
+		payload{
+			FirstName: updatedFirstName,
+			LastName:  updatedLastName,
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("id", "first_name", "last_name"),
+			SearchBy: testscenario.Property{
+				Key:   "last_name",
+				Value: lastName,
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"first_name": updatedFirstName,
+				"last_name":  updatedLastName,
+			},
+		},
+	)
+}


### PR DESCRIPTION
# Description

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

# Live Tests
<img width="326" height="245" alt="image" src="https://github.com/user-attachments/assets/ff9e716d-0bb3-4d50-9093-433eee3094c7" />

