### PR TITLE
fix(gusto): add demo provider for sandbox testing

### DIFF
--- a/providers/gusto.go
+++ b/providers/gusto.go
@@ -1,8 +1,12 @@
 package providers
 
-const Gusto Provider = "gusto"
+const (
+	Gusto     Provider = "gusto"
+	GustoDemo Provider = "gustoDemo"
+)
 
 func init() {
+	// Gusto Production configuration
 	SetInfo(Gusto, ProviderInfo{
 		DisplayName: "Gusto",
 		AuthType:    Oauth2,
@@ -11,6 +15,42 @@ func init() {
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://api.gusto.com/oauth/authorize",
 			TokenURL:                  "https://api.gusto.com/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1775077438/media/gusto.com_1775077438.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1775077356/media/gusto.com_1775077354.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1775077438/media/gusto.com_1775077438.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1775077412/media/gusto.com_1775077412.svg",
+			},
+		},
+	})
+
+	// Gusto Demo configuration
+	SetInfo(GustoDemo, ProviderInfo{
+		DisplayName: "Gusto Demo",
+		AuthType:    Oauth2,
+		BaseURL:     "https://api.gusto-demo.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://api.gusto-demo.com/oauth/authorize",
+			TokenURL:                  "https://api.gusto-demo.com/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/gusto.go
+++ b/providers/gusto.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package providers
 
 const (
@@ -5,7 +6,7 @@ const (
 	GustoDemo Provider = "gustoDemo"
 )
 
-func init() { //nolint:funlen,dupl
+func init() { //nolint:funlen
 	// Gusto Production configuration
 	SetInfo(Gusto, ProviderInfo{
 		DisplayName: "Gusto",

--- a/providers/gusto.go
+++ b/providers/gusto.go
@@ -5,7 +5,7 @@ const (
 	GustoDemo Provider = "gustoDemo"
 )
 
-func init() {
+func init() { //nolint:funlen,dupl
 	// Gusto Production configuration
 	SetInfo(Gusto, ProviderInfo{
 		DisplayName: "Gusto",

--- a/providers/ramp.go
+++ b/providers/ramp.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package providers
 
 const (


### PR DESCRIPTION
Gusto requires production pre-approval for API access. Added a `gustoDemo` provider with `api.gusto-demo.com` URLs so integration testing can be done against the sandbox environment using demo company credentials.