### PR TITLE
[CON-1974] feat(xero): enable read and write support

### DIFF
--- a/providers/xero.go
+++ b/providers/xero.go
@@ -28,9 +28,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     false,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using Api key

# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="978" height="674" alt="image" src="https://github.com/user-attachments/assets/a0b82ae6-d39f-4431-adf2-644c07b97a4c" />
<img width="958" height="867" alt="image" src="https://github.com/user-attachments/assets/ad105c5c-8bed-4c9d-97ae-2de7867fc724" />
<img width="1072" height="693" alt="image" src="https://github.com/user-attachments/assets/ebbc063f-a799-4c26-a14c-a36c2a0ea1aa" />
<img width="1041" height="668" alt="image" src="https://github.com/user-attachments/assets/8b400d55-a95e-4afc-b302-0b0a1c083aa4" />




- [x] Insert screenshot of Svix destination.
<img width="1606" height="927" alt="image" src="https://github.com/user-attachments/assets/113f2225-b8ce-4bb6-8738-0c324be2c4b9" />
<img width="1579" height="899" alt="image" src="https://github.com/user-attachments/assets/985d02cf-3503-4ee0-b517-dcc37fe248a9" />
<img width="1608" height="938" alt="image" src="https://github.com/user-attachments/assets/5a99fe48-2f92-4e3b-81c3-8782b097dcc9" />




- [x] Screenshot of operations on dashboard
<img width="1493" height="832" alt="image" src="https://github.com/user-attachments/assets/da216241-253c-4419-86f5-1fa8ed5cb58b" />
<img width="1501" height="761" alt="image" src="https://github.com/user-attachments/assets/0496ba0c-a838-4d36-9a67-92567e4b01d9" />
<img width="1508" height="819" alt="image" src="https://github.com/user-attachments/assets/946e66fc-820e-45bb-addc-0fae7e03745a" />





# Write
- [x] Insert screenshot of dashboard.
<img width="1503" height="931" alt="image" src="https://github.com/user-attachments/assets/171fb6f1-51f8-4c77-840d-b9634e1f75ac" />
<img width="1497" height="914" alt="image" src="https://github.com/user-attachments/assets/205132c2-405d-4bcd-bb98-81f5aadf51ca" />
<img width="1491" height="865" alt="image" src="https://github.com/user-attachments/assets/3fb04e2d-3e77-4637-84fc-ee417a0d12a1" />



- [x] Insert screenshot of HTTP call.
<img width="1757" height="760" alt="image" src="https://github.com/user-attachments/assets/850f39db-2219-4b15-98d4-69fe80f876ff" />
<img width="1738" height="694" alt="image" src="https://github.com/user-attachments/assets/6e7f2ab4-bb7e-418b-ad81-3ab61a847923" />
<img width="1755" height="635" alt="image" src="https://github.com/user-attachments/assets/10eac8a5-bc52-4889-b014-632022dcd100" />

