### PR TITLE
fix(odoo): use workspace metadata for API domain

### DIFF
--- a/providers/odoo.go
+++ b/providers/odoo.go
@@ -14,7 +14,7 @@ func init() {
 			DocsURL: "https://www.odoo.com/documentation/19.0/developer/reference/external_api.html#configuration",
 		},
 		// e.g. yourcompany.odoo.com,odoo.yourdomain.com
-		BaseURL:  "https://{{.odoo_domain}}",
+		BaseURL:  "https://{{.workspace}}",
 		AuthType: ApiKey,
 		Support: Support{
 			BulkWrite: BulkWriteSupport{
@@ -41,7 +41,7 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "odoo_domain",
+					Name:        "workspace",
 					DisplayName: "API Domain",
 					Prompt:      "Enter your Odoo domain (e.g. yourcompany.odoo.com or odoo.yourdomain.com)",
 				},


### PR DESCRIPTION
Odoo’s baseURL and metadata used a provider-specific template key (odoo_domain), which led to substitution failures