### PR TITLE
fix: correct Salesforce packageInstallURL display name

### DIFF
--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -173,7 +173,7 @@ func init() { // nolint:funlen
 			ProviderParams: []MetadataItemInput{
 				{
 					Name:        "packageInstallURL",
-					DisplayName: "External Client App Install",
+					DisplayName: "External Client App Install URL",
 					Prompt: "If you are using External Client Apps (instead of Connected Apps) to connect your " +
 						"Salesforce account, enter the package install URL that the UI library should show to " +
 						"your users to install your Salesforce managed package.",


### PR DESCRIPTION
## Summary

- Adds missing "URL" suffix to the Salesforce `packageInstallURL` descriptor's `DisplayName`: `"External Client App Install"` → `"External Client App Install URL"`.

## Test plan

- [ ] Verify the dashboard label reads "External Client App Install URL" after catalog regeneration.
