### PR TITLE
[CON-3028] feat(connectWise): Read

### DIFF
--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -2,29 +2,80 @@ package connectwise
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
 )
 
+const apiVersion = "v4_6_release/apis/3.0"
+
 type Connector struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
+	common.RequireMetadata
 
 	components.SchemaProvider
+	components.Reader
+
+	clientID string
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.ConnectWise, params, constructor)
+	connector, err := components.Initialize(providers.ConnectWise, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	connector.clientID = params.Metadata["clientId"]
+
+	return connector, nil
 }
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
+		RequireMetadata: common.RequireMetadata{
+			ExpectedMetadataKeys: []string{"clientId"},
+		},
 	}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		common.ModuleRoot,
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
 	return connector, nil
+}
+
+func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
+	objectPath, err := metadata.Schemas.FindURLPath(common.ModuleRoot, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(c.ModuleInfo().BaseURL, apiVersion, objectPath)
+}
+
+func (c *Connector) clientIdHeader() common.Header {
+	return common.Header{
+		Key:   "ClientId",
+		Value: c.clientID,
+	}
 }

--- a/providers/connectwise/errors.go
+++ b/providers/connectwise/errors.go
@@ -1,0 +1,26 @@
+package connectwise
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+// ResponseError
+// nolint:tagliatelle
+type ResponseError struct {
+	Message string `json:"message"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	return fmt.Errorf("%w: %v", base, r.Message)
+}

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -96,6 +96,9 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			AuthenticatedClient: mockutils.NewClient(),
+			Metadata: map[string]string{
+				"clientId": "dummy",
+			},
 		},
 	)
 	if err != nil {
@@ -103,7 +106,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	}
 
 	// for testing we want to redirect calls to our mock server
-	connector.SetUnitTestBaseURL(mockutils.ReplaceURLOrigin(connector.ModuleInfo().BaseURL, serverURL))
+	connector.SetUnitTestMockServerBaseURL(serverURL)
 
 	return connector, nil
 }

--- a/providers/connectwise/read.go
+++ b/providers/connectwise/read.go
@@ -1,0 +1,92 @@
+package connectwise
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/httpkit"
+	"github.com/spyzhov/ajson"
+)
+
+const defaultPageSize = "1000"
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := c.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.clientIdHeader().ApplyToRequest(req)
+
+	return req, nil
+}
+
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if params.NextPage != "" {
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	url, err := c.getURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("pageSize", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+	if conditions, ok := makeReadCondition(params); ok {
+		url.WithQueryParam("conditions", conditions)
+	}
+
+	return url, nil
+}
+
+// All objects react to the LastUpdated query even if no such field exists in the object format.
+func makeReadCondition(params common.ReadParams) (string, bool) {
+	conditions := make([]string, 0)
+
+	if !params.Since.IsZero() {
+		// Example:
+		// 	LastUpdated = [2016-08-20T18:04:26Z]
+		condition := fmt.Sprintf("LastUpdated >= [%v]", datautils.Time.FormatRFC3339inUTC(params.Since))
+		conditions = append(conditions, condition)
+	}
+
+	if !params.Until.IsZero() {
+		condition := fmt.Sprintf("LastUpdated <= [%v]", datautils.Time.FormatRFC3339inUTC(params.Until))
+		conditions = append(conditions, condition)
+	}
+
+	return strings.Join(conditions, " AND "), true
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	return common.ParseResult(resp,
+		// "" is used, because root level of JSON is right away an array.
+		common.ExtractRecordsFromPath(""),
+		nextRecordsURL(resp),
+		readhelper.MakeGetMarshaledDataWithId(readhelper.IdFieldQuery{Field: "id"}),
+		params.Fields,
+	)
+}
+
+func nextRecordsURL(resp *common.JSONHTTPResponse) common.NextPageFunc {
+	return func(n *ajson.Node) (string, error) {
+		return httpkit.HeaderLink(resp, "next"), nil
+	}
+}

--- a/providers/connectwise/read_test.go
+++ b/providers/connectwise/read_test.go
@@ -1,0 +1,190 @@
+package connectwise
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	errorNotFound := testutils.DataFromFile(t, "read/not-found.json")
+	responseContacts := testutils.DataFromFile(t, "read/contacts.json")
+	responseCampaignsFirstPage := []byte(`[{"name": "Weekly Update #33", "id": 123}]`)
+	responseExportsEmpty := []byte(`[]`)
+
+	nextPageRaw := common.NextPageToken("https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
+	linkHeaderRaw := "<" + nextPageRaw.String() + ">; rel=\"next\""
+	nextPageRelative := common.NextPageToken(testroutines.URLTestServer + "/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "messages"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:  "Error response page not found",
+			Input: common.ReadParams{ObjectName: "messages", Fields: connectors.Fields("id")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound, errorNotFound),
+			}.Server(),
+			ExpectedErrs: []error{
+				testutils.StringError("cannot resolve URL path for given object name"),
+			},
+		},
+		{
+			Name: "Campaigns first page has a link to next",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v4_6_release/apis/3.0/marketing/campaigns"),
+				Then: mockserver.ResponseChainedFuncs(
+					mockserver.Header("Link", linkHeaderRaw),
+					mockserver.Response(http.StatusOK, responseCampaignsFirstPage),
+				),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"name": "Weekly Update #33",
+					},
+					Raw: map[string]any{
+						"name": "Weekly Update #33",
+						"id":   float64(123),
+					},
+				}},
+				NextPage: nextPageRaw,
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read campaigns empty page",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v4_6_release/apis/3.0/marketing/campaigns"),
+				Then:  mockserver.ResponseString(http.StatusOK, `[]`),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read empty exports with null array",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v4_6_release/apis/3.0/marketing/campaigns"),
+				Then:  mockserver.Response(http.StatusOK, responseExportsEmpty),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Contacts first page has a link to next",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("firstName", "lastName"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v4_6_release/apis/3.0/company/contacts"),
+				Then: mockserver.ResponseChainedFuncs(
+					mockserver.Header("Link", linkHeaderRaw),
+					mockserver.Response(http.StatusOK, responseContacts),
+				),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"firstname": "Alex",
+						"lastname":  "Morgan",
+					},
+					Raw: map[string]any{
+						"id":        float64(31045),
+						"firstName": "Alex",
+						"lastName":  "Morgan",
+					},
+				}},
+				NextPage: nextPageRaw,
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Contacts next page consumption",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("firstName", "lastName"),
+				NextPage:   nextPageRelative,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/v4_6_release/apis/3.0/company/contacts/"),
+					mockcond.QueryParam("pageSize", "2"),
+					mockcond.QueryParam("page", "2"),
+					mockcond.QueryParam("conditions", "LastUpdated >= [2025-04-01T20:02:28Z]"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"firstname": "Alex",
+						"lastname":  "Morgan",
+					},
+					Raw: map[string]any{
+						"title": "Operations Manager",
+					},
+					Id: "31045",
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/connectwise/test/read/contacts.json
+++ b/providers/connectwise/test/read/contacts.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 31045,
+    "firstName": "Alex",
+    "lastName": "Morgan",
+    "company": {
+      "id": 20481,
+      "identifier": "ACME_CORP",
+      "name": "Acme Corporation",
+      "_info": {}
+    },
+    "site": {},
+    "inactiveFlag": false,
+    "title": "Operations Manager",
+    "marriedFlag": false,
+    "childrenFlag": true,
+    "portalSecurityLevel": 2,
+    "disablePortalLoginFlag": false,
+    "unsubscribeFlag": false,
+    "mobileGuid": "7f3a2c11-9b6e-4d5a-a9c2-1e8f7b2c4d90",
+    "defaultPhoneType": "Mobile",
+    "defaultPhoneNbr": "5558675309",
+    "defaultBillingFlag": false,
+    "defaultFlag": true,
+    "companyLocation": {},
+    "types": [],
+    "customFields": [
+      {
+        "id": 21,
+        "caption": "external_contact_id",
+        "type": "Number",
+        "entryMethod": "EntryField",
+        "numberOfDecimals": 0,
+        "value": null,
+        "connectWiseId": "c1a9f4e2-3d7b-4c6e-91fa-2b7e9c8d1234",
+        "rowNum": 1,
+        "userDefinedFieldRecId": 21,
+        "podId": "contact_overview"
+      },
+      {
+        "id": 22,
+        "caption": "sync_status",
+        "type": "Text",
+        "entryMethod": "List",
+        "numberOfDecimals": 0,
+        "value": "pending",
+        "connectWiseId": "a8d5c2f9-6b44-4e2d-8c1f-5d3a7b9e5678",
+        "rowNum": 1,
+        "userDefinedFieldRecId": 22,
+        "podId": "contact_detail"
+      }
+    ],
+    "ignoreDuplicates": false,
+    "_info": {}
+  }
+]

--- a/providers/connectwise/test/read/not-found.json
+++ b/providers/connectwise/test/read/not-found.json
@@ -1,0 +1,4 @@
+{
+  "code": "ConnectWiseApi",
+  "message": "The endpoint does not exist."
+}

--- a/test/connectWise/connector.go
+++ b/test/connectWise/connector.go
@@ -10,12 +10,21 @@ import (
 	"github.com/amp-labs/connectors/test/utils"
 )
 
+var clientIdField = credscanning.Field{
+	Name:      "clientId",
+	PathJSON:  "metadata.clientId",
+	SuffixENV: "CLIENT_ID",
+}
+
 func GetConnectWiseConnector(ctx context.Context) *connectwise.Connector {
 	filePath := credscanning.LoadPath(providers.ConnectWise)
-	reader := utils.MustCreateProvCredJSON(filePath, false)
+	reader := utils.MustCreateProvCredJSON(filePath, false, clientIdField)
 
 	conn, err := connectwise.NewConnector(common.ConnectorParams{
 		AuthenticatedClient: utils.NewBasicAuthClient(ctx, reader),
+		Metadata: map[string]string{
+			"clientId": reader.Get(clientIdField),
+		},
 	})
 	if err != nil {
 		utils.Fail("error creating connector", "error", err)

--- a/test/connectWise/read/companies/main.go
+++ b/test/connectWise/read/companies/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/connectWise"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connectWise.GetConnectWiseConnector(ctx)
+
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "companies",
+		Fields:     datautils.NewSet("name", "city", "country"),
+		Since:      time.Now().Add(-1 * time.Hour * 24 * 100),
+		PageSize:   500,
+	})
+}

--- a/test/connectWise/read/configurations/main.go
+++ b/test/connectWise/read/configurations/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/connectWise"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connectWise.GetConnectWiseConnector(ctx)
+
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "configurations",
+		Fields:     datautils.NewSet("company", "contact"),
+		Since:      time.Now().Add(-1 * time.Hour * 24 * 1000),
+		PageSize:   900,
+	})
+}

--- a/test/connectWise/read/contacts/main.go
+++ b/test/connectWise/read/contacts/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/connectWise"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connectWise.GetConnectWiseConnector(ctx)
+
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "contacts",
+		Fields:     datautils.NewSet("firstName", "lastName"),
+		Since:      time.Now().Add(-1 * time.Hour * 24 * 15),
+		PageSize:   1000,
+	})
+}


### PR DESCRIPTION
# Description

Query for incremental read takes effect even for those objects that do not have LastUpdated field. LastUpdated is returned only for one object.

Pagination uses Link header.

Client ID header is a required header. I added definition to connector metadata.

# Live Tests

### Companies
<img width="650" height="552" alt="image" src="https://github.com/user-attachments/assets/2480310b-c59b-45fa-9982-2198a3781329" />

