### PR TITLE
feat(script/proxy): Support Module URLs

### DIFF
--- a/scripts/proxy/proxy.go
+++ b/scripts/proxy/proxy.go
@@ -71,6 +71,7 @@ var readers = []scanning.Reader{
 	credscanning.Fields.Password.GetJSONReader(DefaultCredsFile),
 	credscanning.Fields.ApiSecret.GetJSONReader(DefaultCredsFile),
 	credscanning.Fields.Token.GetJSONReader(DefaultCredsFile),
+	credscanning.Fields.Module.GetJSONReader(DefaultCredsFile),
 }
 
 var debug = flag.Bool("debug", false, "Enable debug logging")

--- a/scripts/utils/proxyserv/common.go
+++ b/scripts/utils/proxyserv/common.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/scanning"
 	"github.com/amp-labs/connectors/common/scanning/credscanning"
 	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
+	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/providers"
 	"golang.org/x/oauth2"
 )
@@ -76,8 +78,36 @@ func getProviderConfig(provider string, catalogVariables []catalogreplacer.Catal
 	return config
 }
 
-func getBaseURL(providerInfo *providers.ProviderInfo) *url.URL {
-	target, err := url.Parse(providerInfo.BaseURL)
+// getBaseURL will use module URL if module is specified in the registry.
+// Otherwise, it will fall back internally to ProviderInfo.BaseURL.
+func (f Factory) getBaseURL() *url.URL {
+	// Determine what module proxy should use.
+	moduleID, err := f.Registry.GetString(credscanning.Fields.Module.Name)
+	if err != nil {
+		moduleID = common.ModuleRoot
+	}
+
+	// Convert catalog variables into the registry of metadata.
+	metadata := make(map[string]string)
+
+	for _, variable := range f.CatalogVariables {
+		plan := variable.GetSubstitutionPlan()
+		metadata[plan.From] = plan.To
+	}
+
+	// Workspace is supplied separately from the metadata registry.
+	workspace := metadata["workspace"]
+
+	providerContext, err := components.NewProviderContext(f.Provider, moduleID, workspace, metadata)
+	if err != nil {
+		panic(err)
+	}
+
+	baseURL := providerContext.ModuleInfo().BaseURL
+
+	slog.Info("Directing calls to", "url", baseURL)
+
+	target, err := url.Parse(baseURL)
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/utils/proxyserv/custom.go
+++ b/scripts/utils/proxyserv/custom.go
@@ -18,7 +18,7 @@ func (f Factory) CreateProxyCustom(ctx context.Context) *Proxy {
 	fields := getCustomFields(providerInfo)
 	secrets := getCustomSecrets(f.Registry, fields)
 	httpClient := setupCustomHTTPClient(ctx, providerInfo, secrets, f.Debug, f.Metadata)
-	baseURL := getBaseURL(providerInfo)
+	baseURL := f.getBaseURL()
 
 	return newProxy(baseURL, httpClient)
 }

--- a/scripts/utils/proxyserv/oauthApiKey.go
+++ b/scripts/utils/proxyserv/oauthApiKey.go
@@ -16,7 +16,7 @@ func (f Factory) CreateProxyAPIKey(ctx context.Context) *Proxy {
 	apiKey := getAPIKey(f.Registry)
 	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
 	httpClient := setupAPIKeyHTTPClient(ctx, providerInfo, apiKey, f.Debug, f.Metadata)
-	baseURL := getBaseURL(providerInfo)
+	baseURL := f.getBaseURL()
 
 	return newProxy(baseURL, httpClient)
 }

--- a/scripts/utils/proxyserv/oauthAuthCode.go
+++ b/scripts/utils/proxyserv/oauthAuthCode.go
@@ -15,7 +15,7 @@ func (f Factory) CreateProxyOAuth2AuthCode(ctx context.Context) *Proxy {
 	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
 	cfg := configureOAuthAuthCode(params.ID, params.Secret, params.Scopes, providerInfo)
 	httpClient := setupOAuth2AuthCodeHTTPClient(ctx, providerInfo, cfg, tokens, f.Debug, f.Metadata)
-	baseURL := getBaseURL(providerInfo)
+	baseURL := f.getBaseURL()
 
 	return newProxy(baseURL, httpClient)
 }

--- a/scripts/utils/proxyserv/oauthBasic.go
+++ b/scripts/utils/proxyserv/oauthBasic.go
@@ -16,7 +16,7 @@ func (f Factory) CreateProxyBasic(ctx context.Context) *Proxy {
 	params := createBasicParams(f.Registry)
 	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
 	httpClient := setupBasicAuthHTTPClient(ctx, providerInfo, params.User, params.Pass, f.Debug, f.Metadata)
-	baseURL := getBaseURL(providerInfo)
+	baseURL := f.getBaseURL()
 
 	return newProxy(baseURL, httpClient)
 }

--- a/scripts/utils/proxyserv/oauthClientCred.go
+++ b/scripts/utils/proxyserv/oauthClientCred.go
@@ -15,7 +15,7 @@ func (f Factory) CreateProxyOAuth2ClientCreds(ctx context.Context) *Proxy {
 	providerInfo := getProviderConfig(f.Provider, f.CatalogVariables)
 	cfg := configureOAuthClientCredentials(params.ID, params.Secret, params.Scopes, providerInfo)
 	httpClient := setupOAuth2ClientCredentialsHTTPClient(ctx, providerInfo, cfg, f.Debug, f.Metadata)
-	baseURL := getBaseURL(providerInfo)
+	baseURL := f.getBaseURL()
 
 	return newProxy(baseURL, httpClient)
 }


### PR DESCRIPTION
# Description
This is for the script users of the connectors library.

The `creds.json` file now reacts to the presense of the `module` property. If present, the correct module info base url will be chosen:
<img width="691" height="237" alt="image" src="https://github.com/user-attachments/assets/90d0b116-b86b-4499-b2d3-81e161bdd470" />
<img width="689" height="237" alt="image" src="https://github.com/user-attachments/assets/53a61db7-d73a-45cb-8b4f-9243f30e9d48" />

Without the module it acts as before, it relies on generic provider BaseURL:
<img width="628" height="64" alt="image" src="https://github.com/user-attachments/assets/86cd6439-62f6-4f74-9dac-ca3371fc84e3" />

