### PR TITLE
[ENG-3709] feat: populate providerAppMetadata for salesforce, hubspot, gmail

### DIFF
--- a/providers/google.go
+++ b/providers/google.go
@@ -87,5 +87,27 @@ func init() {
 			Subscribe: false,
 			Write:     true,
 		},
+		ProviderAppMetadata: &ProviderAppMetadata{
+			ProviderParams: []MetadataItemInput{
+				{
+					Name:        "gcpProjectId",
+					DisplayName: "GCP Project ID",
+					Prompt:      "The ID of the Google Cloud project where your Pub/Sub topic lives. Ampersand uses this to subscribe to Gmail change notifications on behalf of your users.",
+					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.
+					ModuleDependencies: &ModuleDependencies{
+						ModuleGoogleGmail: {},
+					},
+				},
+				{
+					Name:        "gcpPubSubTopicName",
+					DisplayName: "GCP Pub/Sub Topic Name",
+					Prompt:      "The name of the Pub/Sub topic that Gmail will publish change notifications to. Must be in the same GCP project as above and have the Gmail API service account granted publish permissions.",
+					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.
+					ModuleDependencies: &ModuleDependencies{
+						ModuleGoogleGmail: {},
+					},
+				},
+			},
+		},
 	})
 }

--- a/providers/google.go
+++ b/providers/google.go
@@ -92,7 +92,8 @@ func init() {
 				{
 					Name:        "gcpProjectId",
 					DisplayName: "GCP Project ID",
-					Prompt:      "The ID of the Google Cloud project where your Pub/Sub topic lives. Ampersand uses this to subscribe to Gmail change notifications on behalf of your users.",
+					Prompt: "The ID of the Google Cloud project where your Pub/Sub topic lives. " +
+						"Ampersand uses this to subscribe to Gmail change notifications on behalf of your users.",
 					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.
 					ModuleDependencies: &ModuleDependencies{
 						ModuleGoogleGmail: {},
@@ -101,7 +102,9 @@ func init() {
 				{
 					Name:        "gcpPubSubTopicName",
 					DisplayName: "GCP Pub/Sub Topic Name",
-					Prompt:      "The name of the Pub/Sub topic that Gmail will publish change notifications to. Must be in the same GCP project as above and have the Gmail API service account granted publish permissions.",
+					Prompt: "The name of the Pub/Sub topic that Gmail will publish change notifications to. " +
+						"Must be in the same GCP project as above and have the Gmail API service account " +
+						"granted publish permissions.",
 					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.
 					ModuleDependencies: &ModuleDependencies{
 						ModuleGoogleGmail: {},

--- a/providers/google.go
+++ b/providers/google.go
@@ -92,7 +92,8 @@ func init() {
 				{
 					Name:        "gcpProjectId",
 					DisplayName: "GCP Project ID",
-					Prompt: "The ID of the Google Cloud project where your Pub/Sub topic lives. " +
+					Prompt: "If you are using Gmail subscribe actions, this is the ID of the Google Cloud Project " +
+						"where your Pub/Sub topic lives. " +
 						"Ampersand uses this to subscribe to Gmail change notifications on behalf of your users.",
 					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.
 					ModuleDependencies: &ModuleDependencies{
@@ -102,7 +103,8 @@ func init() {
 				{
 					Name:        "gcpPubSubTopicName",
 					DisplayName: "GCP Pub/Sub Topic Name",
-					Prompt: "The name of the Pub/Sub topic that Gmail will publish change notifications to. " +
+					Prompt: "If you are using Gmail subscribe actions, this is the name of the Pub/Sub topic " +
+						"that Gmail will publish change notifications to. " +
 						"Must be in the same GCP project as above and have the Gmail API service account " +
 						"granted publish permissions.",
 					// TODO: add DocsURL once Ampersand docs page for Gmail Pub/Sub setup is published.

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -111,10 +111,10 @@ func init() { //nolint:funlen
 			AuthQueryParams: []MetadataItemInput{
 				{
 					Name:        "optional_scope",
-					DisplayName: "Optional Scope",
+					DisplayName: "Optional Scopes",
 					Prompt: "Optional HubSpot scopes that users can grant during OAuth, " +
-						"beyond the required scopes configured on your provider app.",
-					DocsURL:     "https://developers.hubspot.com/docs/api/working-with-oauth#scopes",
+						"these must also be configured in your HubSpot app.",
+					DocsURL: "https://developers.hubspot.com/docs/api/working-with-oauth#scopes",
 				},
 			},
 		},

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -107,5 +107,15 @@ func init() { //nolint:funlen
 				},
 			},
 		},
+		ProviderAppMetadata: &ProviderAppMetadata{
+			AuthQueryParams: []MetadataItemInput{
+				{
+					Name:        "optional_scope",
+					DisplayName: "Optional Scope",
+					Prompt:      "Optional HubSpot scopes that users can grant during OAuth, beyond the required scopes configured on your provider app.",
+					DocsURL:     "https://developers.hubspot.com/docs/api/working-with-oauth#scopes",
+				},
+			},
+		},
 	})
 }

--- a/providers/hubspot.go
+++ b/providers/hubspot.go
@@ -112,7 +112,8 @@ func init() { //nolint:funlen
 				{
 					Name:        "optional_scope",
 					DisplayName: "Optional Scope",
-					Prompt:      "Optional HubSpot scopes that users can grant during OAuth, beyond the required scopes configured on your provider app.",
+					Prompt: "Optional HubSpot scopes that users can grant during OAuth, " +
+						"beyond the required scopes configured on your provider app.",
 					DocsURL:     "https://developers.hubspot.com/docs/api/working-with-oauth#scopes",
 				},
 			},

--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -174,7 +174,8 @@ func init() { // nolint:funlen
 				{
 					Name:        "packageInstallURL",
 					DisplayName: "Package Install URL",
-					Prompt:      "Enter the package install URL that the UI library should show to your users to install your Salesforce managed package.",
+					Prompt: "Enter the package install URL that the UI library should show to your users " +
+						"to install your Salesforce managed package.",
 					DocsURL:     "https://docs.withampersand.com/provider-guides/salesforce#6-package-the-external-client-app",
 				},
 			},

--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -169,5 +169,15 @@ func init() { // nolint:funlen
 				},
 			},
 		},
+		ProviderAppMetadata: &ProviderAppMetadata{
+			ProviderParams: []MetadataItemInput{
+				{
+					Name:        "packageInstallURL",
+					DisplayName: "Package Install URL",
+					Prompt:      "Enter the package install URL that the UI library should show to your users to install your Salesforce managed package.",
+					DocsURL:     "https://docs.withampersand.com/provider-guides/salesforce#6-package-the-external-client-app",
+				},
+			},
+		},
 	})
 }

--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -173,10 +173,11 @@ func init() { // nolint:funlen
 			ProviderParams: []MetadataItemInput{
 				{
 					Name:        "packageInstallURL",
-					DisplayName: "Package Install URL",
-					Prompt: "Enter the package install URL that the UI library should show to your users " +
-						"to install your Salesforce managed package.",
-					DocsURL:     "https://docs.withampersand.com/provider-guides/salesforce#6-package-the-external-client-app",
+					DisplayName: "External Client App Install",
+					Prompt: "If you are using External Client Apps (instead of Connected Apps) to connect your " +
+						"Salesforce account, enter the package install URL that the UI library should show to " +
+						"your users to install your Salesforce managed package.",
+					DocsURL: "https://docs.withampersand.com/provider-guides/salesforce#6-package-the-external-client-app",
 				},
 			},
 		},

--- a/providers/types.gen.go
+++ b/providers/types.gen.go
@@ -447,6 +447,15 @@ type Oauth2OptsGrantType string
 // Provider defines model for Provider.
 type Provider = string
 
+// ProviderAppMetadata Describes the provider-app-level fields that the Ampersand dashboard should collect from the builder when creating a ProviderApp for this provider. These descriptors tell the dashboard which form fields to render; the submitted values are stored in ProviderApp.metadata.
+type ProviderAppMetadata struct {
+	// AuthQueryParams Descriptors for fields stored in ProviderApp.metadata.authQueryParams (e.g., optional_scope for HubSpot).
+	AuthQueryParams []MetadataItemInput `json:"authQueryParams,omitempty"`
+
+	// ProviderParams Descriptors for fields stored in ProviderApp.metadata.providerParams (e.g., packageInstallURL for Salesforce, gcpProjectId for Gmail).
+	ProviderParams []MetadataItemInput `json:"providerParams,omitempty"`
+}
+
 // ProviderInfo defines model for ProviderInfo.
 type ProviderInfo struct {
 	// ApiKeyOpts Configuration for API key. Must be provided if authType is apiKey.
@@ -485,6 +494,9 @@ type ProviderInfo struct {
 
 	// PostAuthInfoNeeded If true, we require additional information after auth to start making requests.
 	PostAuthInfoNeeded bool `json:"postAuthInfoNeeded,omitempty"`
+
+	// ProviderAppMetadata Describes the provider-app-level fields that the Ampersand dashboard should collect from the builder when creating a ProviderApp for this provider. These descriptors tell the dashboard which form fields to render; the submitted values are stored in ProviderApp.metadata.
+	ProviderAppMetadata *ProviderAppMetadata `json:"providerAppMetadata,omitempty"`
 
 	// ProviderOpts Additional provider-specific metadata.
 	ProviderOpts  ProviderOpts   `json:"providerOpts"`


### PR DESCRIPTION
Adds `ProviderAppMetadata` descriptors on `ProviderInfo` so the Ampersand dashboard knows which provider-app-level fields to render for each provider, using the new schema from openapi.

  - Salesforce → `packageInstallURL`
  - HubSpot → `optional_scope`
  - Gmail (Google module) → `gcpProjectId`, `gcpPubSubTopicName`, scoped to the Gmail module via ModuleDependencies so they only show when the builder picks Gmail.