### PR TITLE
[CON-3149] feat(clio): write functionality

### DIFF
--- a/providers/clio/connector.go
+++ b/providers/clio/connector.go
@@ -65,3 +65,33 @@ func (c *Connector) ListObjectMetadata(
 
 	return nil, common.ErrNotImplemented
 }
+
+func (c *Connector) Delete(
+	ctx context.Context,
+	params connectors.DeleteParams,
+) (*connectors.DeleteResult, error) {
+	if c.Grow != nil {
+		return c.Grow.Delete(ctx, params)
+	}
+
+	if c.Manage != nil {
+		return c.Manage.Delete(ctx, params)
+	}
+
+	return nil, common.ErrNotImplemented
+}
+
+func (c *Connector) Write(
+	ctx context.Context,
+	params connectors.WriteParams,
+) (*connectors.WriteResult, error) {
+	if c.Grow != nil {
+		return c.Grow.Write(ctx, params)
+	}
+
+	if c.Manage != nil {
+		return c.Manage.Write(ctx, params)
+	}
+
+	return nil, common.ErrNotImplemented
+}

--- a/providers/clio/internal/grow/adapter.go
+++ b/providers/clio/internal/grow/adapter.go
@@ -3,15 +3,19 @@ package grow
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
+	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
-// Adapter exposes metadata operations for the Clio Grow module.
 type Adapter struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
+	components.Writer
+	components.Deleter
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
@@ -26,6 +30,29 @@ func constructor(base *components.Connector) (*Adapter, error) {
 	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(
 		adapter.ProviderContext.Module(),
 		Schemas,
+	)
+
+	registry := components.NewEmptyEndpointRegistry()
+	adapter.Writer = writer.NewHTTPWriter(
+		adapter.HTTPClient().Client,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  adapter.buildWriteRequest,
+			ParseResponse: adapter.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	adapter.Deleter = deleter.NewHTTPDeleter(
+		adapter.HTTPClient().Client,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  adapter.buildDeleteRequest,
+			ParseResponse: adapter.parseDeleteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
 	)
 
 	return adapter, nil

--- a/providers/clio/internal/grow/delete.go
+++ b/providers/clio/internal/grow/delete.go
@@ -1,0 +1,25 @@
+package grow
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/clio/internal/shared"
+)
+
+func (c *Adapter) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	return shared.BuildDeleteRequest(ctx, shared.BuildDeleteParams{
+		BaseURL:     c.ProviderInfo().BaseURL,
+		APIPath:     clioGrowAPIPath,
+		Module:      c.Module(),
+		Params:      params,
+		FindURLPath: Schemas.FindURLPath,
+	})
+}
+
+func (c *Adapter) parseDeleteResponse(_ context.Context, params common.DeleteParams,
+	_ *http.Request, resp *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	return shared.ParseDeleteResponse(params, resp)
+}

--- a/providers/clio/internal/grow/write.go
+++ b/providers/clio/internal/grow/write.go
@@ -1,0 +1,27 @@
+package grow
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/clio/internal/shared"
+)
+
+const clioGrowAPIPath = "grow"
+
+func (c *Adapter) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	return shared.BuildWriteRequest(ctx, shared.BuildWriteParams{
+		BaseURL:     c.ProviderInfo().BaseURL,
+		APIPath:     clioGrowAPIPath,
+		Module:      c.Module(),
+		Params:      params,
+		FindURLPath: Schemas.FindURLPath,
+	})
+}
+
+func (c *Adapter) parseWriteResponse(_ context.Context, params common.WriteParams,
+	_ *http.Request, resp *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	return shared.ParseWriteResponse(params, resp)
+}

--- a/providers/clio/internal/manage/adapter.go
+++ b/providers/clio/internal/manage/adapter.go
@@ -3,15 +3,19 @@ package manage
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
+	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
-// Adapter exposes metadata operations for the Clio Manage module.
 type Adapter struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
+	components.Writer
+	components.Deleter
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
@@ -26,6 +30,29 @@ func constructor(base *components.Connector) (*Adapter, error) {
 	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(
 		adapter.ProviderContext.Module(),
 		Schemas,
+	)
+
+	registry := components.NewEmptyEndpointRegistry()
+	adapter.Writer = writer.NewHTTPWriter(
+		adapter.HTTPClient().Client,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  adapter.buildWriteRequest,
+			ParseResponse: adapter.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	adapter.Deleter = deleter.NewHTTPDeleter(
+		adapter.HTTPClient().Client,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  adapter.buildDeleteRequest,
+			ParseResponse: adapter.parseDeleteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
 	)
 
 	return adapter, nil

--- a/providers/clio/internal/manage/delete.go
+++ b/providers/clio/internal/manage/delete.go
@@ -1,0 +1,25 @@
+package manage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/clio/internal/shared"
+)
+
+func (c *Adapter) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	return shared.BuildDeleteRequest(ctx, shared.BuildDeleteParams{
+		BaseURL:     c.ProviderInfo().BaseURL,
+		APIPath:     clioManageAPIPath,
+		Module:      c.Module(),
+		Params:      params,
+		FindURLPath: Schemas.FindURLPath,
+	})
+}
+
+func (c *Adapter) parseDeleteResponse(_ context.Context, params common.DeleteParams,
+	_ *http.Request, resp *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	return shared.ParseDeleteResponse(params, resp)
+}

--- a/providers/clio/internal/manage/test/write-groups-create.json
+++ b/providers/clio/internal/manage/test/write-groups-create.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": 884001,
+    "name": "Scout Unit Group",
+    "type": "AdhocGroup",
+    "etag": "\"etag-create\"",
+    "updated_at": "2026-05-04T12:00:00Z"
+  }
+}

--- a/providers/clio/internal/manage/test/write-groups-update.json
+++ b/providers/clio/internal/manage/test/write-groups-update.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": 884001,
+    "name": "Scout Unit Group Updated",
+    "type": "AdhocGroup",
+    "etag": "\"etag-update\"",
+    "updated_at": "2026-05-04T12:05:00Z"
+  }
+}

--- a/providers/clio/internal/manage/write.go
+++ b/providers/clio/internal/manage/write.go
@@ -1,0 +1,27 @@
+package manage
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/clio/internal/shared"
+)
+
+const clioManageAPIPath = "api/v4"
+
+func (c *Adapter) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	return shared.BuildWriteRequest(ctx, shared.BuildWriteParams{
+		BaseURL:     c.ProviderInfo().BaseURL,
+		APIPath:     clioManageAPIPath,
+		Module:      c.Module(),
+		Params:      params,
+		FindURLPath: Schemas.FindURLPath,
+	})
+}
+
+func (c *Adapter) parseWriteResponse(_ context.Context, params common.WriteParams,
+	_ *http.Request, resp *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	return shared.ParseWriteResponse(params, resp)
+}

--- a/providers/clio/internal/manage/write_test.go
+++ b/providers/clio/internal/manage/write_test.go
@@ -1,0 +1,114 @@
+package manage
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWriteGroups(t *testing.T) {
+	t.Parallel()
+
+	responseCreate := testutils.DataFromFile(t, "write-groups-create.json")
+	responseUpdate := testutils.DataFromFile(t, "write-groups-update.json")
+
+	tests := []testroutines.Write{
+		{
+			Name: "Create group successfully",
+			Input: common.WriteParams{
+				ObjectName: "groups",
+				RecordData: map[string]any{
+					"name": "Scout Unit Group",
+					"type": "AdhocGroup",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Path("/api/v4/groups.json"),
+					mockcond.Body(`{"data":{"name":"Scout Unit Group","type":"AdhocGroup"}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCreate),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "884001",
+				Data: map[string]any{
+					"id":   float64(884001),
+					"name": "Scout Unit Group",
+					"type": "AdhocGroup",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update group successfully",
+			Input: common.WriteParams{
+				ObjectName: "groups",
+				RecordId:   "884001",
+				RecordData: map[string]any{
+					"name": "Scout Unit Group Updated",
+					"type": "AdhocGroup",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPatch),
+					mockcond.Path("/api/v4/groups/884001.json"),
+					mockcond.Body(`{"data":{"name":"Scout Unit Group Updated","type":"AdhocGroup"}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseUpdate),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "884001",
+				Data: map[string]any{
+					"id":   float64(884001),
+					"name": "Scout Unit Group Updated",
+					"type": "AdhocGroup",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return newWriteTestAdapter(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func newWriteTestAdapter(serverURL string) (*Adapter, error) {
+	adapter, err := NewAdapter(common.ConnectorParams{
+		Module:              providers.ModuleClioManage,
+		AuthenticatedClient: mockutils.NewClient(),
+		Workspace:           "app.clio.com",
+		Metadata: map[string]string{
+			"region": "",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	adapter.SetUnitTestMockServerBaseURL(serverURL)
+
+	return adapter, nil
+}

--- a/providers/clio/internal/shared/delete.go
+++ b/providers/clio/internal/shared/delete.go
@@ -1,0 +1,75 @@
+package shared //nolint:revive
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/httpkit"
+)
+
+// BuildDeleteParams carries dependencies for constructing a Clio delete HTTP request.
+type BuildDeleteParams struct {
+	BaseURL     string
+	APIPath     string
+	Module      common.ModuleID
+	Params      common.DeleteParams
+	FindURLPath func(common.ModuleID, string) (string, error)
+}
+
+// BuildDeleteRequest builds DELETE for a single record (Manage `.json` paths vs Grow paths).
+//
+// Docs: https://docs.developers.clio.com/api-docs/
+func BuildDeleteRequest(ctx context.Context, buildParams BuildDeleteParams) (*http.Request, error) {
+	params := buildParams.Params
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	path, err := buildParams.FindURLPath(buildParams.Module, params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	rel := strings.TrimPrefix(path, "/")
+
+	var requestURL *urlbuilder.URL
+
+	switch {
+	case strings.HasSuffix(rel, ".json"):
+		basePath := strings.TrimSuffix(rel, ".json")
+		requestURL, err = urlbuilder.New(buildParams.BaseURL, buildParams.APIPath, basePath+"/"+params.RecordId+".json")
+	default:
+		requestURL, err = urlbuilder.New(buildParams.BaseURL, buildParams.APIPath, rel, params.RecordId)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, h := range params.Headers {
+		req.Header.Add(h.Key, h.Value)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// ParseDeleteResponse maps a successful Clio delete HTTP response into common.DeleteResult.
+// Clio returns 204 No Content (empty body) for successful DELETE; common.ParseJSONResponse handles that.
+func ParseDeleteResponse(_ common.DeleteParams, resp *common.JSONHTTPResponse) (*common.DeleteResult, error) {
+	if !httpkit.Status2xx(resp.Code) {
+		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, resp.Code)
+	}
+
+	return &common.DeleteResult{Success: true}, nil
+}

--- a/providers/clio/internal/shared/write.go
+++ b/providers/clio/internal/shared/write.go
@@ -1,0 +1,106 @@
+package shared //nolint:revive
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+// BuildWriteParams carries dependencies for constructing a Clio write HTTP request.
+type BuildWriteParams struct {
+	BaseURL     string
+	APIPath     string
+	Module      common.ModuleID
+	Params      common.WriteParams
+	FindURLPath func(common.ModuleID, string) (string, error)
+}
+
+// writeURL is Manage …/things.json vs …/things/{id}.json; Grow appends recordId as a path segment.
+func writeURL(baseURL, apiPath, rel, recordID string) (*urlbuilder.URL, error) {
+	if recordID == "" {
+		return urlbuilder.New(baseURL, apiPath, rel)
+	}
+
+	if before, ok := strings.CutSuffix(rel, ".json"); ok {
+		base := before
+
+		return urlbuilder.New(baseURL, apiPath, base+"/"+recordID+".json")
+	}
+
+	return urlbuilder.New(baseURL, apiPath, rel, recordID)
+}
+
+// BuildWriteRequest builds POST (create) or PATCH (update) for Clio Manage / Grow JSON APIs.
+//
+// Docs: https://docs.developers.clio.com/api-docs/
+func BuildWriteRequest(ctx context.Context, buildParams BuildWriteParams) (*http.Request, error) {
+	path, err := buildParams.FindURLPath(buildParams.Module, buildParams.Params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	rel := strings.TrimLeft(path, "/")
+
+	record, err := buildParams.Params.GetRecord()
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(map[string]any{"data": record})
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := writeURL(buildParams.BaseURL, buildParams.APIPath, rel, buildParams.Params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	method := http.MethodPost
+	if buildParams.Params.RecordId != "" {
+		method = http.MethodPatch
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+// ParseWriteResponse maps a Clio JSON write response into common.WriteResult (saved record in "data", per API docs).
+func ParseWriteResponse(params common.WriteParams, resp *common.JSONHTTPResponse) (*common.WriteResult, error) {
+	body, ok := resp.Body()
+	if !ok {
+		return &common.WriteResult{Success: true, RecordId: params.RecordId}, nil
+	}
+
+	data, err := jsonquery.New(body).ObjectRequired("data")
+	if err != nil {
+		return nil, err
+	}
+
+	recordMap, err := jsonquery.Convertor.ObjectToMap(data)
+	if err != nil {
+		return nil, err
+	}
+
+	recordID, err := jsonquery.New(data).TextWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     recordMap,
+	}, nil
+}

--- a/test/clio/manage/write/main.go
+++ b/test/clio/manage/write/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	clioConn "github.com/amp-labs/connectors/providers/clio"
+	connTest "github.com/amp-labs/connectors/test/clio"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type expenseCategoryPayload struct {
+	Name      string  `json:"name"`
+	Rate      float64 `json:"rate"`
+	EntryType string  `json:"entry_type"`
+	UtbmsCode any     `json:"utbms_code"`
+}
+
+type groupPayload struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+	conn := connTest.GetClioManageConnector(ctx)
+
+	slog.Info("Running expense_categories create/update/delete")
+	runExpenseCategoriesCreateUpdateDelete(ctx, conn)
+
+	slog.Info("Running groups create/update/delete")
+	runGroupsCreateUpdateDelete(ctx, conn)
+}
+
+func runExpenseCategoriesCreateUpdateDelete(ctx context.Context, conn *clioConn.Connector) {
+	name := "Scout Expense Category " + gofakeit.LetterN(8)
+	updatedName := "Scout Expense Category Updated " + gofakeit.LetterN(8)
+
+	createRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "expense_categories",
+		RecordData: expenseCategoryPayload{
+			Name:      name,
+			Rate:      0.1,
+			EntryType: "hard_cost",
+			UtbmsCode: nil,
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating expense_category", "error", err)
+	}
+
+	if !createRes.Success {
+		utils.Fail("failed to create expense_category", "response", createRes)
+	}
+
+	utils.DumpJSON(createRes, os.Stdout)
+
+	recordID := createRes.RecordId
+	if recordID == "" {
+		utils.Fail("failed to create expense_category", "reason", "missing record id")
+	}
+
+	updateRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "expense_categories",
+		RecordId:   recordID,
+		RecordData: expenseCategoryPayload{
+			Name:      updatedName,
+			Rate:      0.1,
+			EntryType: "hard_cost",
+			UtbmsCode: nil,
+		},
+	})
+	if err != nil {
+		utils.Fail("error updating expense_category", "error", err)
+	}
+
+	if !updateRes.Success {
+		utils.Fail("failed to update expense_category", "response", updateRes)
+	}
+
+	utils.DumpJSON(updateRes, os.Stdout)
+
+	delRes, err := conn.Delete(ctx, common.DeleteParams{
+		ObjectName: "expense_categories",
+		RecordId:   recordID,
+	})
+	if err != nil {
+		utils.Fail("error deleting expense_category", "error", err)
+	}
+
+	if !delRes.Success {
+		utils.Fail("failed to delete expense_category", "response", delRes)
+	}
+
+	utils.DumpJSON(delRes, os.Stdout)
+}
+
+func runGroupsCreateUpdateDelete(ctx context.Context, conn *clioConn.Connector) {
+
+	name := "Scout Group"
+	updatedName := "Scout Group Updated"
+
+	createRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "groups",
+		RecordData: groupPayload{
+			Name: name,
+			Type: "AdhocGroup",
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating group", "error", err)
+	}
+
+	if !createRes.Success {
+		utils.Fail("failed to create group", "response", createRes)
+	}
+
+	utils.DumpJSON(createRes, os.Stdout)
+
+	recordID := createRes.RecordId
+	if recordID == "" {
+		utils.Fail("failed to create group", "reason", "missing record id")
+	}
+
+	updateRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "groups",
+		RecordId:   recordID,
+		RecordData: groupPayload{
+			Name: updatedName,
+			Type: "AdhocGroup",
+		},
+	})
+	if err != nil {
+		utils.Fail("error updating group", "error", err)
+	}
+
+	if !updateRes.Success {
+		utils.Fail("failed to update group", "response", updateRes)
+	}
+
+	utils.DumpJSON(updateRes, os.Stdout)
+
+	delRes, err := conn.Delete(ctx, common.DeleteParams{
+		ObjectName: "groups",
+		RecordId:   recordID,
+	})
+	if err != nil {
+		utils.Fail("error deleting group", "error", err)
+	}
+
+	if !delRes.Success {
+		utils.Fail("failed to delete group", "response", delRes)
+	}
+
+	utils.DumpJSON(delRes, os.Stdout)
+}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

## Tests 
<img width="1874" height="1213" alt="image" src="https://github.com/user-attachments/assets/8ddfd489-2529-4f82-9042-6fce0b61294a" />
<img width="1786" height="825" alt="image" src="https://github.com/user-attachments/assets/c898674c-3fe4-4b0b-8cc9-37190cec4a7f" />
