### PR TITLE
[ENG-3858]feat: quickbooks remove realmId input metadata

### DIFF
--- a/providers/quickbooks.go
+++ b/providers/quickbooks.go
@@ -38,15 +38,6 @@ func init() { //nolint:funlen
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753942143/media/quickbooks.com_1753942142.svg",
 			},
 		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:        "realmId",
-					DisplayName: "Company ID",
-					DocsURL:     "https://coda.io/@leandro-zubrezki/quickbooks-pack-start-here/find-your-qbo-company-id-15", // nolint:lll
-				},
-			},
-		},
 	})
 
 	SetInfo(QuickbooksSandbox, ProviderInfo{
@@ -79,15 +70,6 @@ func init() { //nolint:funlen
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753941999/media/quickbooks.com_1753941998.png",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753942143/media/quickbooks.com_1753942142.svg",
-			},
-		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:        "realmId",
-					DisplayName: "Company ID",
-					DocsURL:     "https://coda.io/@leandro-zubrezki/quickbooks-pack-start-here/find-your-qbo-company-id-15", // nolint:lll
-				},
 			},
 		},
 	})


### PR DESCRIPTION
### Summary 
QuickBooks's `realmId` arrives in the OAuth callback's query params, so the UI library no longer needs to collect it from users. Removes the `Metadata.Input` entries for `QuickBooks` and `QuickbooksSandbox`.