### PR TITLE
fix: use lowercase module name 

### DIFF
--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -10,7 +10,7 @@ const Hubspot Provider = "hubspot"
 
 const (
 	// ModuleHubspotCRM is the module used for accessing standard CRM objects.
-	ModuleHubspotCRM common.ModuleID = "CRM"
+	ModuleHubspotCRM common.ModuleID = "crm"
 )
 
 func init() { //nolint:funlen


### PR DESCRIPTION
This is the name that builders have to use in their YAML. For modules, we prefer lowercase everywhere else (salesforce, etc), which is why this needs to be lowercase too.