### PR TITLE
housecallPro: treat employee webhooks as passthrough events

### DIFF
--- a/providers/housecallPro/subscriptionEvent.go
+++ b/providers/housecallPro/subscriptionEvent.go
@@ -107,7 +107,8 @@ func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 		return common.SubscriptionEventTypeOther, nil
 	}
 
-	// Employee events are marked as "other" and routed through passthrough because there is no employee get-by-id endpoint.
+	// Employee events are marked as "other" and routed through passthrough
+	// because there is no employee get-by-id endpoint.
 	if strings.HasPrefix(strings.ToLower(eventType), "employee.") {
 		return common.SubscriptionEventTypeOther, nil
 	}

--- a/providers/housecallPro/subscriptionEvent.go
+++ b/providers/housecallPro/subscriptionEvent.go
@@ -107,6 +107,11 @@ func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 		return common.SubscriptionEventTypeOther, nil
 	}
 
+	// Employee events are marked as "other" and routed through passthrough because there is no employee get-by-id endpoint.
+	if strings.HasPrefix(strings.ToLower(eventType), "employee.") {
+		return common.SubscriptionEventTypeOther, nil
+	}
+
 	parts := strings.Split(eventType, ".")
 
 	action := strings.ToLower(parts[len(parts)-1])

--- a/providers/housecallPro/subscriptionEvent_test.go
+++ b/providers/housecallPro/subscriptionEvent_test.go
@@ -231,7 +231,7 @@ func TestSubscriptionEvent_ParsingWeirdSamples(t *testing.T) {
 			event:          "employee.created",
 			payloadKey:     "employee",
 			payloadID:      "pro_1a2b3c4d5e",
-			wantEventType:  common.SubscriptionEventTypeCreate,
+			wantEventType:  common.SubscriptionEventTypeOther,
 			wantObjectName: "employees",
 		},
 	}


### PR DESCRIPTION
Employee webhook enrichment fails because Housecall Pro has no employee get-by-id API. Treating employee events as Other to route them through passthrough and avoid the failing fetch path.