### PR TITLE
[ENG-3815] feat(microsoft): Impl Update Subscription

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -166,6 +166,11 @@ var (
 
 	// ErrMissingHeader indicates that a required header is missing in HTTP response.
 	ErrMissingHeader = errors.New("missing header")
+
+	// ErrPrevSubscriptionResultInvalid is returned when the update subscription expects different shape of data
+	// from previous SubscriptionResult. This should not happen and it points to issues with implementation.
+	// Likely the result was not created properly by previous Create/Update step.
+	ErrPrevSubscriptionResultInvalid = errors.New("previous SubscriptionResult does not match expectations")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/providers/microsoft/internal/subscriber/create.go
+++ b/providers/microsoft/internal/subscriber/create.go
@@ -12,7 +12,17 @@ import (
 	"github.com/amp-labs/connectors/providers/microsoft/internal/webhook"
 )
 
-const subscriptionExpirationWindow = 5 * time.Hour
+const (
+	// timeBufferForValidPayload keeps the requested expiration safely below the
+	// minimum supported subscription lifetime so Microsoft Graph accepts the payload.
+	// We leave a 5-minute margin to account for latency and boundary timing.
+	timeBufferForValidPayload = 5 * time.Minute
+
+	// subscriptionExpirationWindow is the effective minimum lifetime we request.
+	// The target is 6 hours, minus the safety buffer, to stay close to the real
+	// minimum while avoiding "400 BadRequest" on creation.
+	subscriptionExpirationWindow = 6*time.Hour - timeBufferForValidPayload
+)
 
 // Subscribe creates a Microsoft Graph subscription for the specified objects and events.
 //
@@ -216,7 +226,7 @@ type SubscriptionResource struct {
 
 // newPayloadCreateSubscription constructs a subscription payload for creation.
 // Uses clientState to store objectName for identification.
-// Expiration is set to 5 hours to safely fit common maximums (e.g., presence: 1h excluded; others 3-30 days).
+// Expiration is set to a little less than 6 hours to safely fit common maximums.
 //
 // nolint:lll
 // See [lifetime limits](https://learn.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-1.0#subscription-lifetime)
@@ -227,13 +237,29 @@ func newPayloadCreateSubscription(
 ) SubscriptionResource {
 	resource := objectName.String()
 
-	fiveHoursFromNow := time.Now().Add(subscriptionExpirationWindow)
+	sixHoursFromNow := time.Now().Add(subscriptionExpirationWindow)
 	body := SubscriptionResource{
 		ChangeType:          webhook.NewChangeType(events.Events),
 		ObjectName:          objectName,
 		WebhookURL:          webhookURL,
 		Resource:            resource,
-		ExpirationDateTime:  fiveHoursFromNow,
+		ExpirationDateTime:  sixHoursFromNow,
+		IncludeResourceData: false,
+	}
+
+	return body
+}
+
+// Update is only relevant for extending the subscription expiration.
+// > Updates a subscription expiration time for renewal and/or updates the notificationUrl for delivery.
+// https://learn.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-1.0#methods
+func newPayloadRefreshSubscription(
+	webhookURL string,
+) SubscriptionResource {
+	sixHoursFromNow := time.Now().Add(subscriptionExpirationWindow)
+	body := SubscriptionResource{
+		WebhookURL:          webhookURL,
+		ExpirationDateTime:  sixHoursFromNow,
 		IncludeResourceData: false,
 	}
 

--- a/providers/microsoft/internal/subscriber/delete.go
+++ b/providers/microsoft/internal/subscriber/delete.go
@@ -56,6 +56,52 @@ func (s Strategy) DeleteSubscription(
 	return nil
 }
 
+func (s Strategy) deleteSubscriptionsWithResult(ctx context.Context,
+	identifiers []string,
+	prevResult *Result,
+) (*common.SubscriptionResult, error) {
+	subscriptions, objectEvents := prevResult.extractSubscriptionsByIds(identifiers)
+
+	// Attempt removal of the requested subscriptions.
+	// If removal fails (non-nil err), the previous state is unchanged,
+	// and we return a failed result containing the initial state.
+	result, err := s.removeSubscriptionsByIds(ctx, identifiers)
+	if err != nil {
+		return &common.SubscriptionResult{
+			Result:       &Result{Subscriptions: subscriptions},
+			ObjectEvents: objectEvents,
+			Status:       common.SubscriptionStatusFailed,
+		}, err
+	}
+
+	// If there were per-item errors, aggregate them into a single error.
+	status := common.SubscriptionStatusSuccess
+
+	if len(result.Errors) == 0 {
+		// Prune the initial state for every record.
+		for _, id := range identifiers {
+			objectEvents[subscriptions[id].ObjectName] = common.ObjectEvents{}
+			delete(subscriptions, id)
+		}
+	} else {
+		err = nil // must be empty anyway.
+		for _, errWrapper := range result.Errors {
+			err = errors.Join(err, errWrapper.Data)
+		}
+
+		// If aggregation produced an error, mark overall status as failed.
+		if err != nil {
+			status = common.SubscriptionStatusFailed
+		}
+	}
+
+	return &common.SubscriptionResult{
+		Result:       &Result{Subscriptions: subscriptions},
+		ObjectEvents: objectEvents,
+		Status:       status,
+	}, err
+}
+
 // removeSubscriptionsByIds executes batch DELETE for given subscription IDs.
 // Generic helper; returns raw batch result for custom error handling.
 func (s Strategy) removeSubscriptionsByIds(

--- a/providers/microsoft/internal/subscriber/strategy.go
+++ b/providers/microsoft/internal/subscriber/strategy.go
@@ -4,6 +4,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/microsoft/internal/batch"
 )
@@ -57,4 +58,26 @@ type Result struct {
 // https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks?tabs=http#subscription-request
 func (s Strategy) getSubscriptionURL() (*urlbuilder.URL, error) {
 	return urlbuilder.New(s.providerInfo.BaseURL, apiVersion, "subscriptions")
+}
+
+func (r Result) extractSubscriptionsByIds(
+	ids []string,
+) (map[string]SubscriptionResource, map[common.ObjectName]common.ObjectEvents) {
+	// Build initial state (subscriptions and objectEvents) from the previous result,
+	// but only for the requested identifiers. This represents the set of items
+	// that we intend to remove; we'll prune it after seeing which removals succeed.
+	subscriptions := make(map[string]SubscriptionResource)
+	objectEvents := make(map[common.ObjectName]common.ObjectEvents)
+	identifiers := datautils.NewSetFromList(ids)
+
+	for _, sub := range r.Subscriptions {
+		if identifiers.Has(sub.ID) {
+			subscriptions[sub.ID] = sub
+			objectEvents[sub.ObjectName] = common.ObjectEvents{
+				Events: sub.ChangeType.EventTypes(),
+			}
+		}
+	}
+
+	return subscriptions, objectEvents
 }

--- a/providers/microsoft/internal/subscriber/test/create/groups-payload.json
+++ b/providers/microsoft/internal/subscriber/test/create/groups-payload.json
@@ -1,0 +1,15 @@
+{
+  "id": "groups",
+  "method": "POST",
+  "url": "/subscriptions",
+  "body": {
+    "changeType": "deleted",
+    "clientState": "groups",
+    "notificationUrl": "https://test.com/webhook",
+    "resource": "groups",
+    "expirationDateTime": "2026-03-04T10:00:00Z"
+  },
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}

--- a/providers/microsoft/internal/subscriber/test/create/messages-and-groups-response.json
+++ b/providers/microsoft/internal/subscriber/test/create/messages-and-groups-response.json
@@ -1,0 +1,60 @@
+{
+  "responses": [
+    {
+      "id": "groups",
+      "status": 201,
+      "headers": {
+        "Location": "https://subscriptionstore.windows.net/1.0/NA/subscriptions('9d94e78b-4bca-4fd6-b5f4-bc5f26de5bcf')",
+        "Cache-Control": "no-cache",
+        "OData-Version": "4.0",
+        "Content-Type": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+      },
+      "body": {
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity",
+        "id": "9d94e78b-4bca-4fd6-b5f4-bc5f26de5bcf",
+        "resource": "groups",
+        "applicationId": "39d7eec8-2032-4dd3-959f-d92d8a4e2ad3",
+        "changeType": "deleted",
+        "clientState": "groups",
+        "notificationUrl": "https://test.com/webhook",
+        "notificationQueryOptions": null,
+        "lifecycleNotificationUrl": null,
+        "expirationDateTime": "2026-06-19T05:41:27.3734664Z",
+        "creatorId": "ae87552f-48fc-4dec-9322-65040bf9fdfd",
+        "includeResourceData": null,
+        "latestSupportedTlsVersion": "v1_2",
+        "encryptionCertificate": null,
+        "encryptionCertificateId": null,
+        "notificationUrlAppId": null
+      }
+    },
+    {
+      "id": "me/messages",
+      "status": 201,
+      "headers": {
+        "Location": "https://subscriptionstore.windows.net/1.0/NA/subscriptions('5917db81-22d5-426d-af91-e285927592b7')",
+        "Cache-Control": "no-cache",
+        "OData-Version": "4.0",
+        "Content-Type": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+      },
+      "body": {
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity",
+        "id": "5917db81-22d5-426d-af91-e285927592b7",
+        "resource": "me/messages",
+        "applicationId": "39d7eec8-2032-4dd3-959f-d92d8a4e2ad3",
+        "changeType": "created,updated,deleted",
+        "clientState": "me/messages",
+        "notificationUrl": "https://test.com/webhook",
+        "notificationQueryOptions": null,
+        "lifecycleNotificationUrl": null,
+        "expirationDateTime": "2026-06-19T05:41:27.3735745Z",
+        "creatorId": "ae87552f-48fc-4dec-9322-65040bf9fdfd",
+        "includeResourceData": null,
+        "latestSupportedTlsVersion": "v1_2",
+        "encryptionCertificate": null,
+        "encryptionCertificateId": null,
+        "notificationUrlAppId": null
+      }
+    }
+  ]
+}

--- a/providers/microsoft/internal/subscriber/test/create/messages-payload-1.json
+++ b/providers/microsoft/internal/subscriber/test/create/messages-payload-1.json
@@ -1,0 +1,13 @@
+{
+  "id": "me/messages",
+  "method": "POST",
+  "url": "/subscriptions",
+  "body": {
+    "changeType": "created,updated,deleted",
+    "notificationUrl": "https://test.com/webhook",
+    "resource": "me/messages",
+    "clientState": "me/messages",
+    "expirationDateTime": "2026-03-04T10:00:00Z"
+  },
+  "headers": {"Content-Type": "application/json"}
+}

--- a/providers/microsoft/internal/subscriber/test/create/messages-payload-2.json
+++ b/providers/microsoft/internal/subscriber/test/create/messages-payload-2.json
@@ -1,0 +1,13 @@
+{
+  "id": "me/messages",
+  "method": "POST",
+  "url": "/subscriptions",
+  "body": {
+    "changeType": "created,deleted",
+    "notificationUrl": "https://test.com/webhook",
+    "resource": "me/messages",
+    "clientState": "me/messages",
+    "expirationDateTime": "2026-03-04T10:00:00Z"
+  },
+  "headers": {"Content-Type": "application/json"}
+}

--- a/providers/microsoft/internal/subscriber/test/create/messages-response-2.json
+++ b/providers/microsoft/internal/subscriber/test/create/messages-response-2.json
@@ -1,0 +1,32 @@
+{
+  "responses": [
+    {
+      "id": "me/messages",
+      "status": 201,
+      "headers": {
+        "Location": "https://subscriptionstore.windows.net/1.0/NA/subscriptions('813ef41d-28dd-4bc8-a5d3-10bdfc033c99')",
+        "Cache-Control": "no-cache",
+        "OData-Version": "4.0",
+        "Content-Type": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+      },
+      "body": {
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity",
+        "id": "813ef41d-28dd-4bc8-a5d3-10bdfc033c99",
+        "resource": "me/messages",
+        "applicationId": "39d7eec8-2032-4dd3-959f-d92d8a4e2ad3",
+        "changeType": "created,deleted",
+        "clientState": "me/messages",
+        "notificationUrl": "https://test.com/webhook",
+        "notificationQueryOptions": null,
+        "lifecycleNotificationUrl": null,
+        "expirationDateTime": "2026-04-17T17:00:57Z",
+        "creatorId": "ae87552f-48fc-4dec-9322-65040bf9fdfd",
+        "includeResourceData": null,
+        "latestSupportedTlsVersion": "v1_2",
+        "encryptionCertificate": null,
+        "encryptionCertificateId": null,
+        "notificationUrlAppId": null
+      }
+    }
+  ]
+}

--- a/providers/microsoft/internal/subscriber/test/delete/chat-payload.json
+++ b/providers/microsoft/internal/subscriber/test/delete/chat-payload.json
@@ -1,0 +1,8 @@
+{
+  "id": "a33272c7-b187-444c-840f-9e78cc6de127",
+  "method": "DELETE",
+  "url": "/subscriptions/a33272c7-b187-444c-840f-9e78cc6de127",
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}

--- a/providers/microsoft/internal/subscriber/test/patch/calendar-events-payload.json
+++ b/providers/microsoft/internal/subscriber/test/patch/calendar-events-payload.json
@@ -1,0 +1,12 @@
+{
+  "id": "63b01115-ba3f-4db6-a1ef-793797ec340a",
+  "method": "PATCH",
+  "url": "/subscriptions/63b01115-ba3f-4db6-a1ef-793797ec340a",
+  "body": {
+    "expirationDateTime": "2026-03-04T10:00:00Z",
+    "notificationUrl": "https://test.com/webhook"
+  },
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}

--- a/providers/microsoft/internal/subscriber/test/patch/calendar-events-response.json
+++ b/providers/microsoft/internal/subscriber/test/patch/calendar-events-response.json
@@ -1,0 +1,31 @@
+{
+  "responses": [
+    {
+      "id": "me/events",
+      "status": 200,
+      "headers": {
+        "Cache-Control": "no-cache",
+        "OData-Version": "4.0",
+        "Content-Type": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+      },
+      "body": {
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity",
+        "id": "63b01115-ba3f-4db6-a1ef-793797ec340a",
+        "resource": "me/events",
+        "applicationId": "39d7eec8-2032-4dd3-959f-d92d8a4e2ad3",
+        "changeType": "created,deleted",
+        "clientState": "me/events",
+        "notificationUrl": "https://651c-46-150-81-5.ngrok-free.app/",
+        "notificationQueryOptions": null,
+        "lifecycleNotificationUrl": null,
+        "expirationDateTime": "2026-05-01T00:09:21.6065208Z",
+        "creatorId": "ae87552f-48fc-4dec-9322-65040bf9fdfd",
+        "includeResourceData": null,
+        "latestSupportedTlsVersion": "v1_2",
+        "encryptionCertificate": null,
+        "encryptionCertificateId": null,
+        "notificationUrlAppId": null
+      }
+    }
+  ]
+}

--- a/providers/microsoft/internal/subscriber/update.go
+++ b/providers/microsoft/internal/subscriber/update.go
@@ -1,0 +1,16 @@
+package subscriber
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func (s Strategy) UpdateSubscription(
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/providers/microsoft/internal/subscriber/update.go
+++ b/providers/microsoft/internal/subscriber/update.go
@@ -1,0 +1,249 @@
+package subscriber
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/subscriptionhelper"
+	"github.com/amp-labs/connectors/providers/microsoft/internal/batch"
+)
+
+// UpdateSubscription reconciles existing remote subscriptions with the desired state from params.
+// Microsoft Graph does not support full subscription updates, so UpdateSubscription performs
+// targeted create/refresh/delete operations:
+//   - CREATE subscriptions for missing objects
+//   - REFRESH (PATCH expirationDateTime/notificationUrl) subscriptions that are expiring
+//   - DELETE undesired objects
+//   - CREATE/DELETE to imitate update.
+//
+// It returns a merged SubscriptionResult representing the final state after all operations.
+//
+// Microsoft Graph limitation: Only expirationDateTime and notificationUrl are PATCHable.
+// https://learn.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-1.0#methods
+func (s Strategy) UpdateSubscription( // nolint:cyclop,funlen
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	// Partition subscription events into ToCreate, ToKeep, ToUpdate, and ToRemove categories.
+	segmentEvents := subscriptionhelper.SegmentSubscriptionEvents(
+		previousResult.ObjectEvents, params.SubscriptionEvents,
+	)
+
+	// Microsoft Graph API does not support updating subscriptions.
+	// We simulate an update by creating a new subscription and removing the outdated one.
+	for name, events := range segmentEvents.ToUpdate {
+		segmentEvents.ToRemove[name] = common.ObjectEvents{}
+		segmentEvents.ToCreate[name] = events
+	}
+
+	subsReq, err := s.TypedSubscriptionRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	prevRes, err := s.TypedSubscriptionResult(*previousResult)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		createResult, refreshResult, deleteResult *common.SubscriptionResult
+		createErr, refreshErr, deleteErr          error
+	)
+
+	if len(segmentEvents.ToCreate) != 0 {
+		createResult, createErr = s.createSubscription(ctx, common.SubscribeParams{
+			Request:            params.Request,
+			RegistrationResult: params.RegistrationResult,
+			SubscriptionEvents: segmentEvents.ToCreate,
+		})
+	}
+
+	if len(segmentEvents.ToKeep) != 0 {
+		subsToRefresh := make([]string, 0)
+
+		for _, sub := range prevRes.Subscriptions {
+			if segmentEvents.ToKeep.Has(sub.ObjectName) {
+				subsToRefresh = append(subsToRefresh, sub.ID)
+			}
+		}
+
+		if len(subsToRefresh) != 0 {
+			refreshResult, refreshErr = s.refreshSubscription(ctx, subsToRefresh, prevRes, subsReq.WebhookURL)
+		} else {
+			refreshErr = fmt.Errorf("%w: no subscriptions to refresh", common.ErrPrevSubscriptionResultInvalid)
+		}
+	}
+
+	if len(segmentEvents.ToRemove) != 0 {
+		subsToRemove := make([]string, 0)
+
+		for _, sub := range prevRes.Subscriptions {
+			if segmentEvents.ToRemove.Has(sub.ObjectName) {
+				subsToRemove = append(subsToRemove, sub.ID)
+			}
+		}
+
+		if len(subsToRemove) != 0 {
+			deleteResult, deleteErr = s.deleteSubscriptionsWithResult(ctx, subsToRemove, prevRes)
+		} else {
+			deleteErr = fmt.Errorf("%w: no subscriptions to remove", common.ErrPrevSubscriptionResultInvalid)
+		}
+	}
+
+	result, fatalErr := combineResults(createResult, refreshResult, deleteResult)
+	if fatalErr != nil {
+		return nil, fatalErr
+	}
+
+	err = errors.Join(createErr, refreshErr, deleteErr)
+
+	return result, err
+}
+
+// combineResults merges create, refresh, and remove subscription results into a single SubscriptionResult.
+//
+// Semantics:
+//   - refresh is disjoint from both create and remove.
+//   - create and remove are not necessarily disjoint.
+//   - an object appearing in both create and remove represents an update
+//     (remove old subscription + create new subscription).
+//
+// Merge order is significant:
+//   - create and refresh are applied first and are authoritative.
+//   - remove is applied only for objects not already present in the merged state.
+//
+// This ensures updated objects are preserved and not overwritten by stale remove entries.
+// Objects present only in remove represent truly deleted subscriptions and will have an empty event list.
+//
+// Nil inputs are ignored.
+func combineResults( // nolint:cyclop,funlen
+	create, refresh, remove *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	var (
+		status                = common.SubscriptionStatusSuccess
+		combinedEvents        = make(map[common.ObjectName]common.ObjectEvents)
+		combinedSubscriptions = make(map[string]SubscriptionResource)
+	)
+
+	if create != nil {
+		status = status.Resolve(create.Status)
+		maps.Copy(combinedEvents, create.ObjectEvents)
+
+		result, ok := create.Result.(*Result)
+		if !ok {
+			return nil, fmt.Errorf("%w: create.Result cannot be cast to microsoft.Result",
+				common.ErrInvalidImplementation)
+		}
+
+		maps.Copy(combinedSubscriptions, result.Subscriptions)
+	}
+
+	if refresh != nil {
+		status = status.Resolve(refresh.Status)
+		maps.Copy(combinedEvents, refresh.ObjectEvents)
+
+		result, ok := refresh.Result.(*Result)
+		if !ok {
+			return nil, fmt.Errorf("%w: refresh.Result cannot be cast to microsoft.Result",
+				common.ErrInvalidImplementation)
+		}
+
+		maps.Copy(combinedSubscriptions, result.Subscriptions)
+	}
+
+	if remove != nil {
+		status = status.Resolve(remove.Status)
+
+		// Apply remove entries only for objects that were truly deleted.
+		// Objects already present in the state were recreated as part of an update
+		// flow (create + remove) and must be preserved.
+		for objectName, events := range remove.ObjectEvents {
+			if _, exists := combinedEvents[objectName]; !exists {
+				combinedEvents[objectName] = events
+			}
+		}
+
+		result, ok := remove.Result.(*Result)
+		if !ok {
+			return nil, fmt.Errorf("%w: remove.Result cannot be cast to microsoft.Result",
+				common.ErrInvalidImplementation)
+		}
+
+		for subId, sub := range result.Subscriptions {
+			if _, exists := combinedSubscriptions[subId]; !exists {
+				combinedSubscriptions[subId] = sub
+			}
+		}
+	}
+
+	return &common.SubscriptionResult{
+		Result:       &Result{Subscriptions: combinedSubscriptions},
+		ObjectEvents: combinedEvents,
+		Status:       status,
+	}, nil
+}
+
+// refreshSubscription batch-PATCHes expirationDateTime and notificationUrl for subscriptions nearing expiry.
+func (s Strategy) refreshSubscription(ctx context.Context,
+	identifiers []string,
+	prevResult *Result,
+	webhookURL string,
+) (*common.SubscriptionResult, error) {
+	batchParams, err := s.paramsForBatchRefreshSubscriptions(identifiers, webhookURL)
+	if err != nil {
+		return nil, err
+	}
+
+	bundledResponse := batch.Execute[SubscriptionResource](ctx, s.batchStrategy, batchParams)
+
+	status := common.SubscriptionStatusSuccess
+	if len(bundledResponse.Errors) != 0 {
+		// Some requests failed. There is no rollback for refresh operations.
+		// The state must remain unchanged.
+		status = common.SubscriptionStatusFailed
+
+		err = nil
+		for _, wrapper := range bundledResponse.Errors {
+			err = errors.Join(err, wrapper.Data)
+		}
+	}
+
+	subscriptions, objectEvents := prevResult.extractSubscriptionsByIds(identifiers)
+
+	return &common.SubscriptionResult{
+		Result:       &Result{Subscriptions: subscriptions},
+		ObjectEvents: objectEvents,
+		Status:       status,
+	}, err
+}
+
+// paramsForBatchRefreshSubscriptions builds PATCH /subscriptions/{id} requests for subscription renewal.
+func (s Strategy) paramsForBatchRefreshSubscriptions(
+	identifiers []string,
+	webhookURL string,
+) (*batch.Params, error) {
+	batchParams := &batch.Params{}
+
+	for _, subscriptionId := range identifiers {
+		url, err := s.getSubscriptionURL()
+		if err != nil {
+			return nil, err
+		}
+
+		url.AddPath(subscriptionId)
+
+		requestId := batch.RequestID(subscriptionId)
+		body := newPayloadRefreshSubscription(webhookURL)
+		batchParams.WithRequest(requestId, http.MethodPatch, url, body, map[string]any{
+			"Content-Type": "application/json",
+		})
+	}
+
+	return batchParams, nil
+}

--- a/providers/microsoft/internal/subscriber/update_test.go
+++ b/providers/microsoft/internal/subscriber/update_test.go
@@ -1,0 +1,77 @@
+package subscriber
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestUpdate(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	_ = testutils.DataFromFile(t, "delete-not-found.json")
+
+	tests := []testroutines.UpdateSubscription{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Write object and its ID must be included",
+			Input: testroutines.UpdateSubscriptionParams{
+				Params: common.SubscribeParams{
+					Request:            nil,
+					RegistrationResult: nil,
+					SubscriptionEvents: nil,
+				},
+				PreviousResult: nil,
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name: "",
+			Input: testroutines.UpdateSubscriptionParams{
+				Params: common.SubscribeParams{
+					Request:            nil,
+					RegistrationResult: nil,
+					SubscriptionEvents: nil,
+				},
+				PreviousResult: nil,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected: &common.SubscriptionResult{
+				Result:            nil,
+				ObjectEvents:      nil,
+				Status:            "",
+				Objects:           nil,
+				Events:            nil,
+				UpdateFields:      nil,
+				PassThroughEvents: nil,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (components.SubscriptionUpdator, error) {
+				return constructTestStrategy(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/microsoft/internal/subscriber/update_test.go
+++ b/providers/microsoft/internal/subscriber/update_test.go
@@ -1,0 +1,440 @@
+package subscriber
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestUpdate(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	type events = []common.SubscriptionEventType
+	createType := common.SubscriptionEventTypeCreate
+	updateType := common.SubscriptionEventTypeUpdate
+	deleteType := common.SubscriptionEventTypeDelete
+
+	// Inputs for the test: payloads and expected HTTP responses used by the mock server.
+	// - create: payloads used when requesting new subscriptions (messages + groups).
+	payloadSubscribeToMessages1 := testutils.DataFromFile(t, "create/messages-payload-1.json")
+	payloadSubscribeToMessages2 := testutils.DataFromFile(t, "create/messages-payload-2.json")
+	payloadSubscribeToGroups := testutils.DataFromFile(t, "create/groups-payload.json")
+	responseSubscribeToMessagesAndGroups := testutils.DataFromFile(t, "create/messages-and-groups-response.json")
+	responseSubscribeToMessages1 := testutils.DataFromFile(t, "create/messages-response-1.json")
+	responseSubscribeToMessages2 := testutils.DataFromFile(t, "create/messages-response-2.json")
+	// - patch/refresh: payload used to refresh/extend an existing calendar/events subscription.
+	payloadCalendarEventsRefresh := testutils.DataFromFile(t, "patch/calendar-events-payload.json")
+	responseCalendarEventRefresh := testutils.DataFromFile(t, "patch/calendar-events-response.json")
+	// - delete: payloads used to remove obsolete subscriptions (chat, old message subscription).
+	deleteChat := testutils.DataFromFile(t, "delete/chat-payload.json")
+	deleteMessage1 := testutils.DataFromFile(t, "delete/message-payload-1.json")
+	deleteMessage2 := testutils.DataFromFile(t, "delete/message-payload-2.json")
+	responseDelete := testutils.DataFromFile(t, "delete/response.json")
+
+	// List of identifiers used as Inputs or Outputs for the unit tests below.
+	// The ids used in output will be found in the JSON files under "test" repo.
+	idMessage1 := "c27d2493-0518-48db-b994-6d43aa584355"            // Input: Yes. Output: N/A.
+	idMessage2 := "29772d64-ee45-4e64-ab82-481602e07bc2"            // Input: Yes. Output: N/A.
+	idMessageReplaceToCRD := "5917db81-22d5-426d-af91-e285927592b7" // Input: N/A. Output: (create,update,delete)
+	idMessageReplaceToCD := "813ef41d-28dd-4bc8-a5d3-10bdfc033c99"  // Input: N/A. Output: (create,delete)
+	idCalendarEvent := "63b01115-ba3f-4db6-a1ef-793797ec340a"       // Input: Yes. Output: (created,deleted)
+	idChat := "a33272c7-b187-444c-840f-9e78cc6de127"                // Input: Yes. Output: N/A.
+	idGroupBatchResponse := "9d94e78b-4bca-4fd6-b5f4-bc5f26de5bcf"  // Input: N/A. Output: (deleted)
+
+	tests := []testconn.TestCaseUpdateSubscription{
+		{
+			// =========================================================================
+			// TEST 1: Mix of creating, updating, refreshing and removing Microsoft Graph events
+			// =========================================================================
+			// This test validates the complete subscription reconciler workflow:
+			// - Creating new subscriptions for messages (with upgraded event types) and groups
+			// - Refreshing an existing calendar/events subscription (extending expiration)
+			// - Deleting obsolete subscriptions (old messages subscription + leftover chat subscription)
+			Name: "Mix of creating, updating, refreshing and removing Microsoft Graph events",
+			Input: testconn.UpdateSubscriptionParams{
+				PreviousResult: &common.SubscriptionResult{
+					// PreviousResult simulates the current state known to the connector.
+					// It contains several existing subscriptions and respective event types already tracked.
+					Result: &Result{
+						Subscriptions: map[string]SubscriptionResource{
+							// Existing subscription to messages - expected to be replaced by a new
+							// subscription that supports created, updated and deleted events.
+							idMessage1: {
+								ID:         idMessage1,
+								ObjectName: "me/messages",
+								ChangeType: "created",
+								Resource:   "me/messages",
+								WebhookURL: "https://test.com/webhook",
+							},
+							// Existing calendar/events subscription tracking created and deleted.
+							// It should be refreshed (expiration extended).
+							idCalendarEvent: {
+								ID:         idCalendarEvent,
+								ObjectName: "me/events",
+								ChangeType: "created,deleted",
+								Resource:   "me/events",
+								WebhookURL: "https://test.com/webhook",
+							},
+							// Leftover chat subscription present previously but not requested anymore.
+							// Expected to be removed.
+							idChat: {
+								ID:         idChat,
+								ObjectName: "chats",
+								ChangeType: "created",
+								Resource:   "chats",
+								WebhookURL: "https://test.com/webhook",
+							},
+						},
+					},
+					// ObjectEvents defines which event types were being tracked per object
+					// in the previous result. The connector uses these to decide create/update/delete logic.
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": {Events: events{createType}},
+						"me/events":   {Events: events{createType, deleteType}},
+						"chats":       {Events: events{createType}},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+				// Params represents desired subscription state after update.
+				// It contains objects that should be created, refreshed, updated or deleted.
+				Params: common.SubscribeParams{
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": { // Upgrade messages subscription: add update and delete events.
+							Events: events{createType, updateType, deleteType},
+						},
+						"me/events": {Events: events{createType, deleteType}}, // No change in types: refresh only.
+						"groups":    {Events: events{deleteType}},             // New object: create subscription.
+					},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					// Case 1: Create subscriptions for messages and groups in a single batch request.
+					// The test expects POST /v1.0/$batch with the combined payload for new subscriptions.
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(payloadSubscribeToMessages1, payloadSubscribeToGroups),
+					},
+					Then: mockserver.Response(http.StatusCreated, responseSubscribeToMessagesAndGroups),
+				}, {
+					// Case 2: Refresh existing calendar/events subscription expiration (PATCH).
+					// No change to changeType is supported by API; we only prolong the subscription.
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(payloadCalendarEventsRefresh),
+					},
+					Then: mockserver.Response(http.StatusCreated, responseCalendarEventRefresh),
+				}, {
+					// Case 3: Delete obsolete subscriptions:
+					// - An old messages subscription is removed because a newer one was created ("update").
+					// - The chat subscription is removed because it's no longer requested (left-over).
+					// Both deletes are expected in a single batch request.
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(deleteMessage1, deleteChat),
+					},
+					Then: mockserver.Response(http.StatusNoContent, responseDelete),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
+			Expected: &common.SubscriptionResult{
+				// Expected state after reconciler runs:
+				// - New messages subscription replaces the old one and supports created,updated,deleted.
+				// - events subscription remains but gets its expiration refreshed.
+				// - groups subscription is newly created for delete events.
+				Result: &Result{
+					Subscriptions: map[string]SubscriptionResource{
+						idMessageReplaceToCRD: {
+							ID:         idMessageReplaceToCRD,
+							ObjectName: "me/messages",
+							Resource:   "me/messages",
+							ChangeType: "created,updated,deleted",
+							WebhookURL: "https://test.com/webhook",
+						},
+						idCalendarEvent: {
+							ID:         idCalendarEvent,
+							ObjectName: "me/events",
+							ChangeType: "created,deleted",
+							Resource:   "me/events",
+							WebhookURL: "https://test.com/webhook",
+						},
+						idGroupBatchResponse: {
+							ID:         idGroupBatchResponse,
+							ObjectName: "groups",
+							ChangeType: "deleted",
+							Resource:   "groups",
+							WebhookURL: "https://test.com/webhook",
+						},
+					},
+				},
+				// ObjectEvents after update: chats becomes empty (removed), others reflect requested types.
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/messages": {Events: events{createType, updateType, deleteType}},
+					"me/events":   {Events: events{createType, deleteType}},
+					"groups":      {Events: events{deleteType}},
+					"chats":       {Events: nil},
+				},
+				Status: "success",
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// =========================================================================
+			// TEST 2: SubscriptionStatusFailed - Refresh fails
+			// =========================================================================
+			// This test validates error handling when refreshing a subscription fails:
+			// - Only one existing subscription (me/events) that needs to be refreshed
+			// - Mock server returns 500 Internal Server Error on the refresh request
+			// - Expected result: SubscriptionStatusFailed with common.ErrServer
+			// - Original subscription remains intact.
+			Name: "SubscriptionStatusFailed: Refresh fails",
+			Input: testconn.UpdateSubscriptionParams{
+				PreviousResult: &common.SubscriptionResult{
+					Result: &Result{
+						Subscriptions: map[string]SubscriptionResource{
+							idCalendarEvent: {
+								ID:         idCalendarEvent,
+								ObjectName: "me/events",
+								ChangeType: "created,deleted",
+								Resource:   "me/events",
+								WebhookURL: "https://test.com/webhook",
+							},
+						},
+					},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/events": {Events: events{createType, deleteType}},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+				Params: common.SubscribeParams{
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/events": {Events: events{createType, deleteType}},
+					},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				// Mock server expects exactly one PATCH request to refresh the calendar/events subscription
+				// and returns 500 Internal Server Error to simulate refresh failure.
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1.0/$batch"),
+					payloadBatchRequests(payloadCalendarEventsRefresh),
+				},
+				Then: mockserver.Response(http.StatusInternalServerError),
+			}.Server(),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
+			Expected: &common.SubscriptionResult{
+				Result: &Result{
+					Subscriptions: map[string]SubscriptionResource{
+						idCalendarEvent: {
+							ID:         idCalendarEvent,
+							ObjectName: "me/events",
+							ChangeType: "created,deleted",
+							Resource:   "me/events",
+							WebhookURL: "https://test.com/webhook",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/events": {Events: events{createType, deleteType}},
+				},
+				Status: common.SubscriptionStatusFailed,
+			},
+			ExpectedErrs: []error{common.ErrServer},
+		},
+		{
+			// =========================================================================
+			// TEST 3: SubscriptionStatusFailed - Delete fails during update
+			// =========================================================================
+			// This test validates error handling when deleting an obsolete subscription fails:
+			// - Existing subscription to messages (created only) needs to be upgraded (created,updated,deleted)
+			// - Case 1: Create new subscription succeeds (201 Created)
+			// - Case 2: Delete old subscription fails (500 Internal Server Error)
+			// - Expected result: SubscriptionStatusFailed with common.ErrServer
+			// - Both subscriptions remain: new one (updated events) + old one (delete failed)
+			Name: "SubscriptionStatusFailed: Delete fails during update",
+			Input: testconn.UpdateSubscriptionParams{
+				PreviousResult: &common.SubscriptionResult{
+					Result: &Result{
+						Subscriptions: map[string]SubscriptionResource{
+							idMessage1: {
+								ID:         idMessage1,
+								ObjectName: "me/messages",
+								ChangeType: "created",
+								Resource:   "me/messages",
+								WebhookURL: "https://test.com/webhook",
+							},
+						},
+					},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": {Events: events{createType}},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+				Params: common.SubscribeParams{
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": {Events: events{createType, updateType, deleteType}},
+					},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					// Case 1: Create new messages subscription with upgraded event types succeeds.
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(payloadSubscribeToMessages1),
+					},
+					Then: mockserver.Response(http.StatusCreated, responseSubscribeToMessages1),
+				}, {
+					// Case 2: Delete old messages subscription fails with 500 error.
+					// This simulates a transient network issue or API error during deletion.
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(deleteMessage1, deleteMessage2),
+					},
+					Then: mockserver.Response(http.StatusInternalServerError),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
+			Expected: &common.SubscriptionResult{
+				Result: &Result{
+					Subscriptions: map[string]SubscriptionResource{
+						idMessage1: {
+							ID:         idMessage1,
+							ObjectName: "me/messages",
+							ChangeType: "created",
+							Resource:   "me/messages",
+							WebhookURL: "https://test.com/webhook",
+						},
+						idMessageReplaceToCRD: {
+							ID:         idMessageReplaceToCRD,
+							ObjectName: "me/messages",
+							Resource:   "me/messages",
+							ChangeType: "created,updated,deleted",
+							WebhookURL: "https://test.com/webhook",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/messages": {Events: events{createType, updateType, deleteType}},
+				},
+				Status: common.SubscriptionStatusFailed,
+			},
+			ExpectedErrs: []error{common.ErrServer},
+		},
+		{
+			// =========================================================================
+			// TEST 4: Previous result has 2 subscriptions for one object which is cleaned up
+			// =========================================================================
+			// This test validates cleanup logic when duplicate subscriptions exist for the same object:
+			// - Previous state has TWO subscriptions for "me/messages":
+			//   1. subscription A: created,updated,deleted (will be replaced with created,deleted)
+			//   2. subscription B: created only (will be removed)
+			// - Desired state: only created,deleted events for messages
+			// - Case 1: Create new subscription with created,deleted succeeds (201 Created)
+			// - Case 2: Delete BOTH old subscriptions (A + B) succeeds (204 No Content)
+			// - Expected result: SubscriptionStatusSuccess with only the new subscription remaining
+			Name: "Previous result has 2 subscriptions for one object which is cleaned up",
+			Input: testconn.UpdateSubscriptionParams{
+				PreviousResult: &common.SubscriptionResult{
+					Result: &Result{
+						Subscriptions: map[string]SubscriptionResource{
+							idMessage1: {
+								ID:         idMessage1,
+								ObjectName: "me/messages",
+								ChangeType: "created", // will be removed
+								Resource:   "me/messages",
+								WebhookURL: "https://test.com/webhook",
+							},
+							idMessage2: {
+								ID:         idMessage2,
+								ObjectName: "me/messages",
+								Resource:   "me/messages",
+								ChangeType: "created,updated,deleted", // will be replaced with created,deleted
+								WebhookURL: "https://test.com/webhook",
+							},
+						},
+					},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": {Events: events{createType, updateType, deleteType}},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+				Params: common.SubscribeParams{
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"me/messages": {Events: events{createType, deleteType}},
+					},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					// Case 1: Create new messages subscription with reduced event types (created,deleted).
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(payloadSubscribeToMessages2),
+					},
+					Then: mockserver.Response(http.StatusCreated, responseSubscribeToMessages2),
+				}, {
+					// Case 2: Delete BOTH obsolete subscriptions in a single batch request:
+					// - subscription A (created,updated,deleted) - replaced by new one
+					// - subscription B (created only) - no longer needed
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v1.0/$batch"),
+						payloadBatchRequests(deleteMessage1, deleteMessage2),
+					},
+					Then: mockserver.Response(http.StatusNoContent, responseDelete),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
+			Expected: &common.SubscriptionResult{
+				Result: &Result{
+					Subscriptions: map[string]SubscriptionResource{
+						idMessageReplaceToCD: {
+							ID:         idMessageReplaceToCD,
+							ObjectName: "me/messages",
+							Resource:   "me/messages",
+							ChangeType: "created,deleted",
+							WebhookURL: "https://test.com/webhook",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/messages": {Events: events{createType, deleteType}},
+				},
+				Status: common.SubscriptionStatusSuccess,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableSubscriptionUpdater, error) {
+				return constructTestStrategy(tt.Server)
+			})
+		})
+	}
+}

--- a/test/microsoft/subscription/update/main.go
+++ b/test/microsoft/subscription/update/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/microsoft"
+	connTest "github.com/amp-labs/connectors/test/microsoft"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+// IMPORTANT: Run the consumer in the background before starting this test.
+//
+// Microsoft Graph sends a validation request to the webhook URL before it creates
+// a subscription. The webhook handler must be reachable and able to respond to
+// that validation request, otherwise subscription creation will fail.
+//
+// Start the consumer with:
+//
+//	go run test/microsoft/subscription/consumer/main.go
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetMicrosoftGraphConnector(ctx)
+
+	testscenario.SubscriptionCreateUpdateDelete(ctx, conn,
+		func(webhookURL string) *common.SubscribeParams {
+			return &common.SubscribeParams{
+				Request: &microsoft.SubscriptionRequest{
+					WebhookURL: webhookURL,
+				},
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/messages": {
+						Events: []common.SubscriptionEventType{
+							common.SubscriptionEventTypeCreate,
+						},
+					},
+					"me/events": {
+						Events: []common.SubscriptionEventType{
+							common.SubscriptionEventTypeCreate,
+						},
+					},
+				},
+			}
+		},
+		func(webhookURL string) *common.SubscribeParams {
+			return &common.SubscribeParams{
+				Request: &microsoft.SubscriptionRequest{
+					WebhookURL: webhookURL,
+				},
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"me/messages": {
+						Events: []common.SubscriptionEventType{
+							common.SubscriptionEventTypeCreate,
+							common.SubscriptionEventTypeUpdate,
+							common.SubscriptionEventTypeDelete,
+						},
+					},
+					"me/events": {
+						Events: []common.SubscriptionEventType{ // no change
+							common.SubscriptionEventTypeCreate,
+						},
+					},
+				},
+			}
+		},
+	)
+}


### PR DESCRIPTION
# Live Tests

The script creates subscription and then updates it to the new state.

From:
<img width="592" height="318" alt="image" src="https://github.com/user-attachments/assets/19709293-f1a7-44b8-a509-0180c375611f" />

To:
<img width="593" height="357" alt="image" src="https://github.com/user-attachments/assets/fa6a369a-d3cb-4fe3-a6a1-a3714cb8889f" />

Script output:
<img width="689" height="1079" alt="image" src="https://github.com/user-attachments/assets/e7b99e83-980a-4377-81de-6e536d2f7cf0" />

<img width="501" height="1065" alt="image" src="https://github.com/user-attachments/assets/8e78ec1a-1b9b-44d7-9cd9-9fdc5cef078b" />

Just before the delete is invoked calling subscriptions endpoint to view subscription:
<img width="645" height="884" alt="image" src="https://github.com/user-attachments/assets/78eaf4c3-e5c1-4e12-a458-b795e675dd46" />

After the end of the script the subscriptions are removed:
<img width="652" height="268" alt="image" src="https://github.com/user-attachments/assets/8cbd7220-ab3b-4a9a-82d2-8c1d561012a1" />

