### PR TITLE
[Customer Supprot] Fix false negative on Microsoft Token Refresh

### DIFF
--- a/providers/microsoft/connector.go
+++ b/providers/microsoft/connector.go
@@ -55,7 +55,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		JSON: interpreter.DirectFaultyResponder{Callback: handleErrorResponse},
 	}.Handle
 
 	connector.Reader = reader.NewHTTPReader(

--- a/providers/microsoft/connector.go
+++ b/providers/microsoft/connector.go
@@ -54,6 +54,11 @@ func constructor(base *components.Connector) (*Connector, error) {
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
 
+	// DirectFaultyResponder (vs. the default FaultyResponder) gives the
+	// callback access to the raw *http.Response, including headers.
+	// handleErrorResponse needs WWW-Authenticate to detect CAE / step-up
+	// claim challenges on 401s; see providers/microsoft/errors.go for the
+	// classification logic and known limitations.
 	errorHandler := interpreter.ErrorHandler{
 		JSON: interpreter.DirectFaultyResponder{Callback: handleErrorResponse},
 	}.Handle

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -1,8 +1,12 @@
 package microsoft
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 )
 
@@ -29,4 +33,84 @@ func (r ResponseMessageError) CombineErr(base error) error {
 	}
 
 	return fmt.Errorf("%w: %v", base, r.Error.Message)
+}
+
+// defaultJSONResponder handles non-401 responses with the standard Microsoft
+// error-body parsing and default status-code mapping.
+var defaultJSONResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
+
+// handleErrorResponse classifies Microsoft Graph error responses. On 401 it
+// distinguishes transient conditions (CAE claim challenges, token lifetime
+// races right after a refresh, AAD replication lag) from truly-invalid
+// credentials, returning common.ErrRetryable for the former so that the
+// server's workflow layer retries rather than flipping the connection to
+// bad_credentials. All other status codes fall through to the default
+// responder.
+func handleErrorResponse(res *http.Response, body []byte) error {
+	if res.StatusCode != http.StatusUnauthorized {
+		return defaultJSONResponder.HandleErrorResponse(res, body)
+	}
+
+	if reason, ok := claimsChallengeReason(res.Header.Get("WWW-Authenticate")); ok {
+		return fmt.Errorf("%w: microsoft claims challenge (%s)", common.ErrRetryable, reason)
+	}
+
+	if msg, ok := transientAuthErrorMessage(body); ok {
+		return fmt.Errorf("%w: transient microsoft auth error: %s", common.ErrRetryable, msg)
+	}
+
+	return defaultJSONResponder.HandleErrorResponse(res, body)
+}
+
+// claimsChallengeReason detects a Continuous Access Evaluation (CAE) or
+// step-up claim challenge in the WWW-Authenticate header. Microsoft uses
+// error="insufficient_claims" for CAE and error="interaction_required" when
+// the resource requires user interaction to satisfy a policy. The refresh
+// token itself is still valid in these cases; the resource is asking for a
+// new token with extra claims, not signalling revoked credentials.
+func claimsChallengeReason(header string) (string, bool) {
+	if header == "" {
+		return "", false
+	}
+
+	lower := strings.ToLower(header)
+	switch {
+	case strings.Contains(lower, `error="insufficient_claims"`):
+		return "insufficient_claims", true
+	case strings.Contains(lower, `error="interaction_required"`):
+		return "interaction_required", true
+	}
+
+	return "", false
+}
+
+// transientAuthErrorMessage recognises Graph error bodies that indicate a
+// transient authentication failure rather than a permanently-invalid token.
+// These typically occur immediately after a successful refresh due to clock
+// skew between the token-issuing region and the resource region, or due to
+// AAD signing-key replication lag after key rotation. A retry with the same
+// (or a freshly re-minted) token usually succeeds.
+func transientAuthErrorMessage(body []byte) (string, bool) {
+	var messageError ResponseMessageError
+	if err := json.Unmarshal(body, &messageError); err != nil {
+		return "", false
+	}
+
+	if !strings.EqualFold(messageError.Error.Code, "InvalidAuthenticationToken") {
+		return "", false
+	}
+
+	markers := []string{
+		"Lifetime validation failed",
+		"Access token has expired",
+		"The token is not yet valid",
+	}
+
+	for _, marker := range markers {
+		if strings.Contains(messageError.Error.Message, marker) {
+			return messageError.Error.Message, true
+		}
+	}
+
+	return "", false
 }

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -10,6 +10,12 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 )
 
+// errorFormats is the JSON schema set used by the interpreter framework to
+// parse Microsoft error payloads. Microsoft Graph, Outlook, and similar
+// services wrap errors in a single canonical envelope (ResponseMessageError),
+// so we register exactly one template. FormatSwitch picks the best-matching
+// template by MustKeys; nil keys mean "always match this template" when no
+// other candidates are registered.
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 	[]interpreter.FormatTemplate{
 		{
@@ -19,6 +25,15 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 	}...,
 )
 
+// ResponseMessageError is the canonical error envelope used by Microsoft
+// Graph and sibling Microsoft REST APIs. See:
+// https://learn.microsoft.com/en-us/graph/errors
+//
+// The Code field is a machine-readable classifier (e.g. "InvalidAuthenticationToken",
+// "Forbidden", "ResourceNotFound"); Message is a human-readable description whose
+// wording can vary across regions and over time — see transientAuthErrorMessage
+// for notes on matching against it. InnerError carries additional diagnostic
+// detail we currently only surface via generic unmarshalling.
 type ResponseMessageError struct {
 	Error struct {
 		Code       string `json:"code"`
@@ -27,6 +42,12 @@ type ResponseMessageError struct {
 	} `json:"error"`
 }
 
+// CombineErr satisfies the interpreter.ErrorDescriptor contract. The
+// framework calls it with the status-code-derived sentinel (e.g.
+// common.ErrBadRequest, common.ErrAccessToken) and expects us to enrich it
+// with provider-specific context. We wrap the base sentinel with the Graph
+// message so that downstream callers see, e.g., "access token invalid: Lifetime
+// validation failed..." while still being able to errors.Is(err, ErrAccessToken).
 func (r ResponseMessageError) CombineErr(base error) error {
 	if len(r.Error.Message) == 0 {
 		return base
@@ -35,17 +56,36 @@ func (r ResponseMessageError) CombineErr(base error) error {
 	return fmt.Errorf("%w: %v", base, r.Error.Message)
 }
 
-// defaultJSONResponder handles non-401 responses with the standard Microsoft
-// error-body parsing and default status-code mapping.
+// defaultJSONResponder handles any response whose error classification is
+// unambiguous from the HTTP status code alone. It combines the standard
+// status-code mapping (401 -> ErrAccessToken, 403 -> ErrForbidden, 5xx ->
+// ErrServer, etc.) with the Microsoft error-body parser above. handleErrorResponse
+// delegates to this responder for every status except 401, where the extra
+// inspection below is required.
 var defaultJSONResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
 
-// handleErrorResponse classifies Microsoft Graph error responses. On 401 it
-// distinguishes transient conditions (CAE claim challenges, token lifetime
-// races right after a refresh, AAD replication lag) from truly-invalid
-// credentials, returning common.ErrRetryable for the former so that the
-// server's workflow layer retries rather than flipping the connection to
-// bad_credentials. All other status codes fall through to the default
-// responder.
+// handleErrorResponse classifies Microsoft error responses and is the single
+// JSON error handler used by every Microsoft-family connector that shares
+// this package (Microsoft / MicrosoftClientCredentials). It exists to fix a
+// false-positive in the connection-status machinery upstream: the default
+// interpreter maps every 401 to common.ErrAccessToken, and the server treats
+// that as a signal to flip the connection to bad_credentials. Several
+// legitimately-transient conditions at the Microsoft resource tier also
+// surface as 401 — on those, flipping to bad_credentials is a user-visible
+// regression that requires re-auth to clear.
+//
+// Classification strategy on 401:
+//  1. If WWW-Authenticate signals a Continuous Access Evaluation (CAE) or
+//     step-up challenge, the refresh token is still valid; a retry against
+//     the freshly-re-issued token typically succeeds. Return ErrRetryable.
+//  2. If the Graph error body matches a known transient marker (clock skew,
+//     AAD replication race right after refresh), same verdict: ErrRetryable.
+//  3. Otherwise treat as genuinely-invalid credentials and fall through to
+//     the default responder, which will produce ErrAccessToken and — by
+//     design — allow the server to flip the connection.
+//
+// Non-401 responses are unchanged from the prior behaviour and pass straight
+// through to the default responder.
 func handleErrorResponse(res *http.Response, body []byte) error {
 	if res.StatusCode != http.StatusUnauthorized {
 		return defaultJSONResponder.HandleErrorResponse(res, body)
@@ -64,10 +104,25 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 
 // claimsChallengeReason detects a Continuous Access Evaluation (CAE) or
 // step-up claim challenge in the WWW-Authenticate header. Microsoft uses
-// error="insufficient_claims" for CAE and error="interaction_required" when
-// the resource requires user interaction to satisfy a policy. The refresh
-// token itself is still valid in these cases; the resource is asking for a
-// new token with extra claims, not signalling revoked credentials.
+// error="insufficient_claims" for CAE (e.g. session revoked mid-flight by
+// admin action, risk signal, password change) and error="interaction_required"
+// when the resource requires user interaction to satisfy a Conditional Access
+// policy. In both cases the refresh token is still valid — the resource is
+// asking for a new access token with extra claims, not signalling revoked
+// credentials.
+//
+// Known limitation: a full CAE implementation would parse the claims="..."
+// parameter out of the header and feed it back into the next token request
+// so the re-issued access token satisfies the challenge. That requires
+// plumbing through the token source and is out of scope here; we currently
+// just mark the 401 as retryable and rely on Temporal retries to catch the
+// eventual success once whatever transient condition clears. Sustained CAE
+// challenges will still surface as activity failures after the retry budget
+// is exhausted.
+//
+// The matching is deliberately case-insensitive and uses substring lookup
+// rather than full RFC 6750 parsing because the Microsoft header format is
+// stable enough and we only care about the two known values.
 func claimsChallengeReason(header string) (string, bool) {
 	if header == "" {
 		return "", false
@@ -86,10 +141,31 @@ func claimsChallengeReason(header string) (string, bool) {
 
 // transientAuthErrorMessage recognises Graph error bodies that indicate a
 // transient authentication failure rather than a permanently-invalid token.
-// These typically occur immediately after a successful refresh due to clock
-// skew between the token-issuing region and the resource region, or due to
-// AAD signing-key replication lag after key rotation. A retry with the same
-// (or a freshly re-minted) token usually succeeds.
+// These typically occur immediately after a successful refresh due to:
+//   - Clock skew between the token-issuing region (login.microsoftonline.com
+//     shard that minted the access token) and the resource region (Graph
+//     shard validating it) — Azure's ~5-minute `nbf`/`exp` allowance is
+//     occasionally exceeded under load.
+//   - Azure AD signing-key replication lag after a key rotation, where the
+//     resource has not yet fetched the new JWKS entry.
+//
+// In both cases a retry with the same (or a freshly re-minted) token usually
+// succeeds within seconds.
+//
+// The matcher is intentionally conservative:
+//   - We require Error.Code == "InvalidAuthenticationToken"; a message that
+//     looks similar under a different code is more likely a real auth issue.
+//   - The message markers are drawn from observed transient error text. We
+//     deliberately exclude broader patterns like "CompactToken validation
+//     failed" because those are also emitted for genuinely-malformed tokens
+//     and would risk masking real failures.
+//   - Matching is substring-based, not exact — Microsoft varies the trailing
+//     text (e.g. "... the token is expired" vs "... token is expired and can
+//     no longer be used") across regions and versions.
+//
+// Extend `markers` only after confirming from production logs that a given
+// phrase exclusively correlates with a transient condition; misclassifying a
+// real auth failure as retryable delays user-visible error reporting.
 func transientAuthErrorMessage(body []byte) (string, bool) {
 	var messageError ResponseMessageError
 	if err := json.Unmarshal(body, &messageError); err != nil {

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -111,6 +111,18 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 // asking for a new access token with extra claims, not signalling revoked
 // credentials.
 //
+// References:
+//   - Claims challenges / claims requests / CAE client handling:
+//     https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge
+//   - Continuous Access Evaluation (overview + resilience guidance):
+//     https://learn.microsoft.com/en-us/entra/identity-platform/app-resilience-continuous-access-evaluation
+//   - CAE in Conditional Access (operator-facing explanation of which events
+//     cause insufficient_claims):
+//     https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation
+//   - interaction_required is the OIDC standard "step-up" response, used by
+//     Entra when a Conditional Access policy demands MFA/compliant device/etc.:
+//     https://openid.net/specs/openid-connect-core-1_0.html#AuthError
+//
 // Known limitation: a full CAE implementation would parse the claims="..."
 // parameter out of the header and feed it back into the next token request
 // so the re-issued access token satisfies the challenge. That requires
@@ -151,6 +163,23 @@ func claimsChallengeReason(header string) (string, bool) {
 //
 // In both cases a retry with the same (or a freshly re-minted) token usually
 // succeeds within seconds.
+//
+// References:
+//   - Microsoft Graph error response schema (documents the `error.code` /
+//     `error.message` envelope matched here):
+//     https://learn.microsoft.com/en-us/graph/errors
+//   - InvalidAuthenticationToken in the Graph error code reference:
+//     https://learn.microsoft.com/en-us/graph/errors#code-property
+//   - AAD signing key rollover (explains the JWKS replication race that
+//     produces transient signature/lifetime validation failures on freshly
+//     minted tokens):
+//     https://learn.microsoft.com/en-us/entra/identity-platform/signing-key-rollover
+//   - Entra ID (AAD) error code reference — companion to Graph errors, lists
+//     the AADSTS codes that can accompany InvalidAuthenticationToken:
+//     https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
+//   - JWT `nbf` / `exp` semantics that underlie the "not yet valid" and
+//     "lifetime validation failed" messages (RFC 7519 §4.1.4–4.1.5):
+//     https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
 //
 // The matcher is intentionally conservative:
 //   - We require Error.Code == "InvalidAuthenticationToken"; a message that

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -10,12 +10,9 @@ import (
 	"github.com/amp-labs/connectors/common/interpreter"
 )
 
-// errorFormats is the JSON schema set used by the interpreter framework to
-// parse Microsoft error payloads. Microsoft Graph, Outlook, and similar
-// services wrap errors in a single canonical envelope (ResponseMessageError),
-// so we register exactly one template. FormatSwitch picks the best-matching
-// template by MustKeys; nil keys mean "always match this template" when no
-// other candidates are registered.
+// errorFormats registers the single canonical Microsoft error envelope with
+// the interpreter framework. Graph, Outlook, and similar APIs all use this
+// shape; nil MustKeys means "always match.".
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 	[]interpreter.FormatTemplate{
 		{
@@ -25,15 +22,8 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 	}...,
 )
 
-// ResponseMessageError is the canonical error envelope used by Microsoft
-// Graph and sibling Microsoft REST APIs. See:
-// https://learn.microsoft.com/en-us/graph/errors
-//
-// The Code field is a machine-readable classifier (e.g. "InvalidAuthenticationToken",
-// "Forbidden", "ResourceNotFound"); Message is a human-readable description whose
-// wording can vary across regions and over time — see transientAuthErrorMessage
-// for notes on matching against it. InnerError carries additional diagnostic
-// detail we currently only surface via generic unmarshalling.
+// ResponseMessageError is the canonical Microsoft Graph / REST error shape.
+// See https://learn.microsoft.com/en-us/graph/errors.
 type ResponseMessageError struct {
 	Error struct {
 		Code       string `json:"code"`
@@ -42,12 +32,8 @@ type ResponseMessageError struct {
 	} `json:"error"`
 }
 
-// CombineErr satisfies the interpreter.ErrorDescriptor contract. The
-// framework calls it with the status-code-derived sentinel (e.g.
-// common.ErrBadRequest, common.ErrAccessToken) and expects us to enrich it
-// with provider-specific context. We wrap the base sentinel with the Graph
-// message so that downstream callers see, e.g., "access token invalid: Lifetime
-// validation failed..." while still being able to errors.Is(err, ErrAccessToken).
+// CombineErr wraps the status-code sentinel with the provider-side message so
+// errors.Is(err, ErrAccessToken) still works while the log carries context.
 func (r ResponseMessageError) CombineErr(base error) error {
 	if len(r.Error.Message) == 0 {
 		return base
@@ -56,49 +42,24 @@ func (r ResponseMessageError) CombineErr(base error) error {
 	return fmt.Errorf("%w: %v", base, r.Error.Message)
 }
 
-// defaultJSONResponder handles any response whose error classification is
-// unambiguous from the HTTP status code alone. It combines the standard
-// status-code mapping (401 -> ErrAccessToken, 403 -> ErrForbidden, 5xx ->
-// ErrServer, etc.) with the Microsoft error-body parser above.
-// handleErrorResponse delegates to this responder for all non-401 responses,
-// and for 401s that don't match either the transient-marker case or the
-// claim-challenge case — i.e. anything that really is an invalid token.
+// defaultJSONResponder applies the standard status-code → sentinel mapping.
+// handleErrorResponse delegates to it for everything except the two special
+// 401 cases below.
 var defaultJSONResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
 
-// handleErrorResponse classifies Microsoft error responses and is the single
-// JSON error handler used by every Microsoft-family connector that shares
-// this package (Microsoft / MicrosoftClientCredentials). It exists to fix a
-// false-positive in the connection-status machinery upstream: the default
-// interpreter maps every 401 to common.ErrAccessToken, and the server treats
-// that as a signal to flip the connection to bad_credentials. Some 401s
-// actually reflect short-lived, self-healing conditions at the Microsoft
-// resource tier — on those, flipping to bad_credentials is a user-visible
-// regression that requires re-auth to clear.
+// handleErrorResponse classifies Microsoft 401s to avoid flipping connections
+// to bad_credentials on conditions that aren't actually bad credentials.
 //
-// Guiding rule: a 401 is only marked retryable if a retry with the same (or
-// a freshly re-minted) refresh token has a realistic chance of succeeding
-// without any external change. Anything that demands user action or
-// code-level change must *not* be retryable, because retries would just
-// burn the budget and delay surfacing the real problem.
+// Rule: only mark a 401 retryable when a retry with the same refresh token
+// could plausibly succeed. Anything needing user action falls through to the
+// bad-credentials path.
 //
-// Classification strategy on 401:
-//  1. If the Graph error body matches a known transient marker (clock skew,
-//     AAD JWKS replication race right after refresh), the next attempt
-//     almost always succeeds — return common.ErrRetryable.
-//  2. If WWW-Authenticate signals a Continuous Access Evaluation (CAE) or
-//     step-up claim challenge, the refresh token is still usable but the
-//     challenge itself demands new claims that a plain refresh cannot
-//     obtain (admin session revoke, password change, MFA step-up,
-//     compliant-device requirement, etc.). Return a ClaimsChallengeError
-//     that wraps common.ErrAccessToken via the Is method — so the server
-//     flips the connection to bad_credentials (semantically correct: the
-//     user must re-authenticate) while still exposing the structured
-//     details for logging and future UI differentiation.
-//  3. Otherwise fall through to the default responder, which produces
-//     common.ErrAccessToken — by design, the server flips the connection.
+//  1. Transient marker in the error body  → common.ErrRetryable.
+//  2. CAE / step-up claim challenge       → ClaimsChallengeError
+//     (wraps common.ErrAccessToken; server still flips bad_credentials).
+//  3. Everything else                     → default responder (ErrAccessToken).
 //
-// Non-401 responses are unchanged from the prior behaviour and pass straight
-// through to the default responder.
+// Non-401 responses are unchanged.
 func handleErrorResponse(res *http.Response, body []byte) error {
 	if res.StatusCode != http.StatusUnauthorized {
 		return defaultJSONResponder.HandleErrorResponse(res, body)
@@ -115,44 +76,14 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 	return defaultJSONResponder.HandleErrorResponse(res, body)
 }
 
-// claimsChallengeReason detects a Continuous Access Evaluation (CAE) or
-// step-up claim challenge in the WWW-Authenticate header. Microsoft uses
-// error="insufficient_claims" for CAE (e.g. session revoked mid-flight by
-// admin action, risk signal, password change) and error="interaction_required"
-// when the resource requires user interaction to satisfy a Conditional Access
-// policy.
+// claimsChallengeReason detects CAE (insufficient_claims) and step-up
+// (interaction_required) challenges in WWW-Authenticate. These are not
+// retryable — a plain refresh can't satisfy a claim challenge; the user has
+// to re-authenticate. Detection exists to attach diagnostic context.
 //
-// These challenges are not transient — the refresh token by itself can't
-// satisfy the requested claims. MFA step-up needs the user; compliant-device
-// checks need the user's device; admin session revocation needs the user to
-// re-authenticate to create a fresh session. We therefore classify claim
-// challenges as non-retryable and fall through to the bad-credentials path
-// (see ClaimsChallengeError). The detection here exists to attach structured
-// diagnosis details, not to enable retries.
-//
-// References:
-//   - Claims challenges / claims requests / CAE client handling:
-//     https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge
-//   - Continuous Access Evaluation (overview + resilience guidance):
-//     https://learn.microsoft.com/en-us/entra/identity-platform/app-resilience-continuous-access-evaluation
-//   - CAE in Conditional Access (operator-facing explanation of which events
-//     cause insufficient_claims):
-//     https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation
-//   - interaction_required is the OIDC standard "step-up" response, used by
-//     Entra when a Conditional Access policy demands MFA/compliant device/etc.:
-//     https://openid.net/specs/openid-connect-core-1_0.html#AuthError
-//
-// Future work: a full CAE implementation would parse the claims="..."
-// parameter out of the header and feed it back into the next token request
-// so the re-issued access token satisfies the challenge. That would move
-// some (not all) of these challenges from "needs user re-auth" to "the
-// system can auto-satisfy" — e.g., service-principal ACR requirements.
-// Even then, challenges requiring real user interaction (MFA, compliant
-// device) remain non-retryable by definition.
-//
-// The matching is deliberately case-insensitive and uses substring lookup
-// rather than full RFC 6750 parsing because the Microsoft header format is
-// stable enough and we only care about the two known values.
+// See https://learn.microsoft.com/en-us/entra/identity-platform/claims-challenge
+// for the challenge format, and the ClaimsChallengeError type for how the
+// result is propagated.
 func claimsChallengeReason(header string) (string, bool) {
 	if header == "" {
 		return "", false
@@ -169,50 +100,19 @@ func claimsChallengeReason(header string) (string, bool) {
 	return "", false
 }
 
-// transientAuthErrorMessage recognises Graph error bodies that indicate a
-// transient authentication failure rather than a permanently-invalid token.
-// These typically occur immediately after a successful refresh due to:
-//   - Clock skew between the token-issuing region (login.microsoftonline.com
-//     shard that minted the access token) and the resource region (Graph
-//     shard validating it) — Azure's ~5-minute `nbf`/`exp` allowance is
-//     occasionally exceeded under load.
-//   - Azure AD signing-key replication lag after a key rotation, where the
-//     resource has not yet fetched the new JWKS entry.
+// transientAuthErrorMessage recognises Graph 401 bodies that indicate a
+// short-lived failure (clock skew between token-issuing and resource regions,
+// or AAD JWKS replication lag right after a refresh) rather than a truly
+// invalid token. A retry seconds later almost always succeeds.
 //
-// In both cases a retry with the same (or a freshly re-minted) token usually
-// succeeds within seconds.
+// Gated on Error.Code == "InvalidAuthenticationToken" plus one of the
+// observed transient messages. Intentionally conservative — excluded patterns
+// like "CompactToken validation failed" also appear for real failures, and
+// misclassifying them as retryable would mask legitimate bad credentials.
+// Extend `markers` only after production logs confirm a phrase correlates
+// exclusively with transient cases.
 //
-// References:
-//   - Microsoft Graph error response schema (documents the `error.code` /
-//     `error.message` envelope matched here):
-//     https://learn.microsoft.com/en-us/graph/errors
-//   - InvalidAuthenticationToken in the Graph error code reference:
-//     https://learn.microsoft.com/en-us/graph/errors#code-property
-//   - AAD signing key rollover (explains the JWKS replication race that
-//     produces transient signature/lifetime validation failures on freshly
-//     minted tokens):
-//     https://learn.microsoft.com/en-us/entra/identity-platform/signing-key-rollover
-//   - Entra ID (AAD) error code reference — companion to Graph errors, lists
-//     the AADSTS codes that can accompany InvalidAuthenticationToken:
-//     https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
-//   - JWT `nbf` / `exp` semantics that underlie the "not yet valid" and
-//     "lifetime validation failed" messages (RFC 7519 §4.1.4–4.1.5):
-//     https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
-//
-// The matcher is intentionally conservative:
-//   - We require Error.Code == "InvalidAuthenticationToken"; a message that
-//     looks similar under a different code is more likely a real auth issue.
-//   - The message markers are drawn from observed transient error text. We
-//     deliberately exclude broader patterns like "CompactToken validation
-//     failed" because those are also emitted for genuinely-malformed tokens
-//     and would risk masking real failures.
-//   - Matching is substring-based, not exact — Microsoft varies the trailing
-//     text (e.g. "... the token is expired" vs "... token is expired and can
-//     no longer be used") across regions and versions.
-//
-// Extend `markers` only after confirming from production logs that a given
-// phrase exclusively correlates with a transient condition; misclassifying a
-// real auth failure as retryable delays user-visible error reporting.
+// See https://learn.microsoft.com/en-us/graph/errors for the envelope.
 func transientAuthErrorMessage(body []byte) (string, bool) {
 	var messageError ResponseMessageError
 	if err := json.Unmarshal(body, &messageError); err != nil {
@@ -238,49 +138,18 @@ func transientAuthErrorMessage(body []byte) (string, bool) {
 	return "", false
 }
 
-// ClaimsChallengeError is returned by handleErrorResponse when Microsoft
-// responds with a Continuous Access Evaluation or step-up claim challenge
-// on a 401.
+// ClaimsChallengeError is returned for Microsoft CAE and step-up challenges.
+// It wraps common.ErrAccessToken (via Is) so the server's existing
+// bad-credentials flow still fires — semantically correct, the user has to
+// re-authenticate. The struct is exported so the server can errors.As for a
+// future distinct re-auth status; for now, callers get structured detail via
+// the Error() string without needing to know about this type.
 //
-// Claim challenges are NOT retryable. They indicate the user's session is
-// still usable but the resource is demanding additional claims (re-auth,
-// MFA step-up, compliant-device etc.) that cannot be obtained by simply
-// repeating the request with the same refresh token. Retrying would just
-// burn the retry budget and delay the eventual re-auth that the user has
-// to perform. Accordingly this type wraps common.ErrAccessToken via the Is
-// method, so the server flips the connection to bad_credentials via its
-// existing auth-invalidated path — the user-visible signal "your connection
-// needs to be re-established" is correct for a claim challenge even if the
-// underlying cause is subtler than a revoked refresh token.
-//
-// The type exists so the server can still identify these events
-// specifically — via errors.As — and log or surface them differently from
-// a plain bad-credentials flip. That gives us the hook for a future
-// CONNECTION_STATUS_REAUTH_REQUIRED (or similarly-differentiated state)
-// without having to change the classification here.
-//
-// Example server-side use:
-//
-//	chErr, ok := errors.AsType[*microsoft.ClaimsChallengeError](err)
-//	if ok {
-//	    logger.Warn("microsoft claims challenge",
-//	        "reason", chErr.Reason,
-//	        "url", chErr.RequestURL,
-//	        "x_ms_request_id", chErr.MSRequestID,
-//	        "www_authenticate", chErr.WWWAuthenticate)
-//	}
-//
-// Field notes:
-//   - Reason: which of the two WWW-Authenticate error codes fired —
-//     "insufficient_claims" (CAE) or "interaction_required" (step-up).
-//   - WWWAuthenticate: the raw header. The claims="..." parameter inside is
-//     a base64url-encoded JSON object describing exactly what claims Azure
-//     is demanding; operators can decode it to understand the challenge.
-//   - RequestMethod / RequestURL: identify which Graph endpoint rejected
-//     the token. Useful when a single connection drives multiple objects.
-//   - MSRequestID: Microsoft's x-ms-request-id. Pair with Azure sign-in
-//     logs to find the Conditional Access policy that produced the
-//     challenge.
+//   - Reason: "insufficient_claims" (CAE) or "interaction_required" (step-up).
+//   - WWWAuthenticate: raw header; contains a base64 claims="..." payload
+//     operators can decode to see what Azure is demanding.
+//   - RequestMethod / RequestURL: which Graph endpoint rejected the token.
+//   - MSRequestID: x-ms-request-id, for correlation with Azure sign-in logs.
 type ClaimsChallengeError struct {
 	Reason          string
 	WWWAuthenticate string
@@ -289,15 +158,11 @@ type ClaimsChallengeError struct {
 	MSRequestID     string
 }
 
-// Error serialises every diagnostic field into a single string so that
-// existing server-side error logs — e.g. shared/workflow/read/error.go
-// which logs `"error", err` on the ErrAccessToken branch — surface all
-// the details automatically, without the server needing to perform an
-// errors.As and re-log individual fields. The format is:
+// Error packs every field into one string so the existing server-side log
+// pattern `logger.Error("...", "error", err)` surfaces all diagnostic detail
+// without needing an errors.As block on the server. Format:
 //
 //	microsoft claims challenge (<reason>) [<METHOD> <URL>] [x-ms-request-id=<id>] [www-authenticate=<header>]
-//
-// Bracketed sections are omitted when the underlying field is empty.
 func (e *ClaimsChallengeError) Error() string {
 	if e == nil {
 		return ""
@@ -322,20 +187,14 @@ func (e *ClaimsChallengeError) Error() string {
 	return challengeBuilder.String()
 }
 
-// Is lets errors.Is(err, common.ErrAccessToken) return true for this type,
-// so the server's existing auth-invalidated / bad-credentials detection
-// continues to fire for claim challenges without needing to know about
-// this concrete type. Claim challenges explicitly do *not* satisfy
-// errors.Is(err, common.ErrRetryable) — see the type-level comment for the
-// reasoning.
+// Is matches common.ErrAccessToken so the server's existing auth-invalidated
+// path handles claim challenges. Deliberately does NOT match ErrRetryable.
 func (e *ClaimsChallengeError) Is(target error) bool {
 	return target == common.ErrAccessToken
 }
 
-// newClaimsChallengeError extracts the pieces of the response that are
-// useful for diagnosis and packs them into a ClaimsChallengeError. The
-// response's Request may be nil if the response was synthesized (e.g.,
-// in tests), in which case method/url are left empty rather than panicking.
+// newClaimsChallengeError tolerates a nil res.Request (synthesised responses
+// in tests) by leaving method/url empty rather than panicking.
 func newClaimsChallengeError(res *http.Response, reason string) *ClaimsChallengeError {
 	err := &ClaimsChallengeError{
 		Reason:          reason,
@@ -345,6 +204,7 @@ func newClaimsChallengeError(res *http.Response, reason string) *ClaimsChallenge
 
 	if res.Request != nil {
 		err.RequestMethod = res.Request.Method
+
 		if res.Request.URL != nil {
 			err.RequestURL = res.Request.URL.String()
 		}

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -59,9 +59,10 @@ func (r ResponseMessageError) CombineErr(base error) error {
 // defaultJSONResponder handles any response whose error classification is
 // unambiguous from the HTTP status code alone. It combines the standard
 // status-code mapping (401 -> ErrAccessToken, 403 -> ErrForbidden, 5xx ->
-// ErrServer, etc.) with the Microsoft error-body parser above. handleErrorResponse
-// delegates to this responder for every status except 401, where the extra
-// inspection below is required.
+// ErrServer, etc.) with the Microsoft error-body parser above.
+// handleErrorResponse delegates to this responder for all non-401 responses,
+// and for 401s that don't match either the transient-marker case or the
+// claim-challenge case — i.e. anything that really is an invalid token.
 var defaultJSONResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
 
 // handleErrorResponse classifies Microsoft error responses and is the single

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -69,20 +69,32 @@ var defaultJSONResponder = interpreter.NewFaultyResponder(errorFormats, nil) //n
 // this package (Microsoft / MicrosoftClientCredentials). It exists to fix a
 // false-positive in the connection-status machinery upstream: the default
 // interpreter maps every 401 to common.ErrAccessToken, and the server treats
-// that as a signal to flip the connection to bad_credentials. Several
-// legitimately-transient conditions at the Microsoft resource tier also
-// surface as 401 — on those, flipping to bad_credentials is a user-visible
+// that as a signal to flip the connection to bad_credentials. Some 401s
+// actually reflect short-lived, self-healing conditions at the Microsoft
+// resource tier — on those, flipping to bad_credentials is a user-visible
 // regression that requires re-auth to clear.
 //
+// Guiding rule: a 401 is only marked retryable if a retry with the same (or
+// a freshly re-minted) refresh token has a realistic chance of succeeding
+// without any external change. Anything that demands user action or
+// code-level change must *not* be retryable, because retries would just
+// burn the budget and delay surfacing the real problem.
+//
 // Classification strategy on 401:
-//  1. If WWW-Authenticate signals a Continuous Access Evaluation (CAE) or
-//     step-up challenge, the refresh token is still valid; a retry against
-//     the freshly-re-issued token typically succeeds. Return ErrRetryable.
-//  2. If the Graph error body matches a known transient marker (clock skew,
-//     AAD replication race right after refresh), same verdict: ErrRetryable.
-//  3. Otherwise treat as genuinely-invalid credentials and fall through to
-//     the default responder, which will produce ErrAccessToken and — by
-//     design — allow the server to flip the connection.
+//  1. If the Graph error body matches a known transient marker (clock skew,
+//     AAD JWKS replication race right after refresh), the next attempt
+//     almost always succeeds — return common.ErrRetryable.
+//  2. If WWW-Authenticate signals a Continuous Access Evaluation (CAE) or
+//     step-up claim challenge, the refresh token is still usable but the
+//     challenge itself demands new claims that a plain refresh cannot
+//     obtain (admin session revoke, password change, MFA step-up,
+//     compliant-device requirement, etc.). Return a ClaimsChallengeError
+//     that wraps common.ErrAccessToken via the Is method — so the server
+//     flips the connection to bad_credentials (semantically correct: the
+//     user must re-authenticate) while still exposing the structured
+//     details for logging and future UI differentiation.
+//  3. Otherwise fall through to the default responder, which produces
+//     common.ErrAccessToken — by design, the server flips the connection.
 //
 // Non-401 responses are unchanged from the prior behaviour and pass straight
 // through to the default responder.
@@ -92,7 +104,7 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 	}
 
 	if reason, ok := claimsChallengeReason(res.Header.Get("WWW-Authenticate")); ok {
-		return fmt.Errorf("%w: microsoft claims challenge (%s)", common.ErrRetryable, reason)
+		return newClaimsChallengeError(res, reason)
 	}
 
 	if msg, ok := transientAuthErrorMessage(body); ok {
@@ -107,9 +119,15 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 // error="insufficient_claims" for CAE (e.g. session revoked mid-flight by
 // admin action, risk signal, password change) and error="interaction_required"
 // when the resource requires user interaction to satisfy a Conditional Access
-// policy. In both cases the refresh token is still valid — the resource is
-// asking for a new access token with extra claims, not signalling revoked
-// credentials.
+// policy.
+//
+// These challenges are not transient — the refresh token by itself can't
+// satisfy the requested claims. MFA step-up needs the user; compliant-device
+// checks need the user's device; admin session revocation needs the user to
+// re-authenticate to create a fresh session. We therefore classify claim
+// challenges as non-retryable and fall through to the bad-credentials path
+// (see ClaimsChallengeError). The detection here exists to attach structured
+// diagnosis details, not to enable retries.
 //
 // References:
 //   - Claims challenges / claims requests / CAE client handling:
@@ -123,14 +141,13 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 //     Entra when a Conditional Access policy demands MFA/compliant device/etc.:
 //     https://openid.net/specs/openid-connect-core-1_0.html#AuthError
 //
-// Known limitation: a full CAE implementation would parse the claims="..."
+// Future work: a full CAE implementation would parse the claims="..."
 // parameter out of the header and feed it back into the next token request
-// so the re-issued access token satisfies the challenge. That requires
-// plumbing through the token source and is out of scope here; we currently
-// just mark the 401 as retryable and rely on Temporal retries to catch the
-// eventual success once whatever transient condition clears. Sustained CAE
-// challenges will still surface as activity failures after the retry budget
-// is exhausted.
+// so the re-issued access token satisfies the challenge. That would move
+// some (not all) of these challenges from "needs user re-auth" to "the
+// system can auto-satisfy" — e.g., service-principal ACR requirements.
+// Even then, challenges requiring real user interaction (MFA, compliant
+// device) remain non-retryable by definition.
 //
 // The matching is deliberately case-insensitive and uses substring lookup
 // rather than full RFC 6750 parsing because the Microsoft header format is
@@ -218,4 +235,119 @@ func transientAuthErrorMessage(body []byte) (string, bool) {
 	}
 
 	return "", false
+}
+
+// ClaimsChallengeError is returned by handleErrorResponse when Microsoft
+// responds with a Continuous Access Evaluation or step-up claim challenge
+// on a 401.
+//
+// Claim challenges are NOT retryable. They indicate the user's session is
+// still usable but the resource is demanding additional claims (re-auth,
+// MFA step-up, compliant-device etc.) that cannot be obtained by simply
+// repeating the request with the same refresh token. Retrying would just
+// burn the retry budget and delay the eventual re-auth that the user has
+// to perform. Accordingly this type wraps common.ErrAccessToken via the Is
+// method, so the server flips the connection to bad_credentials via its
+// existing auth-invalidated path — the user-visible signal "your connection
+// needs to be re-established" is correct for a claim challenge even if the
+// underlying cause is subtler than a revoked refresh token.
+//
+// The type exists so the server can still identify these events
+// specifically — via errors.As — and log or surface them differently from
+// a plain bad-credentials flip. That gives us the hook for a future
+// CONNECTION_STATUS_REAUTH_REQUIRED (or similarly-differentiated state)
+// without having to change the classification here.
+//
+// Example server-side use:
+//
+//	var chErr *microsoft.ClaimsChallengeError
+//	if errors.As(err, &chErr) {
+//	    logger.Warn("microsoft claims challenge",
+//	        "reason", chErr.Reason,
+//	        "url", chErr.RequestURL,
+//	        "x_ms_request_id", chErr.MSRequestID,
+//	        "www_authenticate", chErr.WWWAuthenticate)
+//	}
+//
+// Field notes:
+//   - Reason: which of the two WWW-Authenticate error codes fired —
+//     "insufficient_claims" (CAE) or "interaction_required" (step-up).
+//   - WWWAuthenticate: the raw header. The claims="..." parameter inside is
+//     a base64url-encoded JSON object describing exactly what claims Azure
+//     is demanding; operators can decode it to understand the challenge.
+//   - RequestMethod / RequestURL: identify which Graph endpoint rejected
+//     the token. Useful when a single connection drives multiple objects.
+//   - MSRequestID: Microsoft's x-ms-request-id. Pair with Azure sign-in
+//     logs to find the Conditional Access policy that produced the
+//     challenge.
+type ClaimsChallengeError struct {
+	Reason          string
+	WWWAuthenticate string
+	RequestMethod   string
+	RequestURL      string
+	MSRequestID     string
+}
+
+// Error serialises every diagnostic field into a single string so that
+// existing server-side error logs — e.g. shared/workflow/read/error.go
+// which logs `"error", err` on the ErrAccessToken branch — surface all
+// the details automatically, without the server needing to perform an
+// errors.As and re-log individual fields. The format is:
+//
+//	microsoft claims challenge (<reason>) [<METHOD> <URL>] [x-ms-request-id=<id>] [www-authenticate=<header>]
+//
+// Bracketed sections are omitted when the underlying field is empty.
+func (e *ClaimsChallengeError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	var challengeBuilder strings.Builder
+
+	fmt.Fprintf(&challengeBuilder, "microsoft claims challenge (%s)", e.Reason)
+
+	if e.RequestURL != "" {
+		fmt.Fprintf(&challengeBuilder, " [%s %s]", e.RequestMethod, e.RequestURL)
+	}
+
+	if e.MSRequestID != "" {
+		fmt.Fprintf(&challengeBuilder, " [x-ms-request-id=%s]", e.MSRequestID)
+	}
+
+	if e.WWWAuthenticate != "" {
+		fmt.Fprintf(&challengeBuilder, " [www-authenticate=%s]", e.WWWAuthenticate)
+	}
+
+	return challengeBuilder.String()
+}
+
+// Is lets errors.Is(err, common.ErrAccessToken) return true for this type,
+// so the server's existing auth-invalidated / bad-credentials detection
+// continues to fire for claim challenges without needing to know about
+// this concrete type. Claim challenges explicitly do *not* satisfy
+// errors.Is(err, common.ErrRetryable) — see the type-level comment for the
+// reasoning.
+func (e *ClaimsChallengeError) Is(target error) bool {
+	return target == common.ErrAccessToken
+}
+
+// newClaimsChallengeError extracts the pieces of the response that are
+// useful for diagnosis and packs them into a ClaimsChallengeError. The
+// response's Request may be nil if the response was synthesized (e.g.,
+// in tests), in which case method/url are left empty rather than panicking.
+func newClaimsChallengeError(res *http.Response, reason string) *ClaimsChallengeError {
+	err := &ClaimsChallengeError{
+		Reason:          reason,
+		WWWAuthenticate: res.Header.Get("WWW-Authenticate"),
+		MSRequestID:     res.Header.Get("X-Ms-Request-Id"),
+	}
+
+	if res.Request != nil {
+		err.RequestMethod = res.Request.Method
+		if res.Request.URL != nil {
+			err.RequestURL = res.Request.URL.String()
+		}
+	}
+
+	return err
 }

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -261,8 +261,8 @@ func transientAuthErrorMessage(body []byte) (string, bool) {
 //
 // Example server-side use:
 //
-//	var chErr *microsoft.ClaimsChallengeError
-//	if errors.As(err, &chErr) {
+//	chErr, ok := errors.AsType[*microsoft.ClaimsChallengeError](err)
+//	if ok {
 //	    logger.Warn("microsoft claims challenge",
 //	        "reason", chErr.Reason,
 //	        "url", chErr.RequestURL,

--- a/providers/microsoft/errors_test.go
+++ b/providers/microsoft/errors_test.go
@@ -3,6 +3,7 @@ package microsoft
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -29,18 +30,18 @@ func TestHandleErrorResponse(t *testing.T) { //nolint:funlen
 		wantErrSubstring string
 	}{
 		{
-			name:            "401 with CAE insufficient_claims is retryable",
+			name:            "401 with CAE insufficient_claims is bad-creds (needs re-auth, not retryable)",
 			status:          http.StatusUnauthorized,
 			wwwAuthenticate: `Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19"`,
 			body:            genericInvalidTokenBody,
-			wantRetryable:   true,
+			wantAccessToken: true,
 		},
 		{
-			name:            "401 with interaction_required is retryable",
+			name:            "401 with interaction_required is bad-creds (needs user interaction, not retryable)",
 			status:          http.StatusUnauthorized,
 			wwwAuthenticate: `Bearer error="interaction_required", error_description="additional auth required"`,
 			body:            genericInvalidTokenBody,
-			wantRetryable:   true,
+			wantAccessToken: true,
 		},
 		{
 			name:             "401 InvalidAuthenticationToken lifetime-expired is retryable",
@@ -126,6 +127,85 @@ func TestHandleErrorResponse(t *testing.T) { //nolint:funlen
 				t.Errorf("expected error to contain %q, got %v", tt.wantErrSubstring, err)
 			}
 		})
+	}
+}
+
+func TestClaimsChallengeErrorExposesStructuredFields(t *testing.T) {
+	t.Parallel()
+
+	reqURL, err := url.Parse("https://graph.microsoft.com/v1.0/users")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    reqURL,
+	}
+
+	res := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{},
+		Request:    req,
+	}
+	res.Header.Set("WWW-Authenticate",
+		`Bearer error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19"`)
+	res.Header.Set("x-ms-request-id", "e9e89775-0174-4796-8446-a8fc421b3600")
+
+	returned := handleErrorResponse(res, []byte(`{"error":{"code":"InvalidAuthenticationToken","message":"x"}}`))
+
+	// Claim challenges are NOT retryable — retries cannot satisfy the
+	// challenge without user action. They must surface as bad credentials
+	// (common.ErrAccessToken) so the server flips the connection and the
+	// user is prompted to re-auth.
+	if !errors.Is(returned, common.ErrAccessToken) {
+		t.Fatalf("expected errors.Is(err, ErrAccessToken) to be true, got %v", returned)
+	}
+
+	if errors.Is(returned, common.ErrRetryable) {
+		t.Fatalf("claim challenge must not be retryable, but errors.Is(err, ErrRetryable) was true: %v", returned)
+	}
+
+	var chErr *ClaimsChallengeError
+	if !errors.As(returned, &chErr) {
+		t.Fatalf("expected errors.As to populate *ClaimsChallengeError, got %T: %v", returned, returned)
+	}
+
+	if chErr.Reason != "insufficient_claims" {
+		t.Errorf("Reason: got %q, want %q", chErr.Reason, "insufficient_claims")
+	}
+
+	if chErr.RequestMethod != http.MethodGet {
+		t.Errorf("RequestMethod: got %q, want %q", chErr.RequestMethod, http.MethodGet)
+	}
+
+	if chErr.RequestURL != "https://graph.microsoft.com/v1.0/users" {
+		t.Errorf("RequestURL: got %q", chErr.RequestURL)
+	}
+
+	if chErr.MSRequestID != "e9e89775-0174-4796-8446-a8fc421b3600" {
+		t.Errorf("MSRequestID: got %q", chErr.MSRequestID)
+	}
+
+	if !strings.Contains(chErr.WWWAuthenticate, `error="insufficient_claims"`) {
+		t.Errorf("WWWAuthenticate: missing original header content, got %q", chErr.WWWAuthenticate)
+	}
+
+	// Error() should include every diagnostic field so the existing server
+	// logger pattern (logger.Error("...", "error", err)) surfaces them all
+	// without requiring an errors.As block on the server side.
+	msg := chErr.Error()
+	for _, want := range []string{
+		"microsoft claims challenge",
+		"insufficient_claims",
+		http.MethodGet,
+		"https://graph.microsoft.com/v1.0/users",
+		"x-ms-request-id=e9e89775-0174-4796-8446-a8fc421b3600",
+		"www-authenticate=",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Error() missing %q\ngot: %s", want, msg)
+		}
 	}
 }
 

--- a/providers/microsoft/errors_test.go
+++ b/providers/microsoft/errors_test.go
@@ -1,0 +1,154 @@
+package microsoft
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestHandleErrorResponse(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	const (
+		genericInvalidTokenBody = `{"error":{"code":"InvalidAuthenticationToken","message":"Access token validation failure."}}`
+		expiredTokenBody        = `{"error":{"code":"InvalidAuthenticationToken","message":"Lifetime validation failed, the token is expired."}}`
+		notYetValidTokenBody    = `{"error":{"code":"InvalidAuthenticationToken","message":"The token is not yet valid."}}`
+		accessExpiredBody       = `{"error":{"code":"InvalidAuthenticationToken","message":"Access token has expired or is not yet valid and can no longer be used."}}`
+	)
+
+	tests := []struct {
+		name             string
+		status           int
+		wwwAuthenticate  string
+		body             string
+		wantRetryable    bool
+		wantAccessToken  bool
+		wantErrSubstring string
+	}{
+		{
+			name:            "401 with CAE insufficient_claims is retryable",
+			status:          http.StatusUnauthorized,
+			wwwAuthenticate: `Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19"`,
+			body:            genericInvalidTokenBody,
+			wantRetryable:   true,
+		},
+		{
+			name:            "401 with interaction_required is retryable",
+			status:          http.StatusUnauthorized,
+			wwwAuthenticate: `Bearer error="interaction_required", error_description="additional auth required"`,
+			body:            genericInvalidTokenBody,
+			wantRetryable:   true,
+		},
+		{
+			name:             "401 InvalidAuthenticationToken lifetime-expired is retryable",
+			status:           http.StatusUnauthorized,
+			body:             expiredTokenBody,
+			wantRetryable:    true,
+			wantErrSubstring: "Lifetime validation failed",
+		},
+		{
+			name:          "401 InvalidAuthenticationToken not-yet-valid is retryable",
+			status:        http.StatusUnauthorized,
+			body:          notYetValidTokenBody,
+			wantRetryable: true,
+		},
+		{
+			name:          "401 InvalidAuthenticationToken access-expired is retryable",
+			status:        http.StatusUnauthorized,
+			body:          accessExpiredBody,
+			wantRetryable: true,
+		},
+		{
+			name:            "401 with no CAE header and non-transient message falls through to access-token error",
+			status:          http.StatusUnauthorized,
+			body:            genericInvalidTokenBody,
+			wantAccessToken: true,
+		},
+		{
+			name:            "401 with empty body falls through to access-token error",
+			status:          http.StatusUnauthorized,
+			body:            "",
+			wantAccessToken: true,
+		},
+		{
+			name:             "403 is unchanged (forbidden)",
+			status:           http.StatusForbidden,
+			body:             `{"error":{"code":"Forbidden","message":"Access denied."}}`,
+			wantErrSubstring: "forbidden",
+		},
+		{
+			name:             "400 is unchanged (bad request)",
+			status:           http.StatusBadRequest,
+			body:             `{"error":{"code":"BadRequest","message":"bad input"}}`,
+			wantErrSubstring: "bad request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &http.Response{
+				StatusCode: tt.status,
+				Header:     http.Header{},
+			}
+			if tt.wwwAuthenticate != "" {
+				res.Header.Set("WWW-Authenticate", tt.wwwAuthenticate)
+			}
+
+			err := handleErrorResponse(res, []byte(tt.body))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if tt.wantRetryable {
+				if !errors.Is(err, common.ErrRetryable) {
+					t.Errorf("expected errors.Is(err, ErrRetryable), got %v", err)
+				}
+				if errors.Is(err, common.ErrAccessToken) {
+					t.Errorf("did not expect ErrAccessToken, got %v", err)
+				}
+			}
+
+			if tt.wantAccessToken {
+				if !errors.Is(err, common.ErrAccessToken) {
+					t.Errorf("expected errors.Is(err, ErrAccessToken), got %v", err)
+				}
+				if errors.Is(err, common.ErrRetryable) {
+					t.Errorf("did not expect ErrRetryable, got %v", err)
+				}
+			}
+
+			if tt.wantErrSubstring != "" && !strings.Contains(err.Error(), tt.wantErrSubstring) {
+				t.Errorf("expected error to contain %q, got %v", tt.wantErrSubstring, err)
+			}
+		})
+	}
+}
+
+func TestClaimsChallengeReason(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		header string
+		want   string
+		ok     bool
+	}{
+		{"", "", false},
+		{`Bearer realm=""`, "", false},
+		{`Bearer error="insufficient_claims", claims="abc"`, "insufficient_claims", true},
+		{`Bearer ERROR="INSUFFICIENT_CLAIMS"`, "insufficient_claims", true},
+		{`Bearer error="interaction_required"`, "interaction_required", true},
+		{`Bearer error="invalid_token"`, "", false},
+	}
+
+	for _, c := range cases {
+		got, ok := claimsChallengeReason(c.header)
+		if ok != c.ok || got != c.want {
+			t.Errorf("claimsChallengeReason(%q) = (%q,%v), want (%q,%v)", c.header, got, ok, c.want, c.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stop the Microsoft connector from classifying every Graph 401 as invalid credentials. Today every 401 maps to `common.ErrAccessToken`, which the server treats as a signal to flip the connection to `CONNECTION_STATUS_BAD_CREDS` — forcing re-auth even when the refresh token is still perfectly valid. This change inspects the response body and headers on 401 and splits the cases:

- **Genuinely transient conditions** (clock skew, AAD signing-key replication lag right after a refresh) → `common.ErrRetryable`, so Temporal retries absorb them and the connection stays healthy.
- **CAE / step-up claim challenges** (session revoked mid-flight, MFA step-up, compliant-device requirement) → a new `ClaimsChallengeError` type that wraps `common.ErrAccessToken`. The server still flips to bad_credentials (correct — the user must re-authenticate), but the error now carries structured diagnostic fields that land in existing server logs for operator visibility.
- **Everything else** on 401 → unchanged; continues to produce `common.ErrAccessToken`.

Non-401 responses are untouched.

## Problem

A Microsoft connection was observed flipping to `bad_credentials` immediately after a successful `login.microsoftonline.com` 200 OK refresh. Tracing the chain:

1. A read activity called Graph with the freshly-minted access token.
2. Graph returned 401 (transient token-validation race / CAE challenge / clock skew — all observed variants in production).
3. The connector's error handler mapped the 401 to `common.ErrAccessToken` unconditionally.
4. `shared/workflow/read/error.go:47-63` flipped the connection to `bad_credentials`, requiring manual re-auth to clear — even though the refresh token was still valid.

