### PR TITLE
[CON-2802] feat: update the Braze provider Base URL provisioning.

### DIFF
--- a/providers/braze.go
+++ b/providers/braze.go
@@ -2,6 +2,9 @@ package providers
 
 const Braze Provider = "braze"
 
+// BrazeEU serves customers using braze's france data-center only, the rest should use Braze.
+const BrazeEU Provider = "brazeEU"
+
 func init() {
 	SetInfo(Braze, ProviderInfo{
 		DisplayName: "Braze",
@@ -46,4 +49,49 @@ func init() {
 			},
 		},
 	})
+
+	SetInfo(BrazeEU, ProviderInfo{
+		DisplayName: "BrazeEU",
+		AuthType:    ApiKey,
+		BaseURL:     "https://rest.{{.workspace}}.braze.eu",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://www.braze.com/docs/api/basics/#creating-rest-api-keys",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565804/media/braze.com_1740565802.png",
+				LogoURL: " https://res.cloudinary.com/dycvts6vp/image/upload/v1740565904/media/braze.com_1740565903.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565804/media/braze.com_1740565802.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565849/media/braze.com_1740565848.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     true,
+			Read:      true,
+			Subscribe: false,
+			Write:     true,
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Instance ID",
+				},
+			},
+		},
+	})
+
 }

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -7,6 +7,7 @@ const (
 	BrazeEU Provider = "brazeEU"
 )
 
+// nolint: funlen
 func init() {
 	SetInfo(Braze, ProviderInfo{
 		DisplayName: "Braze",

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -1,9 +1,11 @@
 package providers
 
-const Braze Provider = "braze"
+const (
+	Braze Provider = "braze"
 
-// BrazeEU serves customers using braze's france data-center only, the rest should use Braze.
-const BrazeEU Provider = "brazeEU"
+	// BrazeEU serves customers using braze's france data-center only, the rest should use Braze.
+	BrazeEU Provider = "brazeEU"
+)
 
 func init() {
 	SetInfo(Braze, ProviderInfo{

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -45,6 +45,7 @@ func init() {
 				{
 					Name:        "workspace",
 					DisplayName: "Instance ID",
+					Prompt:      "Instance ID where your data is being hosted (ex: iad-01, au-01)",
 				},
 			},
 		},
@@ -89,6 +90,7 @@ func init() {
 				{
 					Name:        "workspace",
 					DisplayName: "Instance ID",
+					Prompt:      "Instance ID where your data is being hosted (ex: fra-01, fra-02)",
 				},
 			},
 		},

--- a/providers/braze.go
+++ b/providers/braze.go
@@ -1,18 +1,13 @@
 package providers
 
-const (
-	Braze Provider = "braze"
-
-	// BrazeEU serves customers using braze's france data-center only, the rest should use Braze.
-	BrazeEU Provider = "brazeEU"
-)
+const Braze Provider = "braze"
 
 // nolint: funlen
 func init() {
 	SetInfo(Braze, ProviderInfo{
 		DisplayName: "Braze",
 		AuthType:    ApiKey,
-		BaseURL:     "https://rest.{{.workspace}}.braze.com",
+		BaseURL:     "https://{{.workspace}}",
 		ApiKeyOpts: &ApiKeyOpts{
 			AttachmentType: Header,
 			Header: &ApiKeyOptsHeader{
@@ -47,56 +42,10 @@ func init() {
 			Input: []MetadataItemInput{
 				{
 					Name:        "workspace",
-					DisplayName: "Instance ID",
-					Prompt:      "Instance ID where your data is being hosted (ex: iad-01, au-01)",
+					DisplayName: "Rest Instance Endpoint",
+					Prompt:      "Rest Instance ID where your data is being hosted (ex: rest.iad-01.braze.com)",
 				},
 			},
 		},
 	})
-
-	SetInfo(BrazeEU, ProviderInfo{
-		DisplayName: "BrazeEU",
-		AuthType:    ApiKey,
-		BaseURL:     "https://rest.{{.workspace}}.braze.eu",
-		ApiKeyOpts: &ApiKeyOpts{
-			AttachmentType: Header,
-			Header: &ApiKeyOptsHeader{
-				Name:        "Authorization",
-				ValuePrefix: "Bearer ",
-			},
-			DocsURL: "https://www.braze.com/docs/api/basics/#creating-rest-api-keys",
-		},
-		Media: &Media{
-			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565804/media/braze.com_1740565802.png",
-				LogoURL: " https://res.cloudinary.com/dycvts6vp/image/upload/v1740565904/media/braze.com_1740565903.svg",
-			},
-			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565804/media/braze.com_1740565802.png",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1740565849/media/braze.com_1740565848.svg",
-			},
-		},
-		Support: Support{
-			BulkWrite: BulkWriteSupport{
-				Insert: false,
-				Update: false,
-				Upsert: false,
-				Delete: false,
-			},
-			Proxy:     true,
-			Read:      true,
-			Subscribe: false,
-			Write:     true,
-		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:        "workspace",
-					DisplayName: "Instance ID",
-					Prompt:      "Instance ID where your data is being hosted (ex: fra-01, fra-02)",
-				},
-			},
-		},
-	})
-
 }


### PR DESCRIPTION
- Braze have several regional data centers. The EU data center is unique as it uses `.eu` domain. The rest uses `.com`. 
- This lets the customer provide full base url domain.

Proxy Tests:
<img width="1320" height="680" alt="Screenshot 2026-02-11 at 10 45 49" src="https://github.com/user-attachments/assets/8fc273db-dc0b-42de-ba14-0c62c076b6a6" />


