### PR TITLE
fix: Add quotes to Salesforce metadata default value field

### DIFF
--- a/providers/salesforce/internal/crm/custom/payload.go
+++ b/providers/salesforce/internal/crm/custom/payload.go
@@ -243,7 +243,12 @@ func enhanceWithStringOptions(
 	// Picklists don't specify the default value here. It is done inside ValueSet struct.
 	// Client should pass this when working with Text or LongTextArea.
 	if !definition.ValueType.IsSelectionType() {
-		field.DefaultValue = definition.StringOptions.DefaultValue
+		// For Text and LongTextArea fields, wrap the defaultValue in quotes so Salesforce
+		// treats it as a string literal rather than a field reference in formulas.
+		if definition.StringOptions.DefaultValue != nil {
+			defaultValue := *definition.StringOptions.DefaultValue
+			field.DefaultValue = fmt.Sprintf("%q", defaultValue)
+		}
 	}
 
 	if definition.StringOptions.Pattern != "" {


### PR DESCRIPTION
This just adds quotes to the default string field so that salesforce doesn't confuse the value for a reference