### PR TITLE
 fix(procore): default updatedAt filter 'until' to now and disable write on company/projects

### DIFF
--- a/providers/procore/handlers.go
+++ b/providers/procore/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 )
 
@@ -77,17 +78,22 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 }
 
 func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+
+	if params.NextPage != "" {
+		nextURL, err := urlbuilder.New(params.NextPage.String())
+		if err != nil {
+			return nil, err
+		}
+
+		return c.newRequest(ctx, http.MethodGet, nextURL, nil)
+	}
+
 	url, err := c.buildObjectURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	page := "1"
-	if params.NextPage != "" {
-		page = params.NextPage.String()
-	}
-
-	url.WithQueryParam(queryParamPage, page)
+	url.WithQueryParam(queryParamPage, "1")
 	url.WithQueryParam(queryParamPerPage, strconv.Itoa(resolvePageSize(params.PageSize)))
 
 	if objectRegistry[params.ObjectName].incremental {

--- a/providers/procore/parse.go
+++ b/providers/procore/parse.go
@@ -9,27 +9,31 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// nextPageFromLink returns a NextPageFunc that extracts the next page number
-// from a Procore Link header via `Link: <...page=N>; rel="next"`.
-// The returned token is the bare page number.
+// nextPageFromLink returns a NextPageFunc that extracts the full next-page URL
+// from a Procore Link header via `Link: <...>; rel="next"`.
+//
+// We forward the entire URL (not just the page number) so that filter params
+// captured on the first request — most importantly `filters[updated_at]` — are
+// carried across pages. This keeps the time window stable and avoids
+// duplicates/misses that would occur if the connector recomputed the window
+// (e.g. defaulting `until` to time.Now()) for each page.
+//
 // Example Link header: `<https://api.procore.com/rest/v1.0/companies/12345/objects?page=2&per_page=100>; rel="next",
 //
 //	<https://api.procore.com/rest/v1.0/companies/12345/objects?page=50&per_page=100>; rel="last"`
 //
 // Ref: https://developers.procore.com/reference/rest/docs/pagination
 func nextPageFromLink(linkHeader string) common.NextPageFunc {
-	next := nextPageNumber(linkHeader)
+	next := nextPageURL(linkHeader)
 
 	return func(*ajson.Node) (string, error) {
 		return next, nil
 	}
 }
 
-// nextPageFromResponse returns a NextPageFunc that extracts the next page number
-// Example of Link header: `<https://api.procore.com/rest/v1.0/companies/12345/objects?page=2&per_page=100>; rel="next",
-// Example of paginated url: `https://api.procore.com/rest/v1.0/companies/12345/objects?page=2&per_page=100`
-func nextPageNumber(linkHeader string) string {
-	// If there is no Link header, we assume there are no more pages to fetch and return an empty token.
+// nextPageURL returns the absolute URL for the rel="next" entry in a Procore
+// Link header, or an empty string when there is no next page.
+func nextPageURL(linkHeader string) string {
 	if linkHeader == "" {
 		return ""
 	}
@@ -46,12 +50,13 @@ func nextPageNumber(linkHeader string) string {
 			continue
 		}
 
-		parsed, err := url.Parse(part[start+1 : end])
-		if err != nil {
+		raw := part[start+1 : end]
+
+		if _, err := url.Parse(raw); err != nil {
 			continue
 		}
 
-		return parsed.Query().Get("page")
+		return raw
 	}
 
 	return ""

--- a/providers/procore/parse_test.go
+++ b/providers/procore/parse_test.go
@@ -1,0 +1,65 @@
+package procore
+
+import "testing"
+
+func TestNextPageURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		linkHeader string
+		want       string
+	}{
+		{
+			name:       "empty header returns empty string",
+			linkHeader: "",
+			want:       "",
+		},
+		{
+			name:       "header without rel=next returns empty string",
+			linkHeader: `<https://api.procore.com/rest/v1.0/companies/123/projects?page=10>; rel="last"`,
+			want:       "",
+		},
+		{
+			name:       "extracts the rel=next URL verbatim",
+			linkHeader: `<https://api.procore.com/rest/v1.0/companies/123/projects?page=2&per_page=100>; rel="next"`,
+			want:       "https://api.procore.com/rest/v1.0/companies/123/projects?page=2&per_page=100",
+		},
+		{
+			name: "picks rel=next when multiple rels are present",
+			linkHeader: `<https://api.procore.com/rest/v1.0/companies/123/projects?page=2&per_page=100>; rel="next", ` +
+				`<https://api.procore.com/rest/v1.0/companies/123/projects?page=10&per_page=100>; rel="last"`,
+			want: "https://api.procore.com/rest/v1.0/companies/123/projects?page=2&per_page=100",
+		},
+		{
+			name: "preserves filters[updated_at] in the URL",
+			linkHeader: `<https://api.procore.com/rest/v1.0/companies/4283186/checklist/list_templates` +
+				`?filters%5Bupdated_at%5D=2025-10-01T00%3A00%3A00Z...2026-04-17T23%3A59%3A59Z` +
+				`&page=2&per_page=2>; rel="next"`,
+			want: "https://api.procore.com/rest/v1.0/companies/4283186/checklist/list_templates" +
+				"?filters%5Bupdated_at%5D=2025-10-01T00%3A00%3A00Z...2026-04-17T23%3A59%3A59Z" +
+				"&page=2&per_page=2",
+		},
+		{
+			name:       "missing angle brackets returns empty string",
+			linkHeader: `https://api.procore.com/rest/v1.0/companies/123/projects?page=2; rel="next"`,
+			want:       "",
+		},
+		{
+			name:       "malformed URL returns empty string",
+			linkHeader: `<http://[::1:bad-url>; rel="next"`,
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nextPageURL(tt.linkHeader)
+			if got != tt.want {
+				t.Errorf("nextPageURL(%q) = %q, want %q", tt.linkHeader, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/procore/read_test.go
+++ b/providers/procore/read_test.go
@@ -20,6 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	operationsResponse := testutils.DataFromFile(t, "operations.json")
 
 	since := time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2024, 10, 1, 23, 59, 59, 0, time.UTC)
 
 	tests := []testroutines.Read{
 		{
@@ -87,12 +88,13 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				ObjectName: "company/projects",
 				Fields:     connectors.Fields("id", "name"),
 				Since:      since,
+				Until:      until,
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.Path("/rest/v1.0/companies/" + testCompanyID + "/projects"),
-					mockcond.QueryParam("filters[updated_at]", "2024-10-01T00:00:00Z..."),
+					mockcond.QueryParam("filters[updated_at]", "2024-10-01T00:00:00Z...2024-10-01T23:59:59Z"),
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
@@ -101,7 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			ExpectedErrs: nil,
 		},
 		{
-			Name: "Link header advances NextPage",
+			Name: "Link header advances NextPage with the full URL",
 			Input: common.ReadParams{
 				ObjectName: "company/projects",
 				Fields:     connectors.Fields("id"),
@@ -113,22 +115,53 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					mockserver.Response(http.StatusOK, projectsResponse),
 				),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
-			Expected:     &common.ReadResult{Rows: 2, NextPage: "2", Done: false},
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     2,
+				NextPage: "https://api.procore.com/rest/v1.0/companies/" + testCompanyID + "/projects?page=2&per_page=100",
+				Done:     false,
+			},
 			ExpectedErrs: nil,
 		},
 		{
-			Name: "NextPage token is forwarded to the page query param",
+			Name: "NextPage URL is used verbatim for the follow-up request",
 			Input: common.ReadParams{
 				ObjectName: "company/projects",
 				Fields:     connectors.Fields("id"),
-				NextPage:   "3",
+				NextPage:   common.NextPageToken(testroutines.URLTestServer + "/rest/v1.0/companies/" + testCompanyID + "/projects?page=3&per_page=100"),
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.Path("/rest/v1.0/companies/" + testCompanyID + "/projects"),
 					mockcond.QueryParam("page", "3"),
+					mockcond.QueryParam("per_page", "100"),
+				},
+				Then: mockserver.Response(http.StatusOK, projectsResponse),
+			}.Server(),
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Incremental filter window is preserved across pages",
+			Input: common.ReadParams{
+				ObjectName: "company/projects",
+				Fields:     connectors.Fields("id"),
+				Since:      since,
+				Until:      until,
+				NextPage: common.NextPageToken(testroutines.URLTestServer +
+					"/rest/v1.0/companies/" + testCompanyID + "/projects" +
+					"?filters%5Bupdated_at%5D=2024-10-01T00%3A00%3A00Z...2024-10-01T23%3A59%3A59Z" +
+					"&page=2&per_page=100"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/rest/v1.0/companies/" + testCompanyID + "/projects"),
+					mockcond.QueryParam("page", "2"),
+					mockcond.QueryParam("per_page", "100"),
+					mockcond.QueryParam("filters[updated_at]", "2024-10-01T00:00:00Z...2024-10-01T23:59:59Z"),
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),

--- a/providers/procore/support.go
+++ b/providers/procore/support.go
@@ -29,7 +29,7 @@ const companyIDPlaceholder = "{companyId}"
 var objectRegistry = datautils.Map[string, objectConfig]{ //nolint:gochecknoglobals,lll
 	// ---- v1.0, company-scoped path: rest/v1.0/companies/{companyId}/... ----
 
-	"company/projects":     {path: "rest/v1.0/companies/{companyId}/projects", incremental: true, write: true},
+	"company/projects":     {path: "rest/v1.0/companies/{companyId}/projects", incremental: true},
 	"programs":             {path: "rest/v1.0/companies/{companyId}/programs", write: true},
 	"schedule/resources":   {path: "rest/v1.0/companies/{companyId}/schedule/resources", recordsKey: "resources"},
 	"project_bid_types":    {path: "rest/v1.0/companies/{companyId}/project_bid_types", write: true},

--- a/providers/procore/utils.go
+++ b/providers/procore/utils.go
@@ -68,6 +68,10 @@ func buildUpdatedAtFilter(since, until time.Time) string {
 
 	if !until.IsZero() {
 		u = until.UTC().Format(time.RFC3339)
+	} else {
+		// Procore's API requires a value on the right side of the range,
+		// so if until is not provided, we use the current time as a default.
+		u = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	return s + filterRangeSeparator + u

--- a/providers/procore/utils.go
+++ b/providers/procore/utils.go
@@ -61,7 +61,7 @@ func buildUpdatedAtFilter(since, until time.Time) string {
 		return ""
 	}
 
-	var s, u string
+	var s, u string //nolint:varnamelen
 	if !since.IsZero() {
 		s = since.UTC().Format(time.RFC3339)
 	}

--- a/test/procoresandbox/read/main.go
+++ b/test/procoresandbox/read/main.go
@@ -34,48 +34,64 @@ func main() {
 		return
 	}
 
-	if err := testRead(ctx, conn, "companies", []string{"id", "is_active", "name"}, 1000); err != nil {
+	if _, err := testRead(ctx, conn, "companies", []string{"id", "is_active", "name"}, 1000, ""); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := testRead(ctx, conn, "submittal_statuses", []string{"id", "name", "status"}, 4); err != nil {
+	if _, err := testRead(ctx, conn, "submittal_statuses", []string{"id", "name", "status"}, 4, ""); err != nil {
 		slog.Error(err.Error())
 	}
 
-	if err := testRead(ctx, conn, "vendors", []string{"id", "name", "is_active"}, 1000); err != nil {
+	if _, err := testRead(ctx, conn, "vendors", []string{"id", "name", "is_active"}, 1000, ""); err != nil {
+		slog.Error(err.Error())
+	}
+
+	res, err := testRead(ctx, conn, "checklist/list_templates", []string{"id", "name", "nupdated_atme"}, 2, "")
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
+	if _, err := testRead(ctx, conn, "checklist/list_templates", []string{"id", "name", "updated_at"}, 2, res.NextPage.String()); err != nil {
 		slog.Error(err.Error())
 	}
 
 }
 
-func testRead(ctx context.Context, conn *pd.Connector, objectName string, fields []string, pageSize int) error {
+func testRead(ctx context.Context, conn *pd.Connector, objectName string, fields []string, pageSize int, nextpage string) (*common.ReadResult, error) {
 	params := common.ReadParams{
 		ObjectName: objectName,
 		Fields:     connectors.Fields(fields...),
-		Since:      time.Now().AddDate(0, 0, -1), // 1 day ago
+		Since:      time.Now().AddDate(0, 0, -30), // 30 days ago
 		Until:      time.Now(),
 		PageSize:   pageSize,
+		NextPage:   common.NextPageToken(nextpage),
+	}
+
+	if nextpage == "" {
+		log.Printf("Testing read for object %s with fields %v\n", objectName, fields)
+	} else {
+		log.Printf("Testing read for object %s with fields %v on next page\n", objectName, fields)
 	}
 
 	res, err := conn.Read(ctx, params)
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", objectName, err)
+		return nil, fmt.Errorf("failed to read %s: %w", objectName, err)
 	}
 
 	jsonStr, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {
-		return fmt.Errorf("error marshalling JSON: %w", err)
+		return nil, fmt.Errorf("error marshalling JSON: %w", err)
 	}
 
 	if _, err := os.Stdout.Write(jsonStr); err != nil {
-		return fmt.Errorf("error writing to stdout: %w", err)
+		return nil, fmt.Errorf("error writing to stdout: %w", err)
 	}
 
 	if _, err := os.Stdout.WriteString("\n"); err != nil {
-		return fmt.Errorf("error writing to stdout: %w", err)
+		return nil, fmt.Errorf("error writing to stdout: %w", err)
 	}
 
 	log.Printf("Successfully read %d records for object %s\n", len(res.Data), objectName)
 
-	return nil
+	return res, nil
 }


### PR DESCRIPTION
  - Add default `until` for incremental read to the current time when not provided.
   - Remove `write: true` from `company/projects`. this object is read-only.   
  
  
  - Use the full next-page URL from Procore's response as the pagination token, instead of just the page number.                                                                                                                                                                                                                                                                                       When reading data spread across multiple pages, we used to keep only the page number and rebuild the URL for each page. That meant the time-window filter (`updated_at`) got recomputed every page. means each page ended up using a slightly different "now" value which could return duplicate records or skip some .
  
  Procore already gives us the full URL for the next page in its response, with the time-window filter and page info already included. Using that URL as-is keeps the window locked in from the first page  
  onward, so every page sees the exact same range.  .     
      