### PR TITLE
[CON-911] feat(Greenhouse) : Greenhouse-custom-fields

### DIFF
--- a/providers/greenhouse/connector.go
+++ b/providers/greenhouse/connector.go
@@ -7,10 +7,8 @@ import (
 	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
-	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
-	"github.com/amp-labs/connectors/providers/greenhouse/metadata"
 )
 
 // Connector implements the Greenhouse Harvest API v3.
@@ -23,7 +21,6 @@ type Connector struct {
 	common.RequireAuthenticatedClient
 
 	// Supported operations
-	components.SchemaProvider
 	components.Reader
 	components.Writer
 	components.Deleter
@@ -35,8 +32,6 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
-
-	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
 	errorHandler := interpreter.ErrorHandler{
 		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),

--- a/providers/greenhouse/custom.go
+++ b/providers/greenhouse/custom.go
@@ -1,0 +1,235 @@
+package greenhouse
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// fieldTypeToObjectName maps Greenhouse custom field field_type to connector object names.
+// https://harvestdocs.greenhouse.io/reference/get_v3-custom-fields
+var fieldTypeToObjectName = map[string]string{ //nolint:gochecknoglobals
+	"candidate":      "candidates",
+	"application":    "applications",
+	"job":            "jobs",
+	"opening":        "openings",
+	"offer":          "offers",
+	"user_attribute": "users",
+}
+
+// objectNameToFieldType is the reverse mapping.
+var objectNameToFieldType = func() map[string]string { //nolint:gochecknoglobals
+	m := make(map[string]string)
+	for ft, obj := range fieldTypeToObjectName {
+		m[obj] = ft
+	}
+
+	return m
+}()
+
+// objectsWithCustomFields is the set of objects that support custom fields.
+var objectsWithCustomFields = datautils.NewStringSet( //nolint:gochecknoglobals
+	"candidates", "applications", "jobs", "openings", "offers", "users",
+)
+
+// requestCustomFields fetches custom field definitions from the Greenhouse API for a given object.
+// Returns a map of name_key to customFieldDefinition.
+// For objects that do not support custom fields, an empty map is returned.
+// https://harvestdocs.greenhouse.io/reference/get_v3-custom-fields
+func (c *Connector) requestCustomFields(
+	ctx context.Context, objectName string,
+) (map[string]customFieldDefinition, error) {
+	if !objectsWithCustomFields.Has(objectName) {
+		return map[string]customFieldDefinition{}, nil
+	}
+
+	fieldType, ok := objectNameToFieldType[objectName]
+	if !ok {
+		return map[string]customFieldDefinition{}, nil
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v3", "custom_fields")
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	url.WithQueryParam("field_type", fieldType)
+	url.WithQueryParam("per_page", "500")
+
+	res, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	fieldsResponse, err := common.UnmarshalJSON[[]customFieldDefinition](res)
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	if fieldsResponse == nil {
+		return map[string]customFieldDefinition{}, nil
+	}
+
+	fields := make(map[string]customFieldDefinition)
+
+	for _, field := range *fieldsResponse {
+		if !field.Active {
+			continue
+		}
+
+		fields[field.NameKey] = field
+	}
+
+	return fields, nil
+}
+
+// customFieldDefinition represents a custom field definition from the Greenhouse API.
+// https://harvestdocs.greenhouse.io/reference/get_v3-custom-fields
+type customFieldDefinition struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	NameKey   string `json:"name_key"`
+	FieldType string `json:"field_type"`
+	ValueType string `json:"value_type"`
+	Active    bool   `json:"active"`
+	Private   bool   `json:"private"`
+	Required  bool   `json:"required"`
+}
+
+// getValueType maps Greenhouse custom field value_type to common.ValueType.
+// https://harvestdocs.greenhouse.io/reference/post_v3-custom-fields
+func (f customFieldDefinition) getValueType() common.ValueType {
+	switch f.ValueType {
+	case "short_text", "long_text", "rich_text", "url":
+		return common.ValueTypeString
+	case "yes_no":
+		return common.ValueTypeBoolean
+	case "number":
+		return common.ValueTypeInt
+	case "date":
+		return common.ValueTypeDateTime
+	case "single_select":
+		return common.ValueTypeSingleSelect
+	default:
+		// currency, currency_range, number_range, multi_select, user, linked, header, statement, attachment
+		return common.ValueTypeOther
+	}
+}
+
+// flattenCustomFields moves custom fields from the nested custom_fields map to the root level.
+// In Greenhouse v3, custom_fields is a map keyed by name_key:
+//
+//	{
+//	  "custom_fields": {
+//	    "work_authorization": { "name": "Work Authorization", "type": "boolean", "value": true },
+//	    "bio": { "name": "Bio", "type": "long_text", "value": "Some text" }
+//	  }
+//	}
+//
+// After flattening:
+//
+//	{
+//	  "work_authorization": true,
+//	  "bio": "Some text",
+//	  ...original fields...
+//	}
+func flattenCustomFields(node *ajson.Node) (map[string]any, error) {
+	root, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
+	}
+
+	customFieldsRaw, ok := root["custom_fields"]
+	if !ok || customFieldsRaw == nil {
+		return root, nil
+	}
+
+	customFieldsMap, ok := customFieldsRaw.(map[string]any)
+	if !ok {
+		return root, nil
+	}
+
+	// Move each custom field value to the root level using name_key as the field name.
+	for nameKey, fieldData := range customFieldsMap {
+		fieldMap, ok := fieldData.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		root[nameKey] = fieldMap["value"]
+	}
+
+	return root, nil
+}
+
+// requestCustomFieldOptions fetches options for single_select and multi_select custom fields.
+// https://harvestdocs.greenhouse.io/reference/get_v3-custom-field-options
+func (c *Connector) requestCustomFieldOptions(
+	ctx context.Context, fieldIDs []int,
+) (map[int][]customFieldOption, error) {
+	if len(fieldIDs) == 0 {
+		return map[int][]customFieldOption{}, nil
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v3", "custom_field_options")
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	// Build comma-separated list of field IDs.
+	var idsSb strings.Builder
+
+	for i, id := range fieldIDs {
+		if i > 0 {
+			idsSb.WriteString(",")
+		}
+
+		idsSb.WriteString(strconv.Itoa(id))
+	}
+
+	url.WithQueryParam("custom_field_ids", idsSb.String())
+	url.WithQueryParam("per_page", "500")
+
+	res, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	optionsResponse, err := common.UnmarshalJSON[[]customFieldOption](res)
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	if optionsResponse == nil {
+		return map[int][]customFieldOption{}, nil
+	}
+
+	// Group options by custom_field_id.
+	result := make(map[int][]customFieldOption)
+
+	for _, option := range *optionsResponse {
+		if !option.Active {
+			continue
+		}
+
+		result[option.CustomFieldID] = append(result[option.CustomFieldID], option)
+	}
+
+	return result, nil
+}
+
+// customFieldOption represents a select option for a custom field.
+type customFieldOption struct {
+	ID            int    `json:"id"`
+	CustomFieldID int    `json:"custom_field_id"`
+	Name          string `json:"name"`
+	Active        bool   `json:"active"`
+	SortOrder     int    `json:"sort_order"`
+}

--- a/providers/greenhouse/handlers.go
+++ b/providers/greenhouse/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/httpkit"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/providers/greenhouse/metadata"
@@ -22,6 +23,85 @@ const (
 	// https://developers.greenhouse.io/harvest.html#pagination
 	maxPageSize = 500
 )
+
+// ListObjectMetadata returns metadata for the requested objects, including custom fields.
+// Base metadata comes from the static OpenAPI schema. Custom field definitions are fetched
+// from the Greenhouse API and added as top-level fields.
+// https://harvestdocs.greenhouse.io/reference/get_v3-custom-fields
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	metadataResult, err := metadata.Schemas.Select(c.Module(), objectNames)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, objectName := range objectNames {
+		fields, err := c.requestCustomFields(ctx, objectName)
+		if err != nil {
+			metadataResult.Errors[objectName] = err
+
+			continue
+		}
+
+		objectMetadata := metadataResult.GetObjectMetadata(objectName)
+		if objectMetadata == nil {
+			continue
+		}
+
+		// Collect IDs for select-type fields to fetch options.
+		var selectFieldIDs []int
+
+		for _, field := range fields {
+			if field.ValueType == "single_select" || field.ValueType == "multi_select" {
+				selectFieldIDs = append(selectFieldIDs, field.ID)
+			}
+		}
+
+		// Fetch options for select-type custom fields.
+		options, err := c.requestCustomFieldOptions(ctx, selectFieldIDs)
+		if err != nil {
+			metadataResult.Errors[objectName] = err
+
+			continue
+		}
+
+		// Add each custom field to the object metadata.
+		for nameKey, field := range fields {
+			fieldValues := getFieldValues(options, field.ID)
+
+			objectMetadata.AddFieldMetadata(nameKey, common.FieldMetadata{
+				DisplayName:  field.Name,
+				ValueType:    field.getValueType(),
+				ProviderType: field.ValueType,
+				IsCustom:     goutils.Pointer(true),
+				Values:       fieldValues,
+			})
+		}
+
+		metadataResult.Result[objectName] = *objectMetadata
+	}
+
+	return metadataResult, nil
+}
+
+// getFieldValues returns the list of possible values for select-type custom fields.
+func getFieldValues(options map[int][]customFieldOption, fieldID int) common.FieldValues {
+	opts, ok := options[fieldID]
+	if !ok || len(opts) == 0 {
+		return nil
+	}
+
+	values := make(common.FieldValues, len(opts))
+	for i, opt := range opts {
+		values[i] = common.FieldValue{
+			Value:        opt.Name,
+			DisplayValue: opt.Name,
+		}
+	}
+
+	return values
+}
 
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
 	url, err := c.buildReadURL(params)
@@ -72,12 +152,25 @@ func (c *Connector) parseReadResponse(
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
 		resp,
-		// Empty path means records are at the root level (response is a JSON array, not nested).
-		common.ExtractOptionalRecordsFromPath(""),
+		// Greenhouse v3 list endpoints return bare JSON arrays at root level.
+		getRecords,
 		makeNextRecordsURL(resp),
-		common.GetMarshaledData,
+		common.MakeMarshaledDataFunc(flattenCustomFields),
 		params.Fields,
 	)
+}
+
+// getRecords extracts records from the root-level JSON array.
+func getRecords(node *ajson.Node) ([]*ajson.Node, error) {
+	if node == nil {
+		return nil, nil //nolint:nilnil
+	}
+
+	if node.IsArray() {
+		return node.GetArray()
+	}
+
+	return nil, nil //nolint:nilnil
 }
 
 // Next page is communicated via `Link` header under the `next` rel.
@@ -131,7 +224,6 @@ func (c *Connector) parseWriteResponse(ctx context.Context, params common.WriteP
 ) (*common.WriteResult, error) {
 	body, ok := response.Body()
 	if !ok {
-		// it is unlikely to have no payload
 		return &common.WriteResult{
 			Success: true,
 		}, nil
@@ -184,7 +276,6 @@ func (c *Connector) parseDeleteResponse(ctx context.Context, params common.Delet
 		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, response.Code)
 	}
 
-	// Response body is not used.
 	return &common.DeleteResult{
 		Success: true,
 	}, nil

--- a/providers/greenhouse/metadata_test.go
+++ b/providers/greenhouse/metadata_test.go
@@ -1,17 +1,24 @@
 package greenhouse
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
+func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
+
+	responseCustomFieldDefs := testutils.DataFromFile(t, "read/custom-fields/definitions.json")
+	responseCustomFieldOpts := testutils.DataFromFile(t, "read/custom-fields/options.json")
 
 	tests := []testroutines.Metadata{
 		{
@@ -100,6 +107,58 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								DisplayName:  "id",
 								ValueType:    "int",
 								ProviderType: "integer",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "Metadata includes custom fields from API",
+			Input: []string{"applications"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{
+					{
+						If:   mockcond.Path("/v3/custom_fields"),
+						Then: mockserver.Response(http.StatusOK, responseCustomFieldDefs),
+					},
+					{
+						If:   mockcond.Path("/v3/custom_field_options"),
+						Then: mockserver.Response(http.StatusOK, responseCustomFieldOpts),
+					},
+				},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"applications": {
+						DisplayName: "Applications",
+						Fields: map[string]common.FieldMetadata{
+							// Base schema field
+							"candidate_id": {
+								DisplayName:  "candidate_id",
+								ValueType:    "int",
+								ProviderType: "integer",
+							},
+							// Custom field: number type
+							"interview_score": {
+								DisplayName:  "Interview Score",
+								ValueType:    "int",
+								ProviderType: "number",
+								IsCustom:     goutils.Pointer(true),
+							},
+							// Custom field: single_select with options
+							"referral_source": {
+								DisplayName:  "Referral Source",
+								ValueType:    "singleSelect",
+								ProviderType: "single_select",
+								IsCustom:     goutils.Pointer(true),
+								Values: common.FieldValues{
+									{Value: "Employee Referral", DisplayValue: "Employee Referral"},
+									{Value: "LinkedIn", DisplayValue: "LinkedIn"},
+									{Value: "Job Board", DisplayValue: "Job Board"},
+								},
 							},
 						},
 					},

--- a/providers/greenhouse/read_test.go
+++ b/providers/greenhouse/read_test.go
@@ -19,6 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseError := testutils.DataFromFile(t, "error.json")
 	responseApplicationsFirstPage := testutils.DataFromFile(t, "read/applications/first-page.json")
 	responseApplicationsLastPage := testutils.DataFromFile(t, "read/applications/last-page.json")
+	responseWithCustomFields := testutils.DataFromFile(t, "read/custom-fields/applications-with-custom-fields.json")
 
 	tests := []testroutines.Read{
 		{
@@ -131,6 +132,49 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 					Raw: map[string]any{
 						"status": "rejected",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read applications with custom fields flattened",
+			Input: common.ReadParams{
+				ObjectName: "applications",
+				Fields:     connectors.Fields("id", "interview_score", "referral_source"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v3/applications"),
+				Then:  mockserver.Response(http.StatusOK, responseWithCustomFields),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"id": float64(12345),
+						// Custom fields flattened from custom_fields map to root level.
+						"interview_score": "85.0",
+						"referral_source": "Employee Referral",
+					},
+					Raw: map[string]any{
+						"status": "in_process",
+						// Verify custom_fields is preserved in Raw (not altered).
+						"custom_fields": map[string]any{
+							"interview_score": map[string]any{
+								"name":  "Interview Score",
+								"type":  "number",
+								"value": "85.0",
+							},
+							"referral_source": map[string]any{
+								"name":  "Referral Source",
+								"type":  "single_select",
+								"value": "Employee Referral",
+							},
+						},
 					},
 				}},
 				NextPage: "",

--- a/providers/greenhouse/test/read/custom-fields/applications-with-custom-fields.json
+++ b/providers/greenhouse/test/read/custom-fields/applications-with-custom-fields.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 12345,
+    "candidate_id": 101,
+    "status": "in_process",
+    "stage_name": "Phone Screen",
+    "created_at": "2024-06-15T10:30:00Z",
+    "updated_at": "2024-09-01T14:00:00Z",
+    "custom_fields": {
+      "interview_score": {
+        "name": "Interview Score",
+        "type": "number",
+        "value": "85.0"
+      },
+      "referral_source": {
+        "name": "Referral Source",
+        "type": "single_select",
+        "value": "Employee Referral"
+      }
+    }
+  }
+]

--- a/providers/greenhouse/test/read/custom-fields/definitions.json
+++ b/providers/greenhouse/test/read/custom-fields/definitions.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": 100001,
+    "name": "Interview Score",
+    "name_key": "interview_score",
+    "field_type": "application",
+    "value_type": "number",
+    "active": true,
+    "private": false,
+    "required": false,
+    "sort_order": 0,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 100002,
+    "name": "Referral Source",
+    "name_key": "referral_source",
+    "field_type": "application",
+    "value_type": "single_select",
+    "active": true,
+    "private": false,
+    "required": false,
+    "sort_order": 1,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 100003,
+    "name": "Inactive Field",
+    "name_key": "inactive_field",
+    "field_type": "application",
+    "value_type": "short_text",
+    "active": false,
+    "private": false,
+    "required": false,
+    "sort_order": 2,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  }
+]

--- a/providers/greenhouse/test/read/custom-fields/options.json
+++ b/providers/greenhouse/test/read/custom-fields/options.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 200001,
+    "custom_field_id": 100002,
+    "name": "Employee Referral",
+    "active": true,
+    "sort_order": 0,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 200002,
+    "custom_field_id": 100002,
+    "name": "LinkedIn",
+    "active": true,
+    "sort_order": 1,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 200003,
+    "custom_field_id": 100002,
+    "name": "Job Board",
+    "active": true,
+    "sort_order": 2,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  }
+]


### PR DESCRIPTION
## Description

This PR adds native custom field support for the Greenhouse connector.

### What changed

- Added custom fields to `ListObjectMetadata` for supported Greenhouse objects.
- Added custom field values to `Read` results by flattening `custom_fields.{name_key}.value` into top-level fields.
- Added support for select-type field options (`single_select`, `multi_select`) in metadata values.



### Conventions followed

Read more: [Deep Connectors Guide – Reviewer Checklist](https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist)

- Field key uses Greenhouse `name_key`.
- Human-readable metadata name uses Greenhouse `name`.
- Read output flattens `custom_fields.{name_key}.value` to root-level fields.
- Tests are implemented under `/providers/greenhouse/`.

## Test plan
### Metadata
### Unit test
<img width="1608" height="493" alt="Screenshot 2026-03-26 at 11 04 58 PM" src="https://github.com/user-attachments/assets/9b949877-b1e2-4e7e-a242-eed10a6d3414" />

### Live test
<img width="1608" height="921" alt="Screenshot 2026-03-26 at 11 06 50 PM" src="https://github.com/user-attachments/assets/d24213d1-8291-48e1-b26a-1d9c518294fc" />
<img width="1134" height="921" alt="Screenshot 2026-03-26 at 11 35 43 PM" src="https://github.com/user-attachments/assets/b6818ec6-70c2-4711-ac53-cdb8aee2809a" />

### Read
### Unit test

<img width="1608" height="493" alt="Screenshot 2026-03-26 at 11 05 25 PM" src="https://github.com/user-attachments/assets/f8a4fcd6-19c2-44e0-9e77-fe1454216027" />
### Live test
<img width="1608" height="873" alt="Screenshot 2026-03-26 at 11 05 39 PM" src="https://github.com/user-attachments/assets/de77520d-0271-4d7c-835c-7775f4163d7d" />
<img width="1608" height="873" alt="Screenshot 2026-03-26 at 11 05 44 PM" src="https://github.com/user-attachments/assets/f1fd76d7-5ebc-48ff-acfd-aa8e29b7f721" />
<img width="1608" height="873" alt="Screenshot 2026-03-26 at 11 05 59 PM" src="https://github.com/user-attachments/assets/e7e014ba-8db6-4904-829b-4fb345bef147" />


