### PR TITLE
[ENG-3798]feat: implement GetRecordsByIds for Gmail messages

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -231,8 +231,11 @@ func (c *Connector) RunScheduledMaintenance(
 // Re-exports of Gmail history.list types so external callers can use them
 // without importing the internal mail package.
 type (
-	HistoryListParams = mail.HistoryListParams
-	HistoryListResult = mail.HistoryListResult
+	HistoryListParams  = mail.HistoryListParams
+	HistoryListResult  = mail.HistoryListResult
+	HistoryRecord      = mail.HistoryRecord
+	HistoryMessage     = mail.HistoryMessage
+	HistoryMessageChange = mail.HistoryMessageChange
 )
 
 // HistoryList fetches Gmail mailbox changes since the given history checkpoint.

--- a/providers/google/internal/mail/messages.go
+++ b/providers/google/internal/mail/messages.go
@@ -65,6 +65,41 @@ func (a *Adapter) fetchMessages(
 	return messageRegistry, nil
 }
 
+// fetchMessagesByIDs fetches full message payloads for the given IDs concurrently.
+// This is the same fan-out/fan-in pattern as fetchMessages but accepts explicit IDs
+// instead of extracting them from a collection response.
+func (a *Adapter) fetchMessagesByIDs(ctx context.Context, messageIDs []string) (MessageRecords, error) {
+	if len(messageIDs) == 0 {
+		return MessageRecords{}, nil
+	}
+
+	messagesChannel := make(chan MessageRecord, len(messageIDs))
+	callbacks := make([]simultaneously.Job, 0, len(messageIDs))
+
+	for _, messageID := range messageIDs {
+		callbacks = append(callbacks, a.fetchMessage(messagesChannel, messageID))
+	}
+
+	if err := simultaneously.DoCtx(ctx, -1, callbacks...); err != nil {
+		return nil, err
+	}
+
+	close(messagesChannel)
+
+	messageRegistry := make(MessageRecords, len(messageIDs))
+
+	for message := range messagesChannel {
+		id, ok := message["id"].(string)
+		if !ok {
+			return nil, errors.New("missing field 'id' in response for object 'messages'") // nolint:err113
+		}
+
+		messageRegistry[id] = message
+	}
+
+	return messageRegistry, nil
+}
+
 // fetchMessage returns a concurrently executable job that fetches a single message
 // by ID and sends the fully decoded MessageRecord to messagesChannel.
 func (a *Adapter) fetchMessage(messagesChannel chan MessageRecord, messageId string,

--- a/providers/google/internal/mail/subscribe.go
+++ b/providers/google/internal/mail/subscribe.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
 )
 
 // Errors for subscribe validation failures.
@@ -253,14 +255,46 @@ func (a *Adapter) stopWatch(ctx context.Context) error {
 	return nil
 }
 
-// GetRecordsByIds is not supported for the Gmail mail module.
+// GetRecordsByIds fetches full Gmail message payloads for the given IDs.
+// Only the "messages" object is supported; other objects return ErrGetRecordNotSupportedForObject.
 func (a *Adapter) GetRecordsByIds(ctx context.Context, // nolint: revive
 	objectName string,
 	recordIds []string, //nolint:revive
 	fields []string,
 	associations []string,
 ) ([]common.ReadResultRow, error) {
-	return nil, common.ErrGetRecordNotSupportedForObject
+	if objectName != objectNameMessages {
+		return nil, common.ErrGetRecordNotSupportedForObject
+	}
+
+	if len(recordIds) == 0 {
+		return []common.ReadResultRow{}, nil
+	}
+
+	messages, err := a.fetchMessagesByIDs(ctx, recordIds)
+	if err != nil {
+		return nil, fmt.Errorf("GetRecordsByIds: fetching messages: %w", err)
+	}
+
+	fieldSet := datautils.NewSetFromList(fields)
+	rows := make([]common.ReadResultRow, 0, len(messages))
+
+	for id, msg := range messages {
+		row := common.ReadResultRow{
+			Id:  id,
+			Raw: msg,
+		}
+
+		if len(fieldSet) > 0 {
+			row.Fields = readhelper.SelectFields(msg, fieldSet)
+		} else {
+			row.Fields = msg
+		}
+
+		rows = append(rows, row)
+	}
+
+	return rows, nil
 }
 
 // UpdateSubscription re-issues the watch call with the updated params.


### PR DESCRIPTION
Implement `GetRecordsByIds` for the Gmail `messages` object. Reuses the existing fetchMessage fan-out pattern to hydrate message IDs into full payloads in parallel. Also exports `HistoryRecord` types from the google package for use by server-side dispatch.