### PR TITLE
[ENG-3844] feat(pardot): Prospects custom fields

### DIFF
--- a/providers/pipedrive/internal/crm/metadata.go
+++ b/providers/pipedrive/internal/crm/metadata.go
@@ -64,7 +64,7 @@ func (a *Adapter) ListObjectMetadata(
 
 		if obj == dealsObjectName {
 			// Connector embeds this field during reading.
-			// Therefore, metadata artifically includes this property to advertise this to users.
+			// Therefore, metadata artificially includes this property to advertise this to users.
 			metadata.AddFieldMetadata(productsFieldKey, common.FieldMetadata{
 				DisplayName:  "Products",
 				ValueType:    common.ValueTypeOther,

--- a/providers/salesforce/internal/pardot/metadata.go
+++ b/providers/salesforce/internal/pardot/metadata.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/tools/scrapper"
@@ -28,7 +29,24 @@ var (
 func (a *Adapter) ListObjectMetadata(
 	ctx context.Context, objectNames []string,
 ) (*common.ListObjectMetadataResult, error) {
-	return Schemas.Select(objectNames)
+	result, err := Schemas.Select(objectNames)
+	if err != nil {
+		return nil, err
+	}
+
+	for objectName, metadata := range result.Result {
+		// Prospects is the only object that supports custom fields.
+		// A dedicated API call to collect "prospect custom fields" will happen.
+		if objectName == "prospects" {
+			if err = a.fetchProspectsCustomFields(ctx, &metadata); err != nil {
+				return nil, err
+			}
+
+			result.Result[objectName] = metadata
+		}
+	}
+
+	return result, nil
 }
 
 type pardotSchemas struct {
@@ -43,4 +61,80 @@ func (s *pardotSchemas) Select(objectNames []string) (*common.ListObjectMetadata
 	}
 
 	return s.Metadata.Select(providers.ModuleSalesforceAccountEngagement, objects)
+}
+
+func (a *Adapter) fetchProspectsCustomFields(
+	ctx context.Context, metadata *common.ObjectMetadata,
+) error {
+	// https://developer.salesforce.com/docs/marketing/pardot/guide/custom-field-v5.html#custom-field-query
+	url, err := a.getURL("custom-fields")
+	if err != nil {
+		return err
+	}
+
+	url.WithQueryParam("fields", "id,name,fieldId,type,isRequired")
+
+	endpoint := goutils.Pointer(url.String())
+
+	for endpoint != nil {
+		resp, err := a.JSONHTTPClient().Get(ctx, *endpoint, common.Header{
+			Key:   "Pardot-Business-Unit-Id",
+			Value: a.businessUnitID,
+		})
+		if err != nil {
+			return err
+		}
+
+		response, err := common.UnmarshalJSON[prospectCustomFieldsResponse](resp)
+		if err != nil {
+			return err
+		}
+
+		for _, field := range response.Values {
+			metadata.AddFieldMetadata(field.FieldName(), common.FieldMetadata{
+				DisplayName:  field.DisplayName,
+				ValueType:    field.ValueType(),
+				ProviderType: field.Type,
+				ReadOnly:     goutils.Pointer(false), // can write, modify data
+				IsCustom:     goutils.Pointer(true),
+				IsRequired:   field.IsRequired,
+				Values:       nil, // API does not return anything even for radio buttons or dropdowns.
+				ReferenceTo:  nil, // not applicable
+			})
+		}
+
+		// Go to the next page if it exists.
+		endpoint = response.NextPageURL
+	}
+
+	// Side effects applied to `metadata`.
+	return nil
+}
+
+type prospectCustomFieldsResponse struct {
+	NextPageURL *string                             `json:"nextPageUrl"`
+	Values      []prospectCustomFieldsResponseValue `json:"values"`
+}
+
+type prospectCustomFieldsResponseValue struct {
+	ID          int    `json:"id"`
+	FieldID     string `json:"fieldId"`
+	DisplayName string `json:"name"`
+	Type        string `json:"type"`
+	IsRequired  *bool  `json:"isRequired"`
+}
+
+// FieldName returns a requestable field by Read operation.
+// Custom field id must be suffixed with `__c` to indicate that it is custom field.
+// This is a common practice in Salesforce.
+func (v prospectCustomFieldsResponseValue) FieldName() string {
+	return v.FieldID + "__c"
+}
+
+func (v prospectCustomFieldsResponseValue) ValueType() common.ValueType {
+	if v.Type == "text" {
+		return common.ValueTypeString
+	}
+
+	return common.ValueTypeOther
 }

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -280,6 +280,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
+	prospectsCustomFields := testutils.DataFromFile(t, "pardot/metadata/prospects-custom-fields.json")
+
+	pardotHeader := http.Header{
+		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
+	}
+
 	tests := []testroutines.Metadata{
 		{
 			Name:         "At least one object name must be queried",
@@ -332,6 +338,54 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 							"sentAt":          "sentAt",
 							"listId":          "listId",
 							"salesforceCmsId": "salesforceCmsId",
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Successfully describe Prospects object with custom fields",
+			Input: []string{"Prospects"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/api/v5/objects/custom-fields"),
+					mockcond.Header(pardotHeader),
+				},
+				Then: mockserver.Response(http.StatusOK, prospectsCustomFields),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"prospects": {
+						DisplayName: "Prospects",
+						Fields: map[string]common.FieldMetadata{
+							"email": {
+								DisplayName:  "email",
+								ValueType:    "string",
+								ProviderType: "String",
+								IsRequired:   nil,
+								ReadOnly:     goutils.Pointer(false),
+								IsCustom:     nil,
+							},
+							"biography__c": {
+								DisplayName:  "Biography",
+								ValueType:    "string",
+								ProviderType: "text",
+								IsRequired:   goutils.Pointer(false),
+								ReadOnly:     goutils.Pointer(false),
+								IsCustom:     goutils.Pointer(true),
+							},
+							"hobby__c": {
+								DisplayName:  "Hobby",
+								ValueType:    "other",
+								ProviderType: "radio button",
+								IsRequired:   goutils.Pointer(false),
+								ReadOnly:     goutils.Pointer(false),
+								IsCustom:     goutils.Pointer(true),
+							},
 						},
 					},
 				},

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -470,6 +470,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMissingQuery := testutils.DataFromFile(t, "pardot/read/emails/err-missing-query.json")
 	responseEmailsFirstPage := testutils.DataFromFile(t, "pardot/read/emails/1-first-page.json")
 	responseEmailsEmptyPage := testutils.DataFromFile(t, "pardot/read/emails/2-empty-page.json")
+	responseProspects := testutils.DataFromFile(t, "pardot/read/prospects.json")
 
 	pardotHeader := http.Header{
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
@@ -608,6 +609,70 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Expected: &common.ReadResult{
 				Rows:     0,
 				Data:     []common.ReadResultRow{},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read prospects with custom field",
+			Input: common.ReadParams{
+				ObjectName: "prospects",
+				Fields:     connectors.Fields("hobby__c"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/api/v5/objects/prospects"),
+					mockcond.QueryParam("limit", "1000"),
+					mockcond.QueryParam("fields", "hobby__c"),
+					mockcond.Header(pardotHeader),
+				},
+				Then: mockserver.Response(http.StatusOK, responseProspects),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Id: "55389571",
+					Fields: map[string]any{
+						"hobby__c": nil,
+					},
+					Raw: map[string]any{
+						"id":           float64(55389571),
+						"email":        "a.alexander@sample.com",
+						"firstName":    "Athenasius",
+						"lastName":     "Alexander",
+						"biography__c": nil,
+						"hobby__c":     nil,
+					},
+				}, {
+					Id: "55389574",
+					Fields: map[string]any{
+						"hobby__c": nil,
+					},
+					Raw: map[string]any{
+						"id":           float64(55389574),
+						"email":        "spidey@test.com",
+						"firstName":    "Man",
+						"lastName":     "Spider",
+						"biography__c": nil,
+						"hobby__c":     nil,
+					},
+				}, {
+					Id: "64629229",
+					Fields: map[string]any{
+						"hobby__c": "swimming",
+					},
+					Raw: map[string]any{
+						"id":           float64(64629229),
+						"email":        "b.loretta@sample.com",
+						"firstName":    "Loretta",
+						"lastName":     "Burke",
+						"biography__c": nil,
+						"hobby__c":     "swimming",
+					},
+				}},
 				NextPage: "",
 				Done:     true,
 			},

--- a/providers/salesforce/test/pardot/metadata/prospects-custom-fields.json
+++ b/providers/salesforce/test/pardot/metadata/prospects-custom-fields.json
@@ -1,0 +1,20 @@
+{
+  "nextPageToken": null,
+  "nextPageUrl": null,
+  "values": [
+    {
+      "id": 247666,
+      "fieldId": "biography",
+      "isRequired": false,
+      "name": "Biography",
+      "type": "text"
+    },
+    {
+      "id": 247672,
+      "fieldId": "hobby",
+      "isRequired": false,
+      "name": "Hobby",
+      "type": "radio button"
+    }
+  ]
+}

--- a/providers/salesforce/test/pardot/read/prospects.json
+++ b/providers/salesforce/test/pardot/read/prospects.json
@@ -1,0 +1,30 @@
+{
+  "nextPageToken": null,
+  "nextPageUrl": null,
+  "values": [
+    {
+      "id": 55389571,
+      "email": "a.alexander@sample.com",
+      "firstName": "Athenasius",
+      "lastName": "Alexander",
+      "biography__c": null,
+      "hobby__c": null
+    },
+    {
+      "id": 55389574,
+      "email": "spidey@test.com",
+      "firstName": "Man",
+      "lastName": "Spider",
+      "biography__c": null,
+      "hobby__c": null
+    },
+    {
+      "id": 64629229,
+      "email": "b.loretta@sample.com",
+      "firstName": "Loretta",
+      "lastName": "Burke",
+      "biography__c": null,
+      "hobby__c": "swimming"
+    }
+  ]
+}

--- a/test/salesforce/connector.go
+++ b/test/salesforce/connector.go
@@ -29,7 +29,7 @@ func GetSalesforceAccountEngagementConnector(ctx context.Context) *salesforce.Co
 }
 
 func getSalesforceConnector(ctx context.Context, module common.ModuleID) *salesforce.Connector {
-	reader := getSalesforceJSONReader()
+	reader := getSalesforceJSONReader(module)
 
 	conn, err := salesforce.NewConnector(
 		salesforce.WithClient(ctx, http.DefaultClient, getConfig(reader), reader.GetOauthToken()),
@@ -61,13 +61,13 @@ func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
 }
 
 func GetSalesforceAccessToken() common.AuthToken {
-	reader := getSalesforceJSONReader()
+	reader := getSalesforceJSONReader(providers.ModuleSalesforceCRM)
 
 	return common.AuthToken(reader.Get(credscanning.Fields.AccessToken))
 }
 
-func getSalesforceJSONReader() *credscanning.ProviderCredentials {
-	filePath := credscanning.LoadPath(providers.Salesforce)
+func getSalesforceJSONReader(module string) *credscanning.ProviderCredentials {
+	filePath := credscanning.LoadPath(providers.Salesforce, module)
 	reader := utils.MustCreateProvCredJSON(filePath, true,
 		fieldBusinessUnitID,
 	)

--- a/test/salesforce/pardot/metadata/prospects/main.go
+++ b/test/salesforce/pardot/metadata/prospects/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceAccountEngagementConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"prospects",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	slog.Info("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/test/salesforce/pardot/read/prospects/main.go
+++ b/test/salesforce/pardot/read/prospects/main.go
@@ -25,7 +25,9 @@ func main() {
 	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
 		ObjectName: "prospects",
 		Fields: connectors.Fields(
-			"id", "firstName", "lastName", "email"),
+			"id", "firstName", "lastName", "email",
+			"hobby__c", // Custom field. Comment it, if you don't have it.
+		),
 		Since:    utils.Timestamp("2025-05-16T11:24:11-07:00"),
 		PageSize: 2,
 	})


### PR DESCRIPTION
# Description
For propects additional API call is made to grab it's custom fields. Other objects are not affected.

Read has no changes. Supply a valid field that you got from ListObjectMetadata and it will be returned as expected.

# Live Tests

### ListObjectMetadata
<img width="582" height="761" alt="image" src="https://github.com/user-attachments/assets/a5c0a07d-8ed3-4b5a-b692-16788572061c" />

### Read
<img width="577" height="1147" alt="image" src="https://github.com/user-attachments/assets/3259b275-f170-4e42-9527-a3b03fb30d5a" />
