### PR TITLE
feat(subscriptions): Scripts for consuming events

### DIFF
--- a/internal/datautils/pair.go
+++ b/internal/datautils/pair.go
@@ -1,0 +1,6 @@
+package datautils
+
+type Pair[L, R any] struct {
+	Left  L
+	Right R
+}

--- a/test/utils/dump.go
+++ b/test/utils/dump.go
@@ -9,6 +9,13 @@ import (
 
 // DumpJSON dumps the given value as JSON to the given writer.
 func DumpJSON(v any, w io.Writer) {
+	if bytesData, ok := v.([]byte); ok {
+		jsonData := make(map[string]any)
+		if err := json.Unmarshal(bytesData, &jsonData); err == nil {
+			v = jsonData
+		}
+	}
+
 	// Convert any error interfaces recursively before encoding.
 	convertedValue := substituteErrorsToStrings(v)
 

--- a/test/utils/testscenario/crud.go
+++ b/test/utils/testscenario/crud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -61,6 +62,10 @@ func (p Property) isZero() bool {
 	return p.Key == "" && p.Value == ""
 }
 
+func (p Property) String() string {
+	return fmt.Sprintf("{ %v : %v }", p.Key, p.Value)
+}
+
 // ValidateCreateUpdateDelete is a comprehensive test scenario utilizing Read/Write/Delete connector operations.
 //
 // Flow:
@@ -69,7 +74,8 @@ func (p Property) isZero() bool {
 // 3. Update the object using the "UP" payload.
 // 4. Read again and verify updates took effect.
 // 5. Delete the object at the end.
-func ValidateCreateUpdateDelete[CP, UP any](ctx context.Context, conn ConnectorCRUD, objectName string,
+func ValidateCreateUpdateDelete[CP, UP any](
+	ctx context.Context, conn ConnectorCRUD, objectName string,
 	createPayload CP, updatePayload UP, suite CRUDTestSuite,
 ) {
 	fmt.Println("> TEST Create/Update/Delete", objectName)
@@ -114,7 +120,7 @@ func ValidateCreateUpdateDelete[CP, UP any](ctx context.Context, conn ConnectorC
 
 	// UPDATE
 	fmt.Println("Updating some object properties")
-	err = updateObject(ctx, conn, objectName, objectID, &updatePayload)
+	_, err = updateObject(ctx, conn, objectName, objectID, &updatePayload)
 	failOnError(err)
 	fmt.Println("Validate object has changed accordingly")
 
@@ -181,7 +187,7 @@ func getRecordIdentifierValue(object map[string]any, key string) string {
 }
 
 func createObject[CP any](
-	ctx context.Context, conn ConnectorCRUD, objectName string, payload *CP,
+	ctx context.Context, conn connectors.WriteConnector, objectName string, payload *CP,
 ) (*common.WriteResult, error) {
 	res, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: objectName,
@@ -199,8 +205,10 @@ func createObject[CP any](
 	return res, nil
 }
 
-func readObjects(ctx context.Context, conn ConnectorCRUD,
-	objectName string, fields datautils.StringSet, since time.Time) (*common.ReadResult, error) {
+func readObjects(
+	ctx context.Context, conn connectors.ReadConnector,
+	objectName string, fields datautils.StringSet, since time.Time,
+) (*common.ReadResult, error) {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: objectName,
 		Fields:     fields,
@@ -247,22 +255,22 @@ func searchObjectRecord(res *common.ReadResult, key, value string) (*objectRecor
 }
 
 func updateObject[UP any](
-	ctx context.Context, conn ConnectorCRUD, objectName string, objectID string, payload *UP,
-) error {
+	ctx context.Context, conn connectors.WriteConnector, objectName string, objectID string, payload *UP,
+) (*common.WriteResult, error) {
 	res, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: objectName,
 		RecordId:   objectID,
 		RecordData: payload,
 	})
 	if err != nil {
-		return fmt.Errorf("error updating object: %w", err)
+		return nil, fmt.Errorf("error updating object: %w", err)
 	}
 
 	if !res.Success {
-		return errors.New("failed to update an object")
+		return nil, errors.New("failed to update an object")
 	}
 
-	return nil
+	return res, nil
 }
 
 func removeObject(ctx context.Context, conn ConnectorCRUD, objectName string, objectID string) error {
@@ -283,6 +291,21 @@ func removeObject(ctx context.Context, conn ConnectorCRUD, objectName string, ob
 
 func failOnError(err error) {
 	if err != nil {
-		utils.Fail("fatal", "error", err)
+		utils.Fail("[test failed]", "error", err)
 	}
+}
+
+// printError prints error and returns true if error is not nil.
+func printError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	fmt.Println("[test failed]", "error", err.Error())
+	if httpError, ok := errors.AsType[*common.HTTPError](err); ok {
+		utils.DumpJSON(httpError.Body, os.Stdout)
+		return true
+	}
+
+	return true
 }

--- a/test/utils/testscenario/subscription-cud.go
+++ b/test/utils/testscenario/subscription-cud.go
@@ -1,0 +1,68 @@
+package testscenario
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+type ConnectorSubscriptionManager interface {
+	testroutines.TestableSubscriptionCreator
+	testroutines.TestableSubscriptionUpdater
+	testroutines.TestableSubscriptionRemover
+}
+
+// SubscriptionCreateUpdateDelete is a test scenario utilizing
+// Subscribe/UpdateSubscription/DeleteSubscription connector operations.
+// Each step will be displayed on the screen and to be analyzed by developer.
+func SubscriptionCreateUpdateDelete(
+	ctx context.Context, conn ConnectorSubscriptionManager,
+	createParams, updateParams SubscribeParamBuilder,
+) {
+	fmt.Println("> TEST Subscription Create/Update/Delete")
+	publicURL, ok := getPublicWebhookURL(ctx)
+	if !ok {
+		failOnError(errors.New("webhook URL is needed"))
+	}
+
+	fmt.Println("============= Create =============")
+	result, err := conn.Subscribe(ctx, *createParams(publicURL))
+	if err != nil {
+		fmt.Println("conn.Subscribe() -> failed")
+		failOnError(err)
+	}
+	validateSubscriptionResult(result)
+
+	fmt.Println("============= Update =============")
+	result, err = conn.UpdateSubscription(ctx, *updateParams(publicURL), result)
+	if err != nil {
+		fmt.Println("conn.UpdateSubscription() -> failed")
+		failOnError(err)
+	}
+	validateSubscriptionResult(result)
+
+	fmt.Println("============= Delete =============")
+	err = conn.DeleteSubscription(ctx, *result)
+	if err != nil {
+		fmt.Println("conn.DeleteSubscription() -> failed")
+		failOnError(err)
+	}
+
+	fmt.Println("> Successful test completion")
+}
+
+func validateSubscriptionResult(result *common.SubscriptionResult) {
+	fmt.Println("(1) Result:")
+	utils.DumpJSON(result.Result, os.Stdout)
+	fmt.Println("(2) ObjectEvents:")
+	utils.DumpJSON(result.ObjectEvents, os.Stdout)
+	fmt.Printf("(3) Status: \"%v\"\n", result.Status)
+	if result.Status != common.SubscriptionStatusSuccess {
+		failOnError(errors.New("subscription has not succeeded"))
+	}
+}

--- a/test/utils/testscenario/subscription-messaging.go
+++ b/test/utils/testscenario/subscription-messaging.go
@@ -1,0 +1,254 @@
+package testscenario
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+type ConnectorWebhookSubscriber interface {
+	testroutines.TestableSubscriptionCreator
+	testroutines.TestableWebhookMessageVerifier
+	connectors.ReadConnector
+	connectors.WriteConnector
+	connectors.DeleteConnector
+}
+
+type SubscribeParamBuilder func(webhookURL string) *common.SubscribeParams
+
+type SubscribeReceiveEventsSuite struct {
+	SubscribeParamBuilder SubscribeParamBuilder
+	// ExpectedWebhookCalls is the number of events to wait before quiting the script.
+	//
+	// Number of Operations may be greater than the number of expected events.
+	// Some operations can be utilized for cleaning records.
+	// Ex: You are testing only update. The operations would still need create, delete, not just update.
+	//
+	// Webhook may be called more if there are already some subscriptions that would intervene.
+	// There is no way to protect against these side effects.
+	ExpectedWebhookCalls int
+	Operations           []ConnectorOperation
+	// WebhookRouter allows a list of alternative request handling by the webhook handler.
+	// When conditions are met for the Route that handler is executed.
+	// If there are no custom routes or none match then default webhook handling will take place.
+	// This includes printing events until reaching the number of ExpectedWebhookCalls or
+	// script cancellation.
+	WebhookRouter      WebhookRouter
+	VerificationParams *common.VerificationParams
+	// AutoRemoveSubscription, if true, removes at the end of script execution any subscriptions
+	// that were created as part of this test run. If false, subscriptions are left in place
+	// and must be cleaned up manually.
+	AutoRemoveSubscription bool
+}
+
+type ConnectorMethod string
+
+const (
+	ConnectorMethodCreate ConnectorMethod = "create"
+	ConnectorMethodUpdate ConnectorMethod = "update"
+	ConnectorMethodDelete ConnectorMethod = "delete"
+)
+
+type ConnectorOperation struct {
+	// ObjectName object to create, update or to remove.
+	ObjectName string
+	// Method invokes Write() or Delete().
+	Method ConnectorMethod
+	// Payload relevant for ConnectorMethodCreate and ConnectorMethodUpdate.
+	Payload any
+	// SearchProcedure relevant for ConnectorMethodUpdate and ConnectorMethodDelete.
+	SearchProcedure SearchProcedure
+}
+
+type SearchProcedure struct {
+	ReadFields          datautils.StringSet
+	RecordIdentifierKey string
+	WaitBeforeSearch    time.Duration
+	SearchBy            Property
+}
+
+// ValidateSubscribeReceiveEvents is a comprehensive test scenario utilizing subscription connector operations.
+//
+// Flow:
+// 1. Starts local server
+// 2. Asks user for public URL (ngrok)
+// 3. Creates subscription
+// 4. Optionally triggers events (Write)
+// 5. Waits for webhook(s)
+// 6. Exits cleanly
+func ValidateSubscribeReceiveEvents(
+	ctx context.Context,
+	conn ConnectorWebhookSubscriber,
+	suite SubscribeReceiveEventsSuite,
+) {
+	fmt.Println("> TEST Subscribe/Write/Recieve")
+
+	fmt.Println("============== Starting Webhook Handler ==================")
+	messageChannel := make(chan webhookMessageResult)
+	webhookURL, shutdown := startWebhookHandler(ctx, conn,
+		suite.WebhookRouter, suite.VerificationParams, messageChannel,
+	)
+	defer shutdown()
+
+	fmt.Printf("Local webhook server started at: \"%s\"\n", webhookURL)
+	publicURL, ok := getPublicWebhookURL(ctx)
+	if !ok {
+		return
+	}
+
+	fmt.Println("============== Invoking connector.Subscribe() ==================")
+	params := *suite.SubscribeParamBuilder(publicURL)
+	subscriptionResult, err := conn.Subscribe(ctx, params)
+	if printError(err) {
+		return
+	}
+
+	switch subscriptionResult.Status {
+	case common.SubscriptionStatusPending:
+		fmt.Printf("Connector returned status (%v). Script is not designed to handle this.\n",
+			common.SubscriptionStatusPending)
+		return
+	case common.SubscriptionStatusFailed:
+		utils.DumpJSON(subscriptionResult.Result, os.Stdout)
+		fmt.Println("Subscription failed ❌")
+		return
+	case common.SubscriptionStatusSuccess:
+		utils.DumpJSON(subscriptionResult.Result, os.Stdout)
+		utils.DumpJSON(subscriptionResult.ObjectEvents, os.Stdout)
+		// continue script execution.
+	case common.SubscriptionStatusFailedToRollback:
+		fmt.Println("Subscription encountered failures and then failed to rollback ❌")
+		utils.DumpJSON(subscriptionResult.Result, os.Stdout)
+		utils.DumpJSON(subscriptionResult.ObjectEvents, os.Stdout)
+		return
+	default:
+		fmt.Printf("Unknown subscription status (%v)\n", subscriptionResult.Status)
+		return
+	}
+
+	// Register a defer function to clean up the successful subscription at the end of the script.
+	defer cleanupSubscription(ctx, conn, suite, subscriptionResult)()
+
+	fmt.Println("============== Invoking connector.Write/Delete() ==================")
+	for _, trigger := range suite.Operations {
+		switch trigger.Method {
+		case ConnectorMethodCreate:
+			fmt.Printf("Creating object %v:\n", trigger.ObjectName)
+			createResult, err := createObject[any](ctx, conn, trigger.ObjectName, &trigger.Payload)
+			if printError(err) {
+				return
+			}
+			utils.DumpJSON(createResult, os.Stdout)
+		case ConnectorMethodUpdate:
+			objectID, ok := searchForRecord(ctx, conn, trigger.ObjectName, trigger.SearchProcedure)
+			if !ok {
+				return
+			}
+
+			fmt.Printf("Updating object %v:\n", trigger.ObjectName)
+			updateResult, err := updateObject[any](ctx, conn, trigger.ObjectName, objectID, &trigger.Payload)
+			if printError(err) {
+				return
+			}
+			utils.DumpJSON(updateResult, os.Stdout)
+		case ConnectorMethodDelete:
+			objectID, ok := searchForRecord(ctx, conn, trigger.ObjectName, trigger.SearchProcedure)
+			if !ok {
+				return
+			}
+
+			fmt.Printf("Deleting object %v:\n", trigger.ObjectName)
+			err = removeObject(ctx, conn, trigger.ObjectName, objectID)
+			if printError(err) {
+				return
+			}
+			fmt.Println("... object deleted.")
+		}
+	}
+
+	// Waiting for the events to arrive. Then report on them and exit.
+	// This can be stopped prematurely via context cancellation.
+	receivedNumEvents := 0
+	fmt.Printf("============== Waiting for %d webhook messages ==================\n", suite.ExpectedWebhookCalls)
+
+	for receivedNumEvents < suite.ExpectedWebhookCalls {
+		select {
+		case message := <-messageChannel:
+			receivedNumEvents++
+			fmt.Printf("[%d/%d] Received webhook message:\n", receivedNumEvents, suite.ExpectedWebhookCalls)
+			if message.Error == "" {
+				utils.DumpJSON(message.Body, os.Stdout)
+			} else {
+				utils.DumpJSON(message.Error, os.Stdout)
+			}
+
+		case <-ctx.Done():
+			fmt.Println("Context cancelled, stopping...")
+			return
+		}
+	}
+
+	fmt.Println("============== Done ==================")
+}
+
+func searchForRecord(
+	ctx context.Context, conn ConnectorWebhookSubscriber, objectName string, procedure SearchProcedure,
+) (string, bool) {
+	if procedure.WaitBeforeSearch != 0 {
+		fmt.Println("... waiting")
+		time.Sleep(procedure.WaitBeforeSearch)
+	}
+
+	fmt.Printf("Search object %v by %v\n", objectName, procedure.SearchBy.String())
+	res, err := readObjects(ctx, conn, objectName, procedure.ReadFields, procedure.SearchBy.Since)
+	if printError(err) {
+		return "", false
+	}
+
+	search := procedure.SearchBy
+	object, err := searchObjectRecord(res, search.Key, search.Value)
+	if printError(err) {
+		return "", false
+	}
+
+	objectID := object.getRecordIdentifierValue(procedure.RecordIdentifierKey)
+
+	return objectID, true
+}
+
+func cleanupSubscription(ctx context.Context,
+	conn ConnectorWebhookSubscriber, suite SubscribeReceiveEventsSuite,
+	subscriptionResult *common.SubscriptionResult,
+) func() {
+	return func() {
+		if !suite.AutoRemoveSubscription {
+			fmt.Println(
+				"REMINDER: subscription is still active and must be removed manually.\n" +
+					"To automate cleanup in the future, enable the `AutoRemoveSubscription` option.",
+			)
+			return
+		}
+
+		remover, ok := conn.(testroutines.TestableSubscriptionRemover)
+		if !ok {
+			fmt.Println(
+				"REMINDER: subscription is still active and must be removed manually.\n" +
+					"The connector does not yet implement `components.SubscriptionRemover`.",
+			)
+			return
+		}
+
+		fmt.Println("[CLEANUP] Removing subscription.")
+		err := remover.DeleteSubscription(ctx, *subscriptionResult)
+		if !printError(err) {
+			fmt.Println("[CLEANUP] Subscription removed.")
+		}
+	}
+}

--- a/test/utils/testscenario/webhook-messaging.go
+++ b/test/utils/testscenario/webhook-messaging.go
@@ -1,0 +1,69 @@
+package testscenario
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// WebhookRouter holds a set of conditional HTTP routes that dispatch webhook requests
+// to different handlers based on the RoutingCondition.
+//
+// During webhook processing, each Route is tested in order; the first handler
+// whose condition returns true is called. If no condition matches, the default
+// behavior is to log the message as a JSON object to stdout.
+type WebhookRouter struct {
+	Routes []Route
+}
+
+// RoutingCondition is a predicate that decides whether a given HTTP request
+// should be routed to the associated handler. It returns true if the request
+// matches the condition (e.g., path, method, or header), and false otherwise.
+type RoutingCondition func(request *http.Request) bool
+
+// Route pairs a RoutingCondition with an HTTP handler function. If the condition returns
+// true for an incoming request, the handler is invoked by the webhook server.
+type Route datautils.Pair[RoutingCondition, http.HandlerFunc]
+
+// RunWebhookConsumer starts a long‑running webhook consumer that listens for
+// incoming change‑notification messages from a provider and prints them to stdout.
+//
+// The server routes incoming messages according to the provided webhookRouter:
+// if a route matches the request, the associated handler is called;
+// otherwise, the message is logged as JSON to os.Stdout.
+//
+// Verification parameters are only relevant for connectors that perform validation.
+// The caller can stop this loop only by cancelling the provided context. When ctx.Done()
+// is closed, the webhook server is shut down and the function returns.
+func RunWebhookConsumer(
+	ctx context.Context,
+	conn ConnectorWebhookSubscriber,
+	webhookRouter WebhookRouter,
+	verificationParams *common.VerificationParams,
+) {
+	messageChannel := make(chan webhookMessageResult)
+	_, shutdown := startWebhookHandler(ctx, conn,
+		webhookRouter, verificationParams, messageChannel,
+	)
+	defer shutdown()
+
+	for {
+		select {
+		case message := <-messageChannel:
+			if message.Error == "" {
+				utils.DumpJSON(message.Body, os.Stdout)
+			} else {
+				utils.DumpJSON(message.Error, os.Stdout)
+			}
+			// Infinite loop.
+		case <-ctx.Done():
+			fmt.Println("Context cancelled, stopping...")
+			return
+		}
+	}
+}

--- a/test/utils/testscenario/webhook.go
+++ b/test/utils/testscenario/webhook.go
@@ -1,0 +1,250 @@
+package testscenario
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+const (
+	EnvArgWebhookURL          = "WEBHOOK_URL"
+	WebhookHandlerDefaultPort = "4550"
+)
+
+// getPublicWebhookURL loads webhook URL from the environment variable or from the standard user input.
+func getPublicWebhookURL(ctx context.Context) (url string, ok bool) {
+	defer func() {
+		if ok {
+			fmt.Printf("Webhook URL: \"%v\"\n", url)
+		}
+	}()
+
+	url, ok = os.LookupEnv(EnvArgWebhookURL)
+	if !ok {
+		fmt.Printf("Env variable is missing \"%v\"\n", EnvArgWebhookURL)
+		url, ok = waitForWebhookURLInput(ctx)
+	}
+
+	return url, ok
+}
+
+func waitForWebhookURLInput(ctx context.Context) (string, bool) {
+	fmt.Println("Please provide the public URL (e.g., from ngrok) that tunnels to this local server.")
+	fmt.Print("Public Webhook URL (empty string to cancel): ")
+
+	inputCh := make(chan string)
+	errCh := make(chan error)
+
+	// Routine waiting for standard input.
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			inputCh <- strings.TrimSpace(scanner.Text())
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		fmt.Printf("\nContext cancelled while waiting for webhook URL input.\n")
+		return "", false
+	case err := <-errCh:
+		printError(fmt.Errorf("failed to read public URL: %w", err))
+		return "", false
+	case publicURL := <-inputCh:
+		if publicURL == "" {
+			fmt.Println("Empty input for webhook URL: stopping script.")
+			return "", false
+		}
+
+		if !isValidHTTPS(publicURL) {
+			fmt.Printf("Invalid URL format: %v\n", publicURL)
+			return "", false
+		}
+
+		// proceed normally
+		return publicURL, true
+	}
+}
+
+// startWebhookHandler starts server on the localhost that should be exposed via ngrok
+// to receive webhook messages.
+//
+// Webhook handler will send webhookMessageResult using go channel.
+func startWebhookHandler(
+	ctx context.Context, conn ConnectorWebhookSubscriber,
+	router WebhookRouter,
+	verificationParams *common.VerificationParams,
+	messageChannel chan webhookMessageResult,
+) (string, func()) {
+	// Main server loop.
+	var webhookCancel context.CancelFunc
+	ctx, webhookCancel = context.WithCancel(ctx)
+	webhookHandler := createWebhookHandler(ctx, conn, router, verificationParams, messageChannel)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", webhookHandler)
+
+	// Construct and start server.
+	fmt.Printf("Starting webhook server on :%v\n", WebhookHandlerDefaultPort)
+	server := &http.Server{
+		Addr:    ":" + WebhookHandlerDefaultPort,
+		Handler: mux,
+	}
+
+	fmt.Printf("Run ngrok with command: `ngrok http %v`\n", WebhookHandlerDefaultPort)
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("Server error", "error", err)
+		}
+	}()
+
+	shutdown := func() {
+		fmt.Println("=> Shutting down webhook handler")
+		webhookCancel()
+		_ = server.Shutdown(context.Background())
+		fmt.Println("=> completed")
+	}
+
+	return "http://localhost:" + WebhookHandlerDefaultPort, shutdown
+}
+
+// webhookMessageResult represents a message sent by defaultWebhookHandler.
+// For a successful provider request to a webhook a Body will be populated.
+// In case of any unexpected error in code or from the request itself an Error will be non-empty.
+type webhookMessageResult struct {
+	Body  []byte
+	Error string
+}
+
+// createWebhookHandler creates an HTTP handler function that verifies incoming webhook requests
+// using the connector's VerifyWebhookMessage method. After successful verification, the handler
+// invokes the provided callback function with the verified request body for further processing.
+//
+// The handler reads the request body, constructs a WebhookRequest from the HTTP request,
+// verifies the webhook signature using the connector's verification method, and on success
+// calls the callback with the raw body. If verification fails, the handler returns appropriate
+// HTTP error responses.
+//
+// Parameters:
+//   - ctx: context for the handler operations
+//   - conn: connector implementing WebhookVerifierConnector interface
+//   - verificationParams: provider-specific verification parameters (e.g., secrets)
+//   - onVerified: callback function invoked with the verified request body on successful verification
+//
+// Returns an http.HandlerFunc that can be registered with an HTTP server.
+func createWebhookHandler(
+	ctx context.Context,
+	conn testroutines.TestableWebhookMessageVerifier,
+	router WebhookRouter,
+	verificationParams *common.VerificationParams,
+	messageChannel chan webhookMessageResult,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Select best custom webhook handler.
+		for _, route := range router.Routes {
+			if matches := route.Left(r); matches {
+				// Invoke handler.
+				route.Right(w, r)
+				return
+			}
+		}
+
+		// DEFAULT route handling.
+		defaultWebhookHandler(w, r, conn, ctx, verificationParams, messageChannel)
+	}
+}
+
+func defaultWebhookHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	conn testroutines.TestableWebhookMessageVerifier,
+	ctx context.Context,
+	verificationParams *common.VerificationParams,
+	messageChannel chan webhookMessageResult,
+) {
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error reading body", http.StatusBadRequest)
+		sendMessage(ctx, messageChannel, webhookMessageResult{
+			Error: fmt.Sprintf("error reading request body %v", err),
+		})
+
+		return
+	}
+
+	request := &common.WebhookRequest{
+		Headers: r.Header,
+		Body:    body,
+		URL:     r.URL.String(),
+		Method:  r.Method,
+	}
+
+	valid, err := conn.VerifyWebhookMessage(ctx, request, verificationParams)
+	if err != nil {
+		http.Error(w, "Verification failed", http.StatusUnauthorized)
+		sendMessage(ctx, messageChannel, webhookMessageResult{
+			Error: fmt.Sprintf("VerifyWebhookMessage failed %v", err),
+		})
+
+		return
+	}
+
+	if !valid {
+		http.Error(w, "Invalid signature", http.StatusUnauthorized)
+		sendMessage(ctx, messageChannel, webhookMessageResult{
+			Error: "according to VerifyWebhookMessage the message is invalid",
+		})
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+	sendMessage(ctx, messageChannel, webhookMessageResult{
+		Body: body,
+	})
+}
+
+// sendMessage sends a webhookMessageResult to the channel if possible,
+// or discards it if the context is canceled or done.
+//
+// This is useful when the provider may still be sending events while
+// the server is shutting down (for example, because the expected number
+// of webhook events has arrived, or because a developer canceled the test script).
+// In that case, the send will not block the handler; instead, the message is silently dropped.
+func sendMessage(ctx context.Context, channel chan webhookMessageResult, message webhookMessageResult) {
+	select {
+	case channel <- message:
+	case <-ctx.Done():
+		// We don't care if we couldn't send.
+		// The server is shutting down.
+	}
+}
+
+func isValidHTTPS(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+
+	if u.Scheme != "https" {
+		return false
+	}
+
+	if u.Host == "" {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
# Description

Introduces reusable scripts and test scenarios for working with subscription webhooks locally.

### Key features

* **Webhook consumer script**
  Starts a local webhook server (requires ngrok) and prints incoming events.
  Supports optional custom handling — if a request is not intercepted, it falls back to logging. Some connectors require a response during provider webhook validation; this is handled via `subscription.NewWebhookRouter()`.

* **Subscription + consumer flow script**
  Provides an end-to-end workflow for creating subscriptions and consuming events.

  * The webhook URL (public HTTPS via ngrok) is provided to the script via environment variables or standard input.
  * The script supports graceful shutdown (CTRL+C / kill signal), ensuring:
    * webhook server shuts down cleanly without deadlocks
    * event-waiting loop unblocks and exits safely
  * Supports executing a sequence of connector operations (create/update/delete) to observe real-time event consumption and filtering based on subscription rules.

### Notes

* Requires ngrok for exposing the local webhook.
* Designed for flexible local debugging, manual verification, and experimentation with subscription flows.

# Scripts
### No webhook input
Invallid URL format or empty string exists the script.

<img width="1045" height="405" alt="No webhook input" src="https://github.com/user-attachments/assets/591e4357-b1ed-4862-a935-52b8501f43b9" />

### Event Consuming
Infinite listener which outputs all incoming events.

<img width="2090" height="1459" alt="Webhook Consumer" src="https://github.com/user-attachments/assets/9cb85c5a-7e8e-4a8e-8418-588e9344d044" />

### Killing script
Interrupting the script accepts the signal, gracefully shuts down the webhook handler, and exits the loop that receives messages from the webhook routine.
 
<img width="1066" height="1428" alt="Interupt" src="https://github.com/user-attachments/assets/66533c0c-af74-467d-9833-47c7c9e0b151" />

### Successful script run
Subscribes to create and delete. Then invoke create, update and delete. The 2 expected messeges arrive and update had no side effects.

<img width="1045" height="1332" alt="Calendar events" src="https://github.com/user-attachments/assets/74a424b3-c39b-4c4b-a4e2-25867c6c7b11" />
