### PR TITLE
[CON-2589] fix: add callrail postAuthInfo metadata requirement

### DIFF
--- a/providers/callRail.go
+++ b/providers/callRail.go
@@ -41,5 +41,12 @@ func init() {
 		Labels: &Labels{
 			LabelExperimental: LabelValueTrue,
 		},
+		Metadata: &ProviderMetadata{
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "accountId",
+				},
+			},
+		},
 	})
 }

--- a/providers/callrail/authmetadata.go
+++ b/providers/callrail/authmetadata.go
@@ -26,7 +26,7 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 	c.accountId = account
 
 	cv := map[string]string{
-		"account_id": account,
+		"accountId": account,
 	}
 
 	return &common.PostAuthInfo{

--- a/providers/callrail/authmetadatamodel.go
+++ b/providers/callrail/authmetadatamodel.go
@@ -7,12 +7,12 @@ type AuthMetadataVars struct {
 // NewAuthMetadataVars parses map into the model.
 func NewAuthMetadataVars(data map[string]string) *AuthMetadataVars {
 	return &AuthMetadataVars{
-		AccountID: data["account_id"],
+		AccountID: data["accountId"],
 	}
 }
 
 func (v AuthMetadataVars) AsMap() *map[string]string {
 	return &map[string]string{
-		"account_id": v.AccountID,
+		"accountId": v.AccountID,
 	}
 }


### PR DESCRIPTION
- Adds PostAuthInfo requirement to the  callrail connector.  
- Testing was failing, this looks to be the issue. 

Before(metadata)
<img width="1413" height="696" alt="Screenshot 2026-05-19 at 13 28 55" src="https://github.com/user-attachments/assets/79bba37d-fcd9-404d-ab77-17354fab72df" />

After(metadata)
<img width="1414" height="697" alt="Screenshot 2026-05-19 at 13 29 28" src="https://github.com/user-attachments/assets/d2146e9d-9109-45cf-816e-15fdce3be2f7" />

Before(read)
<img width="1412" height="700" alt="Screenshot 2026-05-19 at 13 37 31" src="https://github.com/user-attachments/assets/01057d25-c838-45ab-8d78-65443db57487" />

After(read)
<img width="1413" height="697" alt="Screenshot 2026-05-19 at 13 29 57" src="https://github.com/user-attachments/assets/32e75169-21b2-4029-a5e7-b3020d8279fc" />
