### PR TITLE
[CON-1934] feat(linear): enable read and write

### DIFF
--- a/providers/linear.go
+++ b/providers/linear.go
@@ -26,9 +26,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth

# Conventions

- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
- [x] Insert screenshot of metadata fields from read object installation.
<img width="950" height="590" alt="image" src="https://github.com/user-attachments/assets/5f40c771-39b0-4087-bb82-f70dabdb9db4" />
<img width="965" height="768" alt="image" src="https://github.com/user-attachments/assets/3415a877-e13c-4cc9-a3fc-5e156f8ce14d" />
<img width="1016" height="891" alt="image" src="https://github.com/user-attachments/assets/72b55714-c52f-44b6-99a1-f6217be2a7a8" />
<img width="978" height="608" alt="image" src="https://github.com/user-attachments/assets/318e05c3-067b-46c7-9897-d51f927461ef" />




- [x] Insert screenshot of Svix destination.
<img width="1609" height="947" alt="image" src="https://github.com/user-attachments/assets/8bc6d481-fbdb-4f79-ab16-a7e753d3ad4f" />
<img width="1598" height="910" alt="image" src="https://github.com/user-attachments/assets/4fa45c55-4f7e-43eb-8dc0-414046b3b5cb" />
<img width="1593" height="936" alt="image" src="https://github.com/user-attachments/assets/eb7f98e9-0687-40fe-91df-b257d1c7c585" />




- [x] Screenshot of operations on dashboard
<img width="1502" height="820" alt="image" src="https://github.com/user-attachments/assets/09800534-0e73-4aad-b90c-40d45673e173" />
<img width="1502" height="805" alt="image" src="https://github.com/user-attachments/assets/4e406cf6-0918-4849-8847-03e920bc8336" />
<img width="1495" height="798" alt="image" src="https://github.com/user-attachments/assets/5e1e1012-1948-4fed-938b-ff8927d5d111" />



# Write
- [x] Insert screenshot of dashboard.
<img width="1501" height="905" alt="image" src="https://github.com/user-attachments/assets/056b0265-8313-4697-954d-3776694a7713" />
<img width="1497" height="937" alt="image" src="https://github.com/user-attachments/assets/7e648751-c133-4439-bb0e-d10286938efe" />
<img width="1503" height="858" alt="image" src="https://github.com/user-attachments/assets/eb413ad9-3eef-4003-87fe-dc65c52322ec" />




- [x] Insert screenshot of HTTP call.
<img width="1386" height="646" alt="image" src="https://github.com/user-attachments/assets/8fee98b4-95bf-4b3a-aa97-ad5e5371da65" />
<img width="1391" height="696" alt="image" src="https://github.com/user-attachments/assets/cc2f58cc-5553-4ad5-9966-d0fd0fa53781" />

<img width="1361" height="757" alt="image" src="https://github.com/user-attachments/assets/5a18c9c8-78de-4af2-af76-ae2c6fb5cd2d" />


