### PR TITLE
fix: Initialize zoho connector with a module

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -350,6 +350,7 @@ func newZohoConnector(
 ) (*zoho.Connector, error) {
 	return zoho.NewConnector(
 		zoho.WithAuthenticatedClient(params.AuthenticatedClient),
+		zoho.WithModule(params.Module),
 	)
 }
 

--- a/providers/zoho/connector.go
+++ b/providers/zoho/connector.go
@@ -23,7 +23,9 @@ type Connector struct {
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {
-	params, err := paramsbuilder.Apply(parameters{}, opts)
+	params, err := paramsbuilder.Apply(parameters{}, opts,
+		WithModule(providers.ZohoCRM), // The module is resolved on behalf of the user if the option is missing.
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- initializes the zoho connector with a module,  sets the crm module as the default module. 