### PR TITLE
feat (phoneburner): Support custom fields

### DIFF
--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -51,6 +51,7 @@ func normalizeCustomFieldKey(label string) string {
 	s = strings.ReplaceAll(s, " ", "_")
 	s = nonAlphaNumUnderscore.ReplaceAllString(s, "_")
 	s = strings.Trim(s, "_")
+
 	for strings.Contains(s, "__") {
 		s = strings.ReplaceAll(s, "__", "_")
 	}
@@ -68,53 +69,14 @@ func (c *Connector) fetchMemberCustomFieldDefinitions(ctx context.Context) ([]me
 	page := 1
 
 	for {
-		url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restPrefix, restVer, "customfields")
+		defs, totalPages, err := c.getMemberCustomFieldDefinitionsPage(ctx, page)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+			return nil, err
 		}
 
-		url.WithQueryParam("page_size", "100")
-		url.WithQueryParam("page", strconv.Itoa(page))
+		out = append(out, defs...)
 
-		resp, err := c.JSONHTTPClient().Get(ctx, url.String())
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-		}
-
-		if err := interpretPhoneBurnerEnvelopeError(resp); err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-		}
-
-		body, ok := resp.Body()
-		if !ok {
-			return nil, fmt.Errorf("%w: empty customfields body", common.ErrResolvingCustomFields)
-		}
-
-		wrapper, err := jsonquery.New(body).ObjectRequired("customfields")
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-		}
-
-		arr, err := jsonquery.New(wrapper).ArrayOptional("customfields")
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-		}
-
-		for _, n := range arr {
-			def, err := jsonquery.ParseNode[memberCustomFieldDefinition](n)
-			if err != nil {
-				return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-			}
-
-			out = append(out, *def)
-		}
-
-		totalPages, err := jsonquery.New(wrapper).IntegerWithDefault("total_pages", 1)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
-		}
-
-		if page >= int(totalPages) {
+		if page >= totalPages {
 			break
 		}
 
@@ -122,6 +84,64 @@ func (c *Connector) fetchMemberCustomFieldDefinitions(ctx context.Context) ([]me
 	}
 
 	return out, nil
+}
+
+func (c *Connector) getMemberCustomFieldDefinitionsPage(ctx context.Context, page int) (
+	[]memberCustomFieldDefinition, int, error,
+) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restPrefix, restVer, "customfields")
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	url.WithQueryParam("page_size", "100")
+	url.WithQueryParam("page", strconv.Itoa(page))
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	if err := interpretPhoneBurnerEnvelopeError(resp); err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	body, ok := resp.Body()
+	if !ok {
+		return nil, 0, fmt.Errorf("%w: empty customfields body", common.ErrResolvingCustomFields)
+	}
+
+	return parseMemberCustomFieldDefinitionsPage(body)
+}
+
+func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFieldDefinition, int, error) {
+	wrapper, err := jsonquery.New(body).ObjectRequired("customfields")
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	arr, err := jsonquery.New(wrapper).ArrayOptional("customfields")
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	out := make([]memberCustomFieldDefinition, 0, len(arr))
+
+	for _, n := range arr {
+		def, err := jsonquery.ParseNode[memberCustomFieldDefinition](n)
+		if err != nil {
+			return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		out = append(out, *def)
+	}
+
+	totalPages, err := jsonquery.New(wrapper).IntegerWithDefault("total_pages", 1)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+	}
+
+	return out, int(totalPages), nil
 }
 
 // flattenContactCustomFieldsInMap promotes each contacts GET "custom_fields" entry to a top-level key

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -15,11 +14,9 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// customFieldKeyPrefix avoids collisions between PhoneBurner custom field display names
-// and built-in contact fields (e.g. "First Name" vs first_name).
+// customFieldKeyPrefix disambiguates member-defined custom field values on the contact from built-in
+// top-level contact keys when we promote custom_fields into the read record.
 const customFieldKeyPrefix = "custom_"
-
-var nonAlphaNumUnderscore = regexp.MustCompile(`[^a-z0-9_]+`) //nolint:gochecknoglobals
 
 // memberCustomFieldDefinition is a row from GET /rest/1/customfields (member-level definitions).
 // See: https://www.phoneburner.com/developer/route_list#customfields
@@ -47,22 +44,12 @@ func memberCustomFieldTypeToValueType(typeID string) common.ValueType {
 	}
 }
 
-// normalizeCustomFieldKey builds a stable, lower_snake_case key used in metadata and read flattening.
-func normalizeCustomFieldKey(label string) string {
-	s := strings.TrimSpace(strings.ToLower(label))
-	s = strings.ReplaceAll(s, " ", "_")
-	s = nonAlphaNumUnderscore.ReplaceAllString(s, "_")
-	s = strings.Trim(s, "_")
-
-	for strings.Contains(s, "__") {
-		s = strings.ReplaceAll(s, "__", "_")
-	}
-
-	return s
-}
-
+// customFieldMetadataKey is the key used in ListObjectMetadata and when flattening contact
+// custom_fields to the read record: [customFieldKeyPrefix] + the provider display name, trimmed only.
+// The name is not slugified. common.ExtractLowercaseFieldsFromRaw still lowercases for lookup, so
+// ReadResultRow.Fields use lowercase keys.
 func customFieldMetadataKey(displayName string) string {
-	return customFieldKeyPrefix + normalizeCustomFieldKey(displayName)
+	return customFieldKeyPrefix + strings.TrimSpace(displayName)
 }
 
 func (c *Connector) fetchMemberCustomFieldDefinitions(ctx context.Context) ([]memberCustomFieldDefinition, error) {
@@ -147,7 +134,7 @@ func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFiel
 }
 
 // flattenContactCustomFieldsInMap promotes each contacts GET "custom_fields" entry to a top-level key
-// using the same naming as ListObjectMetadata (custom_ + normalized display name / name).
+// using the same naming as ListObjectMetadata (see customFieldMetadataKey; "name" matches display_name).
 func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	raw, ok := record["custom_fields"]
 	if !ok || raw == nil {

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -2,7 +2,9 @@ package phoneburner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -181,21 +183,39 @@ func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	return record
 }
 
-func withContactCustomFieldFlatten(inner common.RecordsFunc, objectName string) common.RecordsFunc {
-	return func(node *ajson.Node) ([]map[string]any, error) {
-		out, err := inner(node)
-		if err != nil {
-			return nil, err
+// getMarshaledDataContactsWithCustomFieldsPreservingRaw flattens custom field values into
+// ReadResultRow.Fields while leaving ReadResultRow.Raw as the provider payload (Slab:
+// "ReadResultRow.Raw should not be modified").
+func getMarshaledDataContactsWithCustomFieldsPreservingRaw(
+	records []map[string]any, fields []string,
+) ([]common.ReadResultRow, error) {
+	data := make([]common.ReadResultRow, len(records))
+
+	fields = append(fields, "id")
+
+	//nolint:varnamelen
+	for i, record := range records {
+		rawSnapshot := maps.Clone(record)
+		flattenContactCustomFieldsInMap(record)
+
+		data[i] = common.ReadResultRow{
+			Fields: common.ExtractLowercaseFieldsFromRaw(fields, record),
+			Raw:    rawSnapshot,
 		}
 
-		if objectName != objectContacts {
-			return out, nil
+		var id string
+
+		switch v := data[i].Fields["id"].(type) {
+		case string:
+			id = v
+		case float64:
+			id = strconv.FormatFloat(v, 'f', -1, 64)
+		case json.Number:
+			id = v.String()
 		}
 
-		for i := range out {
-			out[i] = flattenContactCustomFieldsInMap(out[i])
-		}
-
-		return out, nil
+		data[i].Id = id
 	}
+
+	return data, nil
 }

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -170,9 +170,10 @@ func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	return record
 }
 
-// getMarshaledDataContactsWithCustomFieldsPreservingRaw flattens custom field values into
-// ReadResultRow.Fields while leaving ReadResultRow.Raw as the provider payload (Slab:
-// "ReadResultRow.Raw should not be modified").
+// getMarshaledDataContactsWithCustomFieldsPreservingRaw builds each ReadResultRow from two separate
+// shallow copies of the contact map (same intent as copper's MakeMarshaledDataFunc(attachReadCustomFields)):
+// one copy is the provider payload for Raw; the other is flattened in place for Fields. Extracted
+// records in the passed-in slice are not mutated, so Raw and Fields never share the same map.
 func getMarshaledDataContactsWithCustomFieldsPreservingRaw(
 	records []map[string]any, fields []string,
 ) ([]common.ReadResultRow, error) {
@@ -182,12 +183,13 @@ func getMarshaledDataContactsWithCustomFieldsPreservingRaw(
 
 	//nolint:varnamelen
 	for i, record := range records {
-		rawSnapshot := maps.Clone(record)
-		flattenContactCustomFieldsInMap(record)
+		raw := maps.Clone(record)
+		working := maps.Clone(record)
+		flattenContactCustomFieldsInMap(working)
 
 		data[i] = common.ReadResultRow{
-			Fields: common.ExtractLowercaseFieldsFromRaw(fields, record),
-			Raw:    rawSnapshot,
+			Fields: common.ExtractLowercaseFieldsFromRaw(fields, working),
+			Raw:    raw,
 		}
 
 		var id string

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -133,8 +133,9 @@ func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFiel
 	return out, int(totalPages), nil
 }
 
-// flattenContactCustomFieldsInMap promotes each contacts GET "custom_fields" entry to a top-level key
-// using the same naming as ListObjectMetadata (see customFieldMetadataKey; "name" matches display_name).
+// flattenContactCustomFieldsInMap is only for the working copy used to build ReadResultRow.Fields.
+// It must never run on the map used for ReadResultRow.Raw: Raw stays the API shape with nested
+// "custom_fields" only; we do not put merged custom_* top-level keys on Raw.
 func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	raw, ok := record["custom_fields"]
 	if !ok || raw == nil {
@@ -172,8 +173,10 @@ func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 
 // getMarshaledDataContactsWithCustomFieldsPreservingRaw builds each ReadResultRow from two separate
 // shallow copies of the contact map (same intent as copper's MakeMarshaledDataFunc(attachReadCustomFields)):
-// one copy is the provider payload for Raw; the other is flattened in place for Fields. Extracted
-// records in the passed-in slice are not mutated, so Raw and Fields never share the same map.
+// Raw is a clone of the row as returned by the provider (including "custom_fields" array only).
+// Fields are derived from a second clone that flattenContactCustomFieldsInMap mutates, promoting
+// custom values to top-level keys for ExtractLowercaseFieldsFromRaw. Merged custom keys exist only
+// in Fields, not in Raw, and the extracted []map from the response body is not mutated in place.
 func getMarshaledDataContactsWithCustomFieldsPreservingRaw(
 	records []map[string]any, fields []string,
 ) ([]common.ReadResultRow, error) {

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -2,9 +2,7 @@ package phoneburner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"maps"
 	"strconv"
 	"strings"
 
@@ -133,9 +131,10 @@ func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFiel
 	return out, int(totalPages), nil
 }
 
-// flattenContactCustomFieldsInMap is only for the working copy used to build ReadResultRow.Fields.
-// It must never run on the map used for ReadResultRow.Raw: Raw stays the API shape with nested
-// "custom_fields" only; we do not put merged custom_* top-level keys on Raw.
+// flattenContactCustomFieldsInMap promotes contact custom_fields entries to top-level custom_*
+// keys for common.ExtractLowercaseFieldsFromRaw. Used only from readContactRecordTransformer;
+// readhelper.MakeMarshaledDataFuncWithId keeps provider-shaped Raw (separate ObjectToMap) and
+// extracts ReadResultRow.Id from raw.
 func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	raw, ok := record["custom_fields"]
 	if !ok || raw == nil {
@@ -171,43 +170,15 @@ func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
 	return record
 }
 
-// getMarshaledDataContactsWithCustomFieldsPreservingRaw builds each ReadResultRow from two separate
-// shallow copies of the contact map (same intent as copper's MakeMarshaledDataFunc(attachReadCustomFields)):
-// Raw is a clone of the row as returned by the provider (including "custom_fields" array only).
-// Fields are derived from a second clone that flattenContactCustomFieldsInMap mutates, promoting
-// custom values to top-level keys for ExtractLowercaseFieldsFromRaw. Merged custom keys exist only
-// in Fields, not in Raw, and the extracted []map from the response body is not mutated in place.
-func getMarshaledDataContactsWithCustomFieldsPreservingRaw(
-	records []map[string]any, fields []string,
-) ([]common.ReadResultRow, error) {
-	data := make([]common.ReadResultRow, len(records))
-
-	fields = append(fields, "id")
-
-	//nolint:varnamelen
-	for i, record := range records {
-		raw := maps.Clone(record)
-		working := maps.Clone(record)
-		flattenContactCustomFieldsInMap(working)
-
-		data[i] = common.ReadResultRow{
-			Fields: common.ExtractLowercaseFieldsFromRaw(fields, working),
-			Raw:    raw,
-		}
-
-		var id string
-
-		switch v := data[i].Fields["id"].(type) {
-		case string:
-			id = v
-		case float64:
-			id = strconv.FormatFloat(v, 'f', -1, 64)
-		case json.Number:
-			id = v.String()
-		}
-
-		data[i].Id = id
+// readContactRecordTransformer is the common.RecordTransformer passed to
+// readhelper.MakeMarshaledDataFuncWithId for contacts; it only shapes the map used for Fields.
+func readContactRecordTransformer(node *ajson.Node) (map[string]any, error) {
+	record, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, err
 	}
 
-	return data, nil
+	flattenContactCustomFieldsInMap(record)
+
+	return record, nil
 }

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -1,0 +1,181 @@
+package phoneburner
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// customFieldKeyPrefix avoids collisions between PhoneBurner custom field display names
+// and built-in contact fields (e.g. "First Name" vs first_name).
+const customFieldKeyPrefix = "custom_"
+
+var nonAlphaNumUnderscore = regexp.MustCompile(`[^a-z0-9_]+`) //nolint:gochecknoglobals
+
+// memberCustomFieldDefinition is a row from GET /rest/1/customfields (member-level definitions).
+// See: https://www.phoneburner.com/developer/route_list#customfields
+type memberCustomFieldDefinition struct {
+	CustomFieldID string `json:"custom_field_id"`
+	DisplayName   string `json:"display_name"`
+	TypeID        string `json:"type_id"`
+	TypeName      string `json:"type_name"`
+}
+
+func memberCustomFieldTypeToValueType(typeID string) common.ValueType {
+	switch strings.TrimSpace(typeID) {
+	case "1":
+		return common.ValueTypeString
+	case "2":
+		return common.ValueTypeBoolean
+	case "3":
+		return common.ValueTypeDate
+	case "6":
+		return common.ValueTypeSingleSelect
+	case "7":
+		return common.ValueTypeFloat
+	default:
+		return common.ValueTypeOther
+	}
+}
+
+// normalizeCustomFieldKey builds a stable, lower_snake_case key used in metadata and read flattening.
+func normalizeCustomFieldKey(label string) string {
+	s := strings.TrimSpace(strings.ToLower(label))
+	s = strings.ReplaceAll(s, " ", "_")
+	s = nonAlphaNumUnderscore.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	for strings.Contains(s, "__") {
+		s = strings.ReplaceAll(s, "__", "_")
+	}
+
+	return s
+}
+
+func customFieldMetadataKey(displayName string) string {
+	return customFieldKeyPrefix + normalizeCustomFieldKey(displayName)
+}
+
+func (c *Connector) fetchMemberCustomFieldDefinitions(ctx context.Context) ([]memberCustomFieldDefinition, error) {
+	var out []memberCustomFieldDefinition
+
+	page := 1
+
+	for {
+		url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restPrefix, restVer, "customfields")
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		url.WithQueryParam("page_size", "100")
+		url.WithQueryParam("page", strconv.Itoa(page))
+
+		resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		if err := interpretPhoneBurnerEnvelopeError(resp); err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		body, ok := resp.Body()
+		if !ok {
+			return nil, fmt.Errorf("%w: empty customfields body", common.ErrResolvingCustomFields)
+		}
+
+		wrapper, err := jsonquery.New(body).ObjectRequired("customfields")
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		arr, err := jsonquery.New(wrapper).ArrayOptional("customfields")
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		for _, n := range arr {
+			def, err := jsonquery.ParseNode[memberCustomFieldDefinition](n)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+			}
+
+			out = append(out, *def)
+		}
+
+		totalPages, err := jsonquery.New(wrapper).IntegerWithDefault("total_pages", 1)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		if page >= int(totalPages) {
+			break
+		}
+
+		page++
+	}
+
+	return out, nil
+}
+
+// flattenContactCustomFieldsInMap promotes each contacts GET "custom_fields" entry to a top-level key
+// using the same naming as ListObjectMetadata (custom_ + normalized display name / name).
+func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {
+	raw, ok := record["custom_fields"]
+	if !ok || raw == nil {
+		return record
+	}
+
+	list, ok := raw.([]any)
+	if !ok || len(list) == 0 {
+		delete(record, "custom_fields")
+
+		return record
+	}
+
+	for _, item := range list {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := obj["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		key := customFieldMetadataKey(name)
+		if v, exists := obj["value"]; exists {
+			record[key] = v
+		}
+	}
+
+	delete(record, "custom_fields")
+
+	return record
+}
+
+func withContactCustomFieldFlatten(inner common.RecordsFunc, objectName string) common.RecordsFunc {
+	return func(node *ajson.Node) ([]map[string]any, error) {
+		out, err := inner(node)
+		if err != nil {
+			return nil, err
+		}
+
+		if objectName != objectContacts {
+			return out, nil
+		}
+
+		for i := range out {
+			out[i] = flattenContactCustomFieldsInMap(out[i])
+		}
+
+		return out, nil
+	}
+}

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -12,11 +12,6 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// customFieldKeyPrefix is a connector-only namespace (not in PhoneBurner JSON). The provider
-// uses display_name on definitions and name on each contact custom_fields entry; we prefix those
-// labels so flattened values do not collide with built-in contact keys.
-const customFieldKeyPrefix = "custom_"
-
 // memberCustomFieldDefinition is a row from GET /rest/1/customfields (member-level definitions).
 // See: https://www.phoneburner.com/developer/route_list#customfields
 type memberCustomFieldDefinition struct {
@@ -32,8 +27,7 @@ type memberCustomFieldDefinition struct {
 // PhoneBurner documents display_name as required when creating a field (POST) and
 // always includes it in GET examples (https://www.phoneburner.com/developer/route_list#customfields).
 // The list endpoint can still return individual rows with a blank display_name (legacy or
-// partial records); we skip those because our connector keys fields as custom_<display_name>,
-// which must match the "name" on each contact's custom_fields array.
+// partial records); we skip those because we key fields by the provider display name.
 func (d memberCustomFieldDefinition) isUsableForMetadata() bool {
 	return strings.TrimSpace(d.DisplayName) != ""
 }
@@ -55,11 +49,10 @@ func memberCustomFieldTypeToValueType(typeID string) common.ValueType {
 	}
 }
 
-// customFieldMetadataKey builds the ListObjectMetadata / read field name from the provider label
-// (display_name or custom_fields[].name). Callers pass the API string; do not assemble custom_* keys by hand.
-// common.ExtractLowercaseFieldsFromRaw lowercases keys on ReadResultRow.Fields.
+// customFieldMetadataKey is the connector field name for a PhoneBurner custom field: the provider
+// display_name / custom_fields[].name lowercased with spaces preserved (e.g. "Lead Score" -> "lead score").
 func customFieldMetadataKey(displayName string) string {
-	return customFieldKeyPrefix + strings.TrimSpace(displayName)
+	return strings.ToLower(strings.TrimSpace(displayName))
 }
 
 func (c *Connector) fetchMemberCustomFieldDefinitions(ctx context.Context) ([]memberCustomFieldDefinition, error) {
@@ -147,8 +140,8 @@ func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFiel
 	return out, int(totalPages), nil
 }
 
-// flattenContactCustomFieldsInMap promotes contact custom_fields entries to top-level custom_*
-// keys for common.ExtractLowercaseFieldsFromRaw. Used only from readContactRecordTransformer;
+// flattenContactCustomFieldsInMap promotes contact custom_fields entries to top-level keys named
+// by customFieldMetadataKey(name). Used only from readContactRecordTransformer;
 // readhelper.MakeMarshaledDataFuncWithId keeps provider-shaped Raw (separate ObjectToMap) and
 // extracts ReadResultRow.Id from raw.
 func flattenContactCustomFieldsInMap(record map[string]any) map[string]any {

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -12,8 +12,9 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// customFieldKeyPrefix disambiguates member-defined custom field values on the contact from built-in
-// top-level contact keys when we promote custom_fields into the read record.
+// customFieldKeyPrefix is a connector-only namespace (not in PhoneBurner JSON). The provider
+// uses display_name on definitions and name on each contact custom_fields entry; we prefix those
+// labels so flattened values do not collide with built-in contact keys.
 const customFieldKeyPrefix = "custom_"
 
 // memberCustomFieldDefinition is a row from GET /rest/1/customfields (member-level definitions).
@@ -54,10 +55,9 @@ func memberCustomFieldTypeToValueType(typeID string) common.ValueType {
 	}
 }
 
-// customFieldMetadataKey is the key used in ListObjectMetadata and when flattening contact
-// custom_fields to the read record: [customFieldKeyPrefix] + the provider display name, trimmed only.
-// The name is not slugified. common.ExtractLowercaseFieldsFromRaw still lowercases for lookup, so
-// ReadResultRow.Fields use lowercase keys.
+// customFieldMetadataKey builds the ListObjectMetadata / read field name from the provider label
+// (display_name or custom_fields[].name). Callers pass the API string; do not assemble custom_* keys by hand.
+// common.ExtractLowercaseFieldsFromRaw lowercases keys on ReadResultRow.Fields.
 func customFieldMetadataKey(displayName string) string {
 	return customFieldKeyPrefix + strings.TrimSpace(displayName)
 }

--- a/providers/phoneburner/custom.go
+++ b/providers/phoneburner/custom.go
@@ -25,6 +25,18 @@ type memberCustomFieldDefinition struct {
 	TypeName      string `json:"type_name"`
 }
 
+// isUsableForMetadata reports whether a row from GET /rest/1/customfields can be
+// exposed on contacts metadata and read flattening.
+//
+// PhoneBurner documents display_name as required when creating a field (POST) and
+// always includes it in GET examples (https://www.phoneburner.com/developer/route_list#customfields).
+// The list endpoint can still return individual rows with a blank display_name (legacy or
+// partial records); we skip those because our connector keys fields as custom_<display_name>,
+// which must match the "name" on each contact's custom_fields array.
+func (d memberCustomFieldDefinition) isUsableForMetadata() bool {
+	return strings.TrimSpace(d.DisplayName) != ""
+}
+
 func memberCustomFieldTypeToValueType(typeID string) common.ValueType {
 	switch strings.TrimSpace(typeID) {
 	case "1":
@@ -118,6 +130,10 @@ func parseMemberCustomFieldDefinitionsPage(body *ajson.Node) ([]memberCustomFiel
 		def, err := jsonquery.ParseNode[memberCustomFieldDefinition](n)
 		if err != nil {
 			return nil, 0, fmt.Errorf("%w: %w", common.ErrResolvingCustomFields, err)
+		}
+
+		if !def.isUsableForMetadata() {
+			continue
 		}
 
 		out = append(out, *def)

--- a/providers/phoneburner/custom_test.go
+++ b/providers/phoneburner/custom_test.go
@@ -1,0 +1,74 @@
+package phoneburner
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors"
+)
+
+func TestGetMarshaledDataContactsWithCustomFieldsPreservingRaw(t *testing.T) {
+	t.Parallel()
+
+	const leadKey = "custom_Lead Score" // metadata / read request field key (prefix + display name)
+
+	record := map[string]any{
+		"contact_user_id": "30919237",
+		"custom_fields": []any{
+			map[string]any{
+				"name":  "Lead Score",
+				"type":  "7",
+				"value": "42",
+			},
+		},
+	}
+
+	records := []map[string]any{record}
+
+	out, err := getMarshaledDataContactsWithCustomFieldsPreservingRaw(
+		records,
+		connectors.Fields("contact_user_id", leadKey).List(),
+	)
+	if err != nil {
+		t.Fatalf("getMarshaledDataContactsWithCustomFieldsPreservingRaw: %v", err)
+	}
+
+	if len(out) != 1 {
+		t.Fatalf("len(out) = %d", len(out))
+	}
+
+	row := out[0]
+
+	// Fields: flattened custom value (lookup key is lowercased by ExtractLowercaseFieldsFromRaw).
+	if got, want := row.Fields["custom_lead score"], "42"; got != want {
+		t.Fatalf("Fields[custom_lead score] = %v, want %v", got, want)
+	}
+
+	// Raw: must stay provider-shaped; no top-level merged custom key (that would mean we confused
+	// Fields with Raw, e.g. raw["custom_lead_score"] or raw["custom_Lead Score"]).
+	if _, ok := row.Raw["custom_Lead Score"]; ok {
+		t.Fatal(`Raw must not contain flattened custom field key "custom_Lead Score"`)
+	}
+
+	if _, ok := row.Raw["custom_lead score"]; ok {
+		t.Fatal(`Raw must not contain Fields-style lowercased key "custom_lead score"`)
+	}
+
+	cf, ok := row.Raw["custom_fields"]
+	if !ok {
+		t.Fatal(`Raw must still include provider "custom_fields" array`)
+	}
+
+	list, ok := cf.([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("Raw custom_fields = %v", cf)
+	}
+
+	// Input row from extract must be unchanged (we only flatten the working copy).
+	if _, still := record["custom_fields"]; !still {
+		t.Fatal("extracted map must still have custom_fields after marshal")
+	}
+
+	if _, bad := record["custom_Lead Score"]; bad {
+		t.Fatal("extracted map must not be flattened in place")
+	}
+}

--- a/providers/phoneburner/custom_test.go
+++ b/providers/phoneburner/custom_test.go
@@ -4,32 +4,35 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/spyzhov/ajson"
 )
 
-func TestGetMarshaledDataContactsWithCustomFieldsPreservingRaw(t *testing.T) {
+func TestReadContactRecordTransformerAndMarshaledDataWithId(t *testing.T) {
 	t.Parallel()
 
 	const leadKey = "custom_Lead Score" // metadata / read request field key (prefix + display name)
 
-	record := map[string]any{
+	jsonStr := `{
 		"contact_user_id": "30919237",
-		"custom_fields": []any{
-			map[string]any{
-				"name":  "Lead Score",
-				"type":  "7",
-				"value": "42",
-			},
-		},
+		"custom_fields": [
+			{"name": "Lead Score", "type": "7", "value": "42"}
+		]
+	}`
+
+	node, err := ajson.Unmarshal([]byte(jsonStr))
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	records := []map[string]any{record}
-
-	out, err := getMarshaledDataContactsWithCustomFieldsPreservingRaw(
-		records,
-		connectors.Fields("contact_user_id", leadKey).List(),
+	marshalFunc := readhelper.MakeMarshaledDataFuncWithId(
+		readContactRecordTransformer,
+		readhelper.NewIdField("contact_user_id"),
 	)
+
+	out, err := marshalFunc([]*ajson.Node{node}, connectors.Fields("contact_user_id", leadKey).List())
 	if err != nil {
-		t.Fatalf("getMarshaledDataContactsWithCustomFieldsPreservingRaw: %v", err)
+		t.Fatalf("MakeMarshaledDataFuncWithId: %v", err)
 	}
 
 	if len(out) != 1 {
@@ -38,13 +41,16 @@ func TestGetMarshaledDataContactsWithCustomFieldsPreservingRaw(t *testing.T) {
 
 	row := out[0]
 
+	if got, want := row.Id, "30919237"; got != want {
+		t.Fatalf("Id = %q, want %q", got, want)
+	}
+
 	// Fields: flattened custom value (lookup key is lowercased by ExtractLowercaseFieldsFromRaw).
 	if got, want := row.Fields["custom_lead score"], "42"; got != want {
 		t.Fatalf("Fields[custom_lead score] = %v, want %v", got, want)
 	}
 
-	// Raw: must stay provider-shaped; no top-level merged custom key (that would mean we confused
-	// Fields with Raw, e.g. raw["custom_lead_score"] or raw["custom_Lead Score"]).
+	// Raw: must stay provider-shaped; no top-level merged custom key.
 	if _, ok := row.Raw["custom_Lead Score"]; ok {
 		t.Fatal(`Raw must not contain flattened custom field key "custom_Lead Score"`)
 	}
@@ -61,14 +67,5 @@ func TestGetMarshaledDataContactsWithCustomFieldsPreservingRaw(t *testing.T) {
 	list, ok := cf.([]any)
 	if !ok || len(list) != 1 {
 		t.Fatalf("Raw custom_fields = %v", cf)
-	}
-
-	// Input row from extract must be unchanged (we only flatten the working copy).
-	if _, still := record["custom_fields"]; !still {
-		t.Fatal("extracted map must still have custom_fields after marshal")
-	}
-
-	if _, bad := record["custom_Lead Score"]; bad {
-		t.Fatal("extracted map must not be flattened in place")
 	}
 }

--- a/providers/phoneburner/custom_test.go
+++ b/providers/phoneburner/custom_test.go
@@ -1,11 +1,8 @@
 package phoneburner
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/spyzhov/ajson"
 )
 
@@ -46,68 +43,5 @@ func TestParseMemberCustomFieldDefinitionsPage_skipsBlankDisplayName(t *testing.
 
 	if len(defs) != 1 || defs[0].DisplayName != "Lead Score" {
 		t.Fatalf("defs = %#v, want single Lead Score row", defs)
-	}
-}
-
-func TestReadContactRecordTransformerAndMarshaledDataWithId(t *testing.T) {
-	t.Parallel()
-
-	leadKey := customFieldMetadataKey(leadScoreDisplayName)
-
-	jsonStr := `{
-		"contact_user_id": "30919237",
-		"custom_fields": [
-			{"name": "` + leadScoreDisplayName + `", "type": "7", "value": "42"}
-		]
-	}`
-
-	node, err := ajson.Unmarshal([]byte(jsonStr))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	marshalFunc := readhelper.MakeMarshaledDataFuncWithId(
-		readContactRecordTransformer,
-		readhelper.NewIdField("contact_user_id"),
-	)
-
-	out, err := marshalFunc([]*ajson.Node{node}, connectors.Fields("contact_user_id", leadKey).List())
-	if err != nil {
-		t.Fatalf("MakeMarshaledDataFuncWithId: %v", err)
-	}
-
-	if len(out) != 1 {
-		t.Fatalf("len(out) = %d", len(out))
-	}
-
-	row := out[0]
-
-	if got, want := row.Id, "30919237"; got != want {
-		t.Fatalf("Id = %q, want %q", got, want)
-	}
-
-	// Fields: flattened custom value (lookup key is lowercased by ExtractLowercaseFieldsFromRaw).
-	fieldsKey := strings.ToLower(leadKey)
-	if got, want := row.Fields[fieldsKey], "42"; got != want {
-		t.Fatalf("Fields[%q] = %v, want %v", fieldsKey, got, want)
-	}
-
-	// Raw: must stay provider-shaped; no top-level merged custom key.
-	if _, ok := row.Raw[leadKey]; ok {
-		t.Fatalf(`Raw must not contain flattened connector key %q`, leadKey)
-	}
-
-	if _, ok := row.Raw[fieldsKey]; ok {
-		t.Fatalf(`Raw must not contain Fields-style lowercased key %q`, fieldsKey)
-	}
-
-	cf, ok := row.Raw["custom_fields"]
-	if !ok {
-		t.Fatal(`Raw must still include provider "custom_fields" array`)
-	}
-
-	list, ok := cf.([]any)
-	if !ok || len(list) != 1 {
-		t.Fatalf("Raw custom_fields = %v", cf)
 	}
 }

--- a/providers/phoneburner/custom_test.go
+++ b/providers/phoneburner/custom_test.go
@@ -1,6 +1,7 @@
 package phoneburner
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -51,12 +52,12 @@ func TestParseMemberCustomFieldDefinitionsPage_skipsBlankDisplayName(t *testing.
 func TestReadContactRecordTransformerAndMarshaledDataWithId(t *testing.T) {
 	t.Parallel()
 
-	const leadKey = "custom_Lead Score" // metadata / read request field key (prefix + display name)
+	leadKey := customFieldMetadataKey(leadScoreDisplayName)
 
 	jsonStr := `{
 		"contact_user_id": "30919237",
 		"custom_fields": [
-			{"name": "Lead Score", "type": "7", "value": "42"}
+			{"name": "` + leadScoreDisplayName + `", "type": "7", "value": "42"}
 		]
 	}`
 
@@ -86,17 +87,18 @@ func TestReadContactRecordTransformerAndMarshaledDataWithId(t *testing.T) {
 	}
 
 	// Fields: flattened custom value (lookup key is lowercased by ExtractLowercaseFieldsFromRaw).
-	if got, want := row.Fields["custom_lead score"], "42"; got != want {
-		t.Fatalf("Fields[custom_lead score] = %v, want %v", got, want)
+	fieldsKey := strings.ToLower(leadKey)
+	if got, want := row.Fields[fieldsKey], "42"; got != want {
+		t.Fatalf("Fields[%q] = %v, want %v", fieldsKey, got, want)
 	}
 
 	// Raw: must stay provider-shaped; no top-level merged custom key.
-	if _, ok := row.Raw["custom_Lead Score"]; ok {
-		t.Fatal(`Raw must not contain flattened custom field key "custom_Lead Score"`)
+	if _, ok := row.Raw[leadKey]; ok {
+		t.Fatalf(`Raw must not contain flattened connector key %q`, leadKey)
 	}
 
-	if _, ok := row.Raw["custom_lead score"]; ok {
-		t.Fatal(`Raw must not contain Fields-style lowercased key "custom_lead score"`)
+	if _, ok := row.Raw[fieldsKey]; ok {
+		t.Fatalf(`Raw must not contain Fields-style lowercased key %q`, fieldsKey)
 	}
 
 	cf, ok := row.Raw["custom_fields"]

--- a/providers/phoneburner/custom_test.go
+++ b/providers/phoneburner/custom_test.go
@@ -8,6 +8,46 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
+func TestParseMemberCustomFieldDefinitionsPage_skipsBlankDisplayName(t *testing.T) {
+	t.Parallel()
+
+	body, err := ajson.Unmarshal([]byte(`{
+		"customfields": {
+			"customfields": [
+				{
+					"custom_field_id": "1",
+					"display_name": "",
+					"type_id": "1",
+					"type_name": "Text Field"
+				},
+				{
+					"custom_field_id": "215",
+					"display_name": "Lead Score",
+					"type_id": "7",
+					"type_name": "Numeric"
+				}
+			],
+			"total_pages": 1
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defs, totalPages, err := parseMemberCustomFieldDefinitionsPage(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if totalPages != 1 {
+		t.Fatalf("totalPages = %d, want 1", totalPages)
+	}
+
+	if len(defs) != 1 || defs[0].DisplayName != "Lead Score" {
+		t.Fatalf("defs = %#v, want single Lead Score row", defs)
+	}
+}
+
 func TestReadContactRecordTransformerAndMarshaledDataWithId(t *testing.T) {
 	t.Parallel()
 

--- a/providers/phoneburner/metadata.go
+++ b/providers/phoneburner/metadata.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/goutils"
 	pbmetadata "github.com/amp-labs/connectors/providers/phoneburner/metadata"
 )
 
@@ -53,11 +52,13 @@ func (c *Connector) ListObjectMetadata(
 		}
 
 		key := customFieldMetadataKey(def.DisplayName)
+		isCustom := true
+
 		objectMetadata.Fields[key] = common.FieldMetadata{
 			DisplayName:  def.DisplayName,
 			ValueType:    memberCustomFieldTypeToValueType(def.TypeID),
 			ProviderType: def.TypeName,
-			IsCustom:     goutils.Pointer(true),
+			IsCustom:     &isCustom,
 		}
 	}
 

--- a/providers/phoneburner/metadata.go
+++ b/providers/phoneburner/metadata.go
@@ -1,0 +1,67 @@
+package phoneburner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
+	pbmetadata "github.com/amp-labs/connectors/providers/phoneburner/metadata"
+)
+
+// ListObjectMetadata returns static schema fields plus member-defined contact custom fields
+// from GET /rest/1/customfields. See https://www.phoneburner.com/developer/route_list#customfields
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context,
+	objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	if len(objectNames) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	result, err := pbmetadata.Schemas.Select(c.ProviderContext.Module(), objectNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get base metadata: %w", err)
+	}
+
+	if !slices.Contains(objectNames, objectContacts) {
+		return result, nil
+	}
+
+	objectMetadata, ok := result.Result[objectContacts]
+	if !ok {
+		return result, nil
+	}
+
+	definitions, err := c.fetchMemberCustomFieldDefinitions(ctx)
+	if err != nil {
+		slog.Warn("Failed to fetch PhoneBurner custom field definitions; returning base contact metadata only",
+			"error", err)
+
+		return result, nil
+	}
+
+	if objectMetadata.Fields == nil {
+		objectMetadata.Fields = make(common.FieldsMetadata)
+	}
+
+	for _, def := range definitions {
+		if def.DisplayName == "" {
+			continue
+		}
+
+		key := customFieldMetadataKey(def.DisplayName)
+		objectMetadata.Fields[key] = common.FieldMetadata{
+			DisplayName:  def.DisplayName,
+			ValueType:    memberCustomFieldTypeToValueType(def.TypeID),
+			ProviderType: def.TypeName,
+			IsCustom:     goutils.Pointer(true),
+		}
+	}
+
+	result.Result[objectContacts] = objectMetadata
+
+	return result, nil
+}

--- a/providers/phoneburner/metadata.go
+++ b/providers/phoneburner/metadata.go
@@ -47,10 +47,6 @@ func (c *Connector) ListObjectMetadata(
 	}
 
 	for _, def := range definitions {
-		if def.DisplayName == "" {
-			continue
-		}
-
 		key := customFieldMetadataKey(def.DisplayName)
 		isCustom := true
 

--- a/providers/phoneburner/metadata.go
+++ b/providers/phoneburner/metadata.go
@@ -10,8 +10,8 @@ import (
 	pbmetadata "github.com/amp-labs/connectors/providers/phoneburner/metadata"
 )
 
-// ListObjectMetadata returns static schema fields plus member-defined contact custom fields
-// from GET /rest/1/customfields. See https://www.phoneburner.com/developer/route_list#customfields
+// ListObjectMetadata returns static schema fields from embedded OpenAPI metadata.
+// Only contacts may be augmented with member-defined custom fields (see mergeContactsCustomFieldMetadata).
 func (c *Connector) ListObjectMetadata(
 	ctx context.Context,
 	objectNames []string,
@@ -25,13 +25,21 @@ func (c *Connector) ListObjectMetadata(
 		return nil, fmt.Errorf("failed to get base metadata: %w", err)
 	}
 
-	if !slices.Contains(objectNames, objectContacts) {
-		return result, nil
+	// Contacts are the only object with member custom field definitions from the provider API.
+	if slices.Contains(objectNames, objectContacts) {
+		c.mergeContactsCustomFieldMetadata(ctx, result)
 	}
 
+	return result, nil
+}
+
+// mergeContactsCustomFieldMetadata augments result.Result[contacts] with fields from
+// GET /rest/1/customfields. Other objects in result are untouched.
+// See https://www.phoneburner.com/developer/route_list#customfields
+func (c *Connector) mergeContactsCustomFieldMetadata(ctx context.Context, result *common.ListObjectMetadataResult) {
 	objectMetadata, ok := result.Result[objectContacts]
 	if !ok {
-		return result, nil
+		return
 	}
 
 	definitions, err := c.fetchMemberCustomFieldDefinitions(ctx)
@@ -39,7 +47,7 @@ func (c *Connector) ListObjectMetadata(
 		slog.Warn("Failed to fetch PhoneBurner custom field definitions; returning base contact metadata only",
 			"error", err)
 
-		return result, nil
+		return
 	}
 
 	if objectMetadata.Fields == nil {
@@ -59,6 +67,4 @@ func (c *Connector) ListObjectMetadata(
 	}
 
 	result.Result[objectContacts] = objectMetadata
-
-	return result, nil
 }

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -145,7 +145,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "string",
 							},
-							"custom_lead_score": {
+							"custom_Lead Score": {
 								DisplayName:  "Lead Score",
 								ValueType:    "float",
 								ProviderType: "Numeric",

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -1,17 +1,23 @@
 package phoneburner
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
+
+	responseCustomfieldsDefinitions := testutils.DataFromFile(t, "read/customfields-definitions.json")
 
 	tests := []testroutines.Metadata{
 		{
@@ -108,6 +114,42 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								DisplayName:  "Title",
 								ValueType:    "string",
 								ProviderType: "string",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Contacts metadata merges member custom field definitions from GET /rest/1/customfields",
+			Input: []string{"contacts"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/rest/1/customfields"),
+					mockcond.QueryParam("page_size", "100"),
+					mockcond.QueryParam("page", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCustomfieldsDefinitions),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"contacts": {
+						DisplayName: "Contacts",
+						Fields: map[string]common.FieldMetadata{
+							"contact_user_id": {
+								DisplayName:  "Contact User Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"custom_lead_score": {
+								DisplayName:  "Lead Score",
+								ValueType:    "float",
+								ProviderType: "Numeric",
+								IsCustom:     goutils.Pointer(true),
 							},
 						},
 					},

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -16,6 +15,8 @@ import (
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
+
+	isCustomField := true
 
 	responseCustomfieldsDefinitions := testutils.DataFromFile(t, "read/customfields-definitions.json")
 
@@ -149,7 +150,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								DisplayName:  "Lead Score",
 								ValueType:    "float",
 								ProviderType: "Numeric",
-								IsCustom:     goutils.Pointer(true),
+								IsCustom:     &isCustomField,
 							},
 						},
 					},

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -146,8 +146,8 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								ValueType:    "string",
 								ProviderType: "string",
 							},
-							"custom_Lead Score": {
-								DisplayName:  "Lead Score",
+							customFieldMetadataKey(leadScoreDisplayName): {
+								DisplayName:  leadScoreDisplayName,
 								ValueType:    "float",
 								ProviderType: "Numeric",
 								IsCustom:     &isCustomField,

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -16,9 +16,9 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	isCustomField := true
-
 	responseCustomfieldsDefinitions := testutils.DataFromFile(t, "read/customfields-definitions.json")
+
+	isCustomField := true
 
 	tests := []testroutines.Metadata{
 		{

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -166,18 +166,21 @@ func parseReadResponse(
 		}
 	}
 
-	baseRecords, err := recordsFunc(params.ObjectName)
+	records, err := recordsFunc(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	records := withContactCustomFieldFlatten(baseRecords, params.ObjectName)
+	marshalFunc := common.GetMarshaledData
+	if params.ObjectName == objectContacts {
+		marshalFunc = getMarshaledDataContactsWithCustomFieldsPreservingRaw
+	}
 
 	return common.ParseResult(
 		response,
 		records,
 		nextRecordsURL(url, params.ObjectName),
-		common.GetMarshaledData,
+		marshalFunc,
 		params.Fields,
 	)
 }

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -173,6 +173,8 @@ func parseReadResponse(
 
 	marshalFunc := common.GetMarshaledData
 	if params.ObjectName == objectContacts {
+		// Contacts: custom fields are merged into Fields from a copy; Raw is a separate copy of the
+		// provider row (see getMarshaledDataContactsWithCustomFieldsPreservingRaw).
 		marshalFunc = getMarshaledDataContactsWithCustomFieldsPreservingRaw
 	}
 

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -166,10 +166,12 @@ func parseReadResponse(
 		}
 	}
 
-	records, err := recordsFunc(params.ObjectName)
+	baseRecords, err := recordsFunc(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
+
+	records := withContactCustomFieldFlatten(baseRecords, params.ObjectName)
 
 	return common.ParseResult(
 		response,

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -153,17 +153,8 @@ func parseReadResponse(
 		return nil, err
 	}
 
-	switch params.ObjectName {
-	case objectMembers:
-		if !params.Since.IsZero() || !params.Until.IsZero() {
-			return parseFilteredObjectResponse(params, response, objectMembers, "date_added", nextRecordsURL(url, objectMembers))
-		}
-	case objectVoicemails:
-		if !params.Since.IsZero() || !params.Until.IsZero() {
-			return parseFilteredObjectResponse(
-				params, response, objectVoicemails, "created_when", nextRecordsURL(url, objectVoicemails),
-			)
-		}
+	if res, handled, err := readWithClientSideTimeFilterIfNeeded(params, response, url); handled {
+		return res, err
 	}
 
 	records, err := recordsFunc(params.ObjectName)
@@ -185,6 +176,36 @@ func parseReadResponse(
 		marshalFunc,
 		params.Fields,
 	)
+}
+
+// readWithClientSideTimeFilterIfNeeded handles members and voicemails when Since/Until require
+// client-side filtering. If it returns handled true, res and err are the outcome; otherwise the
+// caller should use the standard read path.
+func readWithClientSideTimeFilterIfNeeded(
+	params common.ReadParams,
+	response *common.JSONHTTPResponse,
+	url *urlbuilder.URL,
+) (res *common.ReadResult, handled bool, err error) {
+	if params.Since.IsZero() && params.Until.IsZero() {
+		return nil, false, nil
+	}
+
+	switch params.ObjectName {
+	case objectMembers:
+		r, e := parseFilteredObjectResponse(
+			params, response, objectMembers, "date_added", nextRecordsURL(url, objectMembers),
+		)
+
+		return r, true, e
+	case objectVoicemails:
+		r, e := parseFilteredObjectResponse(
+			params, response, objectVoicemails, "created_when", nextRecordsURL(url, objectVoicemails),
+		)
+
+		return r, true, e
+	default:
+		return nil, false, nil
+	}
 }
 
 // parseFilteredObjectResponse handles time-filtered reads for objects that do not natively

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -157,23 +157,29 @@ func parseReadResponse(
 		return res, err
 	}
 
+	if params.ObjectName == objectContacts {
+		return common.ParseResult(
+			response,
+			common.MakeRecordsFunc(objectContacts, objectContacts),
+			nextRecordsURL(url, params.ObjectName),
+			readhelper.MakeMarshaledDataFuncWithId(
+				readContactRecordTransformer,
+				readhelper.NewIdField("contact_user_id"),
+			),
+			params.Fields,
+		)
+	}
+
 	records, err := recordsFunc(params.ObjectName)
 	if err != nil {
 		return nil, err
-	}
-
-	marshalFunc := common.GetMarshaledData
-	if params.ObjectName == objectContacts {
-		// Contacts: custom fields are merged into Fields from a copy; Raw is a separate copy of the
-		// provider row (see getMarshaledDataContactsWithCustomFieldsPreservingRaw).
-		marshalFunc = getMarshaledDataContactsWithCustomFieldsPreservingRaw
 	}
 
 	return common.ParseResult(
 		response,
 		records,
 		nextRecordsURL(url, params.ObjectName),
-		marshalFunc,
+		common.GetMarshaledData,
 		params.Fields,
 	)
 }

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -135,6 +135,12 @@ func applyTimeScopingToURL(url *urlbuilder.URL, params common.ReadParams) {
 	}
 }
 
+// parseReadResponse parses list/read responses for PhoneBurner objects.
+//
+// Custom fields are supported only for contacts: GET /rest/1/contacts returns each contact
+// with a custom_fields array in the normal payload (no separate embed). For contacts we
+// flatten those entries to custom_<display_name> keys on Fields via readContactRecordTransformer;
+// other objects use standard marshaling without custom-field handling.
 func parseReadResponse(
 	_ context.Context,
 	params common.ReadParams,

--- a/providers/phoneburner/read.go
+++ b/providers/phoneburner/read.go
@@ -139,7 +139,7 @@ func applyTimeScopingToURL(url *urlbuilder.URL, params common.ReadParams) {
 //
 // Custom fields are supported only for contacts: GET /rest/1/contacts returns each contact
 // with a custom_fields array in the normal payload (no separate embed). For contacts we
-// flatten those entries to custom_<display_name> keys on Fields via readContactRecordTransformer;
+// flatten those entries to lowercase display-name keys on Fields via readContactRecordTransformer;
 // other objects use standard marshaling without custom-field handling.
 func parseReadResponse(
 	_ context.Context,

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -85,7 +85,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Name: "Read contacts flattens custom_fields to custom_ prefixed keys",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
-				Fields:     connectors.Fields("contact_user_id", "custom_lead_score"),
+				Fields:     connectors.Fields("contact_user_id", "custom_Lead Score"),
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -102,7 +102,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"contact_user_id":   "30919237",
-						"custom_lead_score": "42",
+						"custom_lead score": "42",
 					},
 					Raw: map[string]any{
 						"contact_user_id": "30919237",

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -105,8 +105,22 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"custom_lead_score": "42",
 					},
 					Raw: map[string]any{
-						"contact_user_id":   "30919237",
-						"custom_lead_score": "42",
+						"contact_user_id": "30919237",
+						"owner_id":        "13514766",
+						"first_name":      "John",
+						"last_name":       "Demo",
+						"date_added":      "2023-10-15 10:38:07",
+						"raw_phone":       "6025551234",
+						"primary_email": map[string]any{
+							"email": "john.demo@example.com",
+						},
+						"custom_fields": []any{
+							map[string]any{
+								"name":  "Lead Score",
+								"type":  "7",
+								"value": "42",
+							},
+						},
 					},
 				}},
 				NextPage: "",

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -18,6 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
 	responseContacts := testutils.DataFromFile(t, "read/contacts.json")
+	responseContactsWithCustomFields := testutils.DataFromFile(t, "read/contacts-with-custom-fields.json")
 	responseDialSessions := testutils.DataFromFile(t, "read/dialsession.json")
 	responseFolders := testutils.DataFromFile(t, "read/folders.json")
 	responseMembers := testutils.DataFromFile(t, "read/members.json")
@@ -79,6 +80,39 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				NextPage: "",
 				Done:     true,
 			},
+		},
+		{
+			Name: "Read contacts flattens custom_fields to custom_ prefixed keys",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("contact_user_id", "custom_lead_score"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/rest/1/contacts"),
+					mockcond.QueryParam("page_size", "100"),
+					mockcond.QueryParam("page", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsWithCustomFields),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"contact_user_id":   "30919237",
+						"custom_lead_score": "42",
+					},
+					Raw: map[string]any{
+						"contact_user_id":   "30919237",
+						"custom_lead_score": "42",
+					},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
 		},
 		{
 			Name: "Read contacts with Since sends updated_from/update_to in PST",

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -3,7 +3,6 @@ package phoneburner
 import (
 	"net/http"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -84,7 +83,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			},
 		},
 		{
-			Name: "Read contacts flattens custom_fields to custom_ prefixed keys",
+			Name: "Read contacts flattens custom_fields by display name",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
 				Fields:     connectors.Fields("contact_user_id", customFieldMetadataKey(leadScoreDisplayName)),
@@ -104,8 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
 						"contact_user_id": "30919237",
-						// lowercased by ExtractLowercaseFieldsFromRaw
-						strings.ToLower(customFieldMetadataKey(leadScoreDisplayName)): "42",
+						"lead score":      "42",
 					},
 					Raw: map[string]any{
 						"contact_user_id": "30919237",

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -108,21 +109,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					},
 					Raw: map[string]any{
 						"contact_user_id": "30919237",
-						"owner_id":        "13514766",
-						"first_name":      "John",
-						"last_name":       "Demo",
-						"date_added":      "2023-10-15 10:38:07",
-						"raw_phone":       "6025551234",
-						"primary_email": map[string]any{
-							"email": "john.demo@example.com",
-						},
-						"custom_fields": []any{
-							map[string]any{
-								"name":  "Lead Score",
-								"type":  "7",
-								"value": "42",
-							},
-						},
+						"custom_fields":   mockutils.Any{},
 					},
 				}},
 				NextPage: "",

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -3,6 +3,7 @@ package phoneburner
 import (
 	"net/http"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,7 +86,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Name: "Read contacts flattens custom_fields to custom_ prefixed keys",
 			Input: common.ReadParams{
 				ObjectName: "contacts",
-				Fields:     connectors.Fields("contact_user_id", "custom_Lead Score"),
+				Fields:     connectors.Fields("contact_user_id", customFieldMetadataKey(leadScoreDisplayName)),
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -101,8 +102,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
-						"contact_user_id":   "30919237",
-						"custom_lead score": "42",
+						"contact_user_id": "30919237",
+						// lowercased by ExtractLowercaseFieldsFromRaw
+						strings.ToLower(customFieldMetadataKey(leadScoreDisplayName)): "42",
 					},
 					Raw: map[string]any{
 						"contact_user_id": "30919237",

--- a/providers/phoneburner/test/read/contacts-with-custom-fields.json
+++ b/providers/phoneburner/test/read/contacts-with-custom-fields.json
@@ -1,0 +1,31 @@
+{
+  "http_status": 200,
+  "status": "success",
+  "contacts": {
+    "member_user_id": "13514766",
+    "contacts": [
+      {
+        "contact_user_id": "30919237",
+        "owner_id": "13514766",
+        "first_name": "John",
+        "last_name": "Demo",
+        "date_added": "2023-10-15 10:38:07",
+        "raw_phone": "6025551234",
+        "primary_email": {
+          "email": "john.demo@example.com"
+        },
+        "custom_fields": [
+          {
+            "name": "Lead Score",
+            "type": "7",
+            "value": "42"
+          }
+        ]
+      }
+    ],
+    "page": 1,
+    "page_size": 1,
+    "total_pages": 1,
+    "total_results": 1
+  }
+}

--- a/providers/phoneburner/test/read/customfields-definitions.json
+++ b/providers/phoneburner/test/read/customfields-definitions.json
@@ -1,0 +1,24 @@
+{
+  "http_status": 200,
+  "status": "success",
+  "customfields": {
+    "customfields": [
+      {
+        "custom_field_id": "215",
+        "display_name": "Lead Score",
+        "type_id": "7",
+        "type_name": "Numeric",
+        "display_order": "0",
+        "_link": {
+          "self": {
+            "href": "rest/1/customfields/215"
+          }
+        }
+      }
+    ],
+    "page_size": 100,
+    "total_results": "1",
+    "page": 1,
+    "total_pages": 1
+  }
+}

--- a/providers/phoneburner/test_constants_test.go
+++ b/providers/phoneburner/test_constants_test.go
@@ -1,0 +1,6 @@
+package phoneburner
+
+// leadScoreDisplayName is the PhoneBurner label from test fixtures: customfields display_name
+// and contact custom_fields[].name (see test/read/*.json). Connector field keys are built via
+// customFieldMetadataKey(leadScoreDisplayName), not hand-written custom_* strings.
+const leadScoreDisplayName = "Lead Score"

--- a/providers/phoneburner/test_constants_test.go
+++ b/providers/phoneburner/test_constants_test.go
@@ -1,6 +1,6 @@
 package phoneburner
 
 // leadScoreDisplayName is the PhoneBurner label from test fixtures: customfields display_name
-// and contact custom_fields[].name (see test/read/*.json). Connector field keys are built via
-// customFieldMetadataKey(leadScoreDisplayName), not hand-written custom_* strings.
+// and contact custom_fields[].name (see test/read/*.json). Connector field keys use
+// customFieldMetadataKey(leadScoreDisplayName) -> "lead score".
 const leadScoreDisplayName = "Lead Score"


### PR DESCRIPTION
## Description
This PR adds native custom field support for the PhoneBurner connector on the contacts object: definitions are discovered in ListObjectMetadata, and read responses expose custom values in ReadResultRow.Fields while keeping ReadResultRow.Raw as the provider payload (nested custom_fields unchanged on Raw).

## What changed

- `ListObjectMetadata`: When contacts is requested, merges member-defined definitions from GET /rest/1/customfields (paginated, page_size=100) into ObjectMetadata.Fields with IsCustom: true, ValueType / ProviderType from PhoneBurner’s type_id / type_name.
- `Read`: For contacts, flattens each row’s custom_fields entries (name, type, value) to root-level keys in Fields (custom_<normalized_name>), matching metadata keys.
- `Resilience`: If definitions fetch fails, logs a warning and returns base contact metadata only (no hard failure on the whole metadata response).
- `Errors`: Definition fetch / parse failures use common.ErrResolvingCustomFields where appropriate.

## Conventions followed

Read more: Deep Connectors Guide – Reviewer Checklist
- `Field keys`: custom_ + normalized label (lowercase, spaces → underscores, non-alphanumeric stripped) so custom labels do not collide with built-in contact fields.
- `Human-readable names`: FieldMetadata.DisplayName uses PhoneBurner display_name (definitions) / name (read payload); users select by the same logical names as in the UI-oriented API.
- `Fields vs Raw`: Custom values appear in ReadResultRow.Fields; Raw is a shallow clone of the row before flattening (Slab: do not mutate provider-shaped Raw).
- `Metadata fetch`: Definitions loaded once per metadata call (paginated list), not per contact row.

## Supported objects

- `contacts` only. Other objects in this connector (folders, members, dialsession, tags, voicemails) are not covered by the same documented custom_fields + /rest/1/customfields pattern for bulk read.

## How it works

Operation | API used | What it does
-- | -- | --
Metadata | GET /rest/1/customfields | Loads all pages of definitions, merges into contacts Fields with IsCustom: true.
Read | GET /rest/1/contacts (unchanged) | Response still includes nested custom_fields; connector clones row → Raw, flattens copy → Fields with custom_* keys.

## Live Testing
### Unit Test
#### Metadata
<img width="1678" height="814" alt="Screenshot 2026-04-22 at 10 08 05 AM" src="https://github.com/user-attachments/assets/19c60c04-3f6b-4958-b1e6-57b3c78c9532" />

#### Read
<img width="1680" height="676" alt="Screenshot 2026-04-22 at 10 16 01 AM" src="https://github.com/user-attachments/assets/fd4df9e0-8b59-4d0c-a4a0-e36be0553d7c" />
<img width="1680" height="769" alt="Screenshot 2026-04-22 at 10 16 20 AM" src="https://github.com/user-attachments/assets/0f74aa3a-e054-4854-b3c9-70ecac37e57f" />
<img width="1680" height="773" alt="Screenshot 2026-04-22 at 10 16 36 AM" src="https://github.com/user-attachments/assets/d794b4dc-30ac-4cbf-b8ee-f10b1d9d01cd" />

### Integration Test
<img width="1680" height="828" alt="Screenshot 2026-04-22 at 12 54 28 PM" src="https://github.com/user-attachments/assets/798c62b9-e63e-4116-ac4b-aa0bc5381640" />
<img width="1673" height="861" alt="Screenshot 2026-04-22 at 12 54 59 PM" src="https://github.com/user-attachments/assets/b0cceb25-f9e3-497c-bb19-11415f01de47" />
<img width="1680" height="884" alt="Screenshot 2026-04-22 at 12 55 16 PM" src="https://github.com/user-attachments/assets/d26439c9-88b0-4763-bca2-c8774db1f726" />

