### PR TITLE
[CON-2040] feat: [loxo] Metadata functionality

### DIFF
--- a/providers/loxo/README.md
+++ b/providers/loxo/README.md
@@ -1,0 +1,66 @@
+# Loxo connector
+
+
+## Supported Objects 
+Below is an exhaustive list of objects & methods supported on the objects
+
+
+| Object                                    | Resource                                 | Method     |
+| ----------------------------------------- | ---------------------------------------- | ---------- |
+| activity_types                            | activity_types                           | read       |
+| address_types                             | address_types                            | read       |
+| bonus_payment_types                       | bonus_payment_types                      | read       |
+| bonus_types                               | bonus_types                              | read       |
+| companies                                 | companies                                | read       |
+| company_global_statuses                   | company_global_statuses                  | read       |
+| company_types                             | company_types                            | read       |
+| compensation_types                        | compensation_types                       | read       |
+| countries                                 | countries                                | read       |
+| currencies                                | currencies                               | read       |
+| deal_workflows                            | deal_workflows                           | read       |
+| deals                                     | deals                                    | read       |
+| disability_statuses                       | disability_statuses                      | read       |
+| diversity_types                           | diversity_types                          | read       |
+| dynamic_fields                            | dynamic_fields                           | read       |
+| education_types                           | education_types                          | read       |
+| email_tracking                            | email_tracking                           | read       |
+| email_types                               | email_types                              | read       |
+| equity_types                              | equity_types                             | read       |
+| ethnicities                               | ethnicities                              | read       |
+| fee_types                                 | fee_types                                | read       |
+| form_templates                            | form_templates                           | read       |
+| forms                                     | forms                                    | read       |
+| genders                                   | genders                                  | read       |
+| job_categories                            | job_categories                           | read       |
+| job_contact_types                         | job_contact_types                        | read       |
+| job_owner_types                           | job_owner_types                          | read       |
+| job_statuses                              | job_statuses                             | read       |
+| job_types                                 | job_types                                | read       |
+| jobs                                      | jobs                                     | read       |
+| people                                    | people                                   | read       |
+| people/emails                             | people/emails                            | read       |
+| person_phones                             | person_phones                            | read       |
+| people/update_by_email                    | people/update_by_email                   | read       |
+| person_events                             | person_events                            | read       |
+| person_global_statuses                    | person_global_statuses                   | read       |
+| person_lists                              | person_lists                             | read       |
+| person_share_field_types                  | person_share_field_types                 | read       |
+| person_types                              | person_types                             | read       |
+| phone_types                               | phone_types                              | read       |
+| placements                                | placements                               | read       |
+| pronouns                                  | pronouns                                 | read       |
+| question_types                            | question_types                           | read       |
+| schedule_items                            | schedule_items                           | read       |
+| scorecards                                | scorecards                               | read       |
+| scorecard_recommendation_types            | scorecards/scorecard_recommendation_types| read       |
+| scorecard_types                           | scorecards/scorecard_types               | read       |
+| scorecard_templates                       | scorecards/scorecard_templates           | read       |
+| scorecard_visibility_types                | scorecards/scorecard_visibility_types    | read       |
+| seniority_levels                          | seniority_levels                         | read       |
+| sms                                       | sms                                      | read       |
+| social_profile_types                      | social_profile_types                     | read       |
+| source_types                              | source_types                             | read       |
+| users                                     | users                                    | read       |
+| veteran_statuses                          | veteran_statuses                         | read       |
+| workflow_stages                           | workflow_stages                          | read       |
+| workflows                                 | workflows                                | read       |

--- a/providers/loxo/connector.go
+++ b/providers/loxo/connector.go
@@ -1,0 +1,52 @@
+package loxo
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	// Basic connector
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+
+	// Supported operations
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	// Create base connector with provider info
+	conn, err := components.Initialize(providers.Loxo, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	// Set the metadata provider for the connector
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				HTML: &interpreter.DirectFaultyResponder{Callback: connector.interpretHTMLError},
+			}.Handle,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/loxo/errors.go
+++ b/providers/loxo/errors.go
@@ -1,0 +1,29 @@
+package loxo
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+func (c *Connector) interpretHTMLError(res *http.Response, body []byte) error {
+	base := interpreter.DefaultStatusCodeMappingToErr(res, body)
+
+	document, err := goquery.NewDocumentFromReader(bytes.NewReader(body))
+	if err != nil {
+		// ignore HTML that cannot be understood
+		return base
+	}
+
+	// Message is located under the <pre></pre> tag
+	message := document.Find("head > title").Text()
+
+	if message == "" {
+		return base // nothing meaningful found, return base error
+	}
+
+	return fmt.Errorf("%w: %v", base, message)
+}

--- a/providers/loxo/handlers.go
+++ b/providers/loxo/handlers.go
@@ -1,0 +1,69 @@
+package loxo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	if objectWithPrefixValue.Has(objectName) {
+		objectName = "scorecards/" + objectName
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		DisplayName: naming.CapitalizeFirstLetterEveryWord(objectName),
+	}
+
+	body, ok := response.Body()
+	if !ok {
+		return nil, common.ErrEmptyJSONHTTPResponse
+	}
+
+	nodePath := objectsNodePath.Get(objectName)
+
+	res, err := jsonquery.New(body).ArrayOptional(nodePath)
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := jsonquery.Convertor.ArrayToMap(res)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(record) == 0 {
+		return nil, common.ErrMissingMetadata
+	}
+
+	for field := range record[0] {
+		objectMetadata.Fields[field] = common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    common.ValueTypeOther,
+			ProviderType: "",
+			ReadOnly:     false,
+			Values:       nil,
+		}
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/loxo/metadata_test.go
+++ b/providers/loxo/metadata_test.go
@@ -1,0 +1,137 @@
+package loxo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	companiesResponse := testutils.DataFromFile(t, "companies.json")
+	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
+
+	tests := []testroutines.Metadata{
+		{
+			Name:  "Successfully describe multiple objects with metadata",
+			Input: []string{"companies", "currencies"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/companies"),
+					Then: mockserver.Response(http.StatusOK, companiesResponse),
+				}, {
+					If:   mockcond.Path("/currencies"),
+					Then: mockserver.Response(http.StatusOK, currenciesResponse),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"companies": {
+						DisplayName: "Companies",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName: "id",
+								ValueType:   "other",
+							},
+							"name": {
+								DisplayName: "name",
+								ValueType:   "other",
+							},
+							"url": {
+								DisplayName: "url",
+								ValueType:   "other",
+							},
+							"job_count": {
+								DisplayName: "job_count",
+								ValueType:   "other",
+							},
+							"owned_by_name": {
+								DisplayName: "owned_by_name",
+								ValueType:   "other",
+							},
+							"owned_by_id": {
+								DisplayName: "owned_by_id",
+								ValueType:   "other",
+							},
+						},
+						FieldsMap: nil,
+					},
+					"currencies": {
+						DisplayName: "Currencies",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName: "id",
+								ValueType:   "other",
+							},
+							"code": {
+								DisplayName: "code",
+								ValueType:   "other",
+							},
+							"name": {
+								DisplayName: "name",
+								ValueType:   "other",
+							},
+							"symbol": {
+								DisplayName: "symbol",
+								ValueType:   "other",
+							},
+							"precision": {
+								DisplayName: "precision",
+								ValueType:   "other",
+							},
+							"default": {
+								DisplayName: "default",
+								ValueType:   "other",
+							},
+							"position": {
+								DisplayName: "position",
+								ValueType:   "other",
+							},
+						},
+						FieldsMap: nil,
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+		Metadata: map[string]string{
+			"domain":      "pod4.app.loxo.co",
+			"agency_slug": "integration-user-loxo-withampersand-com",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// for testing we want to redirect calls to our mock server
+	connector.SetBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/providers/loxo/test/companies.json
+++ b/providers/loxo/test/companies.json
@@ -1,0 +1,17 @@
+{
+    "scroll_id": "5B313735363133353831343636312C313135383637325D",
+    "total_count": 1,
+    "facets": {
+        "global_status_aggs": []
+    },
+    "companies": [
+        {
+            "id": 1158672,
+            "name": "Ampersand",
+            "url": "http://withampersand.com",
+            "job_count": 1,
+            "owned_by_name": "Ampersand Developer",
+            "owned_by_id": 1832617
+        }
+    ]
+}

--- a/providers/loxo/test/currencies.json
+++ b/providers/loxo/test/currencies.json
@@ -1,0 +1,11 @@
+[
+    {
+        "id": 1,
+        "code": "USD",
+        "name": "United States Dollar",
+        "symbol": "$",
+        "precision": 2,
+        "default": true,
+        "position": 1
+    }
+]

--- a/providers/loxo/utils.go
+++ b/providers/loxo/utils.go
@@ -1,0 +1,73 @@
+package loxo
+
+import (
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
+	"activity_types":                 "",
+	"address_types":                  "",
+	"bonus_payment_types":            "",
+	"bonus_types":                    "",
+	"company_global_statuses":        "",
+	"company_types":                  "",
+	"compensation_types":             "",
+	"currencies":                     "",
+	"deal_workflows":                 "",
+	"disability_statuses":            "",
+	"diversity_types":                "",
+	"dynamic_fields":                 "",
+	"education_types":                "",
+	"email_types":                    "",
+	"equity_types":                   "",
+	"ethnicities":                    "",
+	"fee_types":                      "",
+	"genders":                        "",
+	"job_categories":                 "",
+	"job_contact_types":              "",
+	"job_owner_types":                "",
+	"job_statuses":                   "",
+	"job_types":                      "",
+	"person_global_statuses":         "",
+	"person_lists":                   "",
+	"person_share_field_types":       "",
+	"person_types":                   "",
+	"phone_types":                    "",
+	"pronouns":                       "",
+	"question_types":                 "",
+	"scorecard_recommendation_types": "",
+	"scorecard_types":                "",
+	"scorecard_visibility_types":     "",
+	"seniority_levels":               "",
+	"social_profile_types":           "",
+	"users":                          "",
+	"veteran_statuses":               "",
+	"workflow_stages":                "",
+	"workflows":                      "",
+	"companies":                      "companies",
+	"countries":                      "countries",
+	"deals":                          "deals",
+	"email_tracking":                 "tracking",
+	"form_templates":                 "form_templates",
+	"forms":                          "forms",
+	"jobs":                           "results",
+	"people":                         "people",
+	"people/emails":                  "person_emails",
+	"people/phones":                  "person_phones",
+	"person_events":                  "person_events",
+	"placements":                     "placements",
+	"schedule_items":                 "schedule_items",
+	"scorecards":                     "scorecards",
+	"sms":                            "sms",
+	"source_types":                   "source_types",
+}, func(objectName string) string {
+	return objectName
+},
+)
+
+var objectWithPrefixValue = datautils.NewSet( //nolint:gochecknoglobals
+	"scorecard_recommendation_types",
+	"scorecard_types",
+	"scorecard_templates",
+	"scorecard_visibility_types ",
+)

--- a/test/loxo/connector.go
+++ b/test/loxo/connector.go
@@ -1,0 +1,43 @@
+package loxo
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/loxo"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+var fieldDomain = credscanning.Field{ //nolint:gochecknoglobals
+	Name:      "domain",
+	PathJSON:  "substitutions.domain",
+	SuffixENV: "DOMAIN",
+}
+
+var fieldAgencySlug = credscanning.Field{ //nolint:gochecknoglobals
+	Name:      "agency_slug",
+	PathJSON:  "substitutions.agency_slug",
+	SuffixENV: "AGENCY_SLUG",
+}
+
+func GetLoxoConnector(ctx context.Context) *loxo.Connector {
+	filePath := credscanning.LoadPath(providers.Loxo)
+	reader := utils.MustCreateProvCredJSON(filePath, false, fieldDomain, fieldAgencySlug)
+
+	client := utils.NewAPIKeyClient(ctx, reader, providers.Loxo)
+
+	conn, err := loxo.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+		Metadata: map[string]string{
+			"domain":      reader.Get(fieldDomain),
+			"agency_slug": reader.Get(fieldAgencySlug),
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating Loxo App connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/loxo/metadata/main.go
+++ b/test/loxo/metadata/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/amp-labs/connectors/test/loxo"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := loxo.GetLoxoConnector(ctx)
+
+	m, err := conn.ListObjectMetadata(ctx, []string{"companies", "countries", "deals", "activity_types", "people"})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the results
+	utils.DumpJSON(m, os.Stdout)
+}


### PR DESCRIPTION
# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [ ] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Sample metadata response
<img width="1122" height="812" alt="image" src="https://github.com/user-attachments/assets/66ef988e-f95e-432b-8839-40eb4107553b" />

<img width="1167" height="821" alt="image" src="https://github.com/user-attachments/assets/eaa3c624-624c-4f13-a2a6-89bb79d8ef15" />

<img width="1170" height="718" alt="image" src="https://github.com/user-attachments/assets/fe82eb0e-8297-48cf-88d0-24a21996940a" />

# Testcase result
<img width="1496" height="787" alt="image" src="https://github.com/user-attachments/assets/76e2ced9-f32f-4620-bc3c-1c5a7450ec15" />
