### PR TITLE
feat(google): Impl ProxyConnector

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -17,6 +17,7 @@ import (
 // Only one adapter can be non-nil and will be delegated to on reading/writing operations.
 type Connector struct {
 	*components.Connector
+	*components.URLs
 	common.RequireAuthenticatedClient
 
 	Calendar *calendar.Adapter
@@ -33,6 +34,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	connector.URLs = components.NewURLs(connector.Connector)
 
 	if connector.Module() == providers.ModuleGoogleCalendar {
 		adapter, err := calendar.NewAdapter(params)


### PR DESCRIPTION
After this change:
* When creating a connector you can ask if it is of `ProxyConnector` type (only Google connector is)
* then invoke `ProxyModuleURL`
* create reverse proxy using module URL.