### PR TITLE
tidy(atlassian): Jira module

### DIFF
--- a/providers/atlassian/internal/jira/adapter.go
+++ b/providers/atlassian/internal/jira/adapter.go
@@ -1,0 +1,40 @@
+package jira
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const apiVersion = "3"
+
+type Adapter struct {
+	*components.Connector
+}
+
+func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
+	return components.Init(providers.Atlassian, params, constructor)
+}
+
+func constructor(_ common.ConnectorParams, base *components.Connector) (*Adapter, error) {
+	adapter := &Adapter{
+		Connector: base,
+	}
+
+	adapter.SetErrorHandler(interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		HTML: &interpreter.DirectFaultyResponder{Callback: interpretHTMLError},
+	}.Handle)
+
+	return adapter, nil
+}
+
+// URL format for providers.ModuleAtlassianJira follows structure applicable to Oauth2 Atlassian apps:
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/#other-integrations
+func (a *Adapter) getModuleURL(path ...string) (*urlbuilder.URL, error) {
+	path = append([]string{apiVersion}, path...)
+
+	return urlbuilder.New(a.ModuleInfo().BaseURL, path...)
+}

--- a/providers/atlassian/internal/jira/delete.go
+++ b/providers/atlassian/internal/jira/delete.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"context"
@@ -7,12 +7,12 @@ import (
 )
 
 // Delete removes Jira issue.
-func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*common.DeleteResult, error) {
+func (a *Adapter) Delete(ctx context.Context, config common.DeleteParams) (*common.DeleteResult, error) {
 	if err := config.ValidateParams(); err != nil {
 		return nil, err
 	}
 
-	url, err := c.getModuleURL("issue")
+	url, err := a.getModuleURL("issue")
 	if err != nil {
 		return nil, err
 	}
@@ -20,7 +20,7 @@ func (c *Connector) Delete(ctx context.Context, config common.DeleteParams) (*co
 	url.AddPath(config.RecordId)
 
 	// 204 NoContent is expected
-	_, err = c.JSONHTTPClient().Delete(ctx, url.String())
+	_, err = a.JSONHTTPClient().Delete(ctx, url.String())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/atlassian/internal/jira/errors.go
+++ b/providers/atlassian/internal/jira/errors.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"bytes"
@@ -82,7 +82,7 @@ func (r ResponseStatusError) CombineErr(base error) error {
 	return fmt.Errorf("%w: %v - %v", base, r.Error, r.Message)
 }
 
-func (c *Connector) interpretHTMLError(res *http.Response, body []byte) error {
+func interpretHTMLError(res *http.Response, body []byte) error {
 	base := interpreter.DefaultStatusCodeMappingToErr(res, body)
 
 	document, err := goquery.NewDocumentFromReader(bytes.NewReader(body))

--- a/providers/atlassian/internal/jira/metadata.go
+++ b/providers/atlassian/internal/jira/metadata.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 // Supports only Issue object. Therefore, objectNames argument is ignored.
 // API Reference:
 // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-fields/#api-rest-api-2-field-get
-func (c *Connector) ListObjectMetadata(ctx context.Context, _ []string) (*common.ListObjectMetadataResult, error) {
-	url, err := c.getModuleURL("field")
+func (a *Adapter) ListObjectMetadata(ctx context.Context, _ []string) (*common.ListObjectMetadataResult, error) {
+	url, err := a.getModuleURL("field")
 	if err != nil {
 		return nil, err
 	}
 
-	rsp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	rsp, err := a.JSONHTTPClient().Get(ctx, url.String())
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (c *Connector) ListObjectMetadata(ctx context.Context, _ []string) (*common
 		return nil, errors.Join(ErrMissingMetadata, common.ErrEmptyJSONHTTPResponse)
 	}
 
-	fields, err := c.parseFieldsJiraIssue(body)
+	fields, err := a.parseFieldsJiraIssue(body)
 	if err != nil {
 		return nil, errors.Join(ErrParsingMetadata, err)
 	}

--- a/providers/atlassian/internal/jira/metadataFields.go
+++ b/providers/atlassian/internal/jira/metadataFields.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"errors"
@@ -13,7 +13,7 @@ var (
 )
 
 // Converts API response into the fields' registry.
-func (c *Connector) parseFieldsJiraIssue(node *ajson.Node) (map[string]string, error) {
+func (a *Adapter) parseFieldsJiraIssue(node *ajson.Node) (map[string]string, error) {
 	arr, err := node.GetArray()
 	if err != nil {
 		return nil, err

--- a/providers/atlassian/internal/jira/parse.go
+++ b/providers/atlassian/internal/jira/parse.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"errors"

--- a/providers/atlassian/internal/jira/read.go
+++ b/providers/atlassian/internal/jira/read.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"context"
@@ -27,7 +27,7 @@ type issueRequest struct {
 // * ObjectName - ignored.
 // * NextPage - to get next page which may have no elements left.
 // * Since - to scope the time frame, precision is in minutes.
-func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
+func (a *Adapter) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
 	if err := config.ValidateParams(true); err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 			"using Atlassian connector with unknown object", "objectName", config.ObjectName)
 	}
 
-	url, err := c.getSearchIssuesURL()
+	url, err := a.getSearchIssuesURL()
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 		reqBody.NextPageToken = config.NextPage.String()
 	}
 
-	resp, err := c.JSONHTTPClient().Post(ctx, url.String(), reqBody)
+	resp, err := a.JSONHTTPClient().Post(ctx, url.String(), reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common
 	)
 }
 
-func (c *Connector) getSearchIssuesURL() (*urlbuilder.URL, error) {
+func (a *Adapter) getSearchIssuesURL() (*urlbuilder.URL, error) {
 	// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post
-	return c.getModuleURL("search/jql")
+	return a.getModuleURL("search/jql")
 }

--- a/providers/atlassian/internal/jira/write.go
+++ b/providers/atlassian/internal/jira/write.go
@@ -1,4 +1,4 @@
-package atlassian
+package jira
 
 import (
 	"context"
@@ -13,12 +13,12 @@ import (
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
 // Update issue docs:
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put
-func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
+func (a *Adapter) Write(ctx context.Context, config common.WriteParams) (*common.WriteResult, error) {
 	if err := config.ValidateParams(); err != nil {
 		return nil, err
 	}
 
-	url, err := c.getModuleURL("issue")
+	url, err := a.getModuleURL("issue")
 	if err != nil {
 		return nil, err
 	}
@@ -27,10 +27,10 @@ func (c *Connector) Write(ctx context.Context, config common.WriteParams) (*comm
 	if len(config.RecordId) == 0 {
 		// writing to the entity without id means
 		// that we are extending 'List' resource and creating a new record
-		write = c.JSONHTTPClient().Post
+		write = a.JSONHTTPClient().Post
 	} else {
 		// only put is supported for updating 'Single' resource
-		write = c.JSONHTTPClient().Put
+		write = a.JSONHTTPClient().Put
 
 		url.AddPath(config.RecordId)
 	}

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/atlassian/internal/jira"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
@@ -34,8 +35,8 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Always: mockserver.ResponseString(http.StatusOK, `[]`),
 			}.Server(),
 			ExpectedErrs: []error{
-				ErrMissingMetadata,
-				ErrParsingMetadata,
+				jira.ErrMissingMetadata,
+				jira.ErrParsingMetadata,
 			},
 		},
 		{
@@ -45,7 +46,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, `[{}]`),
 			}.Server(),
-			ExpectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{jira.ErrParsingMetadata},
 		},
 		{
 			Name:  "Field response must have display name",
@@ -54,7 +55,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, `[{"id": "issuerestriction"}]`),
 			}.Server(),
-			ExpectedErrs: []error{ErrParsingMetadata},
+			ExpectedErrs: []error{jira.ErrParsingMetadata},
 		},
 		{
 			Name:  "Successfully describe Issue metadata",

--- a/test/atlassian/auth-metadata/main.go
+++ b/test/atlassian/auth-metadata/main.go
@@ -18,7 +18,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetAtlassianConnector(ctx)
+	conn := connTest.GetJiraConnector(ctx)
 
 	info, err := conn.GetPostAuthInfo(ctx)
 	if err != nil || info.CatalogVars == nil {

--- a/test/atlassian/connector.go
+++ b/test/atlassian/connector.go
@@ -17,7 +17,7 @@ var fieldCloudID = credscanning.Field{
 	SuffixENV: "CLOUD_ID",
 }
 
-func GetAtlassianConnector(ctx context.Context) *atlassian.Connector {
+func GetJiraConnector(ctx context.Context) *atlassian.Connector {
 	return makeAtlassianConnector(ctx, providers.ModuleAtlassianJira)
 }
 

--- a/test/atlassian/jira/metadata/main.go
+++ b/test/atlassian/jira/metadata/main.go
@@ -19,7 +19,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetAtlassianConnector(ctx)
+	conn := connTest.GetJiraConnector(ctx)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
 		"issue",

--- a/test/atlassian/jira/read/main.go
+++ b/test/atlassian/jira/read/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetAtlassianConnector(ctx)
+	conn := connTest.GetJiraConnector(ctx)
 
 	day := 24 * time.Hour
 

--- a/test/atlassian/jira/write-delete/main.go
+++ b/test/atlassian/jira/write-delete/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := connTest.GetAtlassianConnector(ctx)
+	conn := connTest.GetJiraConnector(ctx)
 
 	oldTitle := "The very new title of Jira issue"
 	newTitle := "Fix button dropdown in main menu"


### PR DESCRIPTION
# Description

Atlassian connector owns Jira adapter. This prepares the connector to switch between modules.

# Live Tests
 
### GetPostAuthInfo
<img width="1027" height="30" alt="image" src="https://github.com/user-attachments/assets/b221a1c6-132b-402d-93e7-a4ae0b71cb25" />

### ListObjectMetadata
<img width="457" height="202" alt="image" src="https://github.com/user-attachments/assets/c2b7b6e3-3f8d-4579-b615-5a672c8ccd40" />

### Read
<img width="344" height="160" alt="image" src="https://github.com/user-attachments/assets/8de38be7-4ffb-499b-807c-b627b7a1d829" />

### Write-Delete
<img width="328" height="911" alt="image" src="https://github.com/user-attachments/assets/3d34161d-a14c-4516-8af0-278ebac8d9d6" />

