### PR TITLE
feat(components): Subscription interfaces

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -744,17 +744,34 @@ type SubscriptionEventPreLoadData struct {
 	RequestHeaders *http.Header
 }
 
+// Event represents a raw webhook payload and serves as the common abstraction across all event types in the system.
+// Implementations are expected to provide access to the underlying payload in a normalized map form.
+//
+// The following higher-level event interfaces build on top of Event
+// and should be considered during implementation:
+//   - SubscriptionEvent: core interface for all subscription-related events
+//   - SubscriptionUpdateEvent: specialization for update/change events
+//   - CollapsedSubscriptionEvent: for payloads containing multiple events
+//
+// A concrete provider event type may implement one or more of these
+// interfaces depending on the structure of the incoming webhook payload.
+type Event interface {
+	RawMap() (map[string]any, error)
+}
+
 // SubscriptionEvent is an interface for webhook events coming from the provider.
 // This interface defines methods to extract information from the webhook event.
 type SubscriptionEvent interface {
+	Event
+
 	EventType() (SubscriptionEventType, error)
 	RawEventName() (string, error)
 	ObjectName() (string, error)
 	Workspace() (string, error)
 	RecordId() (string, error)
 	EventTimeStampNano() (int64, error)
-	RawMap() (map[string]any, error)
-	// PreLoadData is used to pre-load data into the subscription event.
+
+	// PreLoadData is used to preload data into the subscription event.
 	// Assume that the data will include the entire request body in case it is needed for the event processing.
 	// This method will be called for every event as the first step in the event processing.
 	PreLoadData(data *SubscriptionEventPreLoadData) error
@@ -762,7 +779,8 @@ type SubscriptionEvent interface {
 
 type SubscriptionUpdateEvent interface {
 	SubscriptionEvent
-	// GetUpdatedFields returns the fields that were updated in the event.
+
+	// UpdatedFields returns the fields that were updated in the event.
 	UpdatedFields() ([]string, error)
 }
 
@@ -770,8 +788,11 @@ type SubscriptionUpdateEvent interface {
 // This interface is used to extract individual events to SubscriptionEvent type
 // from a collapsed event for webhook parsing and processing.
 type CollapsedSubscriptionEvent interface {
+	Event
+
+	// SubscriptionEventList collapses the event response into the list of messages.
+	// In case of an error returns ErrSubscriptionEventList.
 	SubscriptionEventList() ([]SubscriptionEvent, error)
-	RawMap() (map[string]any, error)
 }
 
 // WebhookRequest is a struct that contains the request parameters for a webhook.

--- a/internal/components/subscriptions.go
+++ b/internal/components/subscriptions.go
@@ -1,0 +1,92 @@
+package components
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// SubscriptionInputOutput is a generic helper that provides type-safe implementations
+// of the EmptySubscriptionParams and EmptySubscriptionResult methods
+// required by connectors.SubscribeConnector.
+type SubscriptionInputOutput[I, O any] struct{}
+
+func (SubscriptionInputOutput[I, O]) EmptySubscriptionParams() *common.SubscribeParams {
+	var request I
+
+	return &common.SubscribeParams{
+		Request: &request,
+	}
+}
+
+func (SubscriptionInputOutput[I, O]) EmptySubscriptionResult() *common.SubscriptionResult {
+	var result O
+
+	return &common.SubscriptionResult{
+		Result: &result,
+	}
+}
+
+// WebhookMessageVerifier is the minimal interface for a connector that can verify webhook messages.
+type WebhookMessageVerifier interface {
+	VerifyWebhookMessage(
+		ctx context.Context,
+		request *common.WebhookRequest,
+		params *common.VerificationParams,
+	) (bool, error)
+}
+
+// SubscriptionCreator is the minimal interface for a connector that can create subscriptions.
+type SubscriptionCreator interface {
+	Subscribe(
+		ctx context.Context,
+		params common.SubscribeParams,
+	) (*common.SubscriptionResult, error)
+}
+
+// SubscriptionUpdator is the minimal interface for a connector that can update subscriptions.
+type SubscriptionUpdator interface {
+	UpdateSubscription(
+		ctx context.Context,
+		params common.SubscribeParams,
+		previousResult *common.SubscriptionResult,
+	) (*common.SubscriptionResult, error)
+}
+
+// SubscriptionRemover is the minimal interface for a connector that can delete subscriptions.
+type SubscriptionRemover interface {
+	DeleteSubscription(
+		ctx context.Context,
+		previousResult common.SubscriptionResult,
+	) error
+}
+
+// Compile-time assertion that the minimal subscription interfaces
+// satisfy connectors.SubscribeConnector.
+//
+// Each connector asserts only the interfaces it implements.
+// If connectors.SubscribeConnector changes, the compiler forces updates,
+// causing dependent connectors to fail in tests.
+//
+// Enables incremental, method-by-method implementation with full compatibility.
+var (
+	_ connectors.SubscribeConnector = (*dummySubscribeConnector)(nil)
+)
+
+// dummySubscribeConnector composes the minimal subscription interfaces and
+// required base behavior. It has no implementations and exists purely for
+// compile-time interface verification.
+type dummySubscribeConnector struct {
+	// Base.
+	connectors.BatchRecordReaderConnector
+
+	// Decomposed interfaces (primary).
+	WebhookMessageVerifier
+	SubscriptionCreator
+	SubscriptionUpdator
+	SubscriptionRemover
+
+	// Supporting helpers (secondary).
+	SubscriptionInputOutput[any, any]
+}

--- a/internal/components/subscriptions.go
+++ b/internal/components/subscriptions.go
@@ -1,0 +1,56 @@
+package components
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+var ErrInvalidSubscriptionRequestType = errors.New("request type of common.SubscribeParams is invalid")
+
+// SubscriptionInputOutput is a generic helper that provides out-of-the-box,
+// type-safe implementations of the EmptySubscriptionParams and
+// EmptySubscriptionResult methods required by connectors.SubscribeConnector.
+//
+// It acts as a bridge around the non-generic interface by encapsulating the
+// untyped fields (any) and restoring type safety via generics. By embedding
+// this struct, connectors can work with concrete input/output types without
+// manual casting boilerplate.
+type SubscriptionInputOutput[I, O any] struct{}
+
+func (SubscriptionInputOutput[I, O]) EmptySubscriptionParams() *common.SubscribeParams {
+	var request I
+
+	return &common.SubscribeParams{
+		Request: &request,
+	}
+}
+
+func (SubscriptionInputOutput[I, O]) EmptySubscriptionResult() *common.SubscriptionResult {
+	var result O
+
+	return &common.SubscriptionResult{
+		Result: &result,
+	}
+}
+
+// TypedSubscriptionRequest extracts and casts params.Request into the concrete input type I.
+//
+// It provides a safe way to recover the typed request from the
+// non-generic SubscribeParams, returning an error if the underlying
+// type does not match.
+func (s SubscriptionInputOutput[I, O]) TypedSubscriptionRequest(params common.SubscribeParams) (I, error) {
+	var input I
+
+	if params.Request != nil {
+		var ok bool
+
+		input, ok = params.Request.(I)
+		if !ok {
+			return input, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionRequestType, input, params.Request)
+		}
+	}
+
+	return input, nil
+}

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -3,7 +3,12 @@
 package testroutines
 
 import (
+	"context"
 	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
 )
 
 // ConnectorBuilder is a callback method to construct and configure connector for testing.
@@ -17,4 +22,67 @@ func (builder ConnectorBuilder[C]) Build(t *testing.T, testCaseName string) C {
 	}
 
 	return conn
+}
+
+// TestableWebhookMessageVerifier is the minimal interface for a connector that can verify webhook messages.
+type TestableWebhookMessageVerifier interface {
+	VerifyWebhookMessage(
+		ctx context.Context,
+		request *common.WebhookRequest,
+		params *common.VerificationParams,
+	) (bool, error)
+}
+
+// TestableSubscriptionCreator is the minimal interface for a connector that can create subscriptions.
+type TestableSubscriptionCreator interface {
+	Subscribe(
+		ctx context.Context,
+		params common.SubscribeParams,
+	) (*common.SubscriptionResult, error)
+}
+
+// TestableSubscriptionUpdater is the minimal interface for a connector that can update subscriptions.
+type TestableSubscriptionUpdater interface {
+	UpdateSubscription(
+		ctx context.Context,
+		params common.SubscribeParams,
+		previousResult *common.SubscriptionResult,
+	) (*common.SubscriptionResult, error)
+}
+
+// TestableSubscriptionRemover is the minimal interface for a connector that can delete subscriptions.
+type TestableSubscriptionRemover interface {
+	DeleteSubscription(
+		ctx context.Context,
+		previousResult common.SubscriptionResult,
+	) error
+}
+
+// Compile-time assertion that the minimal subscription interfaces
+// satisfy connectors.SubscribeConnector.
+//
+// Each connector asserts only the interfaces it implements.
+// If connectors.SubscribeConnector changes, the compiler forces updates,
+// causing dependent connectors to fail in tests.
+//
+// Enables incremental, method-by-method implementation with full compatibility and testing.
+var (
+	_ connectors.SubscribeConnector = (*dummySubscribeConnector)(nil)
+)
+
+// dummySubscribeConnector composes the minimal subscription interfaces and
+// required base behavior. It has no implementations and exists purely for
+// compile-time interface verification.
+type dummySubscribeConnector struct {
+	// Base.
+	connectors.BatchRecordReaderConnector
+
+	// Decomposed interfaces (primary).
+	TestableWebhookMessageVerifier
+	TestableSubscriptionCreator
+	TestableSubscriptionUpdater
+	TestableSubscriptionRemover
+
+	// Supporting helpers (secondary).
+	components.SubscriptionInputOutput[any, any]
 }


### PR DESCRIPTION
# Description

This PR refactors the subscription components to improve composability and testability, while working within the constraints of existing interfaces.

### Key changes

* **Interface decomposition for better testing**
  `SubscribeConnector` is split into smaller, focused interfaces (`SubscriptionCreator`, `SubscriptionUpdater`, etc.).
  This makes unit testing simpler and more targeted (single-method interfaces).
  A compile-time assertion via `dummySubscribeConnector` ensures that the composed interfaces remain fully compatible with `SubscribeConnector`.

* **Generic input/output helper**
  Introduces `SubscriptionInputOutput[I, O any]`, which provides out-of-the-box implementations of
  `EmptySubscriptionParams` and `EmptySubscriptionResult`.
  This avoids repetitive boilerplate while preserving type safety.
  Since the original interface cannot be changed to use generics, this acts as a lightweight workaround.

* **Event interface unification (optional/experimental)**
  A new `Event` interface extracts shared behavior from subscription event types and is embedded into each.
  This makes their relationship explicit, while keeping usage flexible. (Can be reverted if needed, it is a proposal)

### Benefits

* Easier and more granular unit testing
* Reduced boilerplate for subscription connectors
* Safer and more modular interface design without breaking existing contracts
* More flexible PRs: implementations can be delivered incrementally without requiring the full `SubscribeConnector` surface.
