### PR TITLE
[CON-3180] feat: add Procore connector

### DIFF
--- a/providers/procore.go
+++ b/providers/procore.go
@@ -1,16 +1,54 @@
 package providers
 
-const Procore Provider = "procore"
+const (
+	Procore        Provider = "procore"
+	ProcoreSandbox Provider = "procoreSandbox"
+)
 
 func init() {
 	SetInfo(Procore, ProviderInfo{
 		DisplayName: "Procore",
 		AuthType:    Oauth2,
-		BaseURL:     "https://www.procore.com",
+		BaseURL:     "https://api.procore.com",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://login.procore.com/oauth/authorize",
 			TokenURL:                  "https://login.procore.com/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",
+			},
+		},
+	})
+
+	SetInfo(ProcoreSandbox, ProviderInfo{
+		DisplayName: "Procore Sandbox",
+		AuthType:    Oauth2,
+		BaseURL:     "https://sandbox.procore.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://login-sandbox.procore.com/oauth/authorize",
+			TokenURL:                  "https://login-sandbox.procore.com/oauth/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},

--- a/providers/procore.go
+++ b/providers/procore.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package providers
 
 const (

--- a/providers/procore.go
+++ b/providers/procore.go
@@ -5,6 +5,7 @@ const (
 	ProcoreSandbox Provider = "procoreSandbox"
 )
 
+//nolint:funlen
 func init() {
 	SetInfo(Procore, ProviderInfo{
 		DisplayName: "Procore",
@@ -31,12 +32,12 @@ func init() {
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",                //nolint: lll
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png", //nolint: lll
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png", //nolint: lll
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",                         //nolint: lll
 			},
 		},
 	})
@@ -66,12 +67,12 @@ func init() {
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",                //nolint: lll
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png", //nolint: lll
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png", //nolint: lll
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",                         //nolint: lll
 			},
 		},
 	})

--- a/providers/procore.go
+++ b/providers/procore.go
@@ -1,0 +1,40 @@
+package providers
+
+const Procore Provider = "procore"
+
+func init() {
+	SetInfo(Procore, ProviderInfo{
+		DisplayName: "Procore",
+		AuthType:    Oauth2,
+		BaseURL:     "https://www.procore.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://login.procore.com/oauth/authorize",
+			TokenURL:                  "https://login.procore.com/oauth/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg",
+			},
+		},
+	})
+}

--- a/providers/ramp.go
+++ b/providers/ramp.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package providers
 
 const (


### PR DESCRIPTION
# Configuration

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/rest/v2.0/companies
<img width="1474" height="636" alt="image" src="https://github.com/user-attachments/assets/f5e01b77-b75e-4fcd-9b81-a5ea30d22722" />


### POST
URL: http://localhost:4444/rest/v1.0/workforce-planning/v2/companies/4276848/groups
<img width="1474" height="617" alt="image" src="https://github.com/user-attachments/assets/9a17193e-2c9e-46a7-a02a-929fcc8b064e" />

### DELETE
URL: http://localhost:4444/rest/v1.0/workforce-planning/v2/companies/4276848/groups/25a4ea97-030a-4c53-b766-82e38ceaf39f
<img width="1479" height="539" alt="image" src="https://github.com/user-attachments/assets/68e63d9c-a85b-43af-88e1-6a0a168f64f0" />



## Pagination
Procore use two query parameters to paginate results:
`per_page` — how many items to return per page. max value is 2000.
`page` — which page to return (1-based).

First Page
<img width="1472" height="586" alt="image" src="https://github.com/user-attachments/assets/3d0ccc20-a01e-4be7-bee1-3753a468b733" />





Next Page
<img width="1473" height="553" alt="image" src="https://github.com/user-attachments/assets/1a1b19bd-e15d-4503-92b6-6e867bc1a9f8" />








# Logo & Icons

## Regular Icon
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428739/Procore-Logo-Signage-Design-PNG_ftf2os.png"/>

## Dark Icon
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428797/Image_1776428788_0_hanjjk.png"/>


## Regular Logo

<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1776428922/media/procore.com_1776428921.svg" />


## Dark Logo

<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/q_auto/f_auto/v1776428963/Procore-Logo-Signature-Design-PNG_vk5wro.png" />
