### PR TITLE
[CON-3195] feat: add support for quickbooks sandbox connector

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -245,6 +245,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Podium:                  wrapper(newPodiumConnector),
 	providers.Pylon:                   wrapper(newPylonConnector),
 	providers.QuickBooks:              wrapper(newQuickbooksConnector),
+	providers.QuickbooksSandbox:       wrapper(newQuickbooksSandboxConnector),
 	providers.Recurly:                 wrapper(newRecurlyConnector),
 	providers.RevenueCat:              wrapper(newRevenueCatConnector),
 	providers.RingCentral:             wrapper(newRingCentral),
@@ -1063,6 +1064,10 @@ func newRingCentral(params common.ConnectorParams) (*ringcentral.Connector, erro
 
 func newQuickbooksConnector(params common.ConnectorParams) (*quickbooks.Connector, error) {
 	return quickbooks.NewConnector(params)
+}
+
+func newQuickbooksSandboxConnector(params common.ConnectorParams) (*quickbooks.Connector, error) {
+	return quickbooks.NewSandboxConnector(params)
 }
 
 func newDropboxSignConnector(params common.ConnectorParams) (*dropboxsign.Connector, error) {

--- a/providers/quickbooks/connector.go
+++ b/providers/quickbooks/connector.go
@@ -47,6 +47,17 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	return conn, nil
 }
 
+func NewSandboxConnector(params common.ConnectorParams) (*Connector, error) {
+	conn, err := components.Initialize(providers.QuickbooksSandbox, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.realmId = params.Metadata["realmId"]
+
+	return conn, nil
+}
+
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 

--- a/scripts/oauth/token.go
+++ b/scripts/oauth/token.go
@@ -344,6 +344,7 @@ func setup() *OAuthApp {
 
 		// Determine the OAuth redirect URL.
 		redirect := fmt.Sprintf("%s://localhost:%d%s", *proto, *port, *callback)
+		// redirect := "https://api.withampersand.com/callbacks/v1/oauth"
 
 		state, err := registry.GetString(credscanning.Fields.State.Name)
 		if err != nil {

--- a/test/quickbooks/connector.go
+++ b/test/quickbooks/connector.go
@@ -38,6 +38,32 @@ func GetQuickBooksConnector(ctx context.Context) *quickbooks.Connector {
 	return conn
 }
 
+func GetQuickBooksSandboxConnector(ctx context.Context) *quickbooks.Connector {
+	filePath := credscanning.LoadPath(providers.QuickbooksSandbox)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := quickbooks.NewSandboxConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+		Metadata: map[string]string{
+			"realmId": "9341456591101632", // QuickBooks Sandbox Company ID
+		},
+	})
+	if err != nil {
+		utils.Fail("create quickbooks sandbox connector", "error: ", err)
+	}
+
+	return conn
+}
+
 func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
 	cfg := &oauth2.Config{
 		ClientID:     reader.Get(credscanning.Fields.ClientId),

--- a/test/quickbooks/sandbox/metadata/main.go
+++ b/test/quickbooks/sandbox/metadata/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/test/quickbooks"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+	connector := quickbooks.GetQuickBooksSandboxConnector(ctx)
+
+	// Test objects that support custom fields
+	slog.Info("Testing metadata for objects WITH custom fields (customer, invoice)...")
+	m, err := connector.ListObjectMetadata(ctx, []string{"customer", "invoice"})
+	if err != nil {
+		utils.Fail("error fetching metadata", "error", err)
+	}
+
+	fmt.Println("\n=== Customer Metadata ===")
+	if customerMeta, ok := m.Result["customer"]; ok {
+		fmt.Printf("DisplayName: %s\n", customerMeta.DisplayName)
+		fmt.Printf("Total Fields: %d\n", len(customerMeta.Fields))
+		fmt.Println("\nFields:")
+		for fieldName, fieldMeta := range customerMeta.Fields {
+			fmt.Printf("  - %s: %s (%s)\n", fieldName, fieldMeta.ValueType, fieldMeta.ProviderType)
+		}
+	} else if err, ok := m.Errors["customer"]; ok {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	fmt.Println("\n=== Invoice Metadata ===")
+	if invoiceMeta, ok := m.Result["invoice"]; ok {
+		fmt.Printf("DisplayName: %s\n", invoiceMeta.DisplayName)
+		fmt.Printf("Total Fields: %d\n", len(invoiceMeta.Fields))
+		fmt.Println("\nFields:")
+		for fieldName, fieldMeta := range invoiceMeta.Fields {
+			fmt.Printf("  - %s: %s (%s)\n", fieldName, fieldMeta.ValueType, fieldMeta.ProviderType)
+		}
+	} else if err, ok := m.Errors["invoice"]; ok {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	// Test objects that DON'T support custom fields
+	slog.Info("\nTesting metadata for objects WITHOUT custom fields (account, item)...")
+	m2, err := connector.ListObjectMetadata(ctx, []string{"account", "item"})
+	if err != nil {
+		utils.Fail("error fetching metadata", "error", err)
+	}
+
+	fmt.Println("\n=== Account Metadata ===")
+	if accountMeta, ok := m2.Result["account"]; ok {
+		fmt.Printf("DisplayName: %s\n", accountMeta.DisplayName)
+		fmt.Printf("Total Fields: %d\n", len(accountMeta.Fields))
+		fmt.Println("(Should only have built-in fields, no custom fields)")
+	} else if err, ok := m2.Errors["account"]; ok {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	// Print full JSON for inspection
+	slog.Info("\n=== Full JSON Output ===")
+	utils.DumpJSON(m, os.Stdout)
+}

--- a/test/quickbooks/sandbox/read/main.go
+++ b/test/quickbooks/sandbox/read/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/quickbooks"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := quickbooks.GetQuickBooksSandboxConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "account",
+		Fields:     connectors.Fields("Id"),
+		Since:      time.Now().Add(-600 * time.Hour),
+	})
+	if err != nil {
+		utils.Fail("error reading from QuickBooks", "error", err)
+	}
+
+	slog.Info("Reading accounts..")
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "item",
+		Fields:     connectors.Fields("Level", "domain", "Name"),
+		Since:      time.Now().Add(-600 * time.Hour),
+	})
+	if err != nil {
+		utils.Fail("error reading from QuickBooks", "error", err)
+	}
+
+	slog.Info("Reading item..")
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "term",
+		Fields:     connectors.Fields("name"),
+		Since:      time.Now().Add(-600 * time.Hour),
+	})
+	if err != nil {
+		utils.Fail("error reading from QuickBooks", "error", err)
+	}
+
+	slog.Info("Reading term..")
+	utils.DumpJSON(res, os.Stdout)
+
+	// Test reading customer with custom fields (requires ?	=enhancedAllCustomFields)
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "customer",
+		Fields:     connectors.Fields("Id", "DisplayName"),
+		Since:      time.Now().Add(-600 * time.Hour),
+	})
+	if err != nil {
+		utils.Fail("error reading from QuickBooks", "error", err)
+	}
+
+	slog.Info("Reading customer (with custom fields support)..")
+	utils.DumpJSON(res, os.Stdout)
+
+	slog.Info("Read operation completed successfully.")
+}

--- a/test/quickbooks/sandbox/write/main.go
+++ b/test/quickbooks/sandbox/write/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	cc "github.com/amp-labs/connectors/providers/quickbooks"
+	"github.com/amp-labs/connectors/test/quickbooks"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	conn := quickbooks.GetQuickBooksSandboxConnector(ctx)
+
+	_, err := testCreatingAccount(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	_, err = testCreatePaymentMethod(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	_, err = testCreateTaxAgency(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func testCreatingAccount(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "account",
+		RecordData: map[string]any{
+			"Name":        gofakeit.Company(),
+			"AccountType": "Accounts Receivable",
+		},
+	}
+
+	slog.Info("Creating account...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.Data["Id"].(string), nil
+}
+
+func testCreatePaymentMethod(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "paymentMethod",
+		RecordData: map[string]any{
+			"Name": gofakeit.CreditCardType(),
+		},
+	}
+
+	slog.Info("Creating payment method...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.Data["Id"].(string), nil
+}
+
+func testCreateTaxAgency(ctx context.Context, conn *cc.Connector) (string, error) {
+	params := common.WriteParams{
+		ObjectName: "taxAgency",
+		RecordData: map[string]any{
+			"DisplayName": gofakeit.Company(),
+		},
+	}
+
+	slog.Info("Creating tax agency...")
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// Print the results
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return res.Data["Id"].(string), nil
+}


### PR DESCRIPTION
# Conventions
- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
  Metadata Live Tests:
<img width="1212" height="816" alt="Screenshot 2026-04-20 at 20 54 21" src="https://github.com/user-attachments/assets/9709e34f-112c-466b-b0a2-59a8c8e24dfe" />

Read Live Tests:
<img width="1414" height="776" alt="Screenshot 2026-04-20 at 20 55 49" src="https://github.com/user-attachments/assets/07535aee-94b2-4ef4-9fd1-e47531969c3c" />


Write Live Tests:
<img width="1413" height="776" alt="Screenshot 2026-04-20 at 20 56 30" src="https://github.com/user-attachments/assets/c9814587-cec1-4e09-9bb3-72aacf3d3fc8" />
