### PR TITLE
[CON-3154] feat: add support to retrieve products when reading leads

### DIFF
--- a/providers/pipedrive/internal/crm/adapter.go
+++ b/providers/pipedrive/internal/crm/adapter.go
@@ -14,21 +14,21 @@ const (
 )
 
 type Adapter struct {
-	Client  *common.JSONHTTPClient
-	BaseURL string
+	Client     *common.JSONHTTPClient
+	moduleInfo *providers.ModuleInfo
 }
 
 func NewAdapter(
 	client *common.JSONHTTPClient, info *providers.ModuleInfo,
 ) *Adapter {
 	return &Adapter{
-		Client:  client,
-		BaseURL: info.BaseURL,
+		Client:     client,
+		moduleInfo: info,
 	}
 }
 
 func (a *Adapter) getAPIURL(apiVersion, object string) (*urlbuilder.URL, error) {
-	return urlbuilder.New(a.BaseURL, apiVersion, object)
+	return urlbuilder.New(a.moduleInfo.BaseURL, apiVersion, object)
 }
 
 func (a *Adapter) constructMetadataURL(objectName string) (*urlbuilder.URL, error) {

--- a/providers/pipedrive/internal/crm/read.go
+++ b/providers/pipedrive/internal/crm/read.go
@@ -16,7 +16,7 @@ const (
 	data                      = "data"
 	dealsObjectName           = "deals"
 	productsField             = "products"
-	maxConcurrentProductFetch = 4
+	maxConcurrentProductFetch = 4 // No strong reason (Pipedrive has 100req/10s)
 )
 
 var supportsIncSync = datautils.NewSet("activities", "deals", "organizations", "persons") // nolint: gochecknoglobals

--- a/providers/pipedrive/internal/crm/read.go
+++ b/providers/pipedrive/internal/crm/read.go
@@ -2,16 +2,21 @@ package crm
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/simultaneously"
 )
 
 const (
-	readAPIVersion = "api/v2"
-	data           = "data"
+	readAPIVersion            = "api/v2"
+	data                      = "data"
+	dealsObjectName           = "deals"
+	productsField             = "products"
+	maxConcurrentProductFetch = 4
 )
 
 var supportsIncSync = datautils.NewSet("activities", "deals", "organizations", "persons") // nolint: gochecknoglobals
@@ -31,12 +36,74 @@ func (a *Adapter) Read(ctx context.Context, params common.ReadParams) (*common.R
 		return nil, err
 	}
 
-	return common.ParseResult(resp,
+	result, err := common.ParseResult(resp,
 		common.ExtractOptionalRecordsFromPath(data),
 		nextRecordsURL(url),
 		common.GetMarshaledData,
 		params.Fields,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.ObjectName == dealsObjectName && params.Fields.Has(productsField) {
+		if err := a.enrichDealsWithProducts(ctx, result.Data); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// enrichDealsWithProducts fetches products for each deal concurrently and injects
+// them into Fields["products"] on each row.
+func (a *Adapter) enrichDealsWithProducts(ctx context.Context, rows []common.ReadResultRow) error {
+	jobs := make([]simultaneously.Job, len(rows))
+
+	for i := range rows {
+		idx := i
+		dealID := rows[i].Id
+
+		jobs[idx] = func(ctx context.Context) error {
+			products, err := a.fetchDealProducts(ctx, dealID)
+			if err != nil {
+				return fmt.Errorf("fetching products for deal %s: %w", dealID, err)
+			}
+
+			// we manually add these cause we have already parsed the response
+			// at this stage.
+			rows[idx].Fields[productsField] = products
+			rows[idx].Raw[productsField] = products
+
+			return nil
+		}
+	}
+
+	return simultaneously.DoCtx(ctx, maxConcurrentProductFetch, jobs...)
+}
+
+// fetchDealProducts calls /api/v2/deals/{id}/products and returns the data array.
+func (a *Adapter) fetchDealProducts(ctx context.Context, dealID string) ([]map[string]any, error) {
+	url, err := urlbuilder.New(a.moduleInfo.BaseURL, readAPIVersion, dealsObjectName, dealID, productsField)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := a.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := common.UnmarshalJSON[records](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Data == nil {
+		return []map[string]any{}, nil
+	}
+
+	return result.Data, nil
 }
 
 func (a *Adapter) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {

--- a/providers/pipedrive/read_test.go
+++ b/providers/pipedrive/read_test.go
@@ -13,6 +13,116 @@ import (
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
+func TestReadCRM(t *testing.T) {
+	t.Parallel()
+
+	dealsResponse := testutils.DataFromFile(t, "deals.json")
+	dealProductsResponse := testutils.DataFromFile(t, "deal-products.json")
+
+	tests := []testroutines.Read{
+		{
+			Name: "Deals include products when products field is requested",
+			Input: common.ReadParams{
+				ObjectName: "deals",
+				Fields:     connectors.Fields("title", "products"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If:   mockcond.Path("/api/v2/deals"),
+						Then: mockserver.Response(http.StatusOK, dealsResponse),
+					},
+					{
+						If:   mockcond.Path("/api/v2/deals/1/products"),
+						Then: mockserver.Response(http.StatusOK, dealProductsResponse),
+					},
+				},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"title": "Test Deal",
+						"products": []map[string]any{
+							{
+								"id":         float64(101),
+								"name":       "Test Product",
+								"quantity":   float64(2),
+								"unit_price": float64(500),
+							},
+							{
+								"id":         float64(102),
+								"name":       "Another Product",
+								"quantity":   float64(1),
+								"unit_price": float64(250),
+							},
+						},
+					},
+					Raw: map[string]any{
+						"id": float64(1),
+						"products": []map[string]any{
+							{
+								"id":         float64(101),
+								"name":       "Test Product",
+								"quantity":   float64(2),
+								"unit_price": float64(500),
+							},
+							{
+								"id":         float64(102),
+								"name":       "Another Product",
+								"quantity":   float64(1),
+								"unit_price": float64(250),
+							},
+						},
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// Server only handles /api/v2/deals — if the products endpoint is accidentally
+			// called it returns 500, which would fail this test.
+			Name: "Deals do not fetch products when products field is not requested",
+			Input: common.ReadParams{
+				ObjectName: "deals",
+				Fields:     connectors.Fields("title"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/api/v2/deals"),
+				Then:  mockserver.Response(http.StatusOK, dealsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"title": "Test Deal",
+					},
+					Raw: map[string]any{
+						"id": float64(1),
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveCRM)
+			})
+		})
+	}
+}
+
 func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 

--- a/providers/pipedrive/test/deal-products.json
+++ b/providers/pipedrive/test/deal-products.json
@@ -1,0 +1,17 @@
+{
+    "success": true,
+    "data": [
+        {
+            "id": 101,
+            "name": "Test Product",
+            "quantity": 2,
+            "unit_price": 500
+        },
+        {
+            "id": 102,
+            "name": "Another Product",
+            "quantity": 1,
+            "unit_price": 250
+        }
+    ]
+}

--- a/providers/pipedrive/test/deals.json
+++ b/providers/pipedrive/test/deals.json
@@ -1,0 +1,14 @@
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "title": "Test Deal",
+      "status": "open",
+      "value": 1000
+    }
+  ],
+  "additional_data": {
+    "next_cursor": null
+  }
+}

--- a/test/pipedrive/read/crm/read.go
+++ b/test/pipedrive/read/crm/read.go
@@ -69,7 +69,7 @@ func readDeals(ctx context.Context, conn *pipedrive.Connector) error {
 	config := connectors.ReadParams{
 		ObjectName: "deals",
 		Since:      time.Now().Add(-720 * time.Hour),
-		Fields:     connectors.Fields("close_time", "id"),
+		Fields:     connectors.Fields("close_time", "id", "products"),
 	}
 
 	result, err := conn.Read(ctx, config)


### PR DESCRIPTION
Context:
Adds support to retrieve products, when reading leads if producst is requested in the read fields.

Live Tests:
<img width="1412" height="776" alt="Screenshot 2026-04-13 at 21 43 42" src="https://github.com/user-attachments/assets/fc2eea92-30c5-43f4-a071-27470a913d7b" />
