### PR TITLE
feat: skip 404s in fetchMessage instead of failing the batch

### DIFF
--- a/providers/google/internal/mail/messages.go
+++ b/providers/google/internal/mail/messages.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
@@ -102,6 +104,11 @@ func (a *Adapter) fetchMessagesByIDs(ctx context.Context, messageIDs []string) (
 
 // fetchMessage returns a concurrently executable job that fetches a single message
 // by ID and sends the fully decoded MessageRecord to messagesChannel.
+//
+// A 404 on a single message is treated as a skip rather than a batch failure: the
+// missing message is debug-logged and the job returns nil so simultaneously.DoCtx
+// does not cancel the other in-flight fetches. Callers therefore receive the
+// partial set of messages that did resolve.
 func (a *Adapter) fetchMessage(messagesChannel chan MessageRecord, messageId string,
 ) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
@@ -112,6 +119,16 @@ func (a *Adapter) fetchMessage(messagesChannel chan MessageRecord, messageId str
 
 		resp, err := a.JSONHTTPClient().Get(ctx, url.String())
 		if err != nil {
+			var httpErr *common.HTTPError
+			if errors.As(err, &httpErr) && httpErr.Status == http.StatusNotFound {
+				logging.Logger(ctx).Debug(
+					"gmail: message not found, skipping",
+					"messageId", messageId,
+				)
+
+				return nil
+			}
+
 			return err
 		}
 

--- a/providers/google/records_test.go
+++ b/providers/google/records_test.go
@@ -1,0 +1,193 @@
+package google
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+// TestMailGetRecordsByIds covers the Gmail subscribe hydration path. The
+// important behavior is that a 404 on a single message id must not fail the
+// whole batch — the caller should receive a partial result set so the
+// messenger can ack the webhook rather than nack-looping into deadletter.
+// Non-404 errors must still be surfaced so real failures aren't hidden.
+func TestMailGetRecordsByIds(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	responseMessageOK1 := testutils.DataFromFile(t, "mail/records-by-ids/message-ok-1.json")
+	responseMessageOK3 := testutils.DataFromFile(t, "mail/records-by-ids/message-ok-3.json")
+	errorNotFound := testutils.DataFromFile(t, "mail/records-by-ids/error-not-found.json")
+	errorServer := testutils.DataFromFile(t, "mail/records-by-ids/error-server.json")
+
+	const (
+		idOK1      = "19dbd733d5637396"
+		idMissing  = "19dbd7822499cd1a" // matches the id from the deadletter log
+		idOK3      = "19dbd78c8b2290af"
+		pathPrefix = "/gmail/v1/users/me/messages/"
+	)
+
+	tests := []struct {
+		name          string
+		object        string
+		ids           []string
+		server        func() *mockserver.Switch
+		expectErrs    []error
+		expectRowIds  []string // sorted
+		expectNoError bool
+	}{
+		{
+			name:   "Unsupported object returns ErrGetRecordNotSupportedForObject",
+			object: "threads",
+			ids:    []string{idOK1},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{Setup: mockserver.ContentJSON()}
+			},
+			expectErrs: []error{common.ErrGetRecordNotSupportedForObject},
+		},
+		{
+			name:   "Empty id list returns empty result without hitting the provider",
+			object: "messages",
+			ids:    []string{},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{Setup: mockserver.ContentJSON()}
+			},
+			expectRowIds:  []string{},
+			expectNoError: true,
+		},
+		{
+			name:   "All ids resolve - every message returned",
+			object: "messages",
+			ids:    []string{idOK1, idOK3},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{
+					Setup: mockserver.ContentJSON(),
+					Cases: []mockserver.Case{
+						{
+							If:   mockcond.Path(pathPrefix + idOK1),
+							Then: mockserver.Response(http.StatusOK, responseMessageOK1),
+						},
+						{
+							If:   mockcond.Path(pathPrefix + idOK3),
+							Then: mockserver.Response(http.StatusOK, responseMessageOK3),
+						},
+					},
+				}
+			},
+			expectRowIds:  []string{idOK1, idOK3},
+			expectNoError: true,
+		},
+		{
+			name:   "One 404 mixed in - batch continues, partial result returned",
+			object: "messages",
+			ids:    []string{idOK1, idMissing, idOK3},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{
+					Setup: mockserver.ContentJSON(),
+					Cases: []mockserver.Case{
+						{
+							If:   mockcond.Path(pathPrefix + idOK1),
+							Then: mockserver.Response(http.StatusOK, responseMessageOK1),
+						},
+						{
+							If:   mockcond.Path(pathPrefix + idMissing),
+							Then: mockserver.Response(http.StatusNotFound, errorNotFound),
+						},
+						{
+							If:   mockcond.Path(pathPrefix + idOK3),
+							Then: mockserver.Response(http.StatusOK, responseMessageOK3),
+						},
+					},
+				}
+			},
+			expectRowIds:  []string{idOK1, idOK3},
+			expectNoError: true,
+		},
+		{
+			name:   "All ids 404 - empty result, no error (caller retries then acks)",
+			object: "messages",
+			ids:    []string{idOK1, idMissing},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{
+					Setup: mockserver.ContentJSON(),
+					Default: mockserver.Response(http.StatusNotFound, errorNotFound),
+				}
+			},
+			expectRowIds:  []string{},
+			expectNoError: true,
+		},
+		{
+			name:   "Non-404 error is still surfaced (500 fails the batch)",
+			object: "messages",
+			ids:    []string{idOK1, idMissing},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{
+					Setup: mockserver.ContentJSON(),
+					Cases: []mockserver.Case{
+						{
+							If:   mockcond.Path(pathPrefix + idOK1),
+							Then: mockserver.Response(http.StatusOK, responseMessageOK1),
+						},
+						{
+							If:   mockcond.Path(pathPrefix + idMissing),
+							Then: mockserver.Response(http.StatusInternalServerError, errorServer),
+						},
+					},
+				}
+			},
+			expectErrs: []error{common.ErrServer},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := tt.server().Server()
+			t.Cleanup(srv.Close)
+
+			conn, err := constructTestMailConnector(srv.URL)
+			if err != nil {
+				t.Fatalf("failed to construct test connector: %v", err)
+			}
+
+			rows, err := conn.GetRecordsByIds(t.Context(), tt.object, tt.ids, nil, nil)
+
+			if tt.expectNoError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, wantErr := range tt.expectErrs {
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("expected error %v in chain, got %v", wantErr, err)
+				}
+			}
+
+			if tt.expectNoError {
+				gotIds := make([]string, 0, len(rows))
+				for _, row := range rows {
+					gotIds = append(gotIds, row.Id)
+				}
+
+				sort.Strings(gotIds)
+
+				if len(gotIds) != len(tt.expectRowIds) {
+					t.Fatalf("expected %d rows, got %d (ids: %v)",
+						len(tt.expectRowIds), len(gotIds), gotIds)
+				}
+
+				for i, want := range tt.expectRowIds {
+					if gotIds[i] != want {
+						t.Fatalf("row %d: expected id %q, got %q (all: %v)",
+							i, want, gotIds[i], gotIds)
+					}
+				}
+			}
+		})
+	}
+}

--- a/providers/google/test/mail/records-by-ids/error-not-found.json
+++ b/providers/google/test/mail/records-by-ids/error-not-found.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "code": 404,
+    "message": "Requested entity was not found.",
+    "errors": [
+      {
+        "message": "Requested entity was not found.",
+        "domain": "global",
+        "reason": "notFound"
+      }
+    ],
+    "status": "NOT_FOUND"
+  }
+}

--- a/providers/google/test/mail/records-by-ids/error-server.json
+++ b/providers/google/test/mail/records-by-ids/error-server.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "code": 500,
+    "message": "Internal error encountered.",
+    "errors": [
+      {
+        "message": "Internal error encountered.",
+        "domain": "global",
+        "reason": "backendError"
+      }
+    ],
+    "status": "INTERNAL"
+  }
+}

--- a/providers/google/test/mail/records-by-ids/message-ok-1.json
+++ b/providers/google/test/mail/records-by-ids/message-ok-1.json
@@ -1,0 +1,9 @@
+{
+  "id": "19dbd733d5637396",
+  "threadId": "19dbd733d5637396",
+  "labelIds": ["INBOX"],
+  "snippet": "Hello from message one",
+  "historyId": "12686666",
+  "internalDate": "1769520000000",
+  "sizeEstimate": 1234
+}

--- a/providers/google/test/mail/records-by-ids/message-ok-3.json
+++ b/providers/google/test/mail/records-by-ids/message-ok-3.json
@@ -1,0 +1,9 @@
+{
+  "id": "19dbd78c8b2290af",
+  "threadId": "19dbd78c8b2290af",
+  "labelIds": ["INBOX"],
+  "snippet": "Hello from message three",
+  "historyId": "12686750",
+  "internalDate": "1769520300000",
+  "sizeEstimate": 2345
+}


### PR DESCRIPTION
### Summary
* When Gmail's GET /users/me/messages/{id} returns 404 for one id in a concurrent batch, the job was returning the error to simultaneously.DoCtx, which cancels the shared context and kills all other in-flight hydrates.
* For the subscribe flow (GetRecordsByIds) this meant one deleted/unknown message id caused the whole webhook batch to be nacked and eventually deadlettered.
* Skip 404s at fetchMessage: debug-log the missing id and return nil so the batch completes with whatever messages did resolve. The subscribe caller (fetchRecordsWithRetry) already tolerates partial/empty results. Non-404 errors are still surfaced so real failures aren't masked.

### Testing
* Added unit tests
* Ran unit tests without the fix and verified they failed and then ran with the fix and verified that passed