### PR TITLE
[CON-2247] feat(amplitude): add Write

### DIFF
--- a/providers/amplitude/connector.go
+++ b/providers/amplitude/connector.go
@@ -1,0 +1,58 @@
+package amplitude
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+	components.Reader
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.Amplitude, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/amplitude/connector.go
+++ b/providers/amplitude/connector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -19,6 +20,7 @@ type Connector struct {
 	// Supported operations
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -50,6 +52,17 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	apiV2 = "2"
+	apiV3 = "3"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -1,0 +1,114 @@
+package amplitude
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+const (
+	apiV2 = "2"
+	apiV3 = "3"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	url, err := c.constructURL(objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	res, err := common.UnmarshalJSON[map[string]any](response)
+	if err != nil {
+		return nil, common.ErrFailedToUnmarshalBody
+	}
+
+	if res == nil || len(*res) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	responseField := objectResponseField.Get(objectName)
+
+	data, ok := (*res)[responseField].([]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the data response field data to an array: %w", common.ErrMissingExpectedValues) // nolint:lll
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("%w: could not find a record to sample fields from", common.ErrMissingExpectedValues)
+	}
+
+	firstRecord, ok := data[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("couldn't convert the first record data to a map: %w", common.ErrMissingExpectedValues)
+	}
+
+	for field, value := range firstRecord {
+		objectMetadata.Fields[field] = common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    inferValueTypeFromData(value),
+			ProviderType: "", // not available
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return &objectMetadata, nil
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if params.NextPage != "" {
+		return http.NewRequestWithContext(ctx, http.MethodGet, params.NextPage.String(), nil)
+	}
+
+	var (
+		url *urlbuilder.URL
+		err error
+	)
+
+	url, err = c.constructURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	responseKey := objectResponseField.Get(params.ObjectName)
+
+	return common.ParseResult(
+		response,
+		common.ExtractRecordsFromPath(responseKey),
+		nextRecordsURL(),
+		common.GetMarshaledData,
+		params.Fields,
+	)
+}

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	apiV2 = "2"
-	apiV3 = "3"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {

--- a/providers/amplitude/handlers.go
+++ b/providers/amplitude/handlers.go
@@ -223,9 +223,11 @@ func (c *Connector) parseWriteResponse(
 	}
 
 	if dataNode == nil {
-		// If the "data" field does not exist, use the root body as the data node.
+		// If object specific response key is not found, use the entire body
 		dataNode = body
 	}
+
+	recordID, _ := jsonquery.New(dataNode).StrWithDefault("id", "")
 
 	respMap, err := jsonquery.Convertor.ObjectToMap(dataNode)
 	if err != nil {
@@ -234,7 +236,7 @@ func (c *Connector) parseWriteResponse(
 
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: "",
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     respMap,
 	}, nil

--- a/providers/amplitude/parse.go
+++ b/providers/amplitude/parse.go
@@ -1,0 +1,15 @@
+package amplitude
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/spyzhov/ajson"
+)
+
+func nextRecordsURL() common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		// There is no pagination implemented in Amplitude API as of now.
+		// So, returning empty string to indicate no next page.
+		// Reference: https://amplitude.com/docs/apis/analytics/chart-annotations#get-all-chart-annotations
+		return "", nil
+	}
+}

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -21,6 +21,12 @@ const (
 	TaxonomyGroupPropertyObject = "taxonomy/group-property"
 )
 
+var objectAPIVersion = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	CohortsObject: apiV3,
+}, func(key string) string {
+	return apiV2
+})
+
 var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
 	CohortsObject: CohortsObject,
 }, func(key string) string {
@@ -32,6 +38,12 @@ func supportedOperations() components.EndpointRegistryInput {
 		AnnotationsObject,
 		CohortsObject,
 		EventsObject,
+		LookupTableObject,
+		TaxonomyCategoryObject,
+		TaxonomyEventObject,
+		TaxonomyEventPropertyObject,
+		TaxonomyUserPropertyObject,
+		TaxonomyGroupPropertyObject,
 	}
 
 	return components.EndpointRegistryInput{

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -1,0 +1,51 @@
+package amplitude
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+const (
+	AnnotationsObject           = "annotations"
+	CohortsObject               = "cohorts"
+	EventsObject                = "events"
+	LookupTableObject           = "lookup_table"
+	TaxonomyCategoryObject      = "taxonomy/category"
+	TaxonomyEventObject         = "taxonomy/event"
+	TaxonomyEventPropertyObject = "taxonomy/event-property"
+	TaxonomyUserPropertyObject  = "taxonomy/user-property"
+	TaxonomyGroupPropertyObject = "taxonomy/group-property"
+)
+
+var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	CohortsObject: CohortsObject,
+}, func(key string) string {
+	return "data"
+})
+
+var apiVersionMap = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	EventsObject: apiV3,
+}, func(key string) string {
+	return apiV2
+})
+
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := []string{
+		AnnotationsObject,
+		CohortsObject,
+		EventsObject,
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -27,12 +27,6 @@ var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{
 	return "data"
 })
 
-var apiVersionMap = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
-	EventsObject: apiV3,
-}, func(key string) string {
-	return apiV2
-})
-
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{
 		AnnotationsObject,

--- a/providers/amplitude/support.go
+++ b/providers/amplitude/support.go
@@ -19,6 +19,17 @@ const (
 	objectNameTaxonomyEventProperty = "taxonomy/event-property"
 	objectNameTaxonomyUserProperty  = "taxonomy/user-property"
 	objectNameTaxonomyGroupProperty = "taxonomy/group-property"
+	objectNameAttribution           = "attribution"
+	objectNameRelease               = "release"
+)
+
+var api2SupportedObjects = datautils.NewSet( //nolint:gochecknoglobals
+	objectNameAttribution,
+)
+
+var supportedParamsPayloadObjectNames = datautils.NewSet( //nolint:gochecknoglobals
+	objectNameAnnotations,
+	objectNameRelease,
 )
 
 var objectAPIVersion = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
@@ -31,6 +42,18 @@ var objectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{
 	objectNameCohorts: objectNameCohorts,
 }, func(key string) string {
 	return "data"
+})
+
+var writeObjectResponseField = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	objectNameAnnotations: "annotation",
+}, func(objectname string) string {
+	return objectname
+})
+
+var payloadKeyMapping = datautils.NewDefaultMap(datautils.Map[string, string]{ //nolint:gochecknoglobals
+	objectNameAttribution: "event",
+}, func(key string) string {
+	return ""
 })
 
 func supportedOperations() components.EndpointRegistryInput {
@@ -46,11 +69,21 @@ func supportedOperations() components.EndpointRegistryInput {
 		objectNameTaxonomyGroupProperty,
 	}
 
+	writeSupport := []string{
+		objectNameAttribution,
+		objectNameAnnotations,
+		objectNameRelease,
+	}
+
 	return components.EndpointRegistryInput{
 		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,
+			},
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
+				Support:  components.WriteSupport,
 			},
 		},
 	}

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,12 +25,11 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-	apiVersion := apiVersionMap.Get(objectName)
 
-	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
+	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
 
 	if objectName == EventsObject {
-		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
+		path = fmt.Sprintf("api/%s/%s/list", apiV2, objectName)
 	}
 
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -1,7 +1,12 @@
 package amplitude
 
 import (
+	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -39,4 +44,36 @@ func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
 	}
 
 	return url, nil
+}
+
+// Helper to extract API key (username) from the auth client.
+func extractAPIKey(client common.AuthenticatedHTTPClient, ctx context.Context) (string, error) {
+	// Use a safe dummy endpoint (e.g., Amplitude's health check or base URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.amplitude.com/health", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	auth := resp.Request.Header.Get("Authorization")
+	if auth == "" || !strings.HasPrefix(auth, "Basic ") {
+		return "", errors.New("no basic auth found") //nolint: err113
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2) //nolint:mnd
+	if len(parts) != 2 {                             //nolint:mnd
+		return "", errors.New("invalid auth format") //nolint: err113
+	}
+
+	return parts[0], nil
 }

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,10 +25,12 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
+	apiVersion := objectAPIVersion.Get(objectName)
+
+	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
 
 	if objectName == EventsObject {
-		path = fmt.Sprintf("api/%s/%s/list", apiV2, objectName)
+		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
 	}
 
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -1,0 +1,42 @@
+package amplitude
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+func inferValueTypeFromData(value any) common.ValueType {
+	if value == nil {
+		return common.ValueTypeOther
+	}
+
+	switch value.(type) {
+	case string:
+		return common.ValueTypeString
+	case float64, int, int64:
+		return common.ValueTypeFloat
+	case bool:
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
+}
+
+func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
+	apiVersion := apiVersionMap.Get(objectName)
+
+	path := fmt.Sprintf("api/%s/%s", apiVersion, objectName)
+
+	if objectName == EventsObject {
+		path = fmt.Sprintf("api/%s/%s/list", apiVersion, objectName)
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return url, nil
+}

--- a/providers/amplitude/utils.go
+++ b/providers/amplitude/utils.go
@@ -25,7 +25,6 @@ func inferValueTypeFromData(value any) common.ValueType {
 }
 
 func (c *Connector) constructURL(objectName string) (*urlbuilder.URL, error) {
-
 	path := fmt.Sprintf("api/%s/%s", apiV2, objectName)
 
 	if objectName == EventsObject {

--- a/test/amplitude/connector.go
+++ b/test/amplitude/connector.go
@@ -1,0 +1,33 @@
+package amplitude
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetAmplitudeConnector(ctx context.Context) *amplitude.Connector {
+	filePath := credscanning.LoadPath(providers.Amplitude)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
+
+	client, err := common.NewBasicAuthHTTPClient(ctx, 
+		reader.Get(credscanning.Fields.Username),
+		reader.Get(credscanning.Fields.Password),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := amplitude.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("create amplitude connector", "error: ", err)
+	}
+
+	return conn
+}

--- a/test/amplitude/metadata/main.go
+++ b/test/amplitude/metadata/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	conn := amplitude.GetAmplitudeConnector(ctx)
 
-	m, err := conn.ListObjectMetadata(ctx, []string{"annotations"})
+	m, err := conn.ListObjectMetadata(ctx, []string{"annotations", "taxonomy/event", "events"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/amplitude/metadata/main.go
+++ b/test/amplitude/metadata/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/test/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := amplitude.GetAmplitudeConnector(ctx)
+
+	m, err := conn.ListObjectMetadata(ctx, []string{"annotations"})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/amplitude/read/main.go
+++ b/test/amplitude/read/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/amplitude"
+	amplitudetest "github.com/amp-labs/connectors/test/amplitude"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := amplitudetest.GetAmplitudeConnector(ctx)
+
+	readAndLog(ctx, conn, amplitude.AnnotationsObject)
+	readAndLog(ctx, conn, amplitude.CohortsObject)
+
+	slog.Info("Read operation completed successfully.")
+}
+
+func readAndLog(ctx context.Context, conn *amplitude.Connector, objectName string) {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+	})
+	if err != nil {
+		utils.Fail("error reading from Amplitude", "object", objectName, "error", err)
+	}
+
+	slog.Info("Reading " + objectName + "..")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/amplitude/write/main.go
+++ b/test/amplitude/write/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	cc "github.com/amp-labs/connectors/providers/amplitude"
+	"github.com/amp-labs/connectors/test/amplitude"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	conn := amplitude.GetAmplitudeConnector(ctx)
+
+	_, err := testCreatingApps(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testCreatingApps(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "apps",
+		RecordData: map[string]any{
+			"name":         "Nightly Data Loads",
+			"namespace":    "nightly-data",
+			"type":         "CUSTOM",
+			"entity":       "Sync",
+			"entityPlural": "Syncs",
+			"icon":         "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"currentColor\" class=\"bi bi-bar-chart-fill\" viewBox=\"0 0 16 16\">\n  <path d=\"M1 11a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm5-5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1z\"/>\n</svg>",
+			"metadata": map[string]any{
+				"foo": "bar",
+			},
+		},
+	}
+
+	slog.Info("Creating an app...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.RecordId, nil
+}

--- a/test/amplitude/write/main.go
+++ b/test/amplitude/write/main.go
@@ -23,7 +23,17 @@ func run() error {
 
 	conn := amplitude.GetAmplitudeConnector(ctx)
 
-	_, err := testCreatingApps(ctx, conn)
+	_, err := testCreatingAnnotations(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	_, err = testCreatingRelease(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	_, err = testCreatingAttribution(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -31,23 +41,79 @@ func run() error {
 	return nil
 }
 
-func testCreatingApps(ctx context.Context, conn *cc.Connector) (string, error) {
+func testCreatingAttribution(ctx context.Context, conn *cc.Connector) (string, error) {
 	params := common.WriteParams{
-		ObjectName: "apps",
+		ObjectName: "attribution",
 		RecordData: map[string]any{
-			"name":         "Nightly Data Loads",
-			"namespace":    "nightly-data",
-			"type":         "CUSTOM",
-			"entity":       "Sync",
-			"entityPlural": "Syncs",
-			"icon":         "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"currentColor\" class=\"bi bi-bar-chart-fill\" viewBox=\"0 0 16 16\">\n  <path d=\"M1 11a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm5-5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1z\"/>\n</svg>",
-			"metadata": map[string]any{
-				"foo": "bar",
+			"event_type": "[YOUR COMPANY] Install",
+			"idfa":       "AEBE52E7-03EE-455A-B3C4-E57283966239",
+			"user_properties": map[string]any{
+				"[YOUR COMPANY] media source": "facebook",
+				"[YOUR COMPANY] campaign":     "refer-a-friend",
 			},
+			"platform": "ios",
 		},
 	}
 
-	slog.Info("Creating an app...")
+	slog.Info("Creating an attribution...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.RecordId, nil
+}
+
+func testCreatingAnnotations(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "annotations",
+		RecordData: map[string]any{
+			"app_id": "679680",
+			"date":   "2025-09-16",
+			"label":  "Version 2.4 Release",
+		},
+	}
+
+	slog.Info("Creating an annotation...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.RecordId, nil
+}
+
+func testCreatingRelease(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "release",
+		RecordData: map[string]any{
+			"version":       "2.2",
+			"release_start": "2025-12-01 00:00:00",
+			"title":         "Version 2. Release",
+		},
+	}
+
+	slog.Info("Creating a release...")
 
 	res, err := conn.Write(ctx, params)
 	if err != nil {

--- a/test/amplitude/write/main.go
+++ b/test/amplitude/write/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	cc "github.com/amp-labs/connectors/providers/amplitude"
 	"github.com/amp-labs/connectors/test/amplitude"
+	"github.com/brianvoe/gofakeit/v6"
 )
 
 func main() {
@@ -107,7 +108,7 @@ func testCreatingRelease(ctx context.Context, conn *cc.Connector) (string, error
 	params := common.WriteParams{
 		ObjectName: "release",
 		RecordData: map[string]any{
-			"version":       "2.2",
+			"version":       gofakeit.AppVersion(),
 			"release_start": "2025-12-01 00:00:00",
 			"title":         "Version 2. Release",
 		},


### PR DESCRIPTION
## Checklist
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [ ] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)


## Sample Write Response
<img width="841" height="484" alt="image" src="https://github.com/user-attachments/assets/7bcfd197-b0f7-4b09-b0ac-407aa1d8beec" />

The third API response returns raw text instead of JSON, so the connector throws an error even though the request was successful

