### PR TITLE
fix: remove accidentally committed subscriber binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,5 @@ output/
 apex
 test/salesforce/apex/apex
 subscribe
+subscriber
 test/salesforce/subscribe/subscribe


### PR DESCRIPTION
Context:
- This was accidentally committed as a compiled binary in https://github.com/amp-labs/connectors/pull/2862
- Adds subscriber to .gitignore 