### PR TITLE
[CON-2163] feat: [chorus] Added the connector

### DIFF
--- a/providers/chorus.go
+++ b/providers/chorus.go
@@ -1,0 +1,33 @@
+package providers
+
+const Chorus Provider = "chorus"
+
+func init() {
+	SetInfo(Chorus, ProviderInfo{
+		DisplayName: "Chorus",
+		AuthType:    Basic,
+		BaseURL:     "https://chorus.ai/api",
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628755/media/chorus.ai_1758628760.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628720/media/chorus.ai_1758628721.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628755/media/chorus.ai_1758628760.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628720/media/chorus.ai_1758628721.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Conventions
- [ ] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Logo & Icons
**Icon for Dark and Regular mode**
<img width="162" height="143" alt="image" src="https://github.com/user-attachments/assets/a1b91c86-a359-4bae-9dee-2e10221e8f66" />

**Logo for Dark and Regular mode**
<img width="524" height="175" alt="image" src="https://github.com/user-attachments/assets/8002ad49-db7f-46c2-a062-cfa0dddf3e42" />

# Note
```
API docs: https://api-docs.zoominfo.com/
Please note: we can develop, but cannot test and therefore cannot release the connector. Reviewer should not expect testing to be done.
```
For info for the Zoominfo connector. The Chorus connector is product of zoominfo, So testing is impossible.

