### PR TITLE
feat(pipeliner): Add incremental reading

### DIFF
--- a/providers/netsuite.go
+++ b/providers/netsuite.go
@@ -91,11 +91,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},

--- a/providers/netsuiteM2M.go
+++ b/providers/netsuiteM2M.go
@@ -103,11 +103,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},

--- a/providers/pipeliner/handlers.go
+++ b/providers/pipeliner/handlers.go
@@ -6,16 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
 )
 
 // DefaultPageSize is number of elements per page.
-const DefaultPageSize = 100
+const DefaultPageSize = "100"
 
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
 	url, err := c.buildReadURL(params)
@@ -45,17 +47,40 @@ func getNextRecordsURL(node *ajson.Node) (string, error) {
 	return jsonquery.New(node, "page_info").StrWithDefault("end_cursor", "")
 }
 
-func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, error) {
-	url, err := c.getReadURL(config.ObjectName)
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	url, err := c.getReadURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	url.WithQueryParam("first", strconv.Itoa(DefaultPageSize))
+	url.WithQueryParam("first", readhelper.PageSizeWithDefaultStr(params, DefaultPageSize))
 
-	if len(config.NextPage) != 0 {
+	if len(params.NextPage) != 0 {
 		// Next page
-		url.WithQueryParam("after", config.NextPage.String())
+		url.WithQueryParam("after", params.NextPage.String())
+	}
+
+	// Filter by time window (_since / _until) according to PipelineR API docs:
+	// https://developers.pipelinersales.com/api-docs/core-api-concepts/api-parameters#filter-filter-op
+	//
+	// The API supports only one filter operator at a time,
+	// so we prioritize `since` (gte) over `until` (lte) when both are not provided.
+	hasSince := !params.Since.IsZero()
+	hasUntil := !params.Until.IsZero()
+
+	hasTimeWindow := hasSince || hasUntil
+	if hasTimeWindow && supportsFilterByTime(params.ObjectName) {
+		// Prioritize `since` over `until`.
+		operator := "gte"
+		if !hasSince {
+			operator = "lte" // Until is not empty.
+		}
+
+		url.WithQueryParam("order-by", "-modified")
+		url.WithQueryParam("filter-op[modified]", operator)
+
+		timestamp := datautils.Time.FormatRFC3339inUTC(params.Since)
+		url.WithQueryParam("filter[modified]", timestamp)
 	}
 
 	return url, nil
@@ -149,4 +174,15 @@ func (c *Connector) parseDeleteResponse(ctx context.Context, params common.Delet
 	return &common.DeleteResult{
 		Success: true,
 	}, nil
+}
+
+// Almost all object support filtering by modified field.
+// There are a select few that have no usable timestamp field.
+func supportsFilterByTime(objectName string) bool {
+	switch strings.ToLower(objectName) {
+	case "activities", "leadoppties", "types":
+		return false
+	default:
+		return true
+	}
 }

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -3,6 +3,7 @@ package pipeliner
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -85,11 +86,24 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: nil,
 		},
 		{
-			Name:  "Next page URL is inferred, when provided with an object",
-			Input: common.ReadParams{ObjectName: "Profiles", Fields: connectors.Fields("id")},
-			Server: mockserver.Fixed{
-				Setup:  mockserver.ContentJSON(),
-				Always: mockserver.Response(http.StatusOK, responseProfilesFirstPage),
+			Name: "Next page URL is inferred, when provided with an object",
+			Input: common.ReadParams{
+				ObjectName: "Profiles",
+				Fields:     connectors.Fields("id"),
+				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
+					time.FixedZone("UTC-8", -8*60*60)),
+				PageSize: 77,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/api/v100/rest/spaces/test-workspace/entities/Profiles"),
+					mockcond.QueryParam("first", "77"),
+					mockcond.QueryParam("order-by", "-modified"),
+					mockcond.QueryParam("filter-op[modified]", "gte"),
+					mockcond.QueryParam("filter[modified]", "2024-09-19T12:30:45Z"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseProfilesFirstPage),
 			}.Server(),
 			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{

--- a/test/pipeliner/read/main.go
+++ b/test/pipeliner/read/main.go
@@ -26,6 +26,7 @@ func main() {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "Contacts",
 		Fields:     connectors.Fields("id", "formatted_name", "account_position"),
+		Since:      utils.Timestamp("2026-02-20T00:13:56.718423+00:00"),
 	})
 	if err != nil {
 		utils.Fail("error reading from Pipeliner", "error", err)


### PR DESCRIPTION
# Live Tests
Read contacts since some timestamp:
<img width="416" height="597" alt="image" src="https://github.com/user-attachments/assets/7520c924-3b17-49ae-9dfe-3e829a579035" />

<img width="389" height="25" alt="image" src="https://github.com/user-attachments/assets/61078d12-c8e6-47dd-a173-a1ac1beab302" />

Newest records are returned first due to the sort query param. A portion of all existing records is return later than the since timestamp:
<img width="456" height="119" alt="image" src="https://github.com/user-attachments/assets/3f86178f-b017-4103-b5a1-720297385575" />
