### PR TITLE
fix: Add support for users object zoho connector

### DIFF
--- a/providers/zohocrm/metadata.go
+++ b/providers/zohocrm/metadata.go
@@ -11,7 +11,10 @@ import (
 
 // restMetadataEndpoint is the resource for retrieving metadata details.
 // doc: https://www.zoho.com/crm/developer/docs/api/v6/field-meta.html
-const restMetadataEndpoint = "settings/fields"
+const (
+	restMetadataEndpoint = "settings/fields"
+	users                = "users"
+)
 
 type metadataFields struct {
 	Fields []map[string]any `json:"fields"`
@@ -96,7 +99,10 @@ func (c *Connector) fetchFieldMetadata(ctx context.Context, capObj string) (*com
 }
 
 func (c *Connector) getMetadata(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	capObj := naming.CapitalizeFirstLetterEveryWord(objectName)
+	capObj := objectName
+	if objectName != users {
+		capObj = naming.CapitalizeFirstLetterEveryWord(objectName)
+	}
 
 	resp, err := c.fetchFieldMetadata(ctx, capObj)
 	if err != nil {

--- a/providers/zohocrm/metadata.go
+++ b/providers/zohocrm/metadata.go
@@ -14,6 +14,7 @@ import (
 const (
 	restMetadataEndpoint = "settings/fields"
 	users                = "users"
+	org                  = "org"
 )
 
 type metadataFields struct {

--- a/providers/zohocrm/parse.go
+++ b/providers/zohocrm/parse.go
@@ -48,3 +48,11 @@ func getNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
 		return "", nil
 	}
 }
+
+func extractRecordsFromPath(objectName string) common.RecordsFunc {
+	if objectName == users {
+		return common.ExtractRecordsFromPath(users)
+	}
+
+	return common.ExtractRecordsFromPath("data")
+}

--- a/providers/zohocrm/read.go
+++ b/providers/zohocrm/read.go
@@ -27,7 +27,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	}
 
 	return common.ParseResult(res,
-		common.ExtractRecordsFromPath("data"),
+		extractRecordsFromPath(config.ObjectName),
 		getNextRecordsURL(url),
 		common.GetMarshaledData,
 		config.Fields,

--- a/providers/zohocrm/url.go
+++ b/providers/zohocrm/url.go
@@ -9,14 +9,20 @@ import (
 )
 
 func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
+	var obj = config.ObjectName
+
 	// Check if we're reading the next-page.
 	if len(config.NextPage) > 0 {
 		return urlbuilder.New(config.NextPage.String())
 	}
 
-	// Object names in ZohoCRM API are case sensitive.
-	// Capitalizing the first character of object names to form correct URL.
-	obj := naming.CapitalizeFirstLetterEveryWord(config.ObjectName)
+	// objects like user, org, org/currencies, __features,
+	// uses lowecased object-names
+	if config.ObjectName != users {
+		// Object names in ZohoCRM API are case sensitive.
+		// Capitalizing the first character of object names to form correct URL.
+		obj = naming.CapitalizeFirstLetterEveryWord(config.ObjectName)
+	}
 
 	url, err := c.getAPIURL(obj)
 	if err != nil {

--- a/providers/zohocrm/url.go
+++ b/providers/zohocrm/url.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
-	var obj = config.ObjectName
+	obj := config.ObjectName
 
 	// Check if we're reading the next-page.
 	if len(config.NextPage) > 0 {

--- a/providers/zohocrm/url.go
+++ b/providers/zohocrm/url.go
@@ -18,7 +18,7 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 
 	// objects like user, org, org/currencies, __features,
 	// uses lowecased object-names
-	if config.ObjectName != users {
+	if config.ObjectName != users && config.ObjectName != org {
 		// Object names in ZohoCRM API are case sensitive.
 		// Capitalizing the first character of object names to form correct URL.
 		obj = naming.CapitalizeFirstLetterEveryWord(config.ObjectName)

--- a/test/zohocrm/metadata/metadata.go
+++ b/test/zohocrm/metadata/metadata.go
@@ -21,7 +21,7 @@ func main() {
 
 	conn := zohocrm.GetZohoConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"leads", "deals", "contacts"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"leads", "deals", "contacts", "users"})
 	if err != nil {
 		utils.Fail("error listing metadata for Zoho", "error", err)
 	}

--- a/test/zohocrm/read/users/users.go
+++ b/test/zohocrm/read/users/users.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils"
+	connTest "github.com/amp-labs/connectors/test/zohocrm"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetZohoConnector(ctx)
+
+	res, err := conn.Read(ctx, connectors.ReadParams{
+		ObjectName: "users",
+		Since:      time.Now().Add(-3000 * time.Hour),
+		Fields:     connectors.Fields("Name", "id"),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
This fixes the users object only, the rest (lowercased) don't use the same metadata retrieval approach as the rest. 

Live Tests:
Meatadata:
<img width="1793" height="1026" alt="Screenshot 2025-09-17 at 21 54 30" src="https://github.com/user-attachments/assets/754c60a2-8721-49ee-8711-8a416c4e78d2" />


Read:
<img width="1994" height="198" alt="Screenshot 2025-09-17 at 21 55 15" src="https://github.com/user-attachments/assets/68ee7a8c-cb4d-4818-ac05-44a21750d60f" />

<img width="1779" height="439" alt="Screenshot 2025-09-17 at 22 03 15" src="https://github.com/user-attachments/assets/63d4f6f7-9dbc-4ed3-be64-7c7acaf3d0e0" />
