### PR TITLE
[CON-2191] feat: Add  ramp connector

### DIFF
--- a/providers/ramp.go
+++ b/providers/ramp.go
@@ -1,9 +1,11 @@
 package providers
 
-const Ramp Provider = "ramp"
-const RampDemo Provider = "rampDemo"
+const (
+	Ramp     Provider = "ramp"
+	RampDemo Provider = "rampDemo"
+)
 
-func init() {
+func init() { //nolint:funlen
 	SetInfo(Ramp, ProviderInfo{
 		DisplayName: "Ramp",
 		AuthType:    Oauth2,


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [ ] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
<img width="1866" height="926" alt="Screenshot 2025-09-26 at 12 18 39" src="https://github.com/user-attachments/assets/5ecf9547-5590-4bb9-b623-93c461596880" />


### POST
<img width="1886" height="644" alt="Screenshot 2025-09-26 at 12 23 21" src="https://github.com/user-attachments/assets/0436ff87-69ab-4ce3-8e00-70c65bdae40c" />

### PATCH
<img width="1890" height="521" alt="Screenshot 2025-09-26 at 12 34 36" src="https://github.com/user-attachments/assets/bec7598b-4bf6-4492-823f-c40fe279fcee" />

## Pagination
<img width="1891" height="936" alt="Screenshot 2025-09-26 at 12 14 40" src="https://github.com/user-attachments/assets/5dc86c6a-b2b7-4513-a8b7-0614a4651268" />

<img width="1887" height="930" alt="Screenshot 2025-09-26 at 12 37 49" src="https://github.com/user-attachments/assets/2da4334a-d373-4435-8020-45c07eefb17b" />


## Raw token response
<img width="1927" height="207" alt="Screenshot 2025-09-26 at 12 57 20" src="https://github.com/user-attachments/assets/63222c4f-67dd-49d6-ac01-53642a5ecf05" />


# Logo & Icons
<img width="2039" height="485" alt="Screenshot 2025-09-26 at 12 11 24" src="https://github.com/user-attachments/assets/dfe967a6-4484-4196-a449-b5bc63cb7112" />
<img width="468" height="458" alt="Screenshot 2025-09-26 at 12 58 23" src="https://github.com/user-attachments/assets/e0b66bac-c0b2-4e56-9db7-00aecfe7c19c" />
<img width="2045" height="456" alt="Screenshot 2025-09-26 at 12 58 45" src="https://github.com/user-attachments/assets/fd455335-196a-4e3b-acf3-41d950fc57d2" />
