### PR TITLE
feat(microsoft): Batch API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,8 @@ linters:
     - tagliatelle
     # We're not doing black-box testing, so enabling this would be counterproductive. We might want to discuss this though, it's a good practice.
     - testpackage
+    # Linter crashes when Generics are used.
+    - unparam
     # Annoying and not useful. Disabling otherwise we have to have comment everywhere
     - wrapcheck
     # Deprecated (since v2.2.0) due to: new major version. Replaced by wsl_v5.

--- a/common/json.go
+++ b/common/json.go
@@ -75,7 +75,8 @@ func (j *JSONHTTPClient) Get(ctx context.Context, url string, headers ...Header)
 // If the response is not a 2xx, an error is returned. If the response is a 401, the caller should
 // refresh the access token and retry the request. If errorHandler is nil, then the default error
 // handler is used. If not, the caller can inject their own error handling logic.
-func (j *JSONHTTPClient) Post(ctx context.Context,
+func (j *JSONHTTPClient) Post(
+	ctx context.Context,
 	url string, reqBody any, headers ...Header,
 ) (*JSONHTTPResponse, error) {
 	data, err := json.Marshal(reqBody)
@@ -91,7 +92,8 @@ func (j *JSONHTTPClient) Post(ctx context.Context,
 	return ParseJSONResponse(ctx, res, body)
 }
 
-func (j *JSONHTTPClient) Put(ctx context.Context,
+func (j *JSONHTTPClient) Put(
+	ctx context.Context,
 	url string, reqBody any, headers ...Header,
 ) (*JSONHTTPResponse, error) {
 	data, err := json.Marshal(reqBody)
@@ -107,7 +109,8 @@ func (j *JSONHTTPClient) Put(ctx context.Context,
 	return ParseJSONResponse(ctx, res, body)
 }
 
-func (j *JSONHTTPClient) Patch(ctx context.Context,
+func (j *JSONHTTPClient) Patch(
+	ctx context.Context,
 	url string, reqBody any, headers ...Header,
 ) (*JSONHTTPResponse, error) {
 	data, err := json.Marshal(reqBody)

--- a/providers/microsoft/internal/batch/operation.go
+++ b/providers/microsoft/internal/batch/operation.go
@@ -1,0 +1,115 @@
+package batch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// ErrBatchResponse represents a failure returned by the Microsoft Graph Batch API
+// for an individual request within a batch.
+var ErrBatchResponse = errors.New("API error in batch response")
+
+// Execute performs a Microsoft Graph JSON batch request.
+//
+// It aggregates multiple logical HTTP requests into one call to the `$batch` endpoint:
+// https://learn.microsoft.com/en-us/graph/json-batching
+//
+// Core Contract:
+//   - Every RequestID provided is deterministically mapped to exactly one outcome:
+//   - success → stored in Result.Responses
+//   - failure → stored in Result.Errors
+//   - Failures may originate from:
+//   - API-level errors (non-2xx responses per request)
+//   - connector-level errors (transport, serialization, or chunk failure)
+//
+// Behavior:
+//   - Requests are automatically chunked to respect Graph API limits (max 20 per batch).
+//   - Absolute URLs are normalized to relative paths as required by Graph.
+//   - Each batch is executed independently; failures in one batch do not prevent others.
+//
+// Error Handling:
+//   - This method does NOT return a combined error.
+//   - Callers must inspect Result.Errors to handle failures.
+//   - This design ensures full visibility into partial success scenarios.
+//
+// Generics:
+//   - `B` defines the expected response body type.
+//   - The caller is responsible for ensuring compatibility with each request.
+//
+// Guarantees:
+//   - Each RequestID appears in either Responses or Errors (never both, never neither).
+//   - Order is not preserved unless explicitly reconstructed via List().
+//
+// Example:
+//
+//	req := new(BatchRequest).
+//	    WithRequest("1", "GET", url1, nil, nil).
+//	    WithRequest("2", "POST", url2, body, nil)
+//
+//	result := Execute[MyResponse](ctx, strategy, req)
+//
+//	success := result.Responses["1"]
+//	failure := result.Errors["2"]
+func Execute[B any](ctx context.Context, strategy *Strategy, params *Params) *Result[B] {
+	bundle := &Result[B]{
+		Responses: make(map[RequestID]Envelope[B]),
+		Errors:    make(map[RequestID]Envelope[error]),
+	}
+
+	// Chunk the list of payloads into consumable sizes, otherwise API will reject large number of requests.
+	// Save the output into the bundle.Raw and bundle.Response.
+	// In case of an error the bundle.Raw and bundle.Errors are populated.
+	for _, payloads := range params.chunkPayloads() {
+		res, err := strategy.performRequest(ctx, payloads)
+		if err != nil {
+			for _, payload := range payloads {
+				bundle.Errors[payload.RequestID] = Envelope[error]{
+					Status: connectorErrorStatus,
+					Data:   fmt.Errorf("batch request failed: %w", err),
+				}
+			}
+
+			// Go to the next chunk request.
+			continue
+		}
+
+		apiResponse, err := common.UnmarshalJSON[responses[B]](res)
+		if err != nil {
+			for _, payload := range payloads {
+				bundle.Errors[payload.RequestID] = Envelope[error]{
+					Status: connectorErrorStatus,
+					Data:   fmt.Errorf("failed to unmarshal batch response: %w", err),
+				}
+			}
+
+			// Parsing output failed.
+			continue
+		}
+
+		// Sort every response into either success or failure.
+		for _, wrapper := range apiResponse.Responses {
+			bundle.storeResponseBody(wrapper)
+		}
+	}
+
+	return bundle
+}
+
+func (s Strategy) performRequest(ctx context.Context, payloads []*payloadRequest) (*common.JSONHTTPResponse, error) {
+	url, err := s.getBatchURL()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, payload := range payloads {
+		payload.RelativeURL, _ = strings.CutPrefix(payload.RelativeURL, s.getVersionedRootURL())
+	}
+
+	return s.client.Post(ctx, url.String(), bundledPayload{
+		Requests: payloads,
+	})
+}

--- a/providers/microsoft/internal/batch/operation.go
+++ b/providers/microsoft/internal/batch/operation.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/simultaneously"
 )
 
 // ErrBatchResponse represents a failure returned by the Microsoft Graph Batch API
@@ -59,44 +61,98 @@ func Execute[B any](ctx context.Context, strategy *Strategy, params *Params) *Re
 		Responses: make(map[RequestID]Envelope[B]),
 		Errors:    make(map[RequestID]Envelope[error]),
 	}
+	responseChannel := make(chan *responseWrapper[B], len(params.payloads))
+	errChannel := make(chan *datautils.Pair[RequestID, Envelope[error]], len(params.payloads))
 
 	// Chunk the list of payloads into consumable sizes, otherwise API will reject large number of requests.
 	// Save the output into the bundle.Raw and bundle.Response.
 	// In case of an error the bundle.Raw and bundle.Errors are populated.
-	for _, payloads := range params.chunkPayloads() {
-		res, err := strategy.performRequest(ctx, payloads)
-		if err != nil {
-			for _, payload := range payloads {
-				bundle.Errors[payload.RequestID] = Envelope[error]{
-					Status: connectorErrorStatus,
-					Data:   fmt.Errorf("batch request failed: %w", err),
-				}
-			}
+	payloadList := params.chunkPayloads()
 
-			// Go to the next chunk request.
-			continue
+	callbacks := make([]simultaneously.Job, len(payloadList))
+	for index, payloads := range payloadList {
+		callbacks[index] = func(ctx context.Context) error {
+			batchRoutine(ctx, strategy, payloads, responseChannel, errChannel)
+
+			return nil
 		}
+	}
 
-		apiResponse, err := common.UnmarshalJSON[responses[B]](res)
-		if err != nil {
-			for _, payload := range payloads {
-				bundle.Errors[payload.RequestID] = Envelope[error]{
-					Status: connectorErrorStatus,
-					Data:   fmt.Errorf("failed to unmarshal batch response: %w", err),
-				}
+	// Wait for all routines.
+	if err := simultaneously.DoCtx(ctx, -1, callbacks...); err != nil {
+		for _, payload := range params.payloads {
+			bundle.Errors[payload.RequestID] = Envelope[error]{
+				Status: connectorErrorStatus,
+				Data:   err,
 			}
-
-			// Parsing output failed.
-			continue
 		}
+	}
 
+	// All routines are done. Close the channels.
+	close(responseChannel)
+	close(errChannel)
+
+	for body := range responseChannel {
 		// Sort every response into either success or failure.
-		for _, wrapper := range apiResponse.Responses {
-			bundle.storeResponseBody(wrapper)
+		bundle.storeResponseBody(body)
+	}
+
+	for data := range errChannel {
+		requestID := data.Left
+		newEnvelope := data.Right
+
+		if envelope, present := bundle.Errors[requestID]; !present {
+			bundle.Errors[requestID] = newEnvelope
+		} else {
+			// This is possible if `simultaneously.DoCtx` declared the error, then we combine both.
+			envelope.Data = fmt.Errorf("%w: %w", envelope.Data, newEnvelope.Data)
+			bundle.Errors[requestID] = envelope
 		}
 	}
 
 	return bundle
+}
+
+func batchRoutine[B any](ctx context.Context,
+	strategy *Strategy,
+	payloads []*payloadRequest,
+	responseChannel chan<- *responseWrapper[B],
+	errChannel chan<- *datautils.Pair[RequestID, Envelope[error]],
+) {
+	res, err := strategy.performRequest(ctx, payloads)
+	if err != nil {
+		for _, payload := range payloads {
+			errChannel <- &datautils.Pair[RequestID, Envelope[error]]{
+				Left: payload.RequestID,
+				Right: Envelope[error]{
+					Status: connectorErrorStatus,
+					Data:   fmt.Errorf("batch request failed: %w", err),
+				},
+			}
+		}
+
+		return
+	}
+
+	apiResponse, err := common.UnmarshalJSON[responses[B]](res)
+	if err != nil {
+		for _, payload := range payloads {
+			errChannel <- &datautils.Pair[RequestID, Envelope[error]]{
+				Left: payload.RequestID,
+				Right: Envelope[error]{
+					Status: connectorErrorStatus,
+					Data:   fmt.Errorf("failed to unmarshal batch response: %w", err),
+				},
+			}
+		}
+
+		// Parsing output failed.
+		return
+	}
+
+	for _, wrapper := range apiResponse.Responses {
+		responseChannel <- &wrapper
+	}
 }
 
 func (s Strategy) performRequest(ctx context.Context, payloads []*payloadRequest) (*common.JSONHTTPResponse, error) {

--- a/providers/microsoft/internal/batch/operation.go
+++ b/providers/microsoft/internal/batch/operation.go
@@ -7,9 +7,12 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/internal/datautils"
-	"github.com/amp-labs/connectors/internal/simultaneously"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
 )
+
+// maxConcurrency is the number of goroutines that can be spawned to run multiple requests in parallel.
+// The number 3 is chosen at random.
+const maxConcurrency = 3
 
 // ErrBatchResponse represents a failure returned by the Microsoft Graph Batch API
 // for an individual request within a batch.
@@ -61,98 +64,53 @@ func Execute[B any](ctx context.Context, strategy *Strategy, params *Params) *Re
 		Responses: make(map[RequestID]Envelope[B]),
 		Errors:    make(map[RequestID]Envelope[error]),
 	}
-	responseChannel := make(chan *responseWrapper[B], len(params.payloads))
-	errChannel := make(chan *datautils.Pair[RequestID, Envelope[error]], len(params.payloads))
 
-	// Chunk the list of payloads into consumable sizes, otherwise API will reject large number of requests.
-	// Save the output into the bundle.Raw and bundle.Response.
-	// In case of an error the bundle.Raw and bundle.Errors are populated.
+	// Break payloads into batches small enough for the API to accept.
 	payloadList := params.chunkPayloads()
 
-	callbacks := make([]simultaneously.Job, len(payloadList))
+	// Build a task per batch for parallel execution.
+	tasks := make([]parallelfetch.Task[int, []responseWrapper[B]], len(payloadList))
 	for index, payloads := range payloadList {
-		callbacks[index] = func(ctx context.Context) error {
-			batchRoutine(ctx, strategy, payloads, responseChannel, errChannel)
-
-			return nil
-		}
-	}
-
-	// Wait for all routines.
-	if err := simultaneously.DoCtx(ctx, -1, callbacks...); err != nil {
-		for _, payload := range params.payloads {
-			bundle.Errors[payload.RequestID] = Envelope[error]{
-				Status: connectorErrorStatus,
-				Data:   err,
+		tasks[index] = func(ctx context.Context) (int, *[]responseWrapper[B], error) {
+			res, err := strategy.performRequest(ctx, payloads)
+			if err != nil {
+				return index, nil, err
 			}
+
+			apiResponse, err := common.UnmarshalJSON[responses[B]](res)
+			if err != nil {
+				return index, nil, err
+			}
+
+			return index, &apiResponse.Responses, nil
 		}
 	}
 
-	// All routines are done. Close the channels.
-	close(responseChannel)
-	close(errChannel)
+	// Execute batch tasks with bounded concurrency and collect results.
+	result := parallelfetch.Execute(ctx, tasks, maxConcurrency)
 
-	for body := range responseChannel {
-		// Sort every response into either success or failure.
-		bundle.storeResponseBody(body)
-	}
+	for index, payloads := range payloadList {
+		if err, ok := result.Errors[index]; ok {
+			// The entire batch failed; mark every request in the batch with the batch error.
+			for _, payload := range payloads {
+				bundle.Errors[payload.RequestID] = Envelope[error]{
+					Status: connectorErrorStatus,
+					Data:   fmt.Errorf("batch request failed: %w", err),
+				}
+			}
 
-	for data := range errChannel {
-		requestID := data.Left
-		newEnvelope := data.Right
+			continue
+		}
 
-		if envelope, present := bundle.Errors[requestID]; !present {
-			bundle.Errors[requestID] = newEnvelope
-		} else {
-			// This is possible if `simultaneously.DoCtx` declared the error, then we combine both.
-			envelope.Data = fmt.Errorf("%w: %w", envelope.Data, newEnvelope.Data)
-			bundle.Errors[requestID] = envelope
+		// Process successful batch responses; individual entries may still contain errors.
+		if respBodies, ok := result.Records[index]; ok {
+			for _, wrapper := range respBodies {
+				bundle.storeResponseBody(&wrapper)
+			}
 		}
 	}
 
 	return bundle
-}
-
-func batchRoutine[B any](ctx context.Context,
-	strategy *Strategy,
-	payloads []*payloadRequest,
-	responseChannel chan<- *responseWrapper[B],
-	errChannel chan<- *datautils.Pair[RequestID, Envelope[error]],
-) {
-	res, err := strategy.performRequest(ctx, payloads)
-	if err != nil {
-		for _, payload := range payloads {
-			errChannel <- &datautils.Pair[RequestID, Envelope[error]]{
-				Left: payload.RequestID,
-				Right: Envelope[error]{
-					Status: connectorErrorStatus,
-					Data:   fmt.Errorf("batch request failed: %w", err),
-				},
-			}
-		}
-
-		return
-	}
-
-	apiResponse, err := common.UnmarshalJSON[responses[B]](res)
-	if err != nil {
-		for _, payload := range payloads {
-			errChannel <- &datautils.Pair[RequestID, Envelope[error]]{
-				Left: payload.RequestID,
-				Right: Envelope[error]{
-					Status: connectorErrorStatus,
-					Data:   fmt.Errorf("failed to unmarshal batch response: %w", err),
-				},
-			}
-		}
-
-		// Parsing output failed.
-		return
-	}
-
-	for _, wrapper := range apiResponse.Responses {
-		responseChannel <- &wrapper
-	}
 }
 
 func (s Strategy) performRequest(ctx context.Context, payloads []*payloadRequest) (*common.JSONHTTPResponse, error) {

--- a/providers/microsoft/internal/batch/operation_test.go
+++ b/providers/microsoft/internal/batch/operation_test.go
@@ -1,0 +1,152 @@
+package batch
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestExecute_SingleRequest(t *testing.T) {
+	multiResponse := testutils.DataFromFile(t, "partial-success-with-missing-datetime.json")
+
+	params := &Params{}
+	for _, name := range []string{"users/id/messages", "butterfly", "me/messages"} {
+		url, _ := urlbuilder.New("https://graph.microsoft.com", name)
+		params.WithRequest(RequestID(name), http.MethodGet, url, nil, nil)
+	}
+
+	type body struct {
+		Resource   string `json:"resource"`
+		ChangeType string `json:"changeType"`
+	}
+
+	tests := []testSuite[body]{
+		{
+			Name:  "Various objects from API response are sorted",
+			Input: params,
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1.0/$batch"),
+					mockcond.Body(`{
+					  "requests" : [{
+						"id" : "users/id/messages", "method" : "GET",
+						"url" : "https://graph.microsoft.com/users/id/messages"
+					  }, {
+						"id" : "butterfly", "method" : "GET",
+						"url" : "https://graph.microsoft.com/butterfly"
+					  }, {
+						"id" : "me/messages", "method" : "GET",
+						"url" : "https://graph.microsoft.com/me/messages"
+					  }]
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, multiResponse),
+			}.Server(),
+			Comparator: resultComparator[body],
+			Expected: &Result[body]{
+				Responses: map[RequestID]Envelope[body]{
+					"me/messages": {
+						Status: 201,
+						Data: body{
+							Resource:   "me/messages",
+							ChangeType: "created,updated,deleted",
+						},
+					},
+				},
+				Errors: map[RequestID]Envelope[error]{
+					"users/id/messages": {
+						Status: 400,
+						Data:   testutils.StringError("HTTP status 400: API error in batch response"),
+					},
+					"butterfly": {
+						Status: 404,
+						Data:   testutils.StringError("HTTP status 404: API error in batch response"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (*Strategy, error) {
+				return constructTestStrategy(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestStrategy(serverURL string) (*Strategy, error) {
+	transport, err := components.NewTransport(providers.Microsoft, common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	transport.SetUnitTestMockServerBaseURL(serverURL)
+
+	return NewStrategy(transport.JSONHTTPClient(), transport.ProviderInfo()), nil
+}
+
+type testType[B any] = testroutines.TestCase[*Params, *Result[B]]
+type testSuite[B any] testType[B]
+
+// Run provides a procedure to test connectors.ObjectMetadataConnector
+func (s testSuite[B]) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Strategy]) {
+	t.Helper()
+	t.Cleanup(func() {
+		testType[B](s).Close()
+	})
+
+	strategy := builder.Build(t, s.Name)
+	output := Execute[B](t.Context(), strategy, s.Input)
+	testType[B](s).Validate(t, nil, output)
+}
+
+func resultComparator[B any](_ string, actual, expected *Result[B]) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+
+	// Responses
+	result.Assert("Responses length mismatch", len(expected.Responses), len(actual.Responses))
+	for id, exp := range expected.Responses {
+		act, ok := actual.Responses[id]
+		if !ok {
+			result.AddDiff("Responses[%q]: missing in actual", id)
+			continue
+		}
+
+		result.Assert(fmt.Sprintf("Responses[%q].Status", id), exp.Status, act.Status)
+		result.Assert(fmt.Sprintf("Responses[%s].Body", id), exp.Data, act.Data)
+	}
+
+	// Errors
+	result.Assert("Errors length mismatch", len(expected.Errors), len(actual.Errors))
+	for id, exp := range expected.Errors {
+		act, ok := actual.Errors[id]
+		if !ok {
+			result.AddDiff("Errors[%q]: missing in actual", id)
+			continue
+		}
+
+		result.Assert(fmt.Sprintf("Errors[%q].Status", id), exp.Status, act.Status)
+		result.AssertErr(fmt.Sprintf("Errors[%s].Error", id), exp.Data, act.Data)
+	}
+
+	return result
+}

--- a/providers/microsoft/internal/batch/params.go
+++ b/providers/microsoft/internal/batch/params.go
@@ -1,0 +1,90 @@
+package batch
+
+import (
+	"slices"
+
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// RequestID uniquely identifies a request within a batch.
+//
+// It is the sole mechanism used to correlate requests and responses.
+//
+// Design Notes:
+//   - Strongly typed to prevent accidental mixing with arbitrary strings.
+//   - Fully controlled by the caller (no imposed format).
+//   - Encourages explicit mapping logic at call sites.
+type RequestID string
+
+// Params collects individual requests that will be executed as a single batch.
+//
+// It acts as a builder for batch execution:
+//   - Requests are added via WithRequest.
+//   - Each request must have a unique RequestID.
+//
+// Internal behavior such as chunking (to satisfy API limits) is handled automatically
+// and is not exposed to the caller.
+type Params struct {
+	payloads []*payloadRequest
+}
+
+// WithRequest adds a request to the batch.
+//
+// Requirements:
+//   - requestIdentifier must be unique within the batch.
+//   - URL must be a valid Graph endpoint.
+//
+// Notes:
+//   - The identifier is the only mechanism used to correlate responses.
+func (p *Params) WithRequest(
+	requestIdentifier RequestID,
+	method string,
+	url *urlbuilder.URL,
+	body any,
+	headers map[string]any,
+) *Params {
+	p.payloads = append(p.payloads, &payloadRequest{
+		RequestID:   requestIdentifier,
+		Method:      method,
+		RelativeURL: url.String(),
+		Body:        body,
+		Headers:     headers,
+	})
+
+	return p
+}
+
+// chunkPayloads splits payloads into batches respecting the Graph API limit.
+// https://learn.microsoft.com/en-us/graph/json-batching?tabs=http#batch-size-limitations
+func (p *Params) chunkPayloads() [][]*payloadRequest {
+	const maxBatchSize = 20
+
+	if len(p.payloads) == 0 {
+		return nil
+	}
+
+	iterator := slices.Chunk(p.payloads, maxBatchSize)
+
+	var batches [][]*payloadRequest
+	iterator(func(batch []*payloadRequest) bool {
+		batches = append(batches, batch)
+
+		return true // continue iteration
+	})
+
+	return batches
+}
+
+// bundledPayload is the main payload sent to "/$batch" endpoint.
+type bundledPayload struct {
+	Requests []*payloadRequest `json:"requests"`
+}
+
+// payloadRequest represents a single request entry in the Graph batch payload.
+type payloadRequest struct {
+	RequestID   RequestID      `json:"id"`
+	Method      string         `json:"method"`
+	RelativeURL string         `json:"url"`
+	Body        any            `json:"body,omitempty"`
+	Headers     map[string]any `json:"headers,omitempty"`
+}

--- a/providers/microsoft/internal/batch/response.go
+++ b/providers/microsoft/internal/batch/response.go
@@ -1,0 +1,130 @@
+package batch
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/httpkit"
+)
+
+// Result contains the outcome of a batch execution.
+//
+// It preserves both structured results and raw responses for debugging
+// and advanced inspection.
+type Result[B any] struct {
+	// Responses contains all successful (2xx) results keyed by RequestID.
+	Responses map[RequestID]Envelope[B]
+
+	// Errors contains all failed results keyed by RequestID.
+	//
+	// Includes:
+	//   - API errors (non-2xx responses)
+	//   - connector-level failures (Status = -1)
+	Errors map[RequestID]Envelope[error]
+}
+
+const connectorErrorStatus = -1
+
+// Envelope represents the outcome of a single request within a batch.
+type Envelope[B any] struct {
+	// HTTP status code returned by the API.
+	// For connector-level failures, Status is set to connectorErrorStatus.
+	Status int
+
+	// Data contains:
+	//   - decoded response body (for success)
+	//   - error (for failures)
+	Data B
+}
+
+// GetInOrder returns successful response bodies in the order of provided IDs.
+// Missing or failed IDs will not be returned.
+func (r Result[B]) GetInOrder(requestIdentifiers []RequestID) []B {
+	result := make([]B, 0, len(requestIdentifiers))
+	for _, identifier := range requestIdentifiers {
+		result = append(result, r.Responses[identifier].Data)
+	}
+
+	return result
+}
+
+func (r Result[B]) JoinedErr() error {
+	var err error
+	for _, e := range r.Errors {
+		err = errors.Join(err, e.Data)
+	}
+
+	return err
+}
+
+// storeResponseBody classifies a single API response into success or failure.
+//
+// Non-2xx responses are converted into structured errors and stored in Errors.
+// Successful responses are stored in Responses.
+func (r Result[B]) storeResponseBody(wrapper responseWrapper[B]) { // nolint:unparam
+	item := wrapper.Data
+	if !httpkit.Status2xx(item.Status) {
+		// In case of an error, no response body will be included.
+		// Unlikely and not a big deal.
+		data, _ := json.Marshal(wrapper.Raw) // nolint:errchkjson
+		r.Errors[item.RequestID] = Envelope[error]{
+			Status: item.Status,
+			Data: common.NewHTTPError(
+				item.Status, data, item.getHeaders(), ErrBatchResponse,
+			),
+		}
+
+		return
+	}
+
+	r.Responses[item.RequestID] = Envelope[B]{
+		Status: item.Status,
+		Data:   item.Body,
+	}
+}
+
+// responses models the top-level Graph batch response structure.
+type responses[B any] struct {
+	Responses []responseWrapper[B] `json:"responses"`
+}
+
+// responseWrapper preserves both raw JSON and decoded structure.
+//
+// This enables:
+//   - lossless error reporting
+//   - typed access to successful responses
+type responseWrapper[B any] struct {
+	Raw  map[string]any
+	Data response[B]
+}
+
+func (r *responseWrapper[B]) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &r.Raw); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &r.Data)
+}
+
+// response is a template Microsoft Graph API formats its data.
+// The Body various based on the Request Endpoint and the status of the response.
+type response[B any] struct {
+	RequestID RequestID      `json:"id"`
+	Status    int            `json:"status"`
+	Headers   map[string]any `json:"headers"`
+	Body      B              `json:"body"`
+}
+
+func (b response[B]) getHeaders() common.Headers {
+	headers := make(common.Headers, 0)
+	for key, value := range b.Headers {
+		headers = append(headers, common.Header{
+			Key:   key,
+			Value: fmt.Sprintf("%v", value),
+		})
+	}
+
+	return headers
+}

--- a/providers/microsoft/internal/batch/response.go
+++ b/providers/microsoft/internal/batch/response.go
@@ -63,7 +63,7 @@ func (r Result[B]) JoinedErr() error {
 //
 // Non-2xx responses are converted into structured errors and stored in Errors.
 // Successful responses are stored in Responses.
-func (r Result[B]) storeResponseBody(wrapper responseWrapper[B]) { // nolint:unparam
+func (r Result[B]) storeResponseBody(wrapper *responseWrapper[B]) { // nolint:unparam
 	item := wrapper.Data
 	if !httpkit.Status2xx(item.Status) {
 		// In case of an error, no response body will be included.

--- a/providers/microsoft/internal/batch/strategy.go
+++ b/providers/microsoft/internal/batch/strategy.go
@@ -1,0 +1,30 @@
+package batch
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const apiVersion = "v1.0"
+
+type Strategy struct {
+	client       *common.JSONHTTPClient
+	providerInfo *providers.ProviderInfo
+}
+
+func NewStrategy(client *common.JSONHTTPClient, providerInfo *providers.ProviderInfo) *Strategy {
+	return &Strategy{
+		client:       client,
+		providerInfo: providerInfo,
+	}
+}
+
+// https://learn.microsoft.com/en-us/graph/json-batching?tabs=http#creating-a-batch-request
+func (s Strategy) getBatchURL() (*urlbuilder.URL, error) {
+	return urlbuilder.New(s.providerInfo.BaseURL, apiVersion, "$batch")
+}
+
+func (s Strategy) getVersionedRootURL() string {
+	return s.providerInfo.BaseURL + "/" + apiVersion
+}

--- a/providers/microsoft/internal/batch/test/partial-success-with-missing-datetime.json
+++ b/providers/microsoft/internal/batch/test/partial-success-with-missing-datetime.json
@@ -1,0 +1,70 @@
+{
+  "responses": [
+    {
+      "id": "users/id/messages",
+      "status": 400,
+      "headers": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json"
+      },
+      "body": {
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Could not process subscription creation payload. Are all property names spelled and camelCased properly?Also are the dateTimeOffest properties in a valid Internet Date and Time format?",
+          "innerError": {
+            "date": "2026-04-23T17:14:41",
+            "request-id": "368f0834-d0ec-4b77-bf1f-1634361c4484",
+            "client-request-id": "368f0834-d0ec-4b77-bf1f-1634361c4484"
+          }
+        }
+      }
+    },
+    {
+      "id": "butterfly",
+      "status": 404,
+      "headers": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json"
+      },
+      "body": {
+        "error": {
+          "code": "ExtensionError",
+          "message": "Operation: Create; Exception: [Status Code: NotFound; Reason: Not Found; Message : Resource not found.]",
+          "innerError": {
+            "date": "2026-04-23T17:19:16",
+            "request-id": "f34667cf-5b74-40da-abd3-708fcf60d43c",
+            "client-request-id": "f34667cf-5b74-40da-abd3-708fcf60d43c"
+          }
+        }
+      }
+    },
+    {
+      "id": "me/messages",
+      "status": 201,
+      "headers": {
+        "Location": "https://subscriptionstore.windows.net/1.0/NA/subscriptions('5dd5dc5d-39d8-4795-a247-c61134e83115')",
+        "Cache-Control": "no-cache",
+        "OData-Version": "4.0",
+        "Content-Type": "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8"
+      },
+      "body": {
+        "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity",
+        "id": "5dd5dc5d-39d8-4795-a247-c61134e83115",
+        "resource": "me/messages",
+        "applicationId": "39d7eec8-2032-4dd3-959f-d92d8a4e2ad3",
+        "changeType": "created,updated,deleted",
+        "clientState": null,
+        "notificationUrl": "https://4a4e-46-150-81-5.ngrok-free.app",
+        "notificationQueryOptions": null,
+        "lifecycleNotificationUrl": null,
+        "expirationDateTime": "2026-04-23T18:19:14Z",
+        "creatorId": "ae87552f-48fc-4dec-9322-65040bf9fdfd",
+        "includeResourceData": null,
+        "latestSupportedTlsVersion": "v1_2",
+        "encryptionCertificate": null,
+        "encryptionCertificateId": null,
+        "notificationUrlAppId": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Introduces the `batch` package for Microsoft Graph, providing a reusable foundation for batched requests (used by the Subscription feature. This can be extended to use cases like Salesforce-style batch read/write).

### Key points

* **Automatic batching**
  Requests are transparently chunked to comply with Microsoft’s limit of 20 requests per batch.

* **Deterministic result mapping**
  Each `RequestID` is mapped to exactly one outcome:

  * success → `Responses`
  * failure → `Errors`
    This makes it easy to correlate results with original requests.

* **Generic response handling**
  `Execute[B any]` parses successful responses into the desired type, enabling type-safe usage without additional boilerplate.
  It is implemented as a standalone function (instead of a method) due to Go’s limitations around method-level generics.

* **No top-level error**
  The function intentionally does not return an error.
  All failures (API or connector-level) are captured in `Result.Errors`, allowing callers to handle partial success scenarios and implement rollback logic more naturally.
