### PR TITLE
[CON-2246] feat(amplitude): add ListMetadata + Read

### DIFF
--- a/providers/amplitude/connector.go
+++ b/providers/amplitude/connector.go
@@ -1,0 +1,58 @@
+package amplitude
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+	components.Reader
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.Amplitude, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	apiV2 = "2"
+	apiV3 = "3"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -1,0 +1,114 @@
+package amplitude
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	apiV2 = "2"
+	apiV3 = "3"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	url, err := c.constructURL(objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	res, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if res == nil || len(*res) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	responseField := objectResponseField.Get(objectName)
+
+	data, ok := (*res)[responseField].([]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := data[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field, value := range firstRecord {
+		objectMetadata.Fields[field] = common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    inferValueTypeFromData(value),
+			ProviderType: "", // not available
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return &objectMetadata, nil
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if params.NextPage != "" {
+		return http.NewRequestWithContext(ctx, http.MethodGet, params.NextPage.String(), nil)
+	}
+
+	var (
+		url *urlbuilder.URL
+		err error
+	)
+
+	url, err = c.constructURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	responseKey := objectResponseField.Get(params.ObjectName)
+
+	return common.ParseResult(
+		response,
+		common.ExtractRecordsFromPath(responseKey),
+		nextRecordsURL(),
+		common.GetMarshaledData,
+		params.Fields,
+	)
+}

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	apiV2 = "2"
-	apiV3 = "3"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/amplitude/parse.go
+++ b/providers/amplitude/parse.go
@@ -1,0 +1,15 @@
+package amplitude
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+func nextRecordsURL() common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		// There is no pagination implemented in Amplitude API as of now.
+		// So, returning empty string to indicate no next page.
+		// Reference: https://amplitude.com/docs/apis/analytics/chart-annotations#get-all-chart-annotations
+		return "", nil
+	}
+}

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -10,40 +10,40 @@ import (
 )
 
 const (
-	AnnotationsObject           = "annotations"
-	CohortsObject               = "cohorts"
-	EventsObject                = "events"
-	LookupTableObject           = "lookup_table"
-	TaxonomyCategoryObject      = "taxonomy/category"
-	TaxonomyEventObject         = "taxonomy/event"
-	TaxonomyEventPropertyObject = "taxonomy/event-property"
-	TaxonomyUserPropertyObject  = "taxonomy/user-property"
-	TaxonomyGroupPropertyObject = "taxonomy/group-property"
+	objectNameAnnotations           = "annotations"
+	objectNameCohorts               = "cohorts"
+	objectNameEvents                = "events"
+	objectNameLookupTable           = "lookup_table"
+	objectNameTaxonomyCategory      = "taxonomy/category"
+	objectNameTaxonomyEvent         = "taxonomy/event"
+	objectNameTaxonomyEventProperty = "taxonomy/event-property"
+	objectNameTaxonomyUserProperty  = "taxonomy/user-property"
+	objectNameTaxonomyGroupProperty = "taxonomy/group-property"
 )
 
 var objectAPIVersion = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
-	CohortsObject: apiV3,
+	objectNameCohorts: apiV3,
 }, func(key string) string {
 	return apiV2
 })
 
 var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
-	CohortsObject: CohortsObject,
+	objectNameCohorts: objectNameCohorts,
 }, func(key string) string {
 	return "data"
 })
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{
-		AnnotationsObject,
-		CohortsObject,
-		EventsObject,
-		LookupTableObject,
-		TaxonomyCategoryObject,
-		TaxonomyEventObject,
-		TaxonomyEventPropertyObject,
-		TaxonomyUserPropertyObject,
-		TaxonomyGroupPropertyObject,
+		objectNameAnnotations,
+		objectNameCohorts,
+		objectNameEvents,
+		objectNameLookupTable,
+		objectNameTaxonomyCategory,
+		objectNameTaxonomyEvent,
+		objectNameTaxonomyEventProperty,
+		objectNameTaxonomyUserProperty,
+		objectNameTaxonomyGroupProperty,
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -21,6 +21,12 @@ const (
 	TaxonomyGroupPropertyObject = "taxonomy/group-property"
 )
 
+var objectAPIVersion = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	CohortsObject: apiV3,
+}, func(key string) string {
+	return apiV2
+})
+
 var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
 	CohortsObject: CohortsObject,
 }, func(key string) string {
@@ -32,6 +38,12 @@ func supportedOperations() components.EndpointRegistryInput {
 		AnnotationsObject,
 		CohortsObject,
 		EventsObject,
+		LookupTableObject,
+		TaxonomyCategoryObject,
+		TaxonomyEventObject,
+		TaxonomyEventPropertyObject,
+		TaxonomyUserPropertyObject,
+		TaxonomyGroupPropertyObject,
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -1,0 +1,51 @@
+package amplitude
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+const (
+	AnnotationsObject           = "annotations"
+	CohortsObject               = "cohorts"
+	EventsObject                = "events"
+	LookupTableObject           = "lookup_table"
+	TaxonomyCategoryObject      = "taxonomy/category"
+	TaxonomyEventObject         = "taxonomy/event"
+	TaxonomyEventPropertyObject = "taxonomy/event-property"
+	TaxonomyUserPropertyObject  = "taxonomy/user-property"
+	TaxonomyGroupPropertyObject = "taxonomy/group-property"
+)
+
+var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	CohortsObject: CohortsObject,
+}, func(key string) string {
+	return "data"
+})
+
+var apiVersionMap = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	EventsObject: apiV3,
+}, func(key string) string {
+	return apiV2
+})
+
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := []string{
+		AnnotationsObject,
+		CohortsObject,
+		EventsObject,
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -27,12 +27,6 @@ var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{
 	return "data"
 })
 
-var apiVersionMap = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
-	EventsObject: apiV3,
-}, func(key string) string {
-	return apiV2
-})
-
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{
 		AnnotationsObject,

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,12 +25,11 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-	apiVersion := apiVersionMap.Get(objectName)
 
-	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
+	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
 
 	if objectName == EventsObject {
-		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
+		path = fmt.Sprintf("api/%s/%s/list", apiV2, objectName)
 	}
 
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,10 +25,12 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
+	apiVersion := objectAPIVersion.Get(objectName)
+
+	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
 
 	if objectName == EventsObject {
-		path = fmt.Sprintf("api/%s/%s/list", apiV2, objectName)
+		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
 	}
 
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -1,0 +1,42 @@
+package amplitude
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+func inferValueTypeFromData(value any) common.ValueType {
+	if value == nil {
+		return common.ValueTypeOther
+	}
+
+	switch value.(type) {
+	case string:
+		return common.ValueTypeString
+	case float64, int, int64:
+		return common.ValueTypeFloat
+	case bool:
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
+}
+
+func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
+	apiVersion := apiVersionMap.Get(objectName)
+
+	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
+
+	if objectName == EventsObject {
+		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return url, nil
+}

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -29,7 +29,7 @@ func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
 
 	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
 
-	if objectName == EventsObject {
+	if objectName == objectNameEvents {
 		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
 	}
 

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,7 +25,6 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-
 	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
 
 	if objectName == EventsObject {

--- a/test/amplitude/connector.go
+++ b/test/amplitude/connector.go
@@ -1,0 +1,33 @@
+package amplitude
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetAmplitudeConnector(ctx context.Context) *amplitude.Connector {
+	filePath := credscanning.LoadPath(providers.Amplitude)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
+
+	client, err := common.NewBasicAuthHTTPClient(ctx, 
+		reader.Get(credscanning.Fields.Username),
+		reader.Get(credscanning.Fields.Password),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := amplitude.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("create amplitude connector", "error: ", err)
+	}
+
+	return conn
+}

--- a/test/amplitude/metadata/main.go
+++ b/test/amplitude/metadata/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	conn := amplitude.GetAmplitudeConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"annotations"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"annotations", "taxonomy/event", "events"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/amplitude/metadata/main.go
+++ b/test/amplitude/metadata/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/test/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := amplitude.GetAmplitudeConnector(ctx)
+
+	m, err := conn.ListObjectMetadata(ctx, []string{"annotations"})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/amplitude/read/main.go
+++ b/test/amplitude/read/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/amplitude"
+	amplitudetest "github.com/amp-labs/connectors/test/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := amplitudetest.GetAmplitudeConnector(ctx)
+
+	readAndLog(ctx, conn, amplitude.AnnotationsObject)
+	readAndLog(ctx, conn, amplitude.CohortsObject)
+
+	slog.Info("Read operation completed successfully.")
+}
+
+func readAndLog(ctx context.Context, conn *amplitude.Connector, objectName string) {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+	})
+	if err != nil {
+		utils.Fail("error reading from Amplitude", "object", objectName, "error", err)
+	}
+
+	slog.Info("Reading " + objectName + "..")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
   * This is not covered in this PR for simplicity
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

## Metadata Tests

### annotations
<img width="747" height="462" alt="image" src="https://github.com/user-attachments/assets/fd467352-8e1c-43cb-bd46-a04943731e8e" />

### events
<img width="804" height="1048" alt="image" src="https://github.com/user-attachments/assets/7945d462-0baf-4588-b926-9b85167b0743" />

### taxonomy/event
<img width="596" height="364" alt="image" src="https://github.com/user-attachments/assets/3ff7aac9-4b09-4f13-9d2b-4f4bb3535555" />


## Read Tests

### Events
<img width="875" height="944" alt="image" src="https://github.com/user-attachments/assets/89738064-faa1-466e-b4fb-a30e711f7da4" />

### annotations
<img width="582" height="373" alt="image" src="https://github.com/user-attachments/assets/6c14eab5-f6e4-4680-a9d1-15d30be04a73" />


### taxonomy/category
<img width="632" height="412" alt="image" src="https://github.com/user-attachments/assets/6bc4e60a-c799-449b-b06c-ba27419238f0" />


### taxonomy/user-property
<img width="758" height="847" alt="image" src="https://github.com/user-attachments/assets/008b6980-8bbe-4cbd-928c-f373e0acc611" />
<img width="705" height="987" alt="image" src="https://github.com/user-attachments/assets/728be5e2-0d86-4c57-baaf-101215c3e2fd" />



