### PR TITLE
[ENG-3793]feat: add HistoryList connector method for Gmail

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -228,6 +228,25 @@ func (c *Connector) RunScheduledMaintenance(
 	return nil, common.ErrNotImplemented
 }
 
+// Re-exports of Gmail history.list types so external callers can use them
+// without importing the internal mail package.
+type (
+	HistoryListParams = mail.HistoryListParams
+	HistoryListResult = mail.HistoryListResult
+)
+
+// HistoryList fetches Gmail mailbox changes since the given history checkpoint.
+// Only valid when the connector is initialized for the Gmail module.
+func (c *Connector) HistoryList(
+	ctx context.Context, params HistoryListParams,
+) (*HistoryListResult, error) {
+	if c.Mail == nil {
+		return nil, common.ErrNotImplemented
+	}
+
+	return c.Mail.HistoryList(ctx, params)
+}
+
 func (c *Connector) setUnitTestBaseURL(url string) {
 	if c.Calendar != nil {
 		c.Calendar.SetUnitTestBaseURL(url)

--- a/providers/google/internal/mail/subscribe.go
+++ b/providers/google/internal/mail/subscribe.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 )
 
 // Errors for subscribe validation failures.
@@ -269,6 +271,138 @@ func (a *Adapter) UpdateSubscription(
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
 	return a.Subscribe(ctx, params)
+}
+
+// HistoryListParams are inputs for Gmail users.history.list.
+// Ref: https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.history/list
+type HistoryListParams struct {
+	// StartHistoryID is the checkpoint to fetch changes since. Required.
+	StartHistoryID string
+
+	// HistoryTypes restricts results to these record types
+	// (messageAdded, messageDeleted, labelAdded, labelRemoved). Optional.
+	HistoryTypes []string
+
+	// LabelID restricts history records to those affecting the given label. Optional.
+	LabelID string
+
+	// MaxResults is the max number of history records per page. Optional (Gmail default: 100, max: 500).
+	MaxResults int
+}
+
+// HistoryMessage is the minimal message shape embedded in history records.
+type HistoryMessage struct {
+	ID       string   `json:"id"`
+	ThreadID string   `json:"threadId"`
+	LabelIDs []string `json:"labelIds,omitempty"`
+}
+
+// HistoryMessageChange wraps a message reference for messagesAdded / messagesDeleted entries.
+type HistoryMessageChange struct {
+	Message HistoryMessage `json:"message"`
+}
+
+// HistoryLabelChange is a labelsAdded / labelsRemoved entry.
+type HistoryLabelChange struct {
+	Message  HistoryMessage `json:"message"`
+	LabelIDs []string       `json:"labelIds,omitempty"`
+}
+
+// HistoryRecord is a single record from the history.list response.
+type HistoryRecord struct {
+	ID              string                 `json:"id"`
+	Messages        []HistoryMessage       `json:"messages,omitempty"`
+	MessagesAdded   []HistoryMessageChange `json:"messagesAdded,omitempty"`
+	MessagesDeleted []HistoryMessageChange `json:"messagesDeleted,omitempty"`
+	LabelsAdded     []HistoryLabelChange   `json:"labelsAdded,omitempty"`
+	LabelsRemoved   []HistoryLabelChange   `json:"labelsRemoved,omitempty"`
+}
+
+// HistoryListResult is the aggregated result from paginating history.list.
+type HistoryListResult struct {
+	// HistoryID is the root historyId from the latest page — use as the next checkpoint.
+	HistoryID string `json:"historyId"`
+
+	// History is the concatenated records across all pages.
+	History []HistoryRecord `json:"history"`
+}
+
+// historyListPage is a single page of the history.list response.
+type historyListPage struct {
+	History       []HistoryRecord `json:"history"`
+	HistoryID     string          `json:"historyId"`
+	NextPageToken string          `json:"nextPageToken"`
+}
+
+// buildHistoryListURL constructs the users.history URL for a single page fetch.
+func (a *Adapter) buildHistoryListURL(params HistoryListParams, pageToken string) (string, error) {
+	historyURL, err := urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, "users/me/history")
+	if err != nil {
+		return "", fmt.Errorf("history.list: building URL: %w", err)
+	}
+
+	historyURL.WithQueryParam("startHistoryId", params.StartHistoryID)
+
+	if len(params.HistoryTypes) > 0 {
+		historyURL.WithQueryParamList("historyTypes", params.HistoryTypes)
+	}
+
+	if params.LabelID != "" {
+		historyURL.WithQueryParam("labelId", params.LabelID)
+	}
+
+	if params.MaxResults > 0 {
+		historyURL.WithQueryParam("maxResults", strconv.Itoa(params.MaxResults))
+	}
+
+	if pageToken != "" {
+		historyURL.WithQueryParam("pageToken", pageToken)
+	}
+
+	return historyURL.String(), nil
+}
+
+// HistoryList fetches Gmail mailbox history since params.StartHistoryID, paginating through all pages.
+// Returns the aggregated records plus the root historyId — the new checkpoint to persist.
+func (a *Adapter) HistoryList(
+	ctx context.Context,
+	params HistoryListParams,
+) (*HistoryListResult, error) {
+	if params.StartHistoryID == "" {
+		return nil, fmt.Errorf("%w: startHistoryId is required", errMissingParams)
+	}
+
+	result := &HistoryListResult{}
+
+	var pageToken string
+
+	for {
+		historyURL, err := a.buildHistoryListURL(params, pageToken)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := a.JSONHTTPClient().Get(ctx, historyURL)
+		if err != nil {
+			return nil, fmt.Errorf("history.list: GET: %w", err)
+		}
+
+		page, err := common.UnmarshalJSON[historyListPage](resp)
+		if err != nil {
+			return nil, fmt.Errorf("history.list: unmarshaling response: %w", err)
+		}
+
+		result.History = append(result.History, page.History...)
+		result.HistoryID = page.HistoryID
+
+		if page.NextPageToken == "" {
+			break
+		}
+
+		pageToken = page.NextPageToken
+	}
+
+	return result, nil
 }
 
 // VerifyWebhookMessage always returns true for Gmail. Gmail push notifications are

--- a/test/google/mail/subscriber/main.go
+++ b/test/google/mail/subscriber/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -39,6 +40,38 @@ func main() {
 	utils.DumpJSON(subscribeResult, os.Stdout)
 
 	slog.Info("created a subscriber")
+
+	// Exercise history.list using the historyId returned from users.watch().
+	// Round-trip through JSON to extract the historyId without reaching into
+	// the internal mail package.
+	var watchPayload struct {
+		HistoryID string `json:"historyId"`
+	}
+
+	raw, err := json.Marshal(subscribeResult.Result)
+	if err != nil {
+		slog.Error("subscription connector", "marshaling watch result", err)
+		return
+	}
+
+	if err := json.Unmarshal(raw, &watchPayload); err != nil {
+		slog.Error("subscription connector", "unmarshaling watch result", err)
+		return
+	}
+
+	historyResult, err := conn.HistoryList(ctx, googleConn.HistoryListParams{
+		StartHistoryID: watchPayload.HistoryID,
+	})
+	if err != nil {
+		slog.Error("subscription connector", "history list action", err)
+		return
+	}
+
+	slog.Info("history.list succeeded",
+		"newCheckpointHistoryId", historyResult.HistoryID,
+		"recordCount", len(historyResult.History))
+
+	utils.DumpJSON(historyResult, os.Stdout)
 
 	subscribeResult, err = conn.Mail.RunScheduledMaintenance(ctx, subscribeParams, subscribeResult)
 	if err != nil {


### PR DESCRIPTION
## Summary
  - Adds `HistoryList()` on the Gmail adapter wrapping `users.history.list`, with pagination
  over `nextPageToken`
  - Re-exports `HistoryListParams` / `HistoryListResult` on `*google.Connector` so external
  (server-side) callers can use them without importing `internal/mail`
  - Extends the existing `test/google/mail/subscriber` harness to exercise `HistoryList` using
  the `historyId` returned from `users.watch()`

  ## Context
  Part of ENG-3798 (ProcessGmailEventWorkflow). The new Temporal workflow will call this method
   each time a Gmail Pub/Sub notification arrives, passing the last-processed checkpoint from
  the upcoming `subscription_states` table and persisting the response's root `historyId` as
  the next checkpoint.

  ## Test plan
  - [x] `go build ./providers/google/... ./test/google/mail/subscriber/...` passes
  - [ ] Live-test via `go run ./test/google/mail/subscriber` (requires
  `google-gmail-creds.json` — deferred; will be exercised end-to-end in the workflow PR)