### PR TITLE
[ENG-3858]feat:use Workspace as realmId, fall back to metadata for legacy connections

### DIFF
--- a/providers/quickbooks/connector.go
+++ b/providers/quickbooks/connector.go
@@ -29,11 +29,22 @@ type Connector struct {
 	components.Reader
 	components.Writer
 
-	// realmID is the Company ID in QuickBooks.
+	// Workspace is the Company ID (realmId) in QuickBooks.
 	// http://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0
-	realmId string
+	Workspace string
 	// graphQLBaseURL is a variable on the struct so it can be mocked in unit tests.
 	graphQLBaseURL string
+}
+
+// resolveWorkspace returns the QuickBooks workspace ref (realmId), preferring
+// params.Workspace and falling back to params.Metadata["realmId"] for legacy
+// connections that stored the realmId in metadata.
+func resolveWorkspace(params common.ConnectorParams) string {
+	if params.Workspace != "" {
+		return params.Workspace
+	}
+
+	return params.Metadata["realmId"]
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -42,7 +53,7 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 		return nil, err
 	}
 
-	conn.realmId = params.Metadata["realmId"]
+	conn.Workspace = resolveWorkspace(params)
 
 	return conn, nil
 }
@@ -53,7 +64,7 @@ func NewSandboxConnector(params common.ConnectorParams) (*Connector, error) {
 		return nil, err
 	}
 
-	conn.realmId = params.Metadata["realmId"]
+	conn.Workspace = resolveWorkspace(params)
 
 	return conn, nil
 }

--- a/providers/quickbooks/handlers.go
+++ b/providers/quickbooks/handlers.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.realmId, "query")
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.Workspace, "query")
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 }
 
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.realmId, "query")
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.Workspace, "query")
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (c *Connector) parseReadResponse(
 }
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.realmId, strings.ToLower(params.ObjectName))
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, c.Workspace, strings.ToLower(params.ObjectName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary
QuickBooks `realmId` is the workspace ref. Read it from `ConnectorParams.Workspace` and use `c.Workspace` when building URLs. Falls back to `params.Metadata["realmId"]` so existing connections keep working until the server-side migration completes.

### Testing

#### Verified reads work when passing the `realmId`
<img width="938" height="864" alt="Screenshot 2026-04-28 at 08 21 03" src="https://github.com/user-attachments/assets/b8e4b00d-2f2f-47ae-8a29-bb469a1bdf4a" />
<img width="1351" height="584" alt="Screenshot 2026-04-28 at 08 20 51" src="https://github.com/user-attachments/assets/666080ae-e176-4119-b3d4-c33b760a4f29" />

#### Verified reads work when `realmId` is stored in the `ProviderWorkspaceRef`
<img width="1410" height="640" alt="Screenshot 2026-04-28 at 08 19 53" src="https://github.com/user-attachments/assets/dcf289b0-7441-4b29-8760-f2400ad014c1" />
<img width="1311" height="554" alt="Screenshot 2026-04-27 at 15 52 25" src="https://github.com/user-attachments/assets/6c2f0071-b20c-4aa0-b845-b2485cca1174" />
