### PR TITLE
feat(components): Constructor with params

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
         - -ST1003 # Poorly chosen identifier.
         - -QF1002 # Convert untagged switch to tagged switch.
         - -QF1008 # Omit embedded fields from selector expression.
+        - -SA1019 # Using a deprecated function, variable, constant or field.
     # https://golangci-lint.run/docs/linters/configuration/#gosec
     gosec:
       excludes:

--- a/internal/components/connector.go
+++ b/internal/components/connector.go
@@ -15,6 +15,27 @@ var ErrSupportNotConfigured = errors.New("support not configured")
 // TODO: Convert this to a type alias for easier usage when we go to go1.24: https://go.dev/doc/go1.24#language
 type ConnectorConstructor[T any] func(*Connector) (*T, error)
 
+// ConnectorConstructorWithParams is a function type for creating a connector instance
+// by building on a base Connector.
+//
+// The base Connector represents a provider from the catalog (providers.ProviderInfo)
+// and includes any values that are inferred or bootstrapped. Specific connectors
+// can embed this base to extend its behavior.
+//
+// It receives:
+//   - params: connector initialization parameters (ConnectorParams)
+//   - base: the initialized Connector built from the provider info
+//
+// Returns the typed connector (*T) or an error.
+//
+// Example:
+//
+//	var myConstructor ConnectorConstructorWithParams[MyConnectorType] =
+//	    func(params common.ConnectorParams, base *Connector) (*MyConnectorType, error) {
+//	        // embed base and initialize MyConnectorType
+//	    }
+type ConnectorConstructorWithParams[T any] func(common.ConnectorParams, *Connector) (*T, error)
+
 // Connector provides a reusable base for API connectors, embedding Transport
 // and explicitly defining core methods (JSONHTTPClient, HTTPClient, Provider, String)
 // to avoid ambiguity when combined with interfaces that embed fmt.Stringer.
@@ -31,10 +52,25 @@ var (
 // Initialize initializes a connector with the given provider and parameters
 // by using Connector as a base type. It runs the constructor with the connector
 // and returns the connector as the specified T type.
+//
+// Deprecated: use Init.
 func Initialize[T any](
 	provider providers.Provider,
 	params common.ConnectorParams,
 	constructor ConnectorConstructor[T],
+) (conn *T, err error) {
+	return Init(provider, params, func(_ common.ConnectorParams, connector *Connector) (*T, error) {
+		return constructor(connector)
+	})
+}
+
+// Init initializes a connector with the given provider and parameters
+// by using Connector as a base type. It runs the constructor with the connector
+// and returns the connector as the specified T type.
+func Init[T any](
+	provider providers.Provider,
+	params common.ConnectorParams,
+	constructor ConnectorConstructorWithParams[T],
 ) (conn *T, err error) {
 	defer goutils.PanicRecovery(func(cause error) {
 		err = cause
@@ -51,7 +87,7 @@ func Initialize[T any](
 		return nil, err
 	}
 
-	conn, err = constructor(&Connector{
+	conn, err = constructor(params, &Connector{
 		Transport:     transport,
 		ProxyResolver: NewProxyResolver(transport.ProviderContext),
 	})


### PR DESCRIPTION
# Description

Connector constructors currently lack access to params, which forces verbose setup outside the constructor.
This PR allows constructors to receive params directly, making initialization simpler and more natural.

Before:
<img width="769" height="425" alt="image" src="https://github.com/user-attachments/assets/33851aa5-123f-4080-a4b9-9d20bda5968f" />

After:
<img width="883" height="322" alt="image" src="https://github.com/user-attachments/assets/c9508293-5af2-4683-8b65-b2fd82cfc5a0" />