### PR TITLE
chore: Remove unused GetOption function

### DIFF
--- a/providers/utils.go
+++ b/providers/utils.go
@@ -181,16 +181,6 @@ func (i *ProviderInfo) SubstituteWith(vars catalogreplacer.CatalogVariables) err
 	return catalogreplacer.NewCatalogSubstitutionRegistry(vars).Apply(i)
 }
 
-func (i *ProviderInfo) GetOption(key string) (string, bool) {
-	if i.ProviderOpts == nil {
-		return "", false
-	}
-
-	val, ok := i.ProviderOpts[key]
-
-	return val, ok
-}
-
 // ReadModuleInfo finds information about the module.
 // If module is not found fallbacks to the default.
 func (i *ProviderInfo) ReadModuleInfo(moduleID common.ModuleID) *ModuleInfo {


### PR DESCRIPTION
@RajatPawar I can't remember why we added ProviderInfo.ProviderOpts, but it isn't used by any providers, so I want to clean it up. 