### PR TITLE
[CON-2413] feat(Expensify): add Write

### DIFF
--- a/providers/expensify/metadata.go
+++ b/providers/expensify/metadata.go
@@ -33,25 +33,26 @@ func (c *Connector) ListObjectMetadata(ctx context.Context,
 	callbacks := make([]simultaneously.Job, 0, len(objectNames))
 
 	for _, object := range objectNames {
-
 		obj := object
+
 		callbacks = append(callbacks, func(ctx context.Context) error {
 			metadata, err := c.fetchObjectMetadata(ctx, obj)
 			if err != nil {
 				mutex.Lock()
+
 				metadataResult.Errors[obj] = err
 				mutex.Unlock()
+
 				return nil //nolint:nilerr // intentionally collecting errors in map, not failing fast
 			}
 
 			mutex.Lock()
+
 			metadataResult.Result[obj] = *metadata
 			mutex.Unlock()
 
 			return nil
-
 		})
-
 	}
 
 	// This will block until all callbacks are done.

--- a/providers/expensify/objects.go
+++ b/providers/expensify/objects.go
@@ -11,6 +11,7 @@ const (
 	objectNameExpenseRules = "expenseRules"
 )
 
+// ref: https://integrations.expensify.com/Integration-Server/doc/#read-get
 var supportedObjectsByRead = datautils.NewSet( //nolint:gochecknoglobals
 	objectNamePolicy,
 )
@@ -23,7 +24,7 @@ var readObjectResponseIdentifier = datautils.NewDefaultMap(map[string]string{ //
 	},
 )
 
-// Supported object names can be found under schemas.json.
+// ref; https://integrations.expensify.com/Integration-Server/doc/#create
 var supportedObjectsByWrite = datautils.NewSet( //nolint:gochecknoglobals
 	objectNamePolicy,
 	objectNameReport,

--- a/providers/expensify/objects.go
+++ b/providers/expensify/objects.go
@@ -4,10 +4,6 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 )
 
-// Some of the objects (allocations, goals, memberships, portfolios, tasks)
-// require us to pass either the team ID or the workspace.
-// although the API documentation doesn’t explicitly state that these fields are mandatory for fetching data, they are.
-
 const (
 	objectNamePolicy       = "policy"
 	objectNameReport       = "report"
@@ -15,7 +11,6 @@ const (
 	objectNameExpenseRules = "expenseRules"
 )
 
-// Supported object names can be found under schemas.json.
 var supportedObjectsByRead = datautils.NewSet( //nolint:gochecknoglobals
 	objectNamePolicy,
 )

--- a/providers/expensify/objects.go
+++ b/providers/expensify/objects.go
@@ -24,7 +24,7 @@ var readObjectResponseIdentifier = datautils.NewDefaultMap(map[string]string{ //
 	},
 )
 
-// ref; https://integrations.expensify.com/Integration-Server/doc/#create
+// ref: https://integrations.expensify.com/Integration-Server/doc/#create
 var supportedObjectsByWrite = datautils.NewSet( //nolint:gochecknoglobals
 	objectNamePolicy,
 	objectNameReport,

--- a/providers/expensify/objects.go
+++ b/providers/expensify/objects.go
@@ -9,7 +9,10 @@ import (
 // although the API documentation doesn’t explicitly state that these fields are mandatory for fetching data, they are.
 
 const (
-	objectNamePolicy = "policy"
+	objectNamePolicy       = "policy"
+	objectNameReport       = "report"
+	objectNameExpenses     = "expenses"
+	objectNameExpenseRules = "expenseRules"
 )
 
 // Supported object names can be found under schemas.json.
@@ -23,4 +26,12 @@ var readObjectResponseIdentifier = datautils.NewDefaultMap(map[string]string{ //
 	func(objectName string) string {
 		return objectName
 	},
+)
+
+// Supported object names can be found under schemas.json.
+var supportedObjectsByWrite = datautils.NewSet( //nolint:gochecknoglobals
+	objectNamePolicy,
+	objectNameReport,
+	objectNameExpenses,
+	objectNameExpenseRules,
 )

--- a/providers/expensify/test/write-policy.json
+++ b/providers/expensify/test/write-policy.json
@@ -1,0 +1,5 @@
+{
+  "policyID": "1A071BFDDFA06534",
+  "policyName": "My New Policy",
+  "responseCode": 200
+}

--- a/providers/expensify/test/write-report.json
+++ b/providers/expensify/test/write-report.json
@@ -1,0 +1,5 @@
+{
+  "reportID": "R005qyoxJjMV",
+  "reportName": "Name of the report",
+  "responseCode": 200
+}

--- a/providers/expensify/utils.go
+++ b/providers/expensify/utils.go
@@ -99,3 +99,18 @@ func buildReadBody(objectName string) (string, error) {
 
 	return string(jsonBody), nil
 }
+
+func buildWriteBody(data any) (string, error) {
+	body := map[string]any{
+		"type": "create",
+	}
+
+	body["inputSettings"] = data
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonBody), nil
+}

--- a/providers/expensify/write.go
+++ b/providers/expensify/write.go
@@ -25,14 +25,14 @@ func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*comm
 	//nolint:bodyclose
 	resp, err := c.executeRequest(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("error executing read request: %w", err)
+		return nil, fmt.Errorf("error executing write request: %w", err)
 	}
 
 	bodyBytes := common.GetResponseBodyOnce(resp)
 
 	var result map[string]any
 	if err = json.Unmarshal(bodyBytes, &result); err != nil {
-		return nil, fmt.Errorf("error parsing read response: %w", err)
+		return nil, fmt.Errorf("error parsing write response: %w", err)
 	}
 
 	// by default Expensify returns 200 status code even for errors,

--- a/providers/expensify/write.go
+++ b/providers/expensify/write.go
@@ -8,8 +8,6 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// Write implements the WriteConnector interface for Amplitude.
-// It handles both JSON and HTML/text responses from the API.
 func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
 	if err := params.ValidateParams(); err != nil {
 		return nil, err

--- a/providers/expensify/write.go
+++ b/providers/expensify/write.go
@@ -43,11 +43,14 @@ func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*comm
 		return nil, err
 	}
 
+	responseIdKey := params.ObjectName + "ID"
+
+	recordID, _ := result[responseIdKey].(string)
+
 	return &common.WriteResult{
 		Success:  true,
-		RecordId: "",
+		RecordId: recordID,
 		Errors:   nil,
 		Data:     result,
 	}, nil
-
 }

--- a/providers/expensify/write.go
+++ b/providers/expensify/write.go
@@ -1,0 +1,53 @@
+package expensify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// Write implements the WriteConnector interface for Amplitude.
+// It handles both JSON and HTML/text responses from the API.
+func (c *Connector) Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	if !supportedObjectsByWrite.Has(params.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	body, err := buildWriteBody(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:bodyclose
+	resp, err := c.executeRequest(ctx, body)
+	if err != nil {
+		return nil, fmt.Errorf("error executing read request: %w", err)
+	}
+
+	bodyBytes := common.GetResponseBodyOnce(resp)
+
+	var result map[string]any
+	if err = json.Unmarshal(bodyBytes, &result); err != nil {
+		return nil, fmt.Errorf("error parsing read response: %w", err)
+	}
+
+	// by default Expensify returns 200 status code even for errors,
+	//  so we need to check the response code in the body to determine if the request was successful or not
+	if err = checkResponseCode(result); err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: "",
+		Errors:   nil,
+		Data:     result,
+	}, nil
+
+}

--- a/providers/expensify/write_test.go
+++ b/providers/expensify/write_test.go
@@ -1,0 +1,120 @@
+package expensify
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	responsePolicy := testutils.DataFromFile(t, "write-policy.json")
+	responseReport := testutils.DataFromFile(t, "write-report.json")
+	responseAuthError := testutils.DataFromFile(t, "error-auth.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs data payload",
+			Input:        common.WriteParams{ObjectName: "policy"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name: "Unsupported object returns operation not supported error",
+			Input: common.WriteParams{
+				ObjectName: "invoices",
+				RecordData: map[string]any{"type": "invoice"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "API authentication error is propagated",
+			Input: common.WriteParams{
+				ObjectName: "policy",
+				RecordData: map[string]any{"type": "policy", "policyName": "Test"},
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusOK, responseAuthError),
+			}.Server(),
+			ExpectedErrs: []error{common.ErrRequestFailed},
+		},
+		{
+			Name: "Successfully create a policy",
+			Input: common.WriteParams{
+				ObjectName: "policy",
+				RecordData: map[string]any{
+					"type":       "policy",
+					"policyName": "My New Policy",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responsePolicy),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "1A071BFDDFA06534",
+				Errors:   nil,
+				Data: map[string]any{
+					"policyID":     "1A071BFDDFA06534",
+					"policyName":   "My New Policy",
+					"responseCode": float64(200),
+				},
+			},
+		},
+		{
+			Name: "Successfully create a report",
+			Input: common.WriteParams{
+				ObjectName: "report",
+				RecordData: map[string]any{
+					"type":     "report",
+					"policyID": "94C31405ED1893F1",
+					"report": map[string]any{
+						"title": "Name of the report",
+					},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPOST(),
+				Then:  mockserver.Response(http.StatusOK, responseReport),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "R005qyoxJjMV",
+				Errors:   nil,
+				Data: map[string]any{
+					"reportID":     "R005qyoxJjMV",
+					"reportName":   "Name of the report",
+					"responseCode": float64(200),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/expensify/write/main.go
+++ b/test/expensify/write/main.go
@@ -28,6 +28,11 @@ func run() error {
 		return err
 	}
 
+	err = testCreatingReport(ctx, conn)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -41,6 +46,46 @@ func testCreatingPolicty(ctx context.Context, conn *cc.Connector) error {
 	}
 
 	slog.Info("Creating new policy...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}
+
+func testCreatingReport(ctx context.Context, conn *cc.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "report",
+		RecordData: map[string]any{
+			"type":     "report",
+			"policyID": "94C31405ED1893F1",
+			"report": map[string]any{
+				"title": "Name of the report",
+			},
+			"employeeEmail": "dipu@withampersand.com",
+			"expenses": []map[string]any{
+				{
+					"date":     "2026-01-01",
+					"currency": "USD",
+					"merchant": "Name of merchant",
+					"amount":   1234,
+				},
+			},
+		},
+	}
+
+	slog.Info("Creating new report...")
 
 	res, err := conn.Write(ctx, params)
 	if err != nil {

--- a/test/expensify/write/main.go
+++ b/test/expensify/write/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	cc "github.com/amp-labs/connectors/providers/expensify"
+	"github.com/amp-labs/connectors/test/expensify"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	conn := expensify.GetConnector(ctx)
+
+	err := testCreatingPolicty(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testCreatingPolicty(ctx context.Context, conn *cc.Connector) error {
+	params := common.WriteParams{
+		ObjectName: "policy",
+		RecordData: map[string]any{
+			"type":       "policy",
+			"policyName": "My New Policy",
+		},
+	}
+
+	slog.Info("Creating new policy...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}

--- a/test/expensify/write/main.go
+++ b/test/expensify/write/main.go
@@ -23,7 +23,7 @@ func run() error {
 
 	conn := expensify.GetConnector(ctx)
 
-	err := testCreatingPolicty(ctx, conn)
+	err := testCreatingPolicy(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func run() error {
 	return nil
 }
 
-func testCreatingPolicty(ctx context.Context, conn *cc.Connector) error {
+func testCreatingPolicy(ctx context.Context, conn *cc.Connector) error {
 	params := common.WriteParams{
 		ObjectName: "policy",
 		RecordData: map[string]any{


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  
## Sample Write response 
```
    ~/Desktop/Ampersand/connectors    dipu/expensify-write *11  go run ./test/expensify/write                                                                                                                  ✔  system   11:32:04 PM  
2026/02/23 23:32:07 INFO Creating new policy...
{
  "success": true,
  "recordId": "02D88BBBFEE6EBED",
  "data": {
    "policyID": "02D88BBBFEE6EBED",
    "policyName": "My New Policy",
    "responseCode": 200
  }
}
2026/02/23 23:32:09 INFO Creating new report...
{
  "success": true,
  "recordId": "R00HKdQdAzza",
  "data": {
    "reportID": "R00HKdQdAzza",
    "reportName": "Name of the report",
    "responseCode": 200
  }
}
```
