### PR TITLE
housecallPro: adjust webhook object resolution for estimate.option and job.appointment events

### DIFF
--- a/providers/housecallPro/subscriptionEvent.go
+++ b/providers/housecallPro/subscriptionEvent.go
@@ -228,9 +228,9 @@ func resourceRecord(evt SubscriptionEvent) (objectName string, record map[string
 }
 
 func resolveEventObject(resource string) (payloadObject string, connectorObject string, err error) {
-	// job appointment and estimate option are not supported.
-	if resource == "job.appointment" || resource == "estimate.option" {
-		return "", "", fmt.Errorf("%w: %q", errUnsupportedWebhookResource, resource)
+	// job appointment is an object supported by subscribe but not read.
+	if resource == "job.appointment" {
+		return "appointment", "job.appointments", nil
 	}
 
 	// event name can be object.action or object.subtype.action.

--- a/providers/housecallPro/subscriptionEvent_test.go
+++ b/providers/housecallPro/subscriptionEvent_test.go
@@ -211,7 +211,7 @@ func TestSubscriptionEvent_ParsingWeirdSamples(t *testing.T) {
 			expectObjectError: true,
 		},
 		{
-			name:           "estimate",
+			name:           "estimate option",
 			event:          "estimate.option.approval_status_changed",
 			payloadKey:     "estimate",
 			payloadID:      "estimate_option_1a2b3c4d5e",

--- a/providers/housecallPro/subscriptionEvent_test.go
+++ b/providers/housecallPro/subscriptionEvent_test.go
@@ -157,25 +157,6 @@ func TestSubscriptionEvent_Interface(t *testing.T) {
 	}
 }
 
-func TestSubscriptionEvent_UnsupportedJobAppointmentPrefix(t *testing.T) {
-	t.Parallel()
-
-	evt := SubscriptionEvent{
-		"event":             "job.appointment.appointment_discarded",
-		"event_occurred_at": "2026-04-03T14:20:38Z",
-		"company_id":        "7141dca7-882d-427b-a9c0-0ba0d74c85cf",
-		"job": map[string]any{
-			"id": "job_ac6f3efd11c14a5aa93e9fc0ab5354ab",
-		},
-	}
-
-	_, err := evt.ObjectName()
-	assert.Assert(t, err != nil)
-
-	_, err = evt.RecordId()
-	assert.Assert(t, err != nil)
-}
-
 func TestSubscriptionEvent_ObjectNameRequiresPayload(t *testing.T) {
 	t.Parallel()
 

--- a/providers/housecallPro/subscriptionEvent_test.go
+++ b/providers/housecallPro/subscriptionEvent_test.go
@@ -229,6 +229,22 @@ func TestSubscriptionEvent_ParsingWeirdSamples(t *testing.T) {
 			wantEventType:     common.SubscriptionEventTypeOther,
 			expectObjectError: true,
 		},
+		{
+			name:           "estimate",
+			event:          "estimate.option.approval_status_changed",
+			payloadKey:     "estimate",
+			payloadID:      "estimate_option_1a2b3c4d5e",
+			wantEventType:  common.SubscriptionEventTypeOther,
+			wantObjectName: "estimates",
+		},
+		{
+			name:           "job appointment",
+			event:          "job.appointment.appointment_discarded",
+			payloadKey:     "appointment",
+			payloadID:      "job_appointment_1a2b3c4d5e",
+			wantEventType:  common.SubscriptionEventTypeOther,
+			wantObjectName: "job.appointments",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Updates webhook resolution for estimate.option to reflect its nested structure under estimates, and adds support for job.appointment webhook events, which were previously not handled.

### TESTS
<img width="2201" height="792" alt="Screenshot from 2026-04-24 21-42-23" src="https://github.com/user-attachments/assets/3d5fb5fb-9f4c-4824-9628-7f8fbfabdbe2" />
