### PR TITLE
[CON-3125] feat(Slack): enable read and write

### DIFF
--- a/providers/slack.go
+++ b/providers/slack.go
@@ -27,9 +27,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1048" height="633" alt="image" src="https://github.com/user-attachments/assets/5d6c6031-a5de-47dc-a8bd-b845529d3249" />
<img width="1023" height="880" alt="image" src="https://github.com/user-attachments/assets/cd231198-d16f-4923-99f8-342a506d9a66" />
<img width="1004" height="642" alt="image" src="https://github.com/user-attachments/assets/6cf1e6ce-567c-46e7-95de-c677912b619c" />




- [x] Insert screenshot of Svix destination.
<img width="1607" height="922" alt="image" src="https://github.com/user-attachments/assets/aa2f764a-a81f-48ba-a8fb-9ecdf19cd8b2" />
<img width="1594" height="968" alt="image" src="https://github.com/user-attachments/assets/819ea0f7-3950-44b6-b706-7b9ca8d2761f" />
<img width="1623" height="902" alt="image" src="https://github.com/user-attachments/assets/28f9865e-2c59-4a49-ab5c-169f29c7198a" />






- [x] Screenshot of operations on dashboard
<img width="1547" height="990" alt="image" src="https://github.com/user-attachments/assets/85b9d167-b5c3-4bf4-9fa1-99b513efb7a1" />
<img width="1543" height="986" alt="image" src="https://github.com/user-attachments/assets/8a2c9ef7-cb7c-437c-aff3-8edb27287a9a" />
<img width="1555" height="971" alt="image" src="https://github.com/user-attachments/assets/b2941203-0380-40dc-a9fb-62b5d9b8844f" />




# Write
- [x] Insert screenshot of dashboard.
<img width="1574" height="987" alt="image" src="https://github.com/user-attachments/assets/c12c316a-e6cf-4b20-b344-57a593ef3314" />
<img width="1507" height="972" alt="image" src="https://github.com/user-attachments/assets/c00aa656-0f19-4f65-be34-d28558451210" />





- [x] Insert screenshot of HTTP call.

<img width="1506" height="705" alt="image" src="https://github.com/user-attachments/assets/147cf925-df99-4e97-b8f6-713e563c009f" />
<img width="1511" height="687" alt="image" src="https://github.com/user-attachments/assets/6e90382a-01f0-47c9-bc4e-0ee8125a6bbe" />


