### PR TITLE
[ENG-3807] refactor(salesforce): parameterize provider name via WithProvider option

### DIFF
--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -56,7 +56,7 @@ func NewConnector(opts ...Option) (*Connector, error) {
 		return nil, err
 	}
 
-	// Default the provider to Salesforce when not explicitly overridden.
+	// Default the provider to Salesforce (OAuth provider) when not explicitly overridden.
 	if params.provider == "" {
 		params.provider = providers.Salesforce
 	}

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -27,6 +27,12 @@ type Connector struct {
 	moduleInfo   *providers.ModuleInfo
 	moduleID     common.ModuleID
 
+	// provider is the provider name this connector reports. It allows the
+	// same implementation to serve twin providers (e.g. salesforceJWT) that
+	// share the underlying Salesforce APIs but differ in auth scheme.
+	// Defaults to providers.Salesforce.
+	provider providers.Provider
+
 	// crmAdapter handles the core Salesforce CRM module.
 	// It provides dedicated support for SalesforceCRM-specific functionality.
 	crmAdapter *crm.Adapter
@@ -50,6 +56,11 @@ func NewConnector(opts ...Option) (*Connector, error) {
 		return nil, err
 	}
 
+	// Default the provider to Salesforce when not explicitly overridden.
+	if params.provider == "" {
+		params.provider = providers.Salesforce
+	}
+
 	conn, err := oldConstructor(params)
 	if err != nil {
 		return nil, err
@@ -67,12 +78,12 @@ func NewConnector(opts ...Option) (*Connector, error) {
 	// Operations are delegated to either one.
 	moduleID := params.Module.Selection.ID
 	if isPardotModule(moduleID) {
-		conn.pardotAdapter, err = pardot.NewAdapter(connectorParams)
+		conn.pardotAdapter, err = pardot.NewAdapter(connectorParams, conn.provider)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		conn.crmAdapter, err = crm.NewAdapter(connectorParams)
+		conn.crmAdapter, err = crm.NewAdapter(connectorParams, conn.provider)
 		if err != nil {
 			return nil, err
 		}
@@ -88,6 +99,7 @@ func oldConstructor(params *parameters) (*Connector, error) {
 			HTTPClient: params.Client.Caller,
 		},
 		moduleID: params.Module.Selection.ID,
+		provider: params.provider,
 	}
 
 	var err error
@@ -108,9 +120,15 @@ func oldConstructor(params *parameters) (*Connector, error) {
 	return conn, nil
 }
 
-// Provider returns the connector provider.
+// Provider returns the connector provider. For twin providers such as
+// salesforceJWT that reuse this implementation with a different auth scheme,
+// this returns the configured provider name (defaulting to providers.Salesforce).
 func (c *Connector) Provider() providers.Provider {
-	return providers.Salesforce
+	if c.provider == "" {
+		return providers.Salesforce
+	}
+
+	return c.provider
 }
 
 // String returns a string representation of the connector, which is useful for logging / debugging.

--- a/providers/salesforce/internal/crm/adapter.go
+++ b/providers/salesforce/internal/crm/adapter.go
@@ -36,8 +36,11 @@ type Adapter struct {
 }
 
 // NewAdapter creates a new crm Adapter configured to work with Salesforce's APIs.
-func NewAdapter(params *common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Salesforce, *params, constructor)
+// The provider argument allows twin providers (e.g. salesforceJWT) to reuse this
+// adapter under a different provider name. Pass providers.Salesforce for the
+// default Salesforce connector.
+func NewAdapter(params *common.ConnectorParams, provider providers.Provider) (*Adapter, error) {
+	return components.Initialize(provider, *params, constructor)
 }
 
 func constructor(base *components.Connector) (*Adapter, error) {

--- a/providers/salesforce/internal/pardot/adapter.go
+++ b/providers/salesforce/internal/pardot/adapter.go
@@ -31,8 +31,11 @@ type Adapter struct {
 }
 
 // NewAdapter creates a new pardot Adapter configured to work with Salesforce's Account Management APIs.
-func NewAdapter(params *common.ConnectorParams) (*Adapter, error) {
-	adapter, err := components.Initialize(providers.Salesforce, *params, constructor)
+// The provider argument allows twin providers (e.g. salesforceJWT) to reuse this
+// adapter under a different provider name. Pass providers.Salesforce for the
+// default Salesforce connector.
+func NewAdapter(params *common.ConnectorParams, provider providers.Provider) (*Adapter, error) {
+	adapter, err := components.Initialize(provider, *params, constructor)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/salesforce/params.go
+++ b/providers/salesforce/params.go
@@ -22,6 +22,11 @@ type parameters struct {
 	paramsbuilder.Metadata
 	paramsbuilder.Module
 	timestampColumn string
+	// provider allows the same Connector implementation to be reused under a
+	// different provider name (e.g. salesforceJWT), which shares the underlying
+	// Salesforce APIs but differs only in its authentication scheme. Defaults
+	// to providers.Salesforce when unset.
+	provider providers.Provider
 }
 
 func newParams(opts []Option) (*common.ConnectorParams, error) { // nolint:unused
@@ -97,5 +102,15 @@ func WithMetadata(metadata map[string]string) Option {
 func WithTimestampColumn(field string) Option {
 	return func(params *parameters) {
 		params.timestampColumn = field
+	}
+}
+
+// WithProvider overrides the provider name this connector reports and uses
+// when looking up ProviderInfo. It is intended for twin providers that reuse
+// the same underlying Salesforce implementation but differ in auth scheme
+// (e.g. salesforceJWT). When unset, the default is providers.Salesforce.
+func WithProvider(provider providers.Provider) Option {
+	return func(params *parameters) {
+		params.provider = provider
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a `WithProvider` Option to the salesforce connector that threads a provider name through `Connector.Provider()` and the internal CRM + Pardot adapters
- Defaults to `providers.Salesforce` when unset, so existing callers are unaffected
- Pure refactor — zero behavior change for the standard salesforce provider

## Why
The Salesforce connector hardcoded `providers.Salesforce` in three places, blocking reuse of the same implementation under a twin provider name. This PR unblocks a follow-up that adds `salesforceJWT` — a twin that shares the CRM/Pardot implementation but authenticates via the OAuth 2.0 JWT Bearer Flow instead of Authorization Code.

## Changes
- `providers/salesforce/params.go` — new `provider` field on `parameters` + `WithProvider` option
- `providers/salesforce/connector.go` — `Connector.provider` field, `Provider()` returns it dynamically, default applied in `NewConnector`
- `providers/salesforce/internal/crm/adapter.go` — `NewAdapter(params, provider)` signature
- `providers/salesforce/internal/pardot/adapter.go` — same

## Test plan
- [x] `go build ./providers/salesforce/... ./connector/...`
- [x] `go test ./providers/salesforce/...` — existing tests pass unmodified
- [ ] Verify no regression in prod salesforce connections after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)