### PR TITLE
feat(microsoft): Set Oauth2 to multi-tenant only

### DIFF
--- a/providers/microsoft.go
+++ b/providers/microsoft.go
@@ -1,20 +1,21 @@
 package providers
 
-// Microsoft supports products including OneDrive Outlook Excel
-// Edge Extensions Sharepoint OneNote Notifications Todos Teams Insights
-// Planner and Personal Contacts.
+// Microsoft is a connector for Microsoft Graph APIs.
+// It supports many products including:
+//
+//	OneDrive, Outlook, Excel, Edge, Extensions, Sharepoint, OneNote
+//	Notifications, Todos, Teams, Insights, Planner, and Personal Contacts.
 const Microsoft Provider = "microsoft"
 
 func init() {
-	// Microsoft Office 365 Configuration
 	SetInfo(Microsoft, ProviderInfo{
 		DisplayName: "Microsoft",
 		AuthType:    Oauth2,
 		BaseURL:     "https://graph.microsoft.com",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://login.microsoftonline.com/{{.workspace}}/oauth2/v2.0/authorize",
-			TokenURL:                  "https://login.microsoftonline.com/{{.workspace}}/oauth2/v2.0/token",
+			AuthURL:                   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+			TokenURL:                  "https://login.microsoftonline.com/common/oauth2/v2.0/token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},
@@ -29,16 +30,6 @@ func init() {
 			Read:      true,
 			Subscribe: false,
 			Write:     true,
-		},
-		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					Name:         "workspace",
-					DisplayName:  "Tenant ID",
-					DefaultValue: "common",
-					DocsURL:      "https://learn.microsoft.com/en-us/graph/auth-register-app-v2#prerequisites",
-				},
-			},
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{

--- a/test/microsoft/connector.go
+++ b/test/microsoft/connector.go
@@ -18,7 +18,6 @@ func GetMicrosoftGraphConnector(ctx context.Context) *microsoft.Connector {
 	conn, err := microsoft.NewConnector(
 		common.ConnectorParams{
 			AuthenticatedClient: utils.NewOauth2Client(ctx, reader, getConfig),
-			Workspace:           reader.Get(credscanning.Fields.Workspace),
 		},
 	)
 	if err != nil {
@@ -29,15 +28,13 @@ func GetMicrosoftGraphConnector(ctx context.Context) *microsoft.Connector {
 }
 
 func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
-	workspace := reader.Get(credscanning.Fields.Workspace)
-
 	return &oauth2.Config{
 		ClientID:     reader.Get(credscanning.Fields.ClientId),
 		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
 		RedirectURL:  "http://localhost:8080/callbacks/v1/oauth",
 		Endpoint: oauth2.Endpoint{
-			AuthURL:   "https://login.microsoftonline.com/" + workspace + "/oauth2/v2.0/authorize",
-			TokenURL:  "https://login.microsoftonline.com/" + workspace + "/oauth2/v2.0/token",
+			AuthURL:   "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+			TokenURL:  "https://login.microsoftonline.com/common/oauth2/v2.0/token",
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
 		Scopes: []string{


### PR DESCRIPTION
# Description

Hard coded `common` URI part in Auth URLs for Microsoft. This means every app must be created in multi-tennant mode in Microsoft Azure.

# Live Tests
Write-delete Outlook calendar events:
<img width="1066" height="980" alt="Peek 2026-05-04 21-28" src="https://github.com/user-attachments/assets/92d8dbec-8180-486a-a2b7-f47767dbf74b" />

Wrirte-delete Outlook messages:
<img width="1066" height="980" alt="Peek 2026-05-04 21-29" src="https://github.com/user-attachments/assets/150c82bc-94ce-47ba-abe7-8df803ace1ec" />

Read messages:
<img width="676" height="918" alt="image" src="https://github.com/user-attachments/assets/1a94dd77-f935-4e1b-9a8d-39c389b6780e" />

Read users:
<img width="621" height="935" alt="image" src="https://github.com/user-attachments/assets/da70fb06-c51c-48e8-8d97-3d695df20cc7" />

