### PR TITLE
[CON-3193] feat(procore): enable Read and Write

### DIFF
--- a/providers/procore.go
+++ b/providers/procore.go
@@ -28,9 +28,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 
 		Metadata: &ProviderMetadata{
@@ -74,9 +74,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 
 		Metadata: &ProviderMetadata{


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [x]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="997" height="618" alt="image" src="https://github.com/user-attachments/assets/c5e7efc3-00de-4317-b1fc-3d836d3c617d" />
<img width="899" height="747" alt="image" src="https://github.com/user-attachments/assets/23d41c16-4c1c-4115-8165-0d4df6b29160" />
<img width="913" height="664" alt="image" src="https://github.com/user-attachments/assets/37548d77-4aa1-4015-8ad6-1318adad36cb" />
<img width="880" height="600" alt="image" src="https://github.com/user-attachments/assets/e55a5193-6e6b-4bb5-ba0a-8c1b22603021" />
<img width="856" height="586" alt="image" src="https://github.com/user-attachments/assets/ae0d2851-3104-4f2a-998b-d28da4c88983" />





- [x] Insert screenshot of Svix destination.
<img width="1620" height="842" alt="image" src="https://github.com/user-attachments/assets/68965abe-bacc-45e3-b002-35deec17b97f" />
<img width="1612" height="832" alt="image" src="https://github.com/user-attachments/assets/7ed85ca8-63f0-4ee0-b65c-3724c839971a" />
<img width="1617" height="845" alt="image" src="https://github.com/user-attachments/assets/ff7649e6-2eb7-4c4a-985c-7a04cd213414" />
<img width="1622" height="923" alt="image" src="https://github.com/user-attachments/assets/c97ca871-935a-457d-9bf0-105c83d1b3ce" />








- [x] Screenshot of operations on dashboard
<img width="1496" height="963" alt="image" src="https://github.com/user-attachments/assets/6aa66a95-4a9b-40a9-88d3-c522232abf27" />
<img width="1494" height="893" alt="image" src="https://github.com/user-attachments/assets/9f502974-04dc-411b-a4ce-97fd82496f52" />
<img width="1497" height="826" alt="image" src="https://github.com/user-attachments/assets/97d22347-3116-4250-a021-f51817dde72d" />






# Write
- [x] Insert screenshot of dashboard.
<img width="1495" height="865" alt="image" src="https://github.com/user-attachments/assets/7e6b7090-1e23-43a5-bdc7-469197e9927f" />
<img width="1491" height="866" alt="image" src="https://github.com/user-attachments/assets/8f082815-a211-4dc0-b1c1-b020f44ab3b1" />
<img width="1500" height="880" alt="image" src="https://github.com/user-attachments/assets/78266d69-1773-4243-abc9-a7da249b566f" />
<img width="1503" height="871" alt="image" src="https://github.com/user-attachments/assets/a7575427-5f3c-45ff-ac52-1bed5cf7d198" />
<img width="1503" height="871" alt="image" src="https://github.com/user-attachments/assets/65569347-edc7-4a53-9d31-dff80a64d43b" />





- [x] Insert screenshot of HTTP call.
<img width="1754" height="659" alt="image" src="https://github.com/user-attachments/assets/843d6803-d33a-407a-abab-3e498ebc9eb6" />
<img width="1748" height="643" alt="image" src="https://github.com/user-attachments/assets/1093ef01-97de-4005-ae24-e6481476ad8a" />
<img width="1749" height="685" alt="image" src="https://github.com/user-attachments/assets/b2ee87e6-7bde-41f2-b369-ab4b3108f401" />
<img width="1749" height="715" alt="image" src="https://github.com/user-attachments/assets/f00dc4ef-7511-4cfa-891a-67cd81379359" />
<img width="1750" height="1013" alt="image" src="https://github.com/user-attachments/assets/625a7728-2388-4e43-abb3-f54833e80827" />


