### PR TITLE
feat(housecallPro): add employees webhook subscription support

### DIFF
--- a/providers/housecallPro/subscriptionEvent.go
+++ b/providers/housecallPro/subscriptionEvent.go
@@ -41,7 +41,8 @@ type SubscriptionEvent map[string]any
 type CollapsedSubscriptionEvent map[string]any
 
 //nolint:gochecknoglobals // Static allowlist of webhook objects we support.
-var supportedEventObjects = datautils.NewSetFromList([]string{"jobs", "customers", "estimates", "invoices", "leads"})
+var supportedEventObjects = datautils.NewSetFromList([]string{"jobs", "customers",
+	"estimates", "invoices", "leads", "employees"})
 
 // VerifyWebhookMessage implements connectors.WebhookVerifierConnector.
 func (*Connector) VerifyWebhookMessage(

--- a/providers/housecallPro/subscriptionEvent_test.go
+++ b/providers/housecallPro/subscriptionEvent_test.go
@@ -226,6 +226,14 @@ func TestSubscriptionEvent_ParsingWeirdSamples(t *testing.T) {
 			wantEventType:  common.SubscriptionEventTypeOther,
 			wantObjectName: "job.appointments",
 		},
+		{
+			name:           "employee created",
+			event:          "employee.created",
+			payloadKey:     "employee",
+			payloadID:      "pro_1a2b3c4d5e",
+			wantEventType:  common.SubscriptionEventTypeCreate,
+			wantObjectName: "employees",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds support for subscribing to employees events.
Employee webhook events are not officially documented. Instead of having a dedicated event (employee.created), employee creation is emitted through the pro.created event.

# Test
<img width="2512" height="379" alt="image" src="https://github.com/user-attachments/assets/92fb79b5-2b19-47c6-8594-25f5e874e1fd" />
