### PR TITLE
[ENG-3777] feat: add Gong `GetRecordsByIds`

### DIFF
--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -83,15 +83,21 @@ func buildReadBody(config common.ReadParams) map[string]any {
 	}
 
 	if config.ObjectName == objectNameCalls {
-		// https://app.gong.io/settings/api/documentation#post-/v2/calls/extensive
-		body["contentSelector"] = map[string]any{
-			"context": "Extended",
-			"exposedFields": map[string]any{
-				"parties": true,
-				"media":   true,
-			},
-		}
+		body["contentSelector"] = callContentSelector()
 	}
 
 	return body
+}
+
+// callContentSelector returns the contentSelector used for POST /v2/calls/extensive, which
+// adds parties + media to the response.
+// https://app.gong.io/settings/api/documentation#post-/v2/calls/extensive
+func callContentSelector() map[string]any {
+	return map[string]any{
+		"context": "Extended",
+		"exposedFields": map[string]any{
+			"parties": true,
+			"media":   true,
+		},
+	}
 }

--- a/providers/gong/record.go
+++ b/providers/gong/record.go
@@ -1,0 +1,87 @@
+package gong
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/gong/metadata"
+)
+
+var _ connectors.BatchRecordReaderConnector = &Connector{}
+
+// GetRecordsByIds fetches full records from Gong for a specific set of IDs.
+// Supported objects:
+//   - calls: POST /v2/calls/extensive with filter.callIds
+//   - users: POST /v2/users/extensive with filter.userIds
+//
+// https://gong.app.gong.io/settings/api/documentation#overview
+func (c *Connector) GetRecordsByIds( //nolint:revive,funlen
+	ctx context.Context,
+	objectName string,
+	ids []string,
+	fields []string,
+	_ []string,
+) ([]common.ReadResultRow, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var (
+		filterKey       string
+		contentSelector map[string]any
+		transformer     common.RecordTransformer
+		extraPath       string
+	)
+
+	switch objectName {
+	case objectNameCalls:
+		// getReadURL already appends /extensive for calls.
+		filterKey = "callIds"
+		contentSelector = callContentSelector()
+		transformer = extractMetaDataFields
+	case objectNameUsers:
+		filterKey = "userIds"
+		extraPath = "extensive" // this endpoint allows filtering by userIds
+	default:
+		return nil, fmt.Errorf("%w: %q", common.ErrGetRecordNotSupportedForObject, objectName)
+	}
+
+	url, err := c.getReadURL(objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if extraPath != "" {
+		url.AddPath(extraPath)
+	}
+
+	body := map[string]any{
+		"filter": map[string]any{filterKey: ids},
+	}
+
+	if contentSelector != nil {
+		body["contentSelector"] = contentSelector
+	}
+
+	response, err := c.Client.Post(ctx, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, objectName)
+
+	readResult, err := common.ParseResult(response,
+		getRecords(responseFieldName),
+		getNextRecordsURL,
+		common.MakeMarshaledDataFunc(transformer),
+		datautils.NewSetFromList(fields),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return readResult.Data, nil
+}

--- a/providers/gong/record_test.go
+++ b/providers/gong/record_test.go
@@ -1,0 +1,203 @@
+package gong
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+type GetRecordsByIdsInput struct {
+	ObjectName string
+	Ids        []string
+	Fields     []string
+}
+
+// nolint:lll,funlen
+func TestGetRecordsByIds(t *testing.T) {
+	t.Parallel()
+
+	callsResp := testutils.DataFromFile(t, "read.json")
+	usersResp := testutils.DataFromFile(t, "get-records-users.json")
+
+	tests := []testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
+		{
+			Name: "Calls by IDs POST to /v2/calls/extensive with callIds filter and contentSelector",
+			Input: GetRecordsByIdsInput{
+				ObjectName: "calls",
+				Ids:        []string{"52947912500572621", "137982752092261989"},
+				Fields:     []string{"id"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/calls/extensive"),
+					mockcond.Body(`{
+						"filter":{"callIds":["52947912500572621","137982752092261989"]},
+						"contentSelector":{"context":"Extended","exposedFields":{"parties":true,"media":true}}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, callsResp),
+			}.Server(),
+			Expected: []common.ReadResultRow{
+				{
+					Id:     "52947912500572621",
+					Fields: map[string]any{"id": "52947912500572621"},
+					Raw: map[string]any{
+						"metaData": map[string]any{
+							"id":             "52947912500572621",
+							"url":            "https://us-49467.app.gong.io/call?id=52947912500572621",
+							"workspaceId":    "1007648505208900737",
+							"clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+							"customData":     "R1201",
+						},
+					},
+				},
+				{
+					Id:     "137982752092261989",
+					Fields: map[string]any{"id": "137982752092261989"},
+					Raw: map[string]any{
+						"metaData": map[string]any{
+							"id":             "137982752092261989",
+							"url":            "https://us-49467.app.gong.io/call?id=137982752092261989",
+							"workspaceId":    "1007648505208900737",
+							"clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+							"customData":     "R1201",
+						},
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Users by IDs POST to /v2/users/extensive with userIds filter and no contentSelector",
+			Input: GetRecordsByIdsInput{
+				ObjectName: "users",
+				Ids:        []string{"8000000000000001", "8000000000000002"},
+				Fields:     []string{"id", "emailAddress", "firstName", "lastName", "active", "title"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/users/extensive"),
+					mockcond.Body(`{"filter":{"userIds":["8000000000000001","8000000000000002"]}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, usersResp),
+			}.Server(),
+			Expected: []common.ReadResultRow{
+				{
+					Id: "8000000000000001",
+					Fields: map[string]any{
+						"id":           "8000000000000001",
+						"emailaddress": "alice@example.com",
+						"firstname":    "Alice",
+						"lastname":     "Anderson",
+						"active":       true,
+						"title":        "Account Executive",
+					},
+					Raw: map[string]any{
+						"id":           "8000000000000001",
+						"emailAddress": "alice@example.com",
+						"firstName":    "Alice",
+						"lastName":     "Anderson",
+						"active":       true,
+						"title":        "Account Executive",
+					},
+				},
+				{
+					Id: "8000000000000002",
+					Fields: map[string]any{
+						"id":           "8000000000000002",
+						"emailaddress": "bob@example.com",
+						"firstname":    "Bob",
+						"lastname":     "Brown",
+						"active":       true,
+						"title":        "Sales Engineer",
+					},
+					Raw: map[string]any{
+						"id":           "8000000000000002",
+						"emailAddress": "bob@example.com",
+						"firstName":    "Bob",
+						"lastName":     "Brown",
+						"active":       true,
+						"title":        "Sales Engineer",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Fields filter limits Fields map to requested fields (plus id) while Raw is untouched",
+			Input: GetRecordsByIdsInput{
+				ObjectName: "users",
+				Ids:        []string{"8000000000000001", "8000000000000002"},
+				Fields:     []string{"emailAddress"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/users/extensive"),
+					mockcond.Body(`{"filter":{"userIds":["8000000000000001","8000000000000002"]}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, usersResp),
+			}.Server(),
+			Expected: []common.ReadResultRow{
+				{
+					Id: "8000000000000001",
+					Fields: map[string]any{
+						"id":           "8000000000000001",
+						"emailaddress": "alice@example.com",
+					},
+					Raw: map[string]any{
+						"id":           "8000000000000001",
+						"emailAddress": "alice@example.com",
+						"firstName":    "Alice",
+						"lastName":     "Anderson",
+						"active":       true,
+						"title":        "Account Executive",
+					},
+				},
+				{
+					Id: "8000000000000002",
+					Fields: map[string]any{
+						"id":           "8000000000000002",
+						"emailaddress": "bob@example.com",
+					},
+					Raw: map[string]any{
+						"id":           "8000000000000002",
+						"emailAddress": "bob@example.com",
+						"firstName":    "Bob",
+						"lastName":     "Brown",
+						"active":       true,
+						"title":        "Sales Engineer",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			t.Cleanup(tt.Close)
+
+			conn, err := constructTestConnector(tt.Server.URL)
+			if err != nil {
+				t.Fatalf("failed to construct test connector: %v", err)
+			}
+
+			result, err := conn.GetRecordsByIds(t.Context(),
+				tt.Input.ObjectName, tt.Input.Ids, tt.Input.Fields, nil)
+
+			tt.Validate(t, err, result)
+		})
+	}
+}

--- a/providers/gong/subscriptionEvent.go
+++ b/providers/gong/subscriptionEvent.go
@@ -1,0 +1,183 @@
+package gong
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strconv"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// Gong's automation rules currently only supports firing webhook for Call creation events.
+// https://help.gong.io/docs/create-a-webhook-rule
+const (
+	gongCallCreatedEvent = "callCreated"
+	gongCallObject       = "Call"
+)
+
+var (
+	_ connectors.WebhookVerifierConnector = &Connector{}
+	_ common.SubscriptionEvent            = SubscriptionEvent{}
+	_ common.CollapsedSubscriptionEvent   = CollapsedSubscriptionEvent{}
+)
+
+var (
+	errTypeMismatch = errors.New("type mismatch")
+	errMissingField = errors.New("missing field")
+)
+
+// VerifyWebhookMessage is a stub that always succeeds
+// TODO: implement verification logic for Gong webhooks.
+func (*Connector) VerifyWebhookMessage(
+	_ context.Context,
+	_ *common.WebhookRequest,
+	_ *common.VerificationParams,
+) (bool, error) {
+	return true, nil
+}
+
+// CollapsedSubscriptionEvent represents the raw webhook payload from Gong.
+// Gong sends one call per webhook, so this simply wraps the single event.
+type CollapsedSubscriptionEvent map[string]any
+
+func (e CollapsedSubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(e), nil
+}
+
+// SubscriptionEventList returns the event as a single-element list.
+// Gong webhooks contain only one record per payload, so no fan-out is needed.
+// https://help.gong.io/docs/payload-sent-to-webhooks
+func (e CollapsedSubscriptionEvent) SubscriptionEventList() ([]common.SubscriptionEvent, error) {
+	return []common.SubscriptionEvent{SubscriptionEvent(e)}, nil
+}
+
+// SubscriptionEvent holds a single Gong webhook event. Gong's "Subscribe"
+// webhook rule only fires on call creation.
+// See https://help.gong.io/docs/payload-sent-to-webhooks for the payload spec.
+//
+// Example Gong webhook payload:
+//
+//	{
+//	  "callData": {
+//	    "metaData": {
+//	      "id": "7782342341192847895",
+//	      "url": "https://app.gong.io/call?id=7782342341192847895",
+//	      "title": "Acme <> Gong | Intro",
+//	      "scheduled": "2024-02-28T15:00:00Z",
+//	      "started":   "2024-02-28T15:02:11Z",
+//	      "duration":  1847,
+//	      "primaryUserId": "234599920309",
+//	      "direction": "Outbound",
+//	      "system":    "Zoom",
+//	      "scope":     "External",
+//	      "media":     "Video",
+//	      "language":  "eng",
+//	      "workspaceId": "3498573645"
+//	    },
+//	    "parties":  [ ... ],
+//	    "content":  { ... }
+//	  },
+//	  "isPrivate": false,
+//	  "isTest":    false
+//	}
+type SubscriptionEvent map[string]any
+
+// PreLoadData is a no-op: Gong webhooks include the full call payload inline,
+// so there's no external data to hydrate.
+func (evt SubscriptionEvent) PreLoadData(_ *common.SubscriptionEventPreLoadData) error {
+	return nil
+}
+
+func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(evt), nil
+}
+
+// EventType returns Create when the payload includes callData; otherwise Other.
+// Gong currently only supports Subscribe for Call creation events.
+func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
+	m := common.StringMap(evt)
+
+	if _, err := m.Get("callData"); err != nil {
+		return common.SubscriptionEventTypeOther, nil //nolint:nilerr
+	}
+
+	return common.SubscriptionEventTypeCreate, nil
+}
+
+// RawEventName returns a hard-coded string because Gong's payload does not carry a raw event name.
+func (evt SubscriptionEvent) RawEventName() (string, error) {
+	return gongCallCreatedEvent, nil
+}
+
+// ObjectName is always "Call" for Gong subscribe webhooks.
+func (evt SubscriptionEvent) ObjectName() (string, error) {
+	return gongCallObject, nil
+}
+
+func (evt SubscriptionEvent) Workspace() (string, error) {
+	meta, err := evt.callMetaData()
+	if err != nil {
+		return "", err
+	}
+
+	return meta.GetString("workspaceId")
+}
+
+// RecordId returns the Gong call ID from callData.metaData.id.
+// Accepts both string (per Gong's docs) and float64.
+func (evt SubscriptionEvent) RecordId() (string, error) {
+	meta, err := evt.callMetaData()
+	if err != nil {
+		return "", err
+	}
+
+	callIDValue, err := meta.Get("id")
+	if err != nil {
+		return "", err
+	}
+
+	switch v := callIDValue.(type) {
+	case string:
+		return v, nil
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
+	default:
+		return "", fmt.Errorf("%w: expected string or number for callData.metaData.id, got %T", errTypeMismatch, callIDValue)
+	}
+}
+
+// EventTimeStampNano returns 0: Gong's webhook payload does not include a
+// delivery timestamp, and the call timing fields (scheduled/started) are not
+// semantically the event time.
+func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
+	return 0, nil
+}
+
+// callMetaData returns the callData.metaData sub-object, where Gong puts
+// the call identity, workspace, and timing fields.
+func (evt SubscriptionEvent) callMetaData() (common.StringMap, error) {
+	callData, err := common.StringMap(evt).Get("callData")
+	if err != nil {
+		return nil, err
+	}
+
+	callMap, callMapOK := callData.(map[string]any)
+	if !callMapOK {
+		return nil, fmt.Errorf("%w: expected callData object, got %T", errTypeMismatch, callData)
+	}
+
+	metaData, hasMetaData := callMap["metaData"]
+	if !hasMetaData {
+		return nil, fmt.Errorf("%w: callData.metaData", errMissingField)
+	}
+
+	metaMap, metaMapOK := metaData.(map[string]any)
+	if !metaMapOK {
+		return nil, fmt.Errorf("%w: expected callData.metaData object, got %T", errTypeMismatch, metaData)
+	}
+
+	return common.StringMap(metaMap), nil
+}

--- a/providers/gong/subscriptionEvent_test.go
+++ b/providers/gong/subscriptionEvent_test.go
@@ -1,0 +1,59 @@
+package gong
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+	"gotest.tools/v3/assert"
+)
+
+// TestSubscriptionEvent_CallCreated exercises the happy path against a real
+// sanitized gong webhook fixture (see test/webhook-call-created.json).
+// Covers RawMap, SubscriptionEventList, EventType, RawEventName, ObjectName,
+// RecordId, Workspace, and EventTimeStampNano in one pass.
+func TestSubscriptionEvent_CallCreated(t *testing.T) {
+	t.Parallel()
+
+	var evt CollapsedSubscriptionEvent
+
+	raw := testutils.DataFromFile(t, "webhook-call-created.json")
+	if err := json.Unmarshal(raw, &evt); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	rawMap, err := evt.RawMap()
+	assert.NilError(t, err)
+	assert.Assert(t, rawMap != nil)
+
+	events, err := evt.SubscriptionEventList()
+	assert.NilError(t, err)
+	assert.Equal(t, len(events), 1)
+
+	subEvt := events[0]
+
+	eventType, err := subEvt.EventType()
+	assert.NilError(t, err)
+	assert.Equal(t, eventType, common.SubscriptionEventTypeCreate)
+
+	rawEventName, err := subEvt.RawEventName()
+	assert.NilError(t, err)
+	assert.Equal(t, rawEventName, "callCreated")
+
+	objectName, err := subEvt.ObjectName()
+	assert.NilError(t, err)
+	assert.Equal(t, objectName, "Call")
+
+	recordID, err := subEvt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, recordID, "4570250816631531513")
+
+	workspace, err := subEvt.Workspace()
+	assert.NilError(t, err)
+	assert.Equal(t, workspace, "1007648505208900737")
+
+	ts, err := subEvt.EventTimeStampNano()
+	assert.NilError(t, err)
+	assert.Equal(t, ts, int64(0))
+}

--- a/providers/gong/test/get-records-users.json
+++ b/providers/gong/test/get-records-users.json
@@ -1,0 +1,26 @@
+{
+  "requestId": "8r2gqar52fo4dkqpsly",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 2,
+    "currentPageNumber": 0
+  },
+  "users": [
+    {
+      "id": "8000000000000001",
+      "emailAddress": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Anderson",
+      "active": true,
+      "title": "Account Executive"
+    },
+    {
+      "id": "8000000000000002",
+      "emailAddress": "bob@example.com",
+      "firstName": "Bob",
+      "lastName": "Brown",
+      "active": true,
+      "title": "Sales Engineer"
+    }
+  ]
+}

--- a/providers/gong/test/webhook-call-created.json
+++ b/providers/gong/test/webhook-call-created.json
@@ -1,0 +1,75 @@
+{
+  "callData": {
+    "collaboration": {},
+    "content": {
+      "scorecardsAnswers": [],
+      "topics": [
+        {"duration": 0, "name": "Call Setup"},
+        {"duration": 144, "name": "Small Talk"},
+        {"duration": 0, "name": "Moving Forward"},
+        {"duration": 0, "name": "Pricing"},
+        {"duration": 0, "name": "Next Steps"},
+        {"duration": 0, "name": "Wrap-Up"}
+      ],
+      "trackers": [
+        {"count": 0, "id": "1685862917844761218", "name": "Pricing (tracker)", "type": "KEYWORD"},
+        {"count": 1, "id": "1793237018173488966", "name": "Objections (tracker)", "type": "KEYWORD"}
+      ]
+    },
+    "context": [],
+    "interaction": {
+      "interactionStats": [
+        {"name": "Talk Ratio", "value": 0},
+        {"name": "Longest Monologue", "value": 0},
+        {"name": "Longest Customer Story", "value": 14},
+        {"name": "Interactivity", "value": 10},
+        {"name": "Patience", "value": 0}
+      ]
+    },
+    "metaData": {
+      "calendarEventId": null,
+      "clientUniqueId": null,
+      "customData": null,
+      "direction": "Inbound",
+      "duration": 147,
+      "id": "4570250816631531513",
+      "isPrivate": false,
+      "language": "eng",
+      "media": "Audio",
+      "meetingUrl": "https://www.conference.com/example-user",
+      "primaryUserId": "1309263961237846110",
+      "purpose": null,
+      "scheduled": "2024-02-17T03:30:00-07:00",
+      "scope": "External",
+      "sdrDisposition": "No Answer",
+      "started": "2024-02-17T03:30:00-07:00",
+      "system": "ClearSlide",
+      "title": "Discuss Use Cases",
+      "url": "https://us-49467.app.gong.io/call?id=4570250816631531513",
+      "workspaceId": "1007648505208900737"
+    },
+    "parties": [
+      {
+        "affiliation": "Unknown",
+        "context": [],
+        "id": "171236364525528710",
+        "methods": ["Attendee"],
+        "name": "Phone Caller #4",
+        "speakerId": "1733377625204635858"
+      },
+      {
+        "affiliation": "Internal",
+        "context": [],
+        "emailAddress": "internal.attendee@example.com",
+        "id": "9178113854064029868",
+        "methods": ["Attendee"],
+        "name": "Internal Attendee",
+        "phoneNumber": "+15555550100",
+        "speakerId": null,
+        "userId": "1309263961237846110"
+      }
+    ]
+  },
+  "isPrivate": false,
+  "isTest": true
+}


### PR DESCRIPTION
Implements GetRecordsByIds for Gong`users` and `calls` objects.   
Used in subscribe workflow to retrieve records by IDs. Gong Subscribe is manually tested here: https://github.com/amp-labs/server/pull/5913