### PR TITLE
[CON-3159] feat(odoo): add proxy

### DIFF
--- a/providers/odoo.go
+++ b/providers/odoo.go
@@ -1,0 +1,51 @@
+package providers
+
+const Odoo Provider = "odoo"
+
+func init() {
+	SetInfo(Odoo, ProviderInfo{
+		DisplayName: "Odoo",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://www.odoo.com/documentation/19.0/developer/reference/external_api.html#configuration",
+		},
+		// e.g. yourcompany.odoo.com,odoo.yourdomain.com
+		BaseURL:  "https://{{.odoo_domain}}",
+		AuthType: ApiKey,
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776183638/media/odoo.com_1776183637.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776183246/media/odoo.com_1776183245.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776183638/media/odoo.com_1776183637.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776183223/media/odoo.com_1776183222.svg",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "odoo_domain",
+					DisplayName: "API Domain",
+					Prompt:      "Enter your Odoo domain (e.g. yourcompany.odoo.com or odoo.yourdomain.com)",
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Configuration


# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [x] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [x] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ]  They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
## Testing


## GET
<img width="2534" height="1152" alt="Screenshot from 2026-04-14 20-01-32" src="https://github.com/user-attachments/assets/fb6f0df5-7e0a-4ad1-ac8e-dab1a150dbdb" />


## POST


####  search
<img width="1571" height="723" alt="Screenshot from 2026-04-14 20-05-06" src="https://github.com/user-attachments/assets/7568e723-35c7-4b88-916d-d9e74fe7dcda" />

#### read
<img width="1932" height="898" alt="Screenshot from 2026-04-14 20-10-57" src="https://github.com/user-attachments/assets/bb609710-05f0-4418-8ac3-87b8fdd83eca" />




####  create
<img width="2534" height="1152" alt="Screenshot from 2026-04-14 18-33-03" src="https://github.com/user-attachments/assets/07e4b839-3b53-47c4-b5fb-3ff6352e31b4" />


####  update
<img width="2534" height="1152" alt="Screenshot from 2026-04-14 18-21-46" src="https://github.com/user-attachments/assets/437f7337-5bb3-4fd9-8fa7-e39b96e953c3" />

####  delete
<img width="2534" height="1152" alt="Screenshot from 2026-04-14 18-24-40" src="https://github.com/user-attachments/assets/4fa15d85-c5dc-48c1-aca5-ed171eb87c97" />





## LOGO AND ICON
 
### Darkmode

 #### Icon
<img src="https://res.cloudinary.com/dycvts6vp/image/upload/v1776183638/media/odoo.com_1776183637.jpg" alt="Icon" width="200">

#### Logo
<img src="https://res.cloudinary.com/dycvts6vp/image/upload/v1776183246/media/odoo.com_1776183245.svg" alt="Logo" width="400">

### Regular

#### Icon
<img src="https://res.cloudinary.com/dycvts6vp/image/upload/v1776183638/media/odoo.com_1776183637.jpg" alt="Regular Icon" width="200">

#### Logo
<img src="https://res.cloudinary.com/dycvts6vp/image/upload/v1776183223/media/odoo.com_1776183222.svg" alt="Regular Logo" width="400">