### PR TITLE
[CON-2250] feat(amplitude): enable Read + Write support

### DIFF
--- a/providers/amplitude.go
+++ b/providers/amplitude.go
@@ -37,7 +37,7 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
 			Write:     false,
 		},

--- a/providers/amplitude.go
+++ b/providers/amplitude.go
@@ -39,7 +39,7 @@ func init() {
 			Proxy:     true,
 			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
# Installation
Mailmonkey using Api key

# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="957" height="840" alt="image" src="https://github.com/user-attachments/assets/364c523f-be7f-4570-b118-26b9983d7e45" />
<img width="1014" height="616" alt="image" src="https://github.com/user-attachments/assets/2303fa2b-c4a7-4107-9dc1-a621fc46ee7f" />
<img width="916" height="597" alt="image" src="https://github.com/user-attachments/assets/b4415e69-9965-400f-a8aa-12311eba7f29" />
<img width="1030" height="586" alt="image" src="https://github.com/user-attachments/assets/4c776619-6224-4ff4-8f0f-90529ad8528b" />


- [x] Insert screenshot of Svix destination.
<img width="1621" height="922" alt="image" src="https://github.com/user-attachments/assets/273f75c8-1b85-4886-be9a-54fe28346460" />
<img width="1618" height="860" alt="image" src="https://github.com/user-attachments/assets/0a151dd7-4971-4273-a2a2-3ac7d92050b5" />
<img width="1624" height="893" alt="image" src="https://github.com/user-attachments/assets/69c2940e-4585-4fb0-8172-b1f2f825aa22" />





- [x] Screenshot of operations on dashboard
<img width="1499" height="896" alt="image" src="https://github.com/user-attachments/assets/e58a0809-029b-4255-9460-611046a9b4f8" />
<img width="1501" height="911" alt="image" src="https://github.com/user-attachments/assets/9b0b22c7-f685-4edb-92ba-f88926dd23f0" />

<img width="1505" height="947" alt="image" src="https://github.com/user-attachments/assets/ba6b0572-4e30-4f95-86e7-b5e4e0bbbbd7" />






# Write
- [x] Insert screenshot of dashboard.
<img width="1500" height="695" alt="image" src="https://github.com/user-attachments/assets/b0168001-2118-4ce9-91b1-e35ded7c5ac2" />
<img width="1502" height="644" alt="image" src="https://github.com/user-attachments/assets/d779f329-f1b4-469e-b43d-f864f9ab426c" />





- [x] Insert screenshot of HTTP call.
<img width="1757" height="560" alt="image" src="https://github.com/user-attachments/assets/fc6813e7-848f-451e-9caa-98345593a2d3" />
<img width="1757" height="868" alt="image" src="https://github.com/user-attachments/assets/04e4cb3f-0874-40a1-8e9f-ad6be9e4b8a2" />

