### PR TITLE
fix: use non-capital provider metadata for LinkedIn connector

### DIFF
--- a/providers/linkedIn.go
+++ b/providers/linkedIn.go
@@ -43,7 +43,7 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "AdAccountId",
+					Name:        "adAccountId",
 					DisplayName: "Ad Account ID",
 					DocsURL:     "https://www.linkedin.com/help/linkedin/answer/a424270/find-linkedin-ads-account-details",
 				},

--- a/providers/linkedin/connector.go
+++ b/providers/linkedin/connector.go
@@ -37,7 +37,7 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 		return nil, err
 	}
 
-	conn.AdAccountId = params.Metadata["AdAccountId"]
+	conn.AdAccountId = params.Metadata["adAccountId"]
 
 	return conn, nil
 }


### PR DESCRIPTION
by convention, we don't capitalize the metadata keys