### PR TITLE
[CON-2872] feat(Workday): Add Workday write and delete connector

### DIFF
--- a/providers/workday/connector.go
+++ b/providers/workday/connector.go
@@ -3,9 +3,11 @@ package workday
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/workday/metadata"
 )
@@ -14,6 +16,8 @@ type Connector struct {
 	*components.Connector
 	components.SchemaProvider
 	components.Reader
+	components.Writer
+	components.Deleter
 
 	// Require authenticated client
 	common.RequireAuthenticatedClient
@@ -53,6 +57,28 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  connector.interpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  connector.interpretError,
+		},
+	)
+
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
 			ErrorHandler:  connector.interpretError,
 		},
 	)

--- a/providers/workday/delete_test.go
+++ b/providers/workday/delete_test.go
@@ -1,0 +1,55 @@
+package workday
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop
+	t.Parallel()
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete object name must be included",
+			Input:        common.DeleteParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Delete worker successfully",
+			Input: common.DeleteParams{
+				ObjectName: "workers",
+				RecordId:   "3aa5550b7fe348b98d7b5741afc65534",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodDelete),
+					mockcond.Path("/ccx/api/v1/testTenant/workers/3aa5550b7fe348b98d7b5741afc65534"),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected: &common.DeleteResult{
+				Success: true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/workday/test/write/workers/create-response.json
+++ b/providers/workday/test/write/workers/create-response.json
@@ -1,0 +1,6 @@
+{
+  "id": "3aa5550b7fe348b98d7b5741afc65534",
+  "descriptor": "Logan McNeil",
+  "primaryWorkEmail": "lmcneil@workday.net",
+  "isManager": true
+}

--- a/providers/workday/test/write/workers/update-response.json
+++ b/providers/workday/test/write/workers/update-response.json
@@ -1,0 +1,6 @@
+{
+  "id": "3aa5550b7fe348b98d7b5741afc65534",
+  "descriptor": "Logan McNeil Updated",
+  "primaryWorkEmail": "lmcneil@workday.net",
+  "isManager": false
+}

--- a/providers/workday/write_test.go
+++ b/providers/workday/write_test.go
@@ -1,0 +1,121 @@
+package workday
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseCreate := testutils.DataFromFile(t, "write/workers/create-response.json")
+	responseUpdate := testutils.DataFromFile(t, "write/workers/update-response.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Input:        common.WriteParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Create worker successfully",
+			Input: common.WriteParams{
+				ObjectName: "workers",
+				RecordData: map[string]any{
+					"descriptor":       "Logan McNeil",
+					"primaryWorkEmail": "lmcneil@workday.net",
+					"isManager":        true,
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Path("/ccx/api/v1/testTenant/workers"),
+				},
+				Then: mockserver.Response(http.StatusCreated, responseCreate),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "3aa5550b7fe348b98d7b5741afc65534",
+				Data: map[string]any{
+					"id":               "3aa5550b7fe348b98d7b5741afc65534",
+					"descriptor":       "Logan McNeil",
+					"primaryWorkEmail": "lmcneil@workday.net",
+					"isManager":        true,
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update worker successfully",
+			Input: common.WriteParams{
+				ObjectName: "workers",
+				RecordId:   "3aa5550b7fe348b98d7b5741afc65534",
+				RecordData: map[string]any{
+					"descriptor": "Logan McNeil Updated",
+					"isManager":  false,
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPatch),
+					mockcond.Path("/ccx/api/v1/testTenant/workers/3aa5550b7fe348b98d7b5741afc65534"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseUpdate),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "3aa5550b7fe348b98d7b5741afc65534",
+				Data: map[string]any{
+					"id":               "3aa5550b7fe348b98d7b5741afc65534",
+					"descriptor":       "Logan McNeil Updated",
+					"primaryWorkEmail": "lmcneil@workday.net",
+					"isManager":        false,
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Write with empty response body",
+			Input: common.WriteParams{
+				ObjectName: "workers",
+				RecordData: map[string]any{
+					"descriptor": "Test Worker",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Path("/ccx/api/v1/testTenant/workers"),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success: true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/workday/delete/main.go
+++ b/test/workday/delete/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils"
+	connTest "github.com/amp-labs/connectors/test/workday"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetWorkdayConnector(ctx)
+
+	result, err := conn.Delete(ctx, connectors.DeleteParams{
+		ObjectName: "workers",
+		RecordId:   "3aa5550b7fe348b98d7b5741afc65534",
+	})
+	if err != nil {
+		utils.Fail("error deleting from workday", "error", err)
+	}
+
+	fmt.Println("workday delete result...")
+	utils.DumpJSON(result, os.Stdout)
+}

--- a/test/workday/write/main.go
+++ b/test/workday/write/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/test/utils"
+	connTest "github.com/amp-labs/connectors/test/workday"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetWorkdayConnector(ctx)
+
+	result, err := conn.Write(ctx, connectors.WriteParams{
+		ObjectName: "workers",
+		RecordData: map[string]any{
+			"descriptor":       "Test Worker",
+			"primaryWorkEmail": "test@workday.net",
+		},
+	})
+	if err != nil {
+		utils.Fail("error writing to workday", "error", err)
+	}
+
+	fmt.Println("workday write result...")
+	utils.DumpJSON(result, os.Stdout)
+}


### PR DESCRIPTION
## Installation                                                                                                                                                              
  Workday using OAuth2.                                                                                                                                                        
                                                                                                                                                                               
  ## Conventions                                                                                                                                                               
  - [x] Connector uses `internal/components`
  - [x] Metadata uses V2 metadata format
  - [x] Read supports pagination
  - [x] Raw response is returned as is for **READ & METADATA**, no formatting or flattening is performed.
  - [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
  - [x] Provider errors are mapped if non-standard (404 → `ErrNotFound`)
  - [ ] Custom fields, if not human readable names, are resolved to readable names.
  - [x] Unit tests cover read/write/delete/metadata logic (placed in /providers/workday)
  - [x] Appropriate object names are used. Objects need to be resources, not actions (`workers` and not `workers.list`).
  - [ ] Modules are only being added because:
     - [ ] They share the same authentication scheme
     - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
     - [ ] Different base URLs
     - [ ] Object name collisions

  ## Write
  ### Unit Tests
<img width="1190" height="437" alt="Screenshot 2026-02-25 at 11 45 56 PM" src="https://github.com/user-attachments/assets/867e7e1a-22ab-4849-88e0-97c4bc2a0c98" />

  ### Live Tests
Live tests will be performed after getting the credentials.
  ## Delete
  ### Unit Tests
<img width="1190" height="316" alt="Screenshot 2026-02-25 at 11 46 22 PM" src="https://github.com/user-attachments/assets/6cc7756c-6a35-4d33-95ce-9fa8d0b2bf80" />

  ### Live Tests
Live tests will be performed after getting the credentials.