### PR TITLE
[CON-2171] feat: [chorus] Metadata functionality

### DIFF
--- a/providers/chorus.go
+++ b/providers/chorus.go
@@ -1,0 +1,33 @@
+package providers
+
+const Chorus Provider = "chorus"
+
+func init() {
+	SetInfo(Chorus, ProviderInfo{
+		DisplayName: "Chorus",
+		AuthType:    Basic,
+		BaseURL:     "https://chorus.ai/api",
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628755/media/chorus.ai_1758628760.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628720/media/chorus.ai_1758628721.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628755/media/chorus.ai_1758628760.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758628720/media/chorus.ai_1758628721.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}

--- a/providers/chorus/README.md
+++ b/providers/chorus/README.md
@@ -1,0 +1,15 @@
+# Chorus connector
+
+
+## Supported Objects 
+Below is an exhaustive list of objects & methods supported on the objects
+
+Chorus API version: v1
+----------------------------------------------------
+| Object           | Resource         | Method     |
+| emails           | emails           | read       |
+| filters          | filters          | read       |
+| playlists        | playlists        | read       |
+| scorecards       | scorecards       | read       |
+| teams            | teams            | read       |
+----------------------------------------------------

--- a/providers/chorus/connector.go
+++ b/providers/chorus/connector.go
@@ -1,0 +1,43 @@
+package chorus
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	return components.Initialize(providers.Chorus, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/chorus/handlers.go
+++ b/providers/chorus/handlers.go
@@ -1,0 +1,78 @@
+package chorus
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+const apiVersion = "v1"
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	body, ok := response.Body()
+	if !ok {
+		return nil, common.ErrEmptyJSONHTTPResponse
+	}
+
+	res, err := jsonquery.New(body).ArrayOptional("data")
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := jsonquery.Convertor.ArrayToMap(res)
+	if err != nil {
+		return nil, err
+	}
+
+	// helper to create FieldMetadata
+	newField := func(name string) common.FieldMetadata {
+		return common.FieldMetadata{
+			DisplayName:  name,
+			ValueType:    common.ValueTypeOther,
+			ProviderType: "", // not available
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	for field, value := range record[0] {
+		if field == "attributes" {
+			if subfields, ok := value.(map[string]any); ok {
+				for subfield := range subfields {
+					objectMetadata.Fields[subfield] = newField(subfield)
+				}
+			} else {
+				return nil, common.ErrMissingFields
+			}
+
+			continue
+		}
+
+		objectMetadata.Fields[field] = newField(field)
+	}
+
+	return &objectMetadata, nil
+}


### PR DESCRIPTION
# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)