### PR TITLE
[ENG-4138] [Attio] Restore event parsing methods

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -764,6 +764,10 @@ type FieldMetadata struct {
 	// True means the field must have a value, false means it is optional.
 	IsRequired *bool
 
+	// FieldId is the provider's unique identifier for this field.
+	// It is nil when the provider does not expose field identifiers.
+	FieldId *string //nolint:revive
+
 	// Values is a list of possible values for this field.
 	// It is applicable only if the type is either singleSelect or multiSelect, otherwise slice is nil.
 	Values []FieldValue

--- a/connectors.go
+++ b/connectors.go
@@ -241,6 +241,23 @@ type WebhookVerifierConnector interface {
 	) (bool, error)
 }
 
+// SubscriptionEventObjectNameConnector resolves the object name for a subscription
+// event whose payload identifies the object only by a provider type id rather than
+// a name (e.g. Attio record.* events carry an id.object_id, a per-workspace UUID).
+//
+// It exists because a plain SubscriptionEvent cannot resolve such an id on its own:
+// the mapping from type id to name is provider state that must be fetched (and may
+// be cached). Callers should prefer this method when a connector implements it, and
+// fall back to SubscriptionEvent.ObjectName() otherwise.
+type SubscriptionEventObjectNameConnector interface {
+	Connector
+
+	// GetObjectNameFromTypeId resolves the object name for the given subscription
+	// event by mapping the event's object type id to an object name, fetching from
+	// the provider (and caching) when necessary.
+	GetObjectNameFromTypeId(ctx context.Context, event common.SubscriptionEvent) (string, error)
+}
+
 // SubscribeConnector defines the interface for connectors that manage webhook subscriptions.
 //
 // Connectors implementing this interface are responsible for creating, updating, and deleting

--- a/providers/attio/connector.go
+++ b/providers/attio/connector.go
@@ -14,6 +14,11 @@ const (
 type Connector struct {
 	BaseURL string
 	Client  *common.JSONHTTPClient
+
+	// objectNameCache memoizes object_id -> api_slug lookups used by
+	// GetObjectNameFromTypeId. The connector is always used via *Connector, so the
+	// embedded lock is never copied.
+	objectNameCache objectNameCache
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {

--- a/providers/attio/metadata.go
+++ b/providers/attio/metadata.go
@@ -185,6 +185,7 @@ func (c *Connector) parseStandardOrCustomMetadata(
 			ValueType:    getFieldValueType(value.Type, value.IsMultiselect),
 			ProviderType: value.Type,
 			ReadOnly:     new(!value.IsWritable),
+			FieldId:      new(value.ID.AttributeID),
 			Values:       defaultValues,
 		}
 	}

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -195,6 +195,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "text",
 								ReadOnly:     new(true),
+								FieldId:      new("14447479-3006-4c0d-8855-61f3001c4990"),
 								Values:       nil,
 							},
 							"domains": {
@@ -202,6 +203,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "multiSelect",
 								ProviderType: "domain",
 								ReadOnly:     new(false),
+								FieldId:      new("c86ffb39-178e-48cd-a613-c125ee2f439f"),
 								Values:       nil,
 							},
 							"name": {
@@ -209,6 +211,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "text",
 								ReadOnly:     new(false),
+								FieldId:      new("3646a06e-28bb-444f-8335-1df342a4c1f4"),
 								Values:       nil,
 							},
 							"team": {
@@ -216,6 +219,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "multiSelect",
 								ProviderType: "record-reference",
 								ReadOnly:     new(false),
+								FieldId:      new("6ae72bca-9421-4fa8-bae2-19ced262607a"),
 								Values: common.FieldValues{
 									{
 										Value:        "d0be3734-3b4d-4094-9925-9dd906941197",
@@ -228,6 +232,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "datetime",
 								ProviderType: "timestamp",
 								ReadOnly:     new(true),
+								FieldId:      new("548a073b-c739-46c7-878a-91739a2fac9c"),
 								Values:       nil,
 							},
 							"created_by": {
@@ -235,6 +240,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "other",
 								ProviderType: "actor-reference",
 								ReadOnly:     new(true),
+								FieldId:      new("9a748587-a979-4682-9a35-5b97d2f6d478"),
 								Values:       nil,
 							},
 						},
@@ -242,6 +248,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							"record_id":  "record_id",
 							"domains":    "domains",
 							"name":       "name",
+							"team":       "team",
 							"created_at": "created_at",
 							"created_by": "created_by",
 						},
@@ -254,6 +261,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "text",
 								ReadOnly:     new(true),
+								FieldId:      new("06826311-cf4c-4c4b-a1fa-f14ce70d0004"),
 								Values:       nil,
 							},
 							"user_id": {
@@ -261,6 +269,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "text",
 								ReadOnly:     new(false),
+								FieldId:      new("529eea7a-2c2b-4d89-b2f7-acd3b3c6a719"),
 								Values:       nil,
 							},
 							"education": {
@@ -268,6 +277,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "multiSelect",
 								ProviderType: "select",
 								ReadOnly:     new(false),
+								FieldId:      new("89c07285-4d31-4fa7-9cbf-779c5f4debf1"),
 								Values: common.FieldValues{
 									{Value: "UG", DisplayValue: "UG"},
 									{Value: "PG", DisplayValue: "PG"},

--- a/providers/attio/record.go
+++ b/providers/attio/record.go
@@ -33,8 +33,10 @@ func (c *Connector) GetRecordsByIds( //nolint:revive
 		return nil, err
 	}
 
+	// Attio's list-records query expects a singular "filter" key.
+	// Ref: https://docs.attio.com/rest-api/guides/filtering-and-sorting
 	payload := map[string]any{
-		"filters": map[string]any{
+		"filter": map[string]any{
 			"record_id": map[string]any{
 				"$in": ids,
 			},

--- a/providers/attio/record_test.go
+++ b/providers/attio/record_test.go
@@ -40,8 +40,18 @@ func TestGetRecordByIds(t *testing.T) {
 
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.Path("/v2/objects/companies/records/query"),
-				Then:  mockserver.Response(http.StatusOK, responseGetRecordsByIds),
+				If: mockcond.And{
+					mockcond.Path("/v2/objects/companies/records/query"),
+					// Attio expects a singular "filter" key with record_id $in.
+					mockcond.Body(`{
+						"filter": {
+							"record_id": {
+								"$in": ["1bdb55e3-67f4-48d3-829b-45db3039a960", "3a95b53c-e7a1-4e53-a4e4-436f72283818"]
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseGetRecordsByIds),
 			}.Server(),
 
 			Expected: []common.ReadResultRow{

--- a/providers/attio/subscribe.go
+++ b/providers/attio/subscribe.go
@@ -9,7 +9,10 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-var _ connectors.SubscribeConnector = &Connector{}
+var (
+	_ connectors.SubscribeConnector                   = &Connector{}
+	_ connectors.SubscriptionEventObjectNameConnector = &Connector{}
+)
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
 	return &common.SubscribeParams{}
@@ -120,11 +123,11 @@ func (c *Connector) DeleteSubscription(
 		return fmt.Errorf("%w: subscription is empty", errMissingParams)
 	}
 
-	err := c.deleteSubscription(ctx, subscriptionData.Data.ID.WebhookID)
+	err := c.deleteSubscription(ctx, subscriptionData.Data.Id.WebhookId)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to delete subscription (ID: %s): %w",
-			subscriptionData.Data.ID.WebhookID,
+			"failed to delete subscription (id: %s): %w",
+			subscriptionData.Data.Id.WebhookId,
 			err,
 		)
 	}
@@ -135,7 +138,7 @@ func (c *Connector) DeleteSubscription(
 func (c *Connector) createSubscriptions(ctx context.Context,
 	payload *subscriptionPayload,
 	updater common.WriteMethod,
-) (*createSubscriptionsResponse, error) {
+) (*CreateSubscriptionsResponse, error) {
 	url, err := c.getSubscribeURL()
 	if err != nil {
 		return nil, err
@@ -146,7 +149,7 @@ func (c *Connector) createSubscriptions(ctx context.Context,
 		return nil, fmt.Errorf("failed to create subscription: %w", err)
 	}
 
-	result, err := common.UnmarshalJSON[createSubscriptionsResponse](resp)
+	result, err := common.UnmarshalJSON[CreateSubscriptionsResponse](resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal subscription response: %w", err)
 	}
@@ -172,7 +175,7 @@ func buildPayload(
 	standardObjects map[common.ObjectName]string,
 	webhookURL string,
 ) (*subscriptionPayload, error) {
-	subscriptions := make([]subscription, 0)
+	subscriptions := make([]Subscription, 0)
 
 	for objectName, events := range subscriptionEvents {
 		for _, event := range events.Events {

--- a/providers/attio/subscribe_test.go
+++ b/providers/attio/subscribe_test.go
@@ -170,15 +170,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
 						Status:    "active",
 						CreatedAt: "2026-01-30T10:06:11.304000000Z",
-						ID: createSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "c570dd25-5ded-44f6-b94a-84250956455d",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "c570dd25-5ded-44f6-b94a-84250956455d",
 						},
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.deleted",
 								Filter: map[string]any{
@@ -271,15 +271,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{
@@ -339,15 +339,15 @@ func TestDeleteSubscribe(t *testing.T) {
 			Name: "Unsubscribe successfully",
 			Input: common.SubscriptionResult{
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{

--- a/providers/attio/subscribe_test.go
+++ b/providers/attio/subscribe_test.go
@@ -65,7 +65,7 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 			}.Server(),
-			ExpectedErrs: []error{testutils.StringError("unsupported_object: object not found. Ensure it is activated in the workspace settings")},
+			ExpectedErrs: []error{errObjectNotFound},
 		},
 
 		{
@@ -104,16 +104,17 @@ func TestCreateSubscribe(t *testing.T) {
 				},
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator: func(serverURL string, actual, expected *common.SubscriptionResult) *testutils.CompareResult {
+			Comparator: func(_ string, actual, expected *common.SubscriptionResult) *testutils.CompareResult {
 				result := testutils.NewCompareResult()
 				if actual == nil {
-					result.AddDiff("actual is nil")
-				} else {
-					result.Assert("Status", common.SubscriptionStatusSuccess, actual.Status)
+					result.AddDiff("actual SubscriptionResult is nil")
+
+					return result
 				}
 
-				return result
+				result.Assert("Status", common.SubscriptionStatusSuccess, actual.Status)
 
+				return result
 			},
 		},
 
@@ -320,17 +321,14 @@ func TestCreateSubscribe(t *testing.T) {
 			result, err := conn.Subscribe(t.Context(), tt.Input)
 
 			tt.Validate(t, err, result)
-
 		})
 	}
-
 }
 
 func TestDeleteSubscribe(t *testing.T) {
 	t.Parallel()
 
 	tests := []testconn.TestCase[common.SubscriptionResult, error]{
-
 		{
 			Name:         "Unsubscribe with missing result data",
 			Server:       mockserver.Dummy(),
@@ -461,5 +459,4 @@ func TestValidationSubscriptionEvents(t *testing.T) {
 
 	err = validateSubscriptionEvents(supportedObjectEvents, standardObjects)
 	assert.NilError(t, err)
-
 }

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -5,7 +5,10 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"maps"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -18,6 +21,13 @@ type (
 	AttioVerificationParams struct {
 		Secret string
 	}
+)
+
+var (
+	_ common.SubscriptionEvent       = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent = SubscriptionEvent{}
+
+	errTypeMismatch = errors.New("type mismatch")
 )
 
 const (
@@ -61,6 +71,168 @@ func (c *Connector) VerifyWebhookMessage(
 	return true, nil
 }
 
+func (evt SubscriptionEvent) PreLoadData(data *common.SubscriptionEventPreLoadData) error {
+	return nil
+}
+
+func (evt SubscriptionEvent) UpdatedFields() ([]string, error) {
+	return nil, errors.New("attio webhooks do not provide updated field information") //nolint:err113
+}
+
+func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
+	return 0, errors.New("attio webhooks do not include event timestamps") //nolint:err113
+}
+
+func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
+	subTypeStr, err := evt.RawEventName()
+	if err != nil {
+		return common.SubscriptionEventTypeOther, fmt.Errorf("error getting raw event name: %w", err)
+	}
+
+	parts := strings.Split(subTypeStr, ".")
+	if len(parts) < 2 { //nolint:mnd
+		// this should never happen unless the provider changes subscription event format
+		return common.SubscriptionEventTypeOther, fmt.Errorf(
+			"%w: '%s'", errUnsupportedSubscriptionEvent, subTypeStr,
+		)
+	}
+
+	switch parts[1] {
+	case "created":
+		return common.SubscriptionEventTypeCreate, nil
+	case "updated":
+		return common.SubscriptionEventTypeUpdate, nil
+	case "deleted":
+		return common.SubscriptionEventTypeDelete, nil
+	default:
+		return common.SubscriptionEventTypeOther, nil
+	}
+}
+
+func (evt SubscriptionEvent) ObjectName() (string, error) {
+	m := evt.asMap()
+
+	events, err := m.Get("events")
+	if err != nil {
+		return "", err
+	}
+
+	eventsMap, ok := events.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
+	}
+
+	name, ok := eventsMap["event_type"].(string)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, name, eventsMap["event_type"])
+	}
+
+	objectName := strings.Split(name, ".")[0]
+
+	return objectName, nil
+}
+
+func (evt SubscriptionEvent) RawEventName() (string, error) {
+	m := evt.asMap()
+
+	events, err := m.Get("events")
+	if err != nil {
+		return "", err
+	}
+
+	eventsMap, ok := events.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
+	}
+
+	eventName, ok := eventsMap["event_type"].(string)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, eventName, eventsMap["event_type"])
+	}
+
+	return eventName, nil
+}
+
+func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(evt), nil
+}
+
+func (evt SubscriptionEvent) RecordId() (string, error) {
+	m := evt.asMap()
+
+	events, err := m.Get("events")
+	if err != nil {
+		return "", err
+	}
+
+	eventsMap, exist := events.(map[string]any)
+	if !exist {
+		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
+	}
+
+	idMap, exist := eventsMap["id"].(map[string]string)
+	if !exist {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, eventsMap["id"])
+	}
+
+	objectName, err := evt.ObjectName()
+	if err != nil {
+		return "", err
+	}
+
+	idKey := objectName + "_id"
+
+	id, ok := idMap[idKey]
+	if !ok {
+		return "", fmt.Errorf("idMap does not contain id %s", idKey) //nolint:err113
+	}
+
+	return id, nil
+}
+
+func (evt SubscriptionEvent) Workspace() (string, error) {
+	m := evt.asMap()
+
+	data, err := m.Get("events")
+	if err != nil {
+		return "", err
+	}
+
+	dataMap, exist := data.(map[string]any)
+	if !exist {
+		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, dataMap, data)
+	}
+
+	idMap, ok := dataMap["id"].(map[string]string)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, dataMap["id"])
+	}
+
+	id, ok := idMap["workspace_id"]
+	if !ok {
+		return "", fmt.Errorf("idMap does not contain id %s", "workspace_id") //nolint:err113
+	}
+
+	return id, nil
+}
+
+// asMap returns the event as a StringMap.
+func (evt SubscriptionEvent) asMap() common.StringMap {
+	// extract first event from events array
+	// Attio sends an array of events, but it only contains one event per webhook call.
+	// So we extract the first event for processing.
+	evtsArray, ok := evt["events"].([]any)
+	if ok && len(evtsArray) > 0 {
+		firstEvt, ok := evtsArray[0].(map[string]any)
+		if ok {
+			return common.StringMap(firstEvt)
+		}
+	}
+
+	// Fallback to returning the whole event if extraction fails
+	return common.StringMap(evt)
+}
+
 func computeSignature(secret string, body []byte) []byte {
 	h := hmac.New(sha256.New, []byte(secret))
 	h.Write(body)
@@ -68,24 +240,59 @@ func computeSignature(secret string, body []byte) []byte {
 	return h.Sum(nil)
 }
 
+// GetFieldNameFromObjectMetadata looks up a field's api_slug from metadata using the object_id and attribute_id.
+// It returns an error if the object or attribute is not found.
+func GetFieldNameFromObjectMetadata(
+	metadata *common.ListObjectMetadataResult,
+	objectID string,
+	attributeID string,
+) (string, error) {
+	obj, ok := metadata.Result[objectID]
+	if !ok {
+		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
+	}
+
+	for fieldName, field := range obj.Fields {
+		if field.FieldId != nil && *field.FieldId == attributeID {
+			return fieldName, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: attribute %q in object %q", common.ErrNotFound, attributeID, objectID)
+}
+
+// GetObjectNameFromObjectMetadata looks up an object's display name from metadata using the object_id.
+// It returns an error if the object is not found.
+func GetObjectNameFromObjectMetadata(
+	metadata *common.ListObjectMetadataResult,
+	objectID string,
+) (string, error) {
+	obj, ok := metadata.Result[objectID]
+	if !ok {
+		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
+	}
+
+	return obj.DisplayName, nil
+}
+
 // Example: Webhook response
 /*
 {
- "webhook_id": "04731154-70d3-42bb-8320-760304c9bbfd",
- "events": [
-   {
-     "event_type": "note.updated",
-     "id": {
-       "workspace_id": "e293215c-210a-4d4a-9913-e2b33da318ab",
-       "note_id": "f83d5cab-571b-47a8-8018-57146f848d19"
-     },
-     "parent_object_id": "ee1e6aa1-ec69-4ef4-a101-3a9abb12e281",
-     "parent_record_id": "9bcad14b-55a5-478d-963b-a4ec598265c6",
-     "actor": {
-       "type": "workspace-member",
-       "id": "f0519378-80b8-4d7c-8874-c6acc1850442"
-     }
-   }
- ]
+  "webhook_id": "04731154-70d3-42bb-8320-760304c9bbfd",
+  "events": [
+    {
+      "event_type": "note.updated",
+      "id": {
+        "workspace_id": "e293215c-210a-4d4a-9913-e2b33da318ab",
+        "note_id": "f83d5cab-571b-47a8-8018-57146f848d19"
+      },
+      "parent_object_id": "ee1e6aa1-ec69-4ef4-a101-3a9abb12e281",
+      "parent_record_id": "9bcad14b-55a5-478d-963b-a4ec598265c6",
+      "actor": {
+        "type": "workspace-member",
+        "id": "f0519378-80b8-4d7c-8874-c6acc1850442"
+      }
+    }
+  ]
 }
 */

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -24,8 +25,9 @@ type (
 )
 
 var (
-	_ common.SubscriptionEvent       = SubscriptionEvent{}
-	_ common.SubscriptionUpdateEvent = SubscriptionEvent{}
+	_ common.SubscriptionEvent          = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent    = SubscriptionEvent{}
+	_ common.CollapsedSubscriptionEvent = CollapsedSubscriptionEvent{}
 
 	errTypeMismatch = errors.New("type mismatch")
 )
@@ -76,7 +78,9 @@ func (evt SubscriptionEvent) PreLoadData(data *common.SubscriptionEventPreLoadDa
 }
 
 func (evt SubscriptionEvent) UpdatedFields() ([]string, error) {
-	return nil, errors.New("attio webhooks do not provide updated field information") //nolint:err113
+	// Attio webhooks do not provide updated field information, so we return an
+	// empty list without an error.
+	return []string{}, nil
 }
 
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
@@ -110,21 +114,9 @@ func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 }
 
 func (evt SubscriptionEvent) ObjectName() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	name, err := evt.RawEventName()
 	if err != nil {
 		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	name, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, name, eventsMap["event_type"])
 	}
 
 	objectName := strings.Split(name, ".")[0]
@@ -133,21 +125,13 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 }
 
 func (evt SubscriptionEvent) RawEventName() (string, error) {
-	m := evt.asMap()
+	// asMap returns the single event object ({event_type, id, ...}), so event_type
+	// is read directly off it.
+	event := evt.asMap()
 
-	events, err := m.Get("events")
-	if err != nil {
-		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
+	eventName, ok := event["event_type"].(string)
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	eventName, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, eventName, eventsMap["event_type"])
+		return "", fmt.Errorf("%w: expected string event_type, got %T", errTypeMismatch, event["event_type"])
 	}
 
 	return eventName, nil
@@ -157,80 +141,139 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 	return maps.Clone(evt), nil
 }
 
+// recordIDKeyByEventObject maps the object portion of an Attio webhook event_type
+// (the part before the ".", e.g. "note-content" in "note-content.updated") to the
+// key that holds the affected record's identifier inside the event "id" object.
+//
+// A naive objectName+"_id" is wrong for some events: note-content events carry a
+// "note_id" (not "note-content_id"), and workspace-member events carry a
+// "workspace_member_id" (underscore, not the hyphenated object name).
+//
+// Each mapping is confirmed against the concrete example "id" object in Attio's
+// webhook reference (source of truth: https://api.attio.com/openapi/webhooks):
+//
+//	record.*             id: {workspace_id, object_id, record_id}
+//	list.*               id: {workspace_id, list_id}
+//	task.*               id: {workspace_id, task_id}
+//	note.* / note-content id: {workspace_id, note_id}
+//	workspace-member.*   id: {workspace_id, workspace_member_id}
+//
+// Per-event reference pages live under
+// https://docs.attio.com/rest-api/webhook-reference (e.g. record-events/recordcreated,
+// note-content-events/note-contentupdated, workspace-member-events/workspace-membercreated).
+//
+//nolint:gochecknoglobals
+var recordIDKeyByEventObject = map[string]string{
+	"record":           "record_id",
+	"list":             "list_id",
+	"task":             "task_id",
+	"note":             "note_id",
+	"note-content":     "note_id",
+	"workspace-member": "workspace_member_id",
+}
+
 func (evt SubscriptionEvent) RecordId() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
 	}
 
-	eventsMap, exist := events.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	idMap, exist := eventsMap["id"].(map[string]string)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, eventsMap["id"])
-	}
-
-	objectName, err := evt.ObjectName()
+	eventName, err := evt.RawEventName()
 	if err != nil {
 		return "", err
 	}
 
-	idKey := objectName + "_id"
+	// event_type has the form "{object}.{action}"; the object portion determines
+	// which key inside the "id" object holds the record identifier.
+	eventObject := strings.Split(eventName, ".")[0]
 
-	id, ok := idMap[idKey]
+	idKey, ok := recordIDKeyByEventObject[eventObject]
 	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", idKey) //nolint:err113
+		return "", fmt.Errorf("%w: no record id key mapping for event %q", errTypeMismatch, eventName)
 	}
 
-	return id, nil
+	return lookupID(idMap, idKey)
 }
 
 func (evt SubscriptionEvent) Workspace() (string, error) {
-	m := evt.asMap()
-
-	data, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
 	}
 
-	dataMap, exist := data.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, dataMap, data)
+	return lookupID(idMap, "workspace_id")
+}
+
+// idMap returns the "id" object of the event as a map[string]any.
+// Attio's webhook id object holds the workspace_id and object-specific
+// identifiers (e.g. note_id, record_id).
+func (evt SubscriptionEvent) idMap() (map[string]any, error) {
+	event := evt.asMap()
+
+	idMap, ok := event["id"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected id to be map[string]any, got %T", errTypeMismatch, event["id"])
 	}
 
-	idMap, ok := dataMap["id"].(map[string]string)
+	return idMap, nil
+}
+
+// lookupID returns the string value stored under key in the event's id map.
+func lookupID(idMap map[string]any, key string) (string, error) {
+	value, ok := idMap[key]
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, dataMap["id"])
+		return "", fmt.Errorf("%w: id map does not contain %q", errTypeMismatch, key)
 	}
 
-	id, ok := idMap["workspace_id"]
+	id, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", "workspace_id") //nolint:err113
+		return "", fmt.Errorf("%w: expected %q to be string, got %T", errTypeMismatch, key, value)
 	}
 
 	return id, nil
 }
 
-// asMap returns the event as a StringMap.
+// asMap returns the single event as a StringMap. A SubscriptionEvent is one
+// event object ({event_type, id, actor}) produced by
+// CollapsedSubscriptionEvent.SubscriptionEventList, so no unwrapping is needed.
 func (evt SubscriptionEvent) asMap() common.StringMap {
-	// extract first event from events array
-	// Attio sends an array of events, but it only contains one event per webhook call.
-	// So we extract the first event for processing.
-	evtsArray, ok := evt["events"].([]any)
-	if ok && len(evtsArray) > 0 {
-		firstEvt, ok := evtsArray[0].(map[string]any)
-		if ok {
-			return common.StringMap(firstEvt)
-		}
+	return common.StringMap(evt)
+}
+
+// CollapsedSubscriptionEvent is the raw Attio webhook payload. Attio delivers a
+// top-level object with an "events" array; each element is an individual event.
+// Currently each delivery carries exactly one event, but the schema notes this
+// may change to support batching, so we fan out every element.
+// Ref: https://api.attio.com/openapi/webhooks
+type CollapsedSubscriptionEvent map[string]any
+
+// RawMap returns a copy of the raw payload.
+func (e CollapsedSubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(e), nil
+}
+
+// SubscriptionEventList fans the top-level "events" array out into one
+// SubscriptionEvent per event.
+func (e CollapsedSubscriptionEvent) SubscriptionEventList() ([]common.SubscriptionEvent, error) {
+	rawEvents, ok := e["events"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected events to be []any, got %T",
+			common.ErrSubscriptionEventList, e["events"])
 	}
 
-	// Fallback to returning the whole event if extraction fails
-	return common.StringMap(evt)
+	events := make([]common.SubscriptionEvent, 0, len(rawEvents))
+
+	for _, raw := range rawEvents {
+		eventMap, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: expected event to be map[string]any, got %T",
+				common.ErrSubscriptionEventList, raw)
+		}
+
+		events = append(events, SubscriptionEvent(eventMap))
+	}
+
+	return events, nil
 }
 
 func computeSignature(secret string, body []byte) []byte {
@@ -240,39 +283,100 @@ func computeSignature(secret string, body []byte) []byte {
 	return h.Sum(nil)
 }
 
-// GetFieldNameFromObjectMetadata looks up a field's api_slug from metadata using the object_id and attribute_id.
-// It returns an error if the object or attribute is not found.
-func GetFieldNameFromObjectMetadata(
-	metadata *common.ListObjectMetadataResult,
-	objectID string,
-	attributeID string,
-) (string, error) {
-	obj, ok := metadata.Result[objectID]
-	if !ok {
-		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
-	}
-
-	for fieldName, field := range obj.Fields {
-		if field.FieldId != nil && *field.FieldId == attributeID {
-			return fieldName, nil
-		}
-	}
-
-	return "", fmt.Errorf("%w: attribute %q in object %q", common.ErrNotFound, attributeID, objectID)
+// objectNameCache maps an Attio object_id to its object name (api_slug). It lives
+// on the Connector so a connector instance resolves the object list at most once
+// (and picks up newly created objects on a cache miss). It is safe for concurrent
+// use.
+type objectNameCache struct {
+	mu sync.RWMutex
+	m  map[string]string
 }
 
-// GetObjectNameFromObjectMetadata looks up an object's display name from metadata using the object_id.
-// It returns an error if the object is not found.
-func GetObjectNameFromObjectMetadata(
-	metadata *common.ListObjectMetadataResult,
-	objectID string,
-) (string, error) {
-	obj, ok := metadata.Result[objectID]
-	if !ok {
-		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
+func (o *objectNameCache) get(objectID string) (string, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	name, ok := o.m[objectID]
+
+	return name, ok
+}
+
+func (o *objectNameCache) store(idToName map[string]string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.m == nil {
+		o.m = make(map[string]string, len(idToName))
 	}
 
-	return obj.DisplayName, nil
+	maps.Copy(o.m, idToName)
+}
+
+// GetObjectNameFromTypeId resolves the object name for a subscription event.
+//
+// Standard and custom object changes arrive as generic record.* events that
+// identify the object only by its id.object_id (a per-workspace UUID). This maps
+// that id to the object's api_slug: it first checks the connector's object_id ->
+// name cache, and on a miss fetches the workspace's objects directly from
+// GET /v2/objects and caches the result.
+// Ref: https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects
+//
+// For core-object events (note, task, list, workspace-member) there is no
+// object_id — the object is already in the event_type — so ObjectName() is returned
+// without any lookup.
+func (c *Connector) GetObjectNameFromTypeId(
+	ctx context.Context, event common.SubscriptionEvent,
+) (string, error) {
+	attioEvent, isAttioEvent := event.(SubscriptionEvent)
+	if !isAttioEvent {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, SubscriptionEvent{}, event)
+	}
+
+	idMap, err := attioEvent.idMap()
+	if err != nil {
+		return "", err
+	}
+
+	objectID, ok := idMap["object_id"].(string)
+	if !ok {
+		// No object_id: a core-object event whose object is in the event_type.
+		return attioEvent.ObjectName()
+	}
+
+	if name, found := c.objectNameCache.get(objectID); found {
+		return name, nil
+	}
+
+	idToName, err := c.fetchObjectIdToName(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	c.objectNameCache.store(idToName)
+
+	name, found := idToName[objectID]
+	if !found {
+		return "", fmt.Errorf("%w: object type %q", common.ErrNotFound, objectID)
+	}
+
+	return name, nil
+}
+
+// fetchObjectIdToName fetches the workspace's objects directly and returns an
+// object_id -> api_slug map.
+// Ref: https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects
+func (c *Connector) fetchObjectIdToName(ctx context.Context) (map[string]string, error) {
+	objects, err := c.readStandardOrCustomObjectsList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list objects: %w", err)
+	}
+
+	idToName := make(map[string]string, len(objects))
+	for _, obj := range objects {
+		idToName[obj.Id.ObjectId] = obj.ApiSlug
+	}
+
+	return idToName, nil
 }
 
 // Example: Webhook response

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -1,29 +1,38 @@
 package attio
 
 import (
-	"errors"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-// newTestEvent creates a SubscriptionEvent for testing.
-// The "events" value is a map (not an array) so that asMap() falls back
-// to returning the raw SubscriptionEvent, which is what the methods expect
-// when they call m.Get("events").
+// newTestEvent creates a single SubscriptionEvent as produced by
+// CollapsedSubscriptionEvent.SubscriptionEventList: one event object holding the
+// event_type and an "id" object. The id values are stored as map[string]any
+// because that is what encoding/json produces when decoding a real webhook body.
 func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
-	inner := map[string]any{
+	event := SubscriptionEvent{
 		"event_type": eventType,
 	}
 
 	if idMap != nil {
-		inner["id"] = idMap
+		id := make(map[string]any, len(idMap))
+		for k, v := range idMap {
+			id[k] = v
+		}
+
+		event["id"] = id
 	}
 
-	return SubscriptionEvent{
-		"events": inner,
-	}
+	return event
 }
 
 func TestSubscriptionEvent_EventType(t *testing.T) {
@@ -56,7 +65,7 @@ func TestSubscriptionEvent_EventType(t *testing.T) {
 			expected: common.SubscriptionEventTypeOther,
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -111,7 +120,7 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 			expected: "record",
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -161,7 +170,7 @@ func TestSubscriptionEvent_RawEventName(t *testing.T) {
 			expected: "record.created",
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -201,12 +210,43 @@ func TestSubscriptionEvent_RecordId(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			name: "Extracts record ID using object name as key",
+			name: "note event uses note_id",
 			event: newTestEvent("note.updated", map[string]string{
 				"workspace_id": "ws-123",
 				"note_id":      "note-456",
 			}),
 			expected: "note-456",
+		},
+		{
+			// note-content events carry note_id, not "note-content_id".
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
+			name: "note-content event uses note_id",
+			event: newTestEvent("note-content.updated", map[string]string{
+				"workspace_id": "ws-123",
+				"note_id":      "note-789",
+			}),
+			expected: "note-789",
+		},
+		{
+			// workspace-member events carry workspace_member_id (underscore).
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
+			name: "workspace-member event uses workspace_member_id",
+			event: newTestEvent("workspace-member.created", map[string]string{
+				"workspace_id":        "ws-123",
+				"workspace_member_id": "wm-001",
+			}),
+			expected: "wm-001",
+		},
+		{
+			// record events carry record_id (alongside object_id).
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
+			name: "record event uses record_id",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-123",
+				"object_id":    "obj-1",
+				"record_id":    "rec-001",
+			}),
+			expected: "rec-001",
 		},
 		{
 			name: "Missing ID key for object",
@@ -216,7 +256,14 @@ func TestSubscriptionEvent_RecordId(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "Missing events key",
+			name: "Unmapped event object returns error",
+			event: newTestEvent("unknown-object.created", map[string]string{
+				"workspace_id": "ws-123",
+			}),
+			expectedErr: true,
+		},
+		{
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -271,7 +318,7 @@ func TestSubscriptionEvent_Workspace(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -327,9 +374,13 @@ func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
 
 	evt := newTestEvent("note.updated", nil)
 
-	_, err := evt.UpdatedFields()
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	fields, err := evt.UpdatedFields()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(fields) != 0 {
+		t.Fatalf("expected empty fields, got %v", fields)
 	}
 }
 
@@ -344,73 +395,111 @@ func TestSubscriptionEvent_EventTimeStampNano(t *testing.T) {
 	}
 }
 
-func TestGetFieldNameFromObjectMetadata(t *testing.T) {
+// TestCollapsedSubscriptionEvent_RealWebhookPayload decodes a real Attio webhook
+// body (via encoding/json, the way the server does), fans it out through
+// SubscriptionEventList, and verifies the parsing methods work end to end on the
+// resulting per-event SubscriptionEvents. It uses two events to also exercise the
+// array fan-out (batching), guarding against the events-array / id map[string]any
+// shape being mishandled.
+func TestCollapsedSubscriptionEvent_RealWebhookPayload(t *testing.T) {
 	t.Parallel()
 
-	metadata := &common.ListObjectMetadataResult{
-		Result: map[string]common.ObjectMetadata{
-			"obj-uuid-1": {
-				DisplayName: "Companies",
-				Fields: map[string]common.FieldMetadata{
-					"name": {
-						DisplayName: "name",
-						FieldId:     new("attr-uuid-1"),
-					},
-					"domains": {
-						DisplayName: "domains",
-						FieldId:     new("attr-uuid-2"),
-					},
-				},
+	body := []byte(`{
+		"webhook_id": "wh-1",
+		"events": [
+			{
+				"event_type": "note.updated",
+				"id": { "workspace_id": "ws-1", "note_id": "note-9" }
 			},
-			"obj-uuid-2": {
-				DisplayName: "People",
-				Fields: map[string]common.FieldMetadata{
-					"email": {
-						DisplayName: "email",
-						FieldId:     nil,
-					},
-				},
-			},
-		},
-		Errors: map[string]error{},
+			{
+				"event_type": "record.created",
+				"id": { "workspace_id": "ws-1", "object_id": "obj-1", "record_id": "rec-2" }
+			}
+		]
+	}`)
+
+	var collapsed CollapsedSubscriptionEvent
+	if err := json.Unmarshal(body, &collapsed); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
 	}
 
+	events, err := collapsed.SubscriptionEventList()
+	if err != nil {
+		t.Fatalf("SubscriptionEventList() error: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	cases := []struct {
+		eventType  common.SubscriptionEventType
+		objectName string
+		recordID   string
+	}{
+		{common.SubscriptionEventTypeUpdate, "note", "note-9"},
+		{common.SubscriptionEventTypeCreate, "record", "rec-2"},
+	}
+
+	for i, want := range cases {
+		evt := events[i]
+
+		eventType, err := evt.EventType()
+		if err != nil {
+			t.Fatalf("event %d EventType() error: %v", i, err)
+		}
+
+		if eventType != want.eventType {
+			t.Fatalf("event %d EventType() = %v, want %v", i, eventType, want.eventType)
+		}
+
+		objectName, err := evt.ObjectName()
+		if err != nil {
+			t.Fatalf("event %d ObjectName() error: %v", i, err)
+		}
+
+		if objectName != want.objectName {
+			t.Fatalf("event %d ObjectName() = %q, want %q", i, objectName, want.objectName)
+		}
+
+		recordID, err := evt.RecordId()
+		if err != nil {
+			t.Fatalf("event %d RecordId() error: %v", i, err)
+		}
+
+		if recordID != want.recordID {
+			t.Fatalf("event %d RecordId() = %q, want %q", i, recordID, want.recordID)
+		}
+
+		workspace, err := evt.Workspace()
+		if err != nil {
+			t.Fatalf("event %d Workspace() error: %v", i, err)
+		}
+
+		if workspace != "ws-1" {
+			t.Fatalf("event %d Workspace() = %q, want %q", i, workspace, "ws-1")
+		}
+	}
+}
+
+func TestCollapsedSubscriptionEvent_SubscriptionEventList_Errors(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name        string
-		objectID    string
-		attributeID string
-		expected    string
-		expectedErr error
+		name  string
+		event CollapsedSubscriptionEvent
 	}{
 		{
-			name:        "Found field by attribute ID",
-			objectID:    "obj-uuid-1",
-			attributeID: "attr-uuid-1",
-			expected:    "name",
+			name:  "missing events key",
+			event: CollapsedSubscriptionEvent{"webhook_id": "wh-1"},
 		},
 		{
-			name:        "Found second field by attribute ID",
-			objectID:    "obj-uuid-1",
-			attributeID: "attr-uuid-2",
-			expected:    "domains",
+			name:  "events is not an array",
+			event: CollapsedSubscriptionEvent{"events": map[string]any{"event_type": "note.updated"}},
 		},
 		{
-			name:        "Object not found",
-			objectID:    "unknown-obj",
-			attributeID: "attr-uuid-1",
-			expectedErr: common.ErrNotFound,
-		},
-		{
-			name:        "Attribute not found in object",
-			objectID:    "obj-uuid-1",
-			attributeID: "unknown-attr",
-			expectedErr: common.ErrNotFound,
-		},
-		{
-			name:        "Nil FieldId is skipped",
-			objectID:    "obj-uuid-2",
-			attributeID: "any-attr",
-			expectedErr: common.ErrNotFound,
+			name:  "event element is not an object",
+			event: CollapsedSubscriptionEvent{"events": []any{"not-an-object"}},
 		},
 	}
 
@@ -418,14 +507,74 @@ func TestGetFieldNameFromObjectMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := GetFieldNameFromObjectMetadata(metadata, tt.objectID, tt.attributeID)
-			if tt.expectedErr != nil {
-				if err == nil {
-					t.Fatalf("expected error %v, got nil", tt.expectedErr)
-				}
+			if _, err := tt.event.SubscriptionEventList(); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
 
-				if !errors.Is(err, tt.expectedErr) {
-					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
+func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
+	t.Parallel()
+
+	objectsResponse := testutils.DataFromFile(t, "objects.json")
+
+	server := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If:    mockcond.Path("/v2/objects"),
+		Then:  mockserver.Response(http.StatusOK, objectsResponse),
+	}.Server()
+	t.Cleanup(server.Close)
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("failed to construct test connector: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    string
+		expectedErr bool
+	}{
+		{
+			// record.* event: object_id resolved via GET /v2/objects.
+			name: "record event resolves object_id to api_slug",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "0e80364d-70b1-44d3-b7ba-0a6a564a7152",
+				"record_id":    "rec-1",
+			}),
+			expected: "people",
+		},
+		{
+			// core-object event: no object_id, falls back to ObjectName() (no fetch).
+			name: "core event falls back to event_type object",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-1",
+				"note_id":      "note-1",
+			}),
+			expected: "note",
+		},
+		{
+			name: "unknown object_id returns error",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "does-not-exist",
+				"record_id":    "rec-1",
+			}),
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := conn.GetObjectNameFromTypeId(t.Context(), tt.event)
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
 				}
 
 				return
@@ -442,68 +591,44 @@ func TestGetFieldNameFromObjectMetadata(t *testing.T) {
 	}
 }
 
-func TestGetObjectNameFromObjectMetadata(t *testing.T) {
+func TestConnector_GetObjectNameFromTypeId_CachesOnConnector(t *testing.T) {
 	t.Parallel()
 
-	metadata := &common.ListObjectMetadataResult{
-		Result: map[string]common.ObjectMetadata{
-			"obj-uuid-1": {
-				DisplayName: "Companies",
-			},
-			"obj-uuid-2": {
-				DisplayName: "People",
-			},
-		},
-		Errors: map[string]error{},
+	objectsResponse := testutils.DataFromFile(t, "objects.json")
+
+	var calls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/objects" {
+			atomic.AddInt32(&calls, 1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(objectsResponse)
+	}))
+	t.Cleanup(server.Close)
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("failed to construct test connector: %v", err)
 	}
 
-	tests := []struct {
-		name        string
-		objectID    string
-		expected    string
-		expectedErr error
-	}{
-		{
-			name:     "Found object display name",
-			objectID: "obj-uuid-1",
-			expected: "Companies",
-		},
-		{
-			name:     "Found second object display name",
-			objectID: "obj-uuid-2",
-			expected: "People",
-		},
-		{
-			name:        "Object not found",
-			objectID:    "unknown-obj",
-			expectedErr: common.ErrNotFound,
-		},
+	// The same connector caches the object list, so repeated resolutions fetch once.
+	for range 3 {
+		name, err := conn.GetObjectNameFromTypeId(t.Context(), newTestEvent("record.created", map[string]string{
+			"object_id": "bb3380d7-06a7-4948-9d62-3e735e782c5c",
+			"record_id": "rec-1",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if name != "companies" {
+			t.Fatalf("expected %q, got %q", "companies", name)
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result, err := GetObjectNameFromObjectMetadata(metadata, tt.objectID)
-			if tt.expectedErr != nil {
-				if err == nil {
-					t.Fatalf("expected error %v, got nil", tt.expectedErr)
-				}
-
-				if !errors.Is(err, tt.expectedErr) {
-					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if result != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, result)
-			}
-		})
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected objects to be fetched once with cache, got %d", got)
 	}
 }

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -1,0 +1,509 @@
+package attio
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// newTestEvent creates a SubscriptionEvent for testing.
+// The "events" value is a map (not an array) so that asMap() falls back
+// to returning the raw SubscriptionEvent, which is what the methods expect
+// when they call m.Get("events").
+func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
+	inner := map[string]any{
+		"event_type": eventType,
+	}
+
+	if idMap != nil {
+		inner["id"] = idMap
+	}
+
+	return SubscriptionEvent{
+		"events": inner,
+	}
+}
+
+func TestSubscriptionEvent_EventType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    common.SubscriptionEventType
+		expectedErr bool
+	}{
+		{
+			name:     "Created event",
+			event:    newTestEvent("record.created", nil),
+			expected: common.SubscriptionEventTypeCreate,
+		},
+		{
+			name:     "Updated event",
+			event:    newTestEvent("note.updated", nil),
+			expected: common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name:     "Deleted event",
+			event:    newTestEvent("record.deleted", nil),
+			expected: common.SubscriptionEventTypeDelete,
+		},
+		{
+			name:     "Unknown action maps to Other",
+			event:    newTestEvent("record.merged", nil),
+			expected: common.SubscriptionEventTypeOther,
+		},
+		{
+			name:        "Missing events key",
+			event:       SubscriptionEvent{},
+			expectedErr: true,
+		},
+		{
+			name:        "Single part event type",
+			event:       newTestEvent("invalid", nil),
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.EventType()
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSubscriptionEvent_ObjectName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:     "Extracts object name from event type",
+			event:    newTestEvent("note.updated", nil),
+			expected: "note",
+		},
+		{
+			name:     "Extracts record object name",
+			event:    newTestEvent("record.created", nil),
+			expected: "record",
+		},
+		{
+			name:        "Missing events key",
+			event:       SubscriptionEvent{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.ObjectName()
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSubscriptionEvent_RawEventName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:     "Returns full event type string",
+			event:    newTestEvent("note.updated", nil),
+			expected: "note.updated",
+		},
+		{
+			name:     "Returns created event type",
+			event:    newTestEvent("record.created", nil),
+			expected: "record.created",
+		},
+		{
+			name:        "Missing events key",
+			event:       SubscriptionEvent{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.RawEventName()
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSubscriptionEvent_RecordId(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name: "Extracts record ID using object name as key",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-123",
+				"note_id":      "note-456",
+			}),
+			expected: "note-456",
+		},
+		{
+			name: "Missing ID key for object",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-123",
+			}),
+			expectedErr: true,
+		},
+		{
+			name:        "Missing events key",
+			event:       SubscriptionEvent{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.RecordId()
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSubscriptionEvent_Workspace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name: "Extracts workspace ID",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-123",
+				"note_id":      "note-456",
+			}),
+			expected: "ws-123",
+		},
+		{
+			name: "Missing workspace_id",
+			event: newTestEvent("note.updated", map[string]string{
+				"note_id": "note-456",
+			}),
+			expectedErr: true,
+		},
+		{
+			name:        "Missing events key",
+			event:       SubscriptionEvent{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.Workspace()
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSubscriptionEvent_RawMap(t *testing.T) {
+	t.Parallel()
+
+	evt := newTestEvent("note.updated", nil)
+
+	result, err := evt.RawMap()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, map[string]any(evt)) {
+		t.Fatal("RawMap should return a copy of the event map")
+	}
+
+	// Verify it's a clone (modifying result doesn't affect original).
+	result["extra"] = "value"
+	if _, exists := evt["extra"]; exists {
+		t.Fatal("RawMap should return a clone, not the original")
+	}
+}
+
+func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
+	t.Parallel()
+
+	evt := newTestEvent("note.updated", nil)
+
+	_, err := evt.UpdatedFields()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestSubscriptionEvent_EventTimeStampNano(t *testing.T) {
+	t.Parallel()
+
+	evt := newTestEvent("note.updated", nil)
+
+	_, err := evt.EventTimeStampNano()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetFieldNameFromObjectMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata := &common.ListObjectMetadataResult{
+		Result: map[string]common.ObjectMetadata{
+			"obj-uuid-1": {
+				DisplayName: "Companies",
+				Fields: map[string]common.FieldMetadata{
+					"name": {
+						DisplayName: "name",
+						FieldId:     new("attr-uuid-1"),
+					},
+					"domains": {
+						DisplayName: "domains",
+						FieldId:     new("attr-uuid-2"),
+					},
+				},
+			},
+			"obj-uuid-2": {
+				DisplayName: "People",
+				Fields: map[string]common.FieldMetadata{
+					"email": {
+						DisplayName: "email",
+						FieldId:     nil,
+					},
+				},
+			},
+		},
+		Errors: map[string]error{},
+	}
+
+	tests := []struct {
+		name        string
+		objectID    string
+		attributeID string
+		expected    string
+		expectedErr error
+	}{
+		{
+			name:        "Found field by attribute ID",
+			objectID:    "obj-uuid-1",
+			attributeID: "attr-uuid-1",
+			expected:    "name",
+		},
+		{
+			name:        "Found second field by attribute ID",
+			objectID:    "obj-uuid-1",
+			attributeID: "attr-uuid-2",
+			expected:    "domains",
+		},
+		{
+			name:        "Object not found",
+			objectID:    "unknown-obj",
+			attributeID: "attr-uuid-1",
+			expectedErr: common.ErrNotFound,
+		},
+		{
+			name:        "Attribute not found in object",
+			objectID:    "obj-uuid-1",
+			attributeID: "unknown-attr",
+			expectedErr: common.ErrNotFound,
+		},
+		{
+			name:        "Nil FieldId is skipped",
+			objectID:    "obj-uuid-2",
+			attributeID: "any-attr",
+			expectedErr: common.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := GetFieldNameFromObjectMetadata(metadata, tt.objectID, tt.attributeID)
+			if tt.expectedErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil", tt.expectedErr)
+				}
+
+				if !errors.Is(err, tt.expectedErr) {
+					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetObjectNameFromObjectMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata := &common.ListObjectMetadataResult{
+		Result: map[string]common.ObjectMetadata{
+			"obj-uuid-1": {
+				DisplayName: "Companies",
+			},
+			"obj-uuid-2": {
+				DisplayName: "People",
+			},
+		},
+		Errors: map[string]error{},
+	}
+
+	tests := []struct {
+		name        string
+		objectID    string
+		expected    string
+		expectedErr error
+	}{
+		{
+			name:     "Found object display name",
+			objectID: "obj-uuid-1",
+			expected: "Companies",
+		},
+		{
+			name:     "Found second object display name",
+			objectID: "obj-uuid-2",
+			expected: "People",
+		},
+		{
+			name:        "Object not found",
+			objectID:    "unknown-obj",
+			expectedErr: common.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := GetObjectNameFromObjectMetadata(metadata, tt.objectID)
+			if tt.expectedErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil", tt.expectedErr)
+				}
+
+				if !errors.Is(err, tt.expectedErr) {
+					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/providers/attio/types.go
+++ b/providers/attio/types.go
@@ -38,10 +38,11 @@ type subscriptionPayload struct {
 
 type subscriptionData struct {
 	TargetURL     string         `json:"target_url"    validate:"required"`
-	Subscriptions []subscription `json:"subscriptions" validate:"required"`
+	Subscriptions []Subscription `json:"subscriptions" validate:"required"`
 }
 
-type subscription struct {
+// Subscription is a single webhook subscription entry (event type + optional filter).
+type Subscription struct {
 	EventType providerEvent `json:"event_type" validate:"required"`
 	// Filter is an object used to limit which webhook events are delivered.
 	// Filters can target specific records (by list_id, entry_id) or specific object (by object_id).
@@ -51,21 +52,24 @@ type subscription struct {
 	Filter any `json:"filter"`
 }
 
-// // createSubscriptionsResponse is the response returned by Attio when a webhook is created.
+// CreateSubscriptionsResponse is the response returned by Attio when a webhook is created.
 // Reference: https://docs.attio.com/rest-api/endpoint-reference/webhooks/create-a-webhook#response-data
-type createSubscriptionsResponse struct {
-	Data createSubscriptionsResponseData `json:"data"`
+type CreateSubscriptionsResponse struct {
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
-type createSubscriptionsResponseID struct {
-	WorkspaceID string `json:"workspace_id"`
-	WebhookID   string `json:"webhook_id"`
+// CreateSubscriptionsResponseId holds the workspace and webhook identifiers of a created webhook.
+type CreateSubscriptionsResponseId struct {
+	WorkspaceId string `json:"workspace_id"`
+	WebhookId   string `json:"webhook_id"`
 }
 
-type createSubscriptionsResponseData struct {
+// CreateSubscriptionsResponseData is the data payload of a created webhook subscription.
+// It is nested in common.SubscriptionResult.Result, so it is exported.
+type CreateSubscriptionsResponseData struct {
 	TargetURL     string                        `json:"target_url"`
-	Subscriptions []subscription                `json:"subscriptions" validate:"required"`
-	ID            createSubscriptionsResponseID `json:"id"`
+	Subscriptions []Subscription                `json:"subscriptions" validate:"required"`
+	Id            CreateSubscriptionsResponseId `json:"id"`
 	Status        string                        `json:"status"`
 	CreatedAt     string                        `json:"created_at"`
 	// Secret used for webhook signature verification.
@@ -76,13 +80,13 @@ type createSubscriptionsResponseData struct {
 
 // SuccessfulSubscription is used internally for rollback tracking.
 type SuccessfulSubscription struct {
-	ID         string
+	Id         string
 	ObjectName string
 	EventName  string
 }
 
 type SubscriptionResult struct {
-	Data createSubscriptionsResponseData `json:"data"`
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
 // providerEvent represents the combined event type string used by Attio.

--- a/providers/attio/utils.go
+++ b/providers/attio/utils.go
@@ -65,7 +65,7 @@ func buildSubscriptionPayloadForCoreObj(
 	objEvents objectEvents,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	providerEvents := objEvents.toProviderEvents(event)
 	if len(providerEvents) == 0 {
 		return nil, fmt.Errorf("%w: object '%s' with event '%s'",
@@ -73,7 +73,7 @@ func buildSubscriptionPayloadForCoreObj(
 	}
 
 	for _, e := range providerEvents {
-		sub = append(sub, subscription{
+		sub = append(sub, Subscription{
 			EventType: e,
 			Filter:    nil,
 		})
@@ -86,7 +86,7 @@ func buildSubscriptionPayloadForStandardObj(
 	standardObjects map[common.ObjectName]string,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	// Handle building subscriptions for standard/custom objects
 	objectId, exists := standardObjects[objectName]
 	if !exists {
@@ -112,7 +112,7 @@ func buildSubscriptionPayloadForStandardObj(
 		},
 	}
 	sub = append(sub,
-		subscription{
+		Subscription{
 			EventType: recordEvent,
 			Filter:    filter,
 		},


### PR DESCRIPTION
From the previous PR, some logics were unexpectedly removed, so this PR restores those event parsing logics.

Plus, this PR is adding logic to get objectnames and field names from the ObjectMetadata object because the event itself does not provide object names and updated field names. 