### PR TITLE
detect INVALID_QUERY_LOCATOR error

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -75,6 +75,9 @@ var (
 	// ErrNotFound is returned when we get a 404 response from the provider.
 	ErrNotFound = errors.New("not found")
 
+	// ErrCursorGone is returned when a cursor used for pagination is no longer valid.
+	ErrCursorGone = errors.New("pagination cursor gone or expired")
+
 	// ErrMissingExpectedValues is returned when response data doesn't have values expected for processing.
 	ErrMissingExpectedValues = errors.New("response data is missing expected values")
 

--- a/providers/salesforce/errors.go
+++ b/providers/salesforce/errors.go
@@ -55,6 +55,8 @@ func (c *Connector) interpretJSONError(res *http.Response, body []byte) error { 
 			fallthrough
 		case "INVALID_FIELD":
 			return createError(common.ErrBadRequest, sfErr, res)
+		case "INVALID_QUERY_LOCATOR":
+			return createError(common.ErrCursorGone, sfErr, res)
 		default:
 			continue
 		}


### PR DESCRIPTION
This detects the INVALID_QUERY_LOCATOR code from Salesforce and returns a typed error that can be caught in the server for more nuanced processing (e.g. deleting the cursor from the state so that it doesn't get used again).