### PR TITLE
fix(gmail): cap concurrent messages.get fetches at 5

### DIFF
--- a/providers/google/internal/mail/messages.go
+++ b/providers/google/internal/mail/messages.go
@@ -18,10 +18,21 @@ import (
 
 // gmailMaxConcurrentFetches caps the number of in-flight messages.get requests per call.
 // Gmail enforces a per-user concurrent-request limit (returns 429 "Too many concurrent
-// requests for user" when exceeded) and a 250 quota-units/sec/user budget where
-// messages.get costs 5 units each. A cap of 5 keeps us under the concurrency wall and
-// uses ~half the quota-unit budget at typical latencies, leaving headroom for retries
-// and other API traffic on the same token.
+// requests for user" when exceeded) and a 15,000 quota-units/min/user budget where
+// messages.get costs 5 units each.
+//
+// Sizing math:
+//   - Per-user budget:  15,000 units/min / 60 = 250 units/sec
+//   - Max sustainable:  250 units/sec / 5 units per get = 50 GETs/sec/user
+//   - For cap = C and avg Gmail latency L ~= 200ms, sustained RPS ~= C / L:
+//       C = 5  -> 25 RPS -> 125 units/sec -> 7,500/min  (50% of budget)
+//       C = 10 -> 50 RPS -> 250 units/sec -> 15,000/min (100% -- no headroom)
+//   - C = 5 stays under the concurrent-request wall AND keeps half the quota-unit
+//     budget free for retries and other API traffic on the same token.
+//
+// Refs:
+//   - Concurrent-request guidance: https://developers.google.com/workspace/gmail/api/guides/handle-errors#concurrent-requests
+//   - Per-user/per-project quota units: https://developers.google.com/workspace/gmail/api/reference/quota
 const gmailMaxConcurrentFetches = 5
 
 // fetchMessages retrieves the full message payloads for all message IDs found

--- a/providers/google/internal/mail/messages.go
+++ b/providers/google/internal/mail/messages.go
@@ -25,14 +25,16 @@ import (
 //   - Per-user budget:  15,000 units/min / 60 = 250 units/sec
 //   - Max sustainable:  250 units/sec / 5 units per get = 50 GETs/sec/user
 //   - For cap = C and avg Gmail latency L ~= 200ms, sustained RPS ~= C / L:
-//       C = 5  -> 25 RPS -> 125 units/sec -> 7,500/min  (50% of budget)
-//       C = 10 -> 50 RPS -> 250 units/sec -> 15,000/min (100% -- no headroom)
+//     C = 5  -> 25 RPS -> 125 units/sec -> 7,500/min  (50% of budget)
+//     C = 10 -> 50 RPS -> 250 units/sec -> 15,000/min (100% -- no headroom)
 //   - C = 5 stays under the concurrent-request wall AND keeps half the quota-unit
 //     budget free for retries and other API traffic on the same token.
 //
 // Refs:
-//   - Concurrent-request guidance: https://developers.google.com/workspace/gmail/api/guides/handle-errors#concurrent-requests
-//   - Per-user/per-project quota units: https://developers.google.com/workspace/gmail/api/reference/quota
+//   - Concurrent-request guidance:
+//     https://developers.google.com/workspace/gmail/api/guides/handle-errors#concurrent-requests
+//   - Per-user/per-project quota units:
+//     https://developers.google.com/workspace/gmail/api/reference/quota
 const gmailMaxConcurrentFetches = 5
 
 // fetchMessages retrieves the full message payloads for all message IDs found

--- a/providers/google/internal/mail/messages.go
+++ b/providers/google/internal/mail/messages.go
@@ -16,6 +16,14 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
+// gmailMaxConcurrentFetches caps the number of in-flight messages.get requests per call.
+// Gmail enforces a per-user concurrent-request limit (returns 429 "Too many concurrent
+// requests for user" when exceeded) and a 250 quota-units/sec/user budget where
+// messages.get costs 5 units each. A cap of 5 keeps us under the concurrency wall and
+// uses ~half the quota-unit budget at typical latencies, leaving headroom for retries
+// and other API traffic on the same token.
+const gmailMaxConcurrentFetches = 5
+
 // fetchMessages retrieves the full message payloads for all message IDs found
 // in the provided collection response.
 //
@@ -44,8 +52,9 @@ func (a *Adapter) fetchMessages(
 		callbacks = append(callbacks, a.fetchMessage(messagesChannel, messageID))
 	}
 
-	// Run all jobs concurrently. If any job fails, context is expected to cancel.
-	if err = simultaneously.DoCtx(ctx, -1, callbacks...); err != nil {
+	// Run jobs with bounded concurrency to avoid Gmail per-user 429s. If any job fails,
+	// context is expected to cancel.
+	if err = simultaneously.DoCtx(ctx, gmailMaxConcurrentFetches, callbacks...); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +91,7 @@ func (a *Adapter) fetchMessagesByIDs(ctx context.Context, messageIDs []string) (
 		callbacks = append(callbacks, a.fetchMessage(messagesChannel, messageID))
 	}
 
-	if err := simultaneously.DoCtx(ctx, -1, callbacks...); err != nil {
+	if err := simultaneously.DoCtx(ctx, gmailMaxConcurrentFetches, callbacks...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Summary
* Gmail returns `429` `"Too many concurrent requests for user"` when subscribe hydration fans out one HTTP GET per message ID with no concurrency limit. The simultaneously package interprets maxConcurrent=-1 as unbounded, so a 60-message batch fired 60 simultaneous requests at Gmail.
* Cap at 5: stays under Gmail's per-user concurrency wall and uses ~half the 250-units/sec quota budget at typical latencies, leaving headroom for retries and other API traffic on the same token.