### PR TITLE
[CON-1921] feat(Quickbooks): add ListMetadata 

### DIFF
--- a/providers/quickbooks/connector.go
+++ b/providers/quickbooks/connector.go
@@ -18,6 +18,7 @@ type Connector struct {
 
 	// Require authenticated client
 	common.RequireAuthenticatedClient
+	common.RequireMetadata
 
 	// Supported operations
 	components.SchemaProvider
@@ -26,8 +27,14 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.QuickBooks, params, constructor)
+	conn, err := components.Initialize(providers.QuickBooks, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.realmID = params.Metadata["realmID"]
+
+	return conn, nil
 }
 
 func constructor(base *components.Connector) (*Connector, error) {

--- a/providers/quickbooks/connector.go
+++ b/providers/quickbooks/connector.go
@@ -1,0 +1,47 @@
+package quickbooks
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const (
+	restAPIPrefix = "v3/company"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+
+	realmID string // QuickBooks Company ID
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.QuickBooks, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeSerial,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/quickbooks/handlers.go
+++ b/providers/quickbooks/handlers.go
@@ -11,8 +11,6 @@ import (
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	c.realmID = "9341455309256114" // QuickBooks Company ID, should be set dynamically
-
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.realmID, "query")
 	if err != nil {
 		return nil, err

--- a/providers/quickbooks/handlers.go
+++ b/providers/quickbooks/handlers.go
@@ -1,0 +1,86 @@
+package quickbooks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	c.realmID = "9341455309256114" // QuickBooks Company ID, should be set dynamically
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.realmID, "query")
+	if err != nil {
+		return nil, err
+	}
+
+	Query := "SELECT * FROM " + naming.CapitalizeFirstLetter(objectName) + " STARTPOSITION 0 MAXRESULTS 1"
+
+	url.WithQueryParam("query", Query)
+
+	httpClient, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpClient.Header.Set("Accept", "application/json")
+
+	return httpClient, nil
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	res, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if res == nil || len(*res) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	QueryResponse, ok := (*res)["QueryResponse"].(map[string]any) // nolint:varnamelen
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field QueryResponse to a map: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	records, ok := QueryResponse[naming.CapitalizeFirstLetter(objectName)].([]any) // nolint:varnamelen
+
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := records[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field, value := range firstRecord {
+		objectMetadata.Fields[field] = common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    inferValueTypeFromData(value),
+			ProviderType: "", // not available
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/quickbooks/metadata_test.go
+++ b/providers/quickbooks/metadata_test.go
@@ -1,0 +1,202 @@
+package quickbooks
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	accountResponse := testutils.DataFromFile(t, "account-read.json")
+	customerResponse := testutils.DataFromFile(t, "customer-read.json")
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Successfully describe multiple objects with metadata",
+			Input: []string{"account", "customer"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.QueryParam("query", "SELECT * FROM Account STARTPOSITION 0 MAXRESULTS 1"),
+					Then: mockserver.Response(http.StatusOK, accountResponse),
+				}, {
+					If:   mockcond.QueryParam("query", "SELECT * FROM Customer STARTPOSITION 0 MAXRESULTS 1"),
+					Then: mockserver.Response(http.StatusOK, customerResponse),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"account": {
+						DisplayName: "Account",
+						Fields: map[string]common.FieldMetadata{
+							"AccountSubType": {
+								DisplayName:  "AccountSubType",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"AccountType": {
+								DisplayName:  "AccountType",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"Active": {
+								DisplayName:  "Active",
+								ValueType:    "boolean",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"Classification": {
+								DisplayName:  "Classification",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"domain": {
+								DisplayName:  "domain",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"sparse": {
+								DisplayName:  "sparse",
+								ValueType:    "boolean",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"FullyQualifiedName": {
+								DisplayName:  "FullyQualifiedName",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"Name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+						},
+						FieldsMap: nil,
+					},
+					"customer": {
+						DisplayName: "Customer",
+						Fields: map[string]common.FieldMetadata{
+							"domain": {
+								DisplayName:  "domain",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"FamilyName": {
+								DisplayName:  "FamilyName",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"DisplayName": {
+								DisplayName:  "DisplayName",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"PreferredDeliveryMethod": {
+								DisplayName:  "PreferredDeliveryMethod",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"GivenName": {
+								DisplayName:  "GivenName",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"FullyQualifiedName": {
+								DisplayName:  "FullyQualifiedName",
+								ValueType:    "string",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"BillWithParent": {
+								DisplayName:  "BillWithParent",
+								ValueType:    "boolean",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+							"Job": {
+								DisplayName:  "Job",
+								ValueType:    "boolean",
+								ProviderType: "",
+								ReadOnly:     false,
+								Values:       nil,
+							},
+						},
+						FieldsMap: nil,
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+		Metadata: map[string]string{
+			"realmID": "123456789",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+
+	return connector, nil
+}

--- a/providers/quickbooks/metadata_test.go
+++ b/providers/quickbooks/metadata_test.go
@@ -44,126 +44,30 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Result: map[string]common.ObjectMetadata{
 					"account": {
 						DisplayName: "Account",
-						Fields: map[string]common.FieldMetadata{
-							"AccountSubType": {
-								DisplayName:  "AccountSubType",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"AccountType": {
-								DisplayName:  "AccountType",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"Active": {
-								DisplayName:  "Active",
-								ValueType:    "boolean",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"Classification": {
-								DisplayName:  "Classification",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"domain": {
-								DisplayName:  "domain",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"sparse": {
-								DisplayName:  "sparse",
-								ValueType:    "boolean",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"FullyQualifiedName": {
-								DisplayName:  "FullyQualifiedName",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"Name": {
-								DisplayName:  "Name",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-						},
+						Fields: buildFieldMetadata(map[string]string{
+							"AccountSubType":     "string",
+							"AccountType":        "string",
+							"Active":             "boolean",
+							"Classification":     "string",
+							"domain":             "string",
+							"sparse":             "boolean",
+							"FullyQualifiedName": "string",
+							"Name":               "string",
+						}),
 						FieldsMap: nil,
 					},
 					"customer": {
 						DisplayName: "Customer",
-						Fields: map[string]common.FieldMetadata{
-							"domain": {
-								DisplayName:  "domain",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"FamilyName": {
-								DisplayName:  "FamilyName",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"DisplayName": {
-								DisplayName:  "DisplayName",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"PreferredDeliveryMethod": {
-								DisplayName:  "PreferredDeliveryMethod",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"GivenName": {
-								DisplayName:  "GivenName",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"FullyQualifiedName": {
-								DisplayName:  "FullyQualifiedName",
-								ValueType:    "string",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"BillWithParent": {
-								DisplayName:  "BillWithParent",
-								ValueType:    "boolean",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-							"Job": {
-								DisplayName:  "Job",
-								ValueType:    "boolean",
-								ProviderType: "",
-								ReadOnly:     false,
-								Values:       nil,
-							},
-						},
+						Fields: buildFieldMetadata(map[string]string{
+							"domain":                  "string",
+							"FamilyName":              "string",
+							"DisplayName":             "string",
+							"PreferredDeliveryMethod": "string",
+							"GivenName":               "string",
+							"FullyQualifiedName":      "string",
+							"BillWithParent":          "boolean",
+							"Job":                     "boolean",
+						}),
 						FieldsMap: nil,
 					},
 				},
@@ -182,6 +86,21 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			})
 		})
 	}
+}
+
+func buildFieldMetadata(fields map[string]string) map[string]common.FieldMetadata {
+	result := make(map[string]common.FieldMetadata)
+	for name, typ := range fields {
+		result[name] = common.FieldMetadata{
+			DisplayName:  name,
+			ValueType:    common.ValueType(typ),
+			ProviderType: "",
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return result
 }
 
 func constructTestConnector(serverURL string) (*Connector, error) {

--- a/providers/quickbooks/test/account-read.json
+++ b/providers/quickbooks/test/account-read.json
@@ -1,0 +1,19 @@
+{
+  "QueryResponse": {
+    "startPosition": 1,
+    "Account": [
+      {
+        "AccountSubType": "AccountsReceivable",
+        "AccountType": "Accounts Receivable",
+        "Active": true,
+        "Classification": "Asset",
+        "domain": "QBO",
+        "sparse": false,
+        "FullyQualifiedName": "Canadian Accounts Receivable",
+        "Name": "Canadian Accounts Receivable"
+      }
+    ],
+    "maxResults": 3
+  },
+  "time": "2015-07-13T12:35:57.651-07:00"
+}

--- a/providers/quickbooks/test/customer-read.json
+++ b/providers/quickbooks/test/customer-read.json
@@ -1,0 +1,19 @@
+{
+  "QueryResponse": {
+    "Customer": [
+      {
+        "domain": "QBO", 
+        "FamilyName": "Lauterbach", 
+        "DisplayName": "Amy's Bird Sanctuary", 
+        "PreferredDeliveryMethod": "Print", 
+        "GivenName": "Amy", 
+        "FullyQualifiedName": "Amy's Bird Sanctuary", 
+        "BillWithParent": false, 
+        "Job": false
+      }
+    ], 
+    "startPosition": 1, 
+    "maxResults": 6
+  }, 
+  "time": "2015-07-23T11:02:25.149-07:00"
+}

--- a/providers/quickbooks/utils.go
+++ b/providers/quickbooks/utils.go
@@ -1,0 +1,20 @@
+package quickbooks
+
+import "github.com/amp-labs/connectors/common"
+
+func inferValueTypeFromData(value any) common.ValueType {
+	if value == nil {
+		return common.ValueTypeOther
+	}
+
+	switch value.(type) {
+	case string:
+		return common.ValueTypeString
+	case float64, int, int64:
+		return common.ValueTypeFloat
+	case bool:
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
+}

--- a/test/quickbooks/connector.go
+++ b/test/quickbooks/connector.go
@@ -27,6 +27,9 @@ func GetQuickBooksConnector(ctx context.Context) *quickbooks.Connector {
 
 	conn, err := quickbooks.NewConnector(common.ConnectorParams{
 		AuthenticatedClient: client,
+		Metadata: map[string]string{
+			"realmID": "9341455309256114", // QuickBooks Company ID, should be set dynamically
+		},
 	})
 	if err != nil {
 		utils.Fail("create quickbooks connector", "error: ", err)

--- a/test/quickbooks/connector.go
+++ b/test/quickbooks/connector.go
@@ -1,0 +1,55 @@
+package quickbooks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/quickbooks"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetQuickBooksConnector(ctx context.Context) *quickbooks.Connector {
+	filePath := credscanning.LoadPath(providers.QuickBooks)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := quickbooks.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("create quickbooks connector", "error: ", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+
+	cfg := &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://appcenter.intuit.com/connect/oauth2",
+			TokenURL:  "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"com.intuit.quickbooks.accounting",
+		},
+		RedirectURL: "https://api.withampersand.com/callbacks/v1/oauth",
+	}
+
+	return cfg
+}

--- a/test/quickbooks/metadata/main.go
+++ b/test/quickbooks/metadata/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/amp-labs/connectors/test/quickbooks"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+	connector := quickbooks.GetQuickBooksConnector(ctx)
+
+	m, err := connector.ListObjectMetadata(ctx, []string{"account"})
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	// Print the results
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/quickbooks/metadata/main.go
+++ b/test/quickbooks/metadata/main.go
@@ -12,7 +12,7 @@ func main() {
 	ctx := context.Background()
 	connector := quickbooks.GetQuickBooksConnector(ctx)
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"account"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"account", "budget"})
 	if err != nil {
 		utils.Fail(err.Error())
 	}

--- a/test/quickbooks/metadata/main.go
+++ b/test/quickbooks/metadata/main.go
@@ -12,7 +12,7 @@ func main() {
 	ctx := context.Background()
 	connector := quickbooks.GetQuickBooksConnector(ctx)
 
-	m, err := connector.ListObjectMetadata(ctx, []string{"account", "budget"})
+	m, err := connector.ListObjectMetadata(ctx, []string{"account", "item"})
 	if err != nil {
 		utils.Fail(err.Error())
 	}


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Sample Metadata Response

### Account
<img width="1207" height="730" alt="image" src="https://github.com/user-attachments/assets/0bebd419-bb51-48bb-889a-065d64c0c79b" />
<img width="1204" height="747" alt="image" src="https://github.com/user-attachments/assets/60e14f48-c6a5-4613-aaf4-f84c004e71e7" />

### Item
<img width="1197" height="740" alt="image" src="https://github.com/user-attachments/assets/ea688b82-6557-453d-93e2-572e9fb213a7" />
<img width="1211" height="619" alt="image" src="https://github.com/user-attachments/assets/0fc26ad6-f853-4ae0-9458-4b81591d3d2b" />



## Sample Testcase Result
<img width="1196" height="344" alt="image" src="https://github.com/user-attachments/assets/22012e18-e96f-4c76-80c6-da2776f4c567" />




