### PR TITLE
[CON-1357] feat(teamwork): Read

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -73,6 +73,9 @@ var (
 	// ErrBadRequest is returned when we get a 400 response from the provider.
 	ErrBadRequest = errors.New("bad request")
 
+	// ErrConflict is returned when we get a 409 response from the provider.
+	ErrConflict = errors.New("conflict")
+
 	// ErrNotFound is returned when we get a 404 response from the provider.
 	ErrNotFound = errors.New("not found")
 

--- a/providers/braintree/read_test.go
+++ b/providers/braintree/read_test.go
@@ -56,7 +56,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
-				testutils.StringError("Invalid search criteria provided"), // nolint:goerr113
+				testutils.StringError("Invalid search criteria provided"),
 			},
 		},
 		{

--- a/providers/google/internal/contacts/errors.go
+++ b/providers/google/internal/contacts/errors.go
@@ -2,6 +2,7 @@ package contacts
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -21,7 +22,7 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 )
 
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
-	http.StatusConflict: common.ErrBadRequest,
+	http.StatusConflict: errors.Join(common.ErrConflict, common.ErrBadRequest),
 }
 
 // ErrorDetails

--- a/providers/google/read_test.go
+++ b/providers/google/read_test.go
@@ -555,7 +555,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrForbidden,
-				testutils.StringError("CSE is not enabled."), // nolint:goerr113
+				testutils.StringError("CSE is not enabled."),
 			},
 		},
 		{
@@ -568,7 +568,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
 				common.ErrNotFound,
-				testutils.StringError("The requested URL /gmail/v1/users/me/butterfly was not found on this server. That’s all we know"), // nolint:goerr113,lll
+				testutils.StringError("The requested URL /gmail/v1/users/me/butterfly was not found on this server. That’s all we know"), // nolint:lll
 			},
 		},
 		{

--- a/providers/intercom/errors.go
+++ b/providers/intercom/errors.go
@@ -43,7 +43,7 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
 	http.StatusPaymentRequired:      common.ErrBadRequest,
 	http.StatusNotAcceptable:        common.ErrBadRequest,
-	http.StatusConflict:             common.ErrBadRequest,
+	http.StatusConflict:             errors.Join(common.ErrConflict, common.ErrBadRequest),
 	http.StatusUnsupportedMediaType: common.ErrBadRequest,
 	http.StatusUnprocessableEntity:  common.ErrBadRequest,
 }

--- a/providers/klaviyo/errors.go
+++ b/providers/klaviyo/errors.go
@@ -1,6 +1,7 @@
 package klaviyo
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,7 +20,7 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 )
 
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
-	http.StatusConflict: common.ErrBadRequest,
+	http.StatusConflict: errors.Join(common.ErrConflict, common.ErrBadRequest),
 }
 
 type ResponseError struct {

--- a/providers/nutshell/errors.go
+++ b/providers/nutshell/errors.go
@@ -2,6 +2,7 @@ package nutshell
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,7 +28,7 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
 	http.StatusMethodNotAllowed:     common.ErrBadRequest,
 	http.StatusUnsupportedMediaType: common.ErrBadRequest,
-	http.StatusConflict:             common.ErrBadRequest,
+	http.StatusConflict:             errors.Join(common.ErrConflict, common.ErrBadRequest),
 }
 
 var textErrorStatusCodeHandler = interpreter.DirectFaultyResponder{ // nolint:gochecknoglobals

--- a/providers/salesforce/delete_test.go
+++ b/providers/salesforce/delete_test.go
@@ -165,7 +165,7 @@ func TestDeletePardot(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
-				testutils.StringError("The requested record was not found."), // nolint:goerr113
+				testutils.StringError("The requested record was not found."),
 			},
 		},
 	}

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -431,7 +431,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
-				testutils.StringError("A required header is missing: Pardot-Business-Unit-Id header not found on request."), // nolint:goerr113
+				testutils.StringError("A required header is missing: Pardot-Business-Unit-Id header not found on request."),
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			}.Server(),
 			ExpectedErrs: []error{
 				common.ErrBadRequest,
-				testutils.StringError("One or more required parameters are missing: fields"), // nolint:goerr113
+				testutils.StringError("One or more required parameters are missing: fields"),
 			},
 		},
 		{

--- a/providers/stripe/errors.go
+++ b/providers/stripe/errors.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -19,7 +20,7 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
 	http.StatusPaymentRequired: common.ErrBadRequest,
-	http.StatusConflict:        common.ErrBadRequest,
+	http.StatusConflict:        errors.Join(common.ErrConflict, common.ErrBadRequest),
 }
 
 type ResponseError struct {

--- a/providers/teamwork/connector.go
+++ b/providers/teamwork/connector.go
@@ -2,11 +2,17 @@ package teamwork
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/teamwork/internal/metadata"
 )
+
+const apiVersion = "v3"
 
 type Connector struct {
 	*components.Connector
@@ -14,6 +20,7 @@ type Connector struct {
 	common.RequireWorkspace
 
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -25,5 +32,29 @@ func constructor(base *components.Connector) (*Connector, error) {
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
+	}.Handle
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
 	return connector, nil
+}
+
+func (c *Connector) getReadURL(objectName string) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.FindURLPath(c.Module(), objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, "projects/api", apiVersion, path)
 }

--- a/providers/teamwork/errors.go
+++ b/providers/teamwork/errors.go
@@ -1,0 +1,58 @@
+package teamwork
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: []string{"message"},
+			Template: func() interpreter.ErrorDescriptor { return &ResponseMessageError{} },
+		},
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseMessageError struct {
+	Message string `json:"message"`
+}
+
+type ResponseError struct {
+	Errors []struct {
+		ID     string `json:"id"`
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+		Meta   any    `json:"meta"`
+	} `json:"errors"`
+}
+
+func (r ResponseMessageError) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, r.Message)
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	if len(r.Errors) == 0 {
+		return base
+	}
+
+	list := make([]error, len(r.Errors))
+
+	for index, object := range r.Errors {
+		list[index] = fmt.Errorf("%v; %v", object.Title, object.Detail) // nolint:err113
+	}
+
+	return fmt.Errorf("%w: %w", base, errors.Join(list...))
+}
+
+var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
+	http.StatusConflict: errors.Join(common.ErrConflict, common.ErrBadRequest),
+}

--- a/providers/teamwork/handlers.go
+++ b/providers/teamwork/handlers.go
@@ -1,0 +1,113 @@
+package teamwork
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/teamwork/internal/metadata"
+	"github.com/spyzhov/ajson"
+)
+
+const defaultPageSize = "500"
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := c.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	// First page
+	url, err := c.getReadURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("pageSize", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+	if !params.Since.IsZero() && objectsWithSinceQuery.Has(params.ObjectName) {
+		url.WithQueryParam("updatedAfter", datautils.Time.FormatRFC3339inUTC(params.Since))
+	}
+
+	if !params.Until.IsZero() && objectsWithUntilQuery.Has(params.ObjectName) {
+		url.WithQueryParam("updatedBefore", datautils.Time.FormatRFC3339inUTC(params.Until))
+	}
+
+	return url, nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(common.ModuleRoot, params.ObjectName)
+
+	url, err := urlbuilder.FromRawURL(request.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		resp,
+		common.ExtractOptionalRecordsFromPath(responseFieldName),
+		makeNextRecordsURL(url),
+		common.GetMarshaledData,
+		params.Fields,
+	)
+}
+
+// makeNextRecordsURL returns a NextPageFunc for Teamwork.com v3 API pagination.
+//
+// Extracts pageOffset from meta.page object, increments it by 1 when hasMore is
+// true, and updates the page query parameter for the next request.
+// See: https://apidocs.teamwork.com/guides/teamwork/how-does-paging-work#v3-endpoint-meta-data
+func makeNextRecordsURL(url *urlbuilder.URL) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		pageObject := jsonquery.New(node, "meta", "page")
+
+		hasMore, err := pageObject.BoolWithDefault("hasMore", false)
+		if err != nil {
+			return "", err
+		}
+
+		if !hasMore {
+			return "", nil
+		}
+
+		pageOffset, err := pageObject.IntegerOptional("pageOffset")
+		if err != nil {
+			return "", err
+		}
+
+		if pageOffset == nil {
+			return "", nil
+		}
+
+		// pageOrigin is 1 because Teamwork page counting starts at page 1 (not 0).
+		// pageOffset is the 0-based distance from origin in the current response.
+		const pageOrigin = 1
+
+		// CurrentPage						= pageOrigin + pageOffset
+		// NextPage		= CurrentPage + 1	= pageOrigin + pageOffset + 1
+		nextPageParam := pageOrigin + *pageOffset + 1
+		url.WithQueryParam("page", strconv.FormatInt(nextPageParam, 10))
+
+		return url.String(), nil
+	}
+}

--- a/providers/teamwork/incremental.go
+++ b/providers/teamwork/incremental.go
@@ -1,0 +1,34 @@
+package teamwork
+
+import "github.com/amp-labs/connectors/internal/datautils"
+
+var objectsWithSinceQuery = datautils.NewSet( // nolint:gochecknoglobals
+	"comments",
+	"companies",
+	"dashboards",
+	"jobroles",
+	"latestactivity",
+	"me/timers",
+	"messages",
+	"milestones",
+	"notebooks",
+	"people",
+	"projects",
+	"risks",
+	"skills",
+	"starred",
+	"statuses",
+	"tags",
+	"tasklists",
+	"tasks",
+	"templates",
+	"time",
+	"timers",
+	"updates",
+)
+
+var objectsWithUntilQuery = datautils.NewSet( // nolint:gochecknoglobals
+	"jobroles",
+	"skills",
+	"tasks",
+)

--- a/providers/teamwork/read_test.go
+++ b/providers/teamwork/read_test.go
@@ -1,0 +1,167 @@
+package teamwork
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseNotFoundError := testutils.DataFromFile(t, "read/object-not-found.json")
+	responseCompaniesFirstPage := testutils.DataFromFile(t, "read/companies/1-first-page.json")
+	responseCompaniesLastPage := testutils.DataFromFile(t, "read/companies/2-last-page.json")
+	responseNotebooksFirstPage := testutils.DataFromFile(t, "read/notebooks/1-first-page.json")
+	responseNotebooksSecondPage := testutils.DataFromFile(t, "read/notebooks/2-second-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:  "Error response is parsed",
+			Input: common.ReadParams{ObjectName: "companies", Fields: connectors.Fields("name")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, responseNotFoundError),
+			}.Server(),
+			ExpectedErrs: []error{
+				testutils.StringError("Not Found"),
+				common.ErrBadRequest,
+			},
+		},
+		{
+			Name: "Read companies first page incrementally",
+			Input: common.ReadParams{
+				ObjectName: "companies",
+				Fields:     connectors.Fields("name", "city"),
+				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
+					time.FixedZone("UTC-8", -8*60*60)),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/projects/api/v3/companies.json"),
+					mockcond.QueryParam("updatedAfter", "2024-09-19T12:30:45Z"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCompaniesFirstPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "Ampersand",
+						"city": "San Francisco",
+					},
+					Raw: map[string]any{
+						"id": float64(1387405),
+					},
+				}, {
+					Fields: map[string]any{
+						"name": "Nike",
+						"city": "Chicago",
+					},
+					Raw: map[string]any{
+						"id": float64(1412778),
+					},
+				}},
+				NextPage: testroutines.URLTestServer + "/projects/api/v3/companies.json?" +
+					"page=2&pageSize=500&" +
+					"updatedAfter=2024-09-19T12:30:45Z",
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read companies second page which is without the next cursor",
+			Input: common.ReadParams{
+				ObjectName: "companies",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/projects/api/v3/companies.json"),
+				Then:  mockserver.Response(http.StatusOK, responseCompaniesLastPage),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows:     0,
+				Data:     []common.ReadResultRow{},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read notebooks first page",
+			Input: common.ReadParams{
+				ObjectName: "notebooks",
+				Fields:     connectors.Fields("name"),
+				PageSize:   1,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/projects/api/v3/notebooks.json"),
+					mockcond.QueryParam("pageSize", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseNotebooksFirstPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"name": "Second notebook"},
+					Raw:    map[string]any{"id": float64(305625)},
+				}},
+				NextPage: testroutines.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read notebooks last page",
+			Input: common.ReadParams{
+				ObjectName: "notebooks",
+				Fields:     connectors.Fields("name"),
+				NextPage:   testroutines.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/projects/api/v3/notebooks.json"),
+					mockcond.QueryParam("pageSize", "1"),
+					mockcond.QueryParam("page", "2"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseNotebooksSecondPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"name": "First notebook"},
+					Raw:    map[string]any{"id": float64(305624)},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/teamwork/test/read/companies/1-first-page.json
+++ b/providers/teamwork/test/read/companies/1-first-page.json
@@ -1,0 +1,89 @@
+{
+  "companies": [
+    {
+      "id": 1387405,
+      "name": "Ampersand",
+      "logoUrl": "",
+      "createdAt": "2024-05-20T23:21:06Z",
+      "updatedAt": null,
+      "addressOne": "",
+      "addressTwo": "",
+      "city": "San Francisco",
+      "state": "",
+      "zip": "",
+      "countryCode": "",
+      "emailOne": "",
+      "emailTwo": "",
+      "emailThree": "",
+      "website": "",
+      "cid": "",
+      "phone": "",
+      "fax": "",
+      "canSeePrivate": true,
+      "isOwner": true,
+      "industryId": null,
+      "industry": null,
+      "companyNameUrl": "1387405-ampersand",
+      "accounts": 1,
+      "collaborators": 0,
+      "contacts": 0,
+      "clients": 0,
+      "clientManagedBy": null,
+      "companyUpdate": null,
+      "companyDomains": [],
+      "tags": [],
+      "status": "active",
+      "currency": {
+        "id": 1,
+        "type": "currencies"
+      }
+    },
+    {
+      "id": 1412778,
+      "name": "Nike",
+      "logoUrl": "",
+      "createdAt": "2025-09-30T21:28:22Z",
+      "updatedAt": "2025-09-30T21:28:30Z",
+      "addressOne": "",
+      "addressTwo": "",
+      "city": "Chicago",
+      "state": "",
+      "zip": "",
+      "countryCode": "",
+      "emailOne": "",
+      "emailTwo": "",
+      "emailThree": "",
+      "website": "",
+      "cid": "",
+      "phone": "",
+      "fax": "",
+      "canSeePrivate": false,
+      "isOwner": false,
+      "industryId": null,
+      "industry": null,
+      "companyNameUrl": "1412778-nike",
+      "accounts": 0,
+      "collaborators": 0,
+      "contacts": 0,
+      "clients": 0,
+      "clientManagedBy": null,
+      "companyUpdate": null,
+      "companyDomains": [],
+      "tags": [],
+      "status": "active",
+      "currency": {
+        "id": 1,
+        "type": "currencies"
+      }
+    }
+  ],
+  "meta": {
+    "page": {
+      "pageOffset": 0,
+      "pageSize": 2,
+      "count": 2,
+      "hasMore": true
+    }
+  },
+  "included": {}
+}

--- a/providers/teamwork/test/read/companies/2-last-page.json
+++ b/providers/teamwork/test/read/companies/2-last-page.json
@@ -1,0 +1,12 @@
+{
+  "companies": [],
+  "meta": {
+    "page": {
+      "pageOffset": 1,
+      "pageSize": 2,
+      "count": 2,
+      "hasMore": false
+    }
+  },
+  "included": {}
+}

--- a/providers/teamwork/test/read/notebooks/1-first-page.json
+++ b/providers/teamwork/test/read/notebooks/1-first-page.json
@@ -1,0 +1,77 @@
+{
+  "notebooks": [
+    {
+      "id": 305625,
+      "name": "Second notebook",
+      "description": "",
+      "contents": "<p>Text and content goes here.</p>",
+      "type": "HTML",
+      "isPrivate": false,
+      "locked": false,
+      "lockedBy": null,
+      "lockedAt": null,
+      "lockdownId": 0,
+      "lockdown": null,
+      "secureContent": false,
+      "isFullWidth": false,
+      "projectId": 1441806,
+      "project": {
+        "id": 1441806,
+        "type": "projects"
+      },
+      "createdByUserID": 583610,
+      "createdBy": 583610,
+      "updatedByUserID": 583610,
+      "updatedBy": 583610,
+      "dateUpdated": "2025-09-30T21:14:15Z",
+      "updatedAt": "2025-09-30T21:14:15Z",
+      "dateCreated": "2025-09-30T21:14:15Z",
+      "createdAt": "2025-09-30T21:14:15Z",
+      "deleted": false,
+      "categoryId": null,
+      "category": null,
+      "notebookVersionID": 1009492,
+      "notebookVersion": {
+        "id": 1009492,
+        "type": "notebookVersions"
+      },
+      "notebookVersionCreatedDateTime": "2025-09-30T21:14:14Z",
+      "notebookVersionUpdatedDateTime": "2025-09-30T21:14:14Z",
+      "latestVersionNo": 1,
+      "versionCount": 1,
+      "commentsCount": 0,
+      "readCommentsCount": 0,
+      "contentHTML": null,
+      "privacy": null,
+      "commentFollowers": {
+        "userIds": null,
+        "users": null,
+        "companyIds": null,
+        "companies": null,
+        "teamIds": null,
+        "teams": null
+      },
+      "changeFollowers": {
+        "userIds": null,
+        "users": null,
+        "companyIds": null,
+        "companies": null,
+        "teamIds": null,
+        "teams": null
+      },
+      "userFollowingChanges": false,
+      "userFollowingComments": false,
+      "tagIds": null,
+      "tags": null
+    }
+  ],
+  "meta": {
+    "page": {
+      "pageOffset": 0,
+      "pageSize": 1,
+      "count": 2,
+      "hasMore": true
+    }
+  },
+  "included": {}
+}

--- a/providers/teamwork/test/read/notebooks/2-second-page.json
+++ b/providers/teamwork/test/read/notebooks/2-second-page.json
@@ -1,0 +1,91 @@
+{
+  "notebooks": [
+    {
+      "id": 305624,
+      "name": "First notebook",
+      "description": "",
+      "contents": "<p>Content</p>",
+      "type": "HTML",
+      "isPrivate": false,
+      "locked": false,
+      "lockedBy": null,
+      "lockedAt": null,
+      "lockdownId": 0,
+      "lockdown": null,
+      "secureContent": false,
+      "isFullWidth": false,
+      "projectId": 1441806,
+      "project": {
+        "id": 1441806,
+        "type": "projects"
+      },
+      "createdByUserID": 583610,
+      "createdBy": 583610,
+      "updatedByUserID": 583610,
+      "updatedBy": 583610,
+      "dateUpdated": "2025-09-30T21:04:12Z",
+      "updatedAt": "2025-09-30T21:04:12Z",
+      "dateCreated": "2025-09-30T21:04:12Z",
+      "createdAt": "2025-09-30T21:04:12Z",
+      "deleted": false,
+      "categoryId": null,
+      "category": null,
+      "notebookVersionID": 1009491,
+      "notebookVersion": {
+        "id": 1009491,
+        "type": "notebookVersions"
+      },
+      "notebookVersionCreatedDateTime": "2025-09-30T21:04:11Z",
+      "notebookVersionUpdatedDateTime": "2025-09-30T21:04:11Z",
+      "latestVersionNo": 1,
+      "versionCount": 1,
+      "commentsCount": 0,
+      "readCommentsCount": 0,
+      "contentHTML": null,
+      "privacy": null,
+      "commentFollowers": {
+        "userIds": [
+          583610
+        ],
+        "users": [
+          {
+            "id": 583610,
+            "type": "users"
+          }
+        ],
+        "companyIds": null,
+        "companies": null,
+        "teamIds": null,
+        "teams": null
+      },
+      "changeFollowers": {
+        "userIds": [
+          583610
+        ],
+        "users": [
+          {
+            "id": 583610,
+            "type": "users"
+          }
+        ],
+        "companyIds": null,
+        "companies": null,
+        "teamIds": null,
+        "teams": null
+      },
+      "userFollowingChanges": true,
+      "userFollowingComments": true,
+      "tagIds": null,
+      "tags": null
+    }
+  ],
+  "meta": {
+    "page": {
+      "pageOffset": 1,
+      "pageSize": 1,
+      "count": 2,
+      "hasMore": false
+    }
+  },
+  "included": {}
+}

--- a/providers/teamwork/test/read/object-not-found.json
+++ b/providers/teamwork/test/read/object-not-found.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not Found"
+}

--- a/test/teamwork/read/companies/main.go
+++ b/test/teamwork/read/companies/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/teamwork"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetTeamworkConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "companies",
+		Fields:     connectors.Fields("name", "city"),
+		// Since:      time.Now().Add(-1 * time.Hour * 24),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/teamwork/read/notebooks/main.go
+++ b/test/teamwork/read/notebooks/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/teamwork"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetTeamworkConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "notebooks",
+		Fields:     connectors.Fields("name"),
+		// Since:      utils.Timestamp("2025-09-30T21:04:11Z"),
+		PageSize: 1,
+		NextPage: "https://ampersand6.teamwork.com/projects/api/v3/notebooks.json?page=2&pageSize=1",
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Description
- [x] Connector uses `internal/components`
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

# Live Tests
<img width="573" height="581" alt="image" src="https://github.com/user-attachments/assets/c4e5dbca-f255-4ca9-8855-de93e64fc2ea" />

