### PR TITLE
[CON-2041] feat: [loxo] Read functionality

### DIFF
--- a/providers/loxo/connector.go
+++ b/providers/loxo/connector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 )
@@ -20,6 +21,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -42,6 +44,24 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.SingleObjectMetadataHandlers{
 			BuildRequest:  connector.buildSingleObjectMetadataRequest,
 			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				HTML: &interpreter.DirectFaultyResponder{Callback: connector.interpretHTMLError},
+			}.Handle,
+		},
+	)
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
 			ErrorHandler: interpreter.ErrorHandler{
 				HTML: &interpreter.DirectFaultyResponder{Callback: connector.interpretHTMLError},
 			}.Handle,

--- a/providers/loxo/handlers.go
+++ b/providers/loxo/handlers.go
@@ -3,6 +3,7 @@ package loxo
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
@@ -66,4 +67,47 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 	}
 
 	return &objectMetadata, nil
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if len(params.NextPage) != 0 {
+		// Next page.
+		url, err := urlbuilder.New(params.NextPage.String())
+		if err != nil {
+			return nil, err
+		}
+
+		return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if paginationObjects.Has(params.ObjectName) {
+		url.WithQueryParam("per_page", strconv.Itoa(defaultPageSize))
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	url, err := urlbuilder.FromRawURL(request.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		response,
+		common.ExtractRecordsFromPath(objectsNodePath.Get(params.ObjectName)),
+		makeNextRecordsURL(url, params.ObjectName),
+		common.GetMarshaledData,
+		params.Fields,
+	)
 }

--- a/providers/loxo/read_test.go
+++ b/providers/loxo/read_test.go
@@ -1,0 +1,140 @@
+package loxo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	peopleResponse := testutils.DataFromFile(t, "people.json")
+	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
+	countriesResponse := testutils.DataFromFile(t, "countries.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Read list of people",
+			Input: common.ReadParams{ObjectName: "people", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/people"),
+				Then:  mockserver.Response(http.StatusOK, peopleResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"id":                           float64(1388693),
+							"name":                         "George",
+							"profile_picture_thumb_url":    "/profile_pictures/thumb/missing.png",
+							"profile_picture_original_url": "/profile_pictures/original/missing.png",
+							"person_types": []any{
+								map[string]any{
+									"id":   float64(2157),
+									"name": "Candidate",
+								},
+							},
+							"emails": []any{
+								map[string]any{
+									"id":            float64(922436),
+									"value":         "george123@gmail.com",
+									"email_type_id": float64(1455),
+								},
+							},
+							"linkedin_url": "https://www.linkedin.com/search/results/people/?keywords=George",
+							"source_type": map[string]any{
+								"id":   float64(38518),
+								"name": "API",
+							},
+						},
+					},
+				},
+				NextPage: testroutines.URLTestServer +
+					"/people?per_page=100&scroll_id=5B313735363231393831313237352C302E302C313338383639335D",
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of currencies",
+			Input: common.ReadParams{ObjectName: "currencies", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/currencies"),
+				Then:  mockserver.Response(http.StatusOK, currenciesResponse),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"id":        float64(1),
+							"code":      "USD",
+							"name":      "United States Dollar",
+							"symbol":    "$",
+							"precision": float64(2),
+							"default":   true,
+							"position":  float64(1),
+						},
+					},
+				},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Read list of countries",
+			Input: common.ReadParams{ObjectName: "countries", Fields: connectors.Fields("")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/countries"),
+				Then:  mockserver.Response(http.StatusOK, countriesResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{},
+						Raw: map[string]any{
+							"id":        float64(3),
+							"name":      "Afghanistan",
+							"code":      "AF",
+							"long_code": "AFG",
+						},
+					},
+				},
+				NextPage: testroutines.URLTestServer + "/countries?per_page=100&page=101",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/loxo/support.go
+++ b/providers/loxo/support.go
@@ -1,0 +1,79 @@
+package loxo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+)
+
+func supportedOperations() components.EndpointRegistryInput { // nolint:funlen
+	readSupport := []string{
+		"activity_types",
+		"address_types",
+		"bonus_payment_types",
+		"bonus_types",
+		"companies",
+		"company_global_statuses",
+		"company_types",
+		"compensation_types",
+		"countries",
+		"currencies",
+		"deal_workflows",
+		"deals",
+		"disability_statuses",
+		"diversity_types",
+		"dynamic_fields",
+		"education_types",
+		"email_tracking",
+		"email_types",
+		"equity_types",
+		"ethnicities",
+		"fee_types",
+		"form_templates",
+		"forms",
+		"genders",
+		"job_categories",
+		"job_contact_types",
+		"job_owner_types",
+		"job_statuses",
+		"job_types",
+		"jobs",
+		"people",
+		"people/emails",
+		"person_phones",
+		"people/update_by_email",
+		"person_events",
+		"person_global_statuses",
+		"person_lists",
+		"person_share_field_types",
+		"person_types",
+		"phone_types",
+		"placements",
+		"pronouns",
+		"question_types",
+		"schedule_items",
+		"scorecards",
+		"scorecards/scorecard_recommendation_types",
+		"scorecards/scorecard_types",
+		"scorecards/scorecard_visibility_types",
+		"seniority_levels",
+		"sms",
+		"social_profile_types",
+		"source_types",
+		"users",
+		"veteran_statuses",
+		"workflow_stages",
+		"workflows",
+	}
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/loxo/test/countries.json
+++ b/providers/loxo/test/countries.json
@@ -1,0 +1,14 @@
+{
+    "current_page": 100,
+    "total_pages": 252,
+    "per_page": 1,
+    "total_count": 252,
+    "countries": [
+        {
+            "id": 3,
+            "name": "Afghanistan",
+            "code": "AF",
+            "long_code": "AFG"
+        }
+    ]
+}

--- a/providers/loxo/test/people.json
+++ b/providers/loxo/test/people.json
@@ -1,0 +1,30 @@
+{
+    "scroll_id": "5B313735363231393831313237352C302E302C313338383639335D",
+    "total_count": 3,
+    "people": [
+        {
+            "id": 1388693,
+            "name": "George",
+            "profile_picture_thumb_url": "/profile_pictures/thumb/missing.png",
+            "profile_picture_original_url": "/profile_pictures/original/missing.png",
+            "person_types": [
+                {
+                    "id": 2157,
+                    "name": "Candidate"
+                }
+            ],
+            "emails": [
+                {
+                    "id": 922436,
+                    "value": "george123@gmail.com",
+                    "email_type_id": 1455
+                }
+            ],
+            "linkedin_url": "https://www.linkedin.com/search/results/people/?keywords=George",
+            "source_type": {
+                "id": 38518,
+                "name": "API"
+            }
+        }
+    ]
+}

--- a/providers/loxo/utils.go
+++ b/providers/loxo/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-const defaultPageSize = 1
+const defaultPageSize = 100
 
 var objectsNodePath = datautils.NewDefaultMap(map[string]string{ //nolint:gochecknoglobals
 	"activity_types":                 "",

--- a/test/loxo/read/main.go
+++ b/test/loxo/read/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	ap "github.com/amp-labs/connectors/providers/loxo"
+	"github.com/amp-labs/connectors/test/loxo"
+)
+
+func main() {
+	os.Exit(MainFn())
+}
+
+func MainFn() int {
+	conn := loxo.GetLoxoConnector(context.Background())
+
+	err := testRead(context.Background(), conn, "forms", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "deals", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	err = testRead(context.Background(), conn, "countries", []string{""})
+	if err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func testRead(ctx context.Context, conn *ap.Connector, objName string, fields []string) error {
+	params := common.ReadParams{
+		ObjectName: objName,
+		Fields:     connectors.Fields(fields...),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", objName, err)
+	}
+
+	// Print the results.
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
# Conventions
- [x] Connector uses `internal/components`
- [ ] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [ ] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Sample read response
<img width="1276" height="398" alt="image" src="https://github.com/user-attachments/assets/e5af5495-5d47-4d79-ab2a-56098b813ea4" />

<img width="568" height="758" alt="image" src="https://github.com/user-attachments/assets/dbbbcbcf-f108-40ea-b3e1-b579337ceb7d" />

<img width="1091" height="317" alt="image" src="https://github.com/user-attachments/assets/24a1ac53-385c-49da-8c78-db0673cd273f" />

# Testcase result
<img width="1500" height="901" alt="image" src="https://github.com/user-attachments/assets/74e35d31-6041-404e-98c5-919da3b38ba6" />

