### PR TITLE
[ENG-3831] fix: transcode non-UTF-8 HTTP response bodies before JSON parsing

### DIFF
--- a/common/json.go
+++ b/common/json.go
@@ -3,15 +3,18 @@ package common
 
 import (
 	"context"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/spyzhov/ajson"
+	"golang.org/x/net/html/charset"
 )
 
 // JSONHTTPClient is an HTTP client which makes certain assumptions, such as
@@ -147,6 +150,12 @@ func ParseJSONResponse(res *http.Response, body []byte) (*JSONHTTPResponse, erro
 		return nil, err
 	}
 
+	// Transcode the response body to UTF-8 if the Content-Type header specifies a
+	// non-UTF-8 charset. Some providers (e.g. Pardot) return JSON encoded in
+	// ISO-8859-1 or other legacy charsets, which corrupts non-ASCII characters
+	// when the raw bytes are treated as UTF-8.
+	body = transcodeToUTF8(body, res.Header.Get("Content-Type"))
+
 	// Unmarshall the response body into JSON
 	jsonBody, err := ajson.Unmarshal(body)
 	if err != nil {
@@ -241,4 +250,36 @@ func EnsureContentType(pattern string, res *http.Response, errOnMissing bool) er
 	}
 
 	return nil
+}
+
+// transcodeToUTF8 converts the given body bytes to UTF-8 if the Content-Type header
+// specifies a non-UTF-8 charset. If the charset is missing, empty, or already UTF-8,
+// the original bytes are returned unchanged.
+func transcodeToUTF8(body []byte, contentType string) []byte {
+	if len(contentType) == 0 || len(body) == 0 {
+		return body
+	}
+
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return body
+	}
+
+	charsetLabel := strings.ToLower(params["charset"])
+	if charsetLabel == "" || charsetLabel == "utf-8" || charsetLabel == "utf8" {
+		return body
+	}
+
+	reader, err := charset.NewReaderLabel(charsetLabel, bytes.NewReader(body))
+	if err != nil {
+		// Unknown charset — return the original bytes rather than failing.
+		return body
+	}
+
+	decoded, err := io.ReadAll(reader)
+	if err != nil {
+		return body
+	}
+
+	return decoded
 }

--- a/common/json_test.go
+++ b/common/json_test.go
@@ -1073,3 +1073,100 @@ func TestEnsureContentType_InvalidPattern(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to compile regex")
 }
+
+// ============================================================================
+// CHARSET TRANSCODING TESTS
+// ============================================================================
+
+func TestTranscodeToUTF8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		body        []byte
+		contentType string
+		expected    string
+	}{
+		{
+			name:        "UTF-8 body with no charset header is unchanged",
+			body:        []byte(`{"name":"João"}`),
+			contentType: "application/json",
+			expected:    `{"name":"João"}`,
+		},
+		{
+			name:        "UTF-8 body with explicit utf-8 charset is unchanged",
+			body:        []byte(`{"name":"João"}`),
+			contentType: "application/json; charset=utf-8",
+			expected:    `{"name":"João"}`,
+		},
+		{
+			name:        "ISO-8859-1 body with charset header is transcoded",
+			body:        []byte{'{', '"', 'n', 'a', 'm', 'e', '"', ':', '"', 'J', 'o', 0xe3, 'o', '"', '}'},
+			contentType: "application/json; charset=ISO-8859-1",
+			expected:    `{"name":"João"}`,
+		},
+		{
+			name:        "Windows-1252 body with charset header is transcoded",
+			body:        []byte{'{', '"', 'v', '"', ':', '"', 0x93, 'h', 'i', 0x94, '"', '}'},
+			contentType: "application/json; charset=windows-1252",
+			expected:    "{\"v\":\"\u201chi\u201d\"}",
+		},
+		{
+			name:        "Empty body is unchanged",
+			body:        []byte{},
+			contentType: "application/json; charset=ISO-8859-1",
+			expected:    "",
+		},
+		{
+			name:        "Empty content type leaves body unchanged",
+			body:        []byte(`{"ok":true}`),
+			contentType: "",
+			expected:    `{"ok":true}`,
+		},
+		{
+			name:        "Unknown charset falls back to original bytes",
+			body:        []byte(`{"ok":true}`),
+			contentType: "application/json; charset=nonexistent-encoding",
+			expected:    `{"ok":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := transcodeToUTF8(tt.body, tt.contentType)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestParseJSONResponse_TranscodesISO88591(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a Pardot-like response: JSON body with ISO-8859-1 encoded characters.
+	// 0xe1 = á in ISO-8859-1, 0xfa = ú in ISO-8859-1
+	isoBody := []byte(`{"firstName":"` + string([]byte{0x4a, 0x6f, 0xe3, 0x6f}) + `"}`)
+	// "João" with ã as 0xe3 in ISO-8859-1
+
+	res := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json; charset=ISO-8859-1"},
+		},
+		Body: io.NopCloser(bytes.NewReader(isoBody)),
+	}
+
+	response, err := ParseJSONResponse(res, isoBody)
+	require.NoError(t, err)
+
+	body, ok := response.Body()
+	require.True(t, ok)
+
+	firstName, err := body.GetKey("firstName")
+	require.NoError(t, err)
+
+	firstNameStr, err := firstName.GetString()
+	require.NoError(t, err)
+	assert.Equal(t, "João", firstNameStr)
+}


### PR DESCRIPTION
## Summary

- Adds charset detection and UTF-8 transcoding to `ParseJSONResponse` in `common/json.go`
- When the `Content-Type` header specifies a non-UTF-8 charset (e.g. `charset=ISO-8859-1`), response body bytes are transcoded to UTF-8 before JSON unmarshalling
- Uses `golang.org/x/net/html/charset` (already a dependency, used in `printable.go` for logging) for charset detection and conversion
- Falls through gracefully when charset is missing, already UTF-8, or unrecognized

## Context

Dreamhub reported non-ASCII characters being mangled in webhook payloads for the Pardot provider. Investigation traced the issue to `ParseJSONResponse` reading raw response bytes as UTF-8 without checking the response's declared charset. Pardot's API returns JSON encoded in ISO-8859-1, causing:

- Characters like `á`, `ã`, `ü` (exist in ISO-8859-1) → `�` (U+FFFD) when their single-byte encoding is misread as UTF-8
- Characters like `Š`, `ě` (don't exist in ISO-8859-1) → `?` (replaced upstream by Pardot's API itself, not recoverable)

This fix resolves the first category. The second is a Pardot/Salesforce-side data fidelity limitation.

## Test plan

- [x] Unit tests for `transcodeToUTF8` covering: UTF-8 passthrough, ISO-8859-1 transcoding, Windows-1252 transcoding, empty body, empty content type, unknown charset fallback
- [x] Integration test `TestParseJSONResponse_TranscodesISO88591` verifying the full `ParseJSONResponse` path with ISO-8859-1 encoded JSON
- [x] Full `common` package test suite passes with no regressions
- [ ] Manual verification with Dreamhub's Pardot installation after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)