### PR TITLE
[ENG-3844] fix(pardot): Hide unreadable fields

### DIFF
--- a/providers/salesforce/internal/pardot/metadata.go
+++ b/providers/salesforce/internal/pardot/metadata.go
@@ -91,6 +91,13 @@ func (a *Adapter) fetchProspectsCustomFields(
 		}
 
 		for _, field := range response.Values {
+			if field.IsArrayField() {
+				// Array fields should not be advertised by ListObjectMetadata.
+				// Underlying endpoint used by Read(Prospects) fails when such fields are used.
+				// Individual, per-record request would work, but would be deemed costly.
+				continue
+			}
+
 			metadata.AddFieldMetadata(field.FieldName(), common.FieldMetadata{
 				DisplayName:  field.DisplayName,
 				ValueType:    field.ValueType(),
@@ -131,10 +138,36 @@ func (v prospectCustomFieldsResponseValue) FieldName() string {
 	return v.FieldID + "__c"
 }
 
+// ValueType returns a mapping of a field type to Ampersand defined field types.
+// https://developer.salesforce.com/docs/marketing/pardot/guide/custom-field-v5.html#required-editable-fields
 func (v prospectCustomFieldsResponseValue) ValueType() common.ValueType {
-	if v.Type == "text" {
+	switch strings.ToLower(v.Type) {
+	case "text", "textarea", "radio button", "dropdown", "hidden", "crm user":
 		return common.ValueTypeString
+	case "multi-select", "checkbox":
+		return common.ValueTypeMultiSelect
+	case "number":
+		return common.ValueTypeFloat
+	case "date":
+		// Salesforce performs validation on a string. It must be properly formatted date.
+		return common.ValueTypeDate
+	default:
+		return common.ValueTypeOther
 	}
+}
 
-	return common.ValueTypeOther
+// IsArrayField reports if the custom field of a prospect holds an array.
+// Alternatively it can be a string, a float.
+//
+// Array custom fields are not supported by Prospect Query endpoint.
+// https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html#requesting-custom-fields
+func (v prospectCustomFieldsResponseValue) IsArrayField() bool {
+	switch strings.ToLower(v.Type) {
+	case "multi-select":
+		return true
+	case "checkbox":
+		return true
+	default:
+		return false
+	}
 }

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -356,7 +357,20 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 				},
 				Then: mockserver.Response(http.StatusOK, prospectsCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: func(
+				serverURL string, actual, expected *common.ListObjectMetadataResult,
+			) *mockutils.CompareResult {
+				result := mockutils.NewCompareResult()
+				// Usual subset comparison.
+				result.Merge(testroutines.ComparatorSubsetMetadata(serverURL, actual, expected))
+
+				// The "language" field must be excluded from the response.
+				if _, present := actual.Result["prospects"].Fields["language__c"]; present {
+					result.AddDiff("Result['prospects']['language__c'] is present, but expected to be missing")
+				}
+
+				return result
+			},
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"prospects": {
@@ -380,8 +394,16 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 							},
 							"hobby__c": {
 								DisplayName:  "Hobby",
-								ValueType:    "other",
+								ValueType:    "string",
 								ProviderType: "radio button",
+								IsRequired:   goutils.Pointer(false),
+								ReadOnly:     goutils.Pointer(false),
+								IsCustom:     goutils.Pointer(true),
+							},
+							"age__c": {
+								DisplayName:  "Age",
+								ValueType:    "float",
+								ProviderType: "number",
 								IsRequired:   goutils.Pointer(false),
 								ReadOnly:     goutils.Pointer(false),
 								IsCustom:     goutils.Pointer(true),

--- a/providers/salesforce/test/pardot/metadata/prospects-custom-fields.json
+++ b/providers/salesforce/test/pardot/metadata/prospects-custom-fields.json
@@ -15,6 +15,20 @@
       "isRequired": false,
       "name": "Hobby",
       "type": "radio button"
+    },
+    {
+      "id": 247674,
+      "fieldId": "language",
+      "isRequired": false,
+      "name": "Language",
+      "type": "multi-select"
+    },
+    {
+      "id": 247704,
+      "fieldId": "age",
+      "isRequired": false,
+      "name": "Age",
+      "type": "number"
     }
   ]
 }


### PR DESCRIPTION
# Description

Prospect custom fields that are of array type are not supported by usual Prospect.Query endpoint and therefore are omitted from ListObjectMetadata response.

# Unit Tests
By commenting out the logic that hides array fields the test fails correctly and reports with clear message:
<img width="996" height="991" alt="image" src="https://github.com/user-attachments/assets/16179ed7-addf-43e7-9cba-ca508957298a" />


# Live Tests
Language field is of array type. ListObjectMetadata does not return it, while other custom fields are present as before:

<img width="740" height="771" alt="image" src="https://github.com/user-attachments/assets/af79744c-2532-4e72-be98-1b3edf0c717e" />
