### PR TITLE
[ENG-3906] feat(hubspot/marketing): Read campaigns

### DIFF
--- a/providers/hubspot/internal/core/objects.go
+++ b/providers/hubspot/internal/core/objects.go
@@ -9,13 +9,26 @@ const (
 	DefaultPageSizeInt = int64(100)
 )
 
-// ObjectsWithoutPropertiesAPISupport is a list of objectsNames that are part of Hubspot CRM Module
-// but exist outside Object Properties APIs.
-//
-// These objects cannot be accessed via `~/crm/v3/objects/{objectTypeId}/...`
-//
-// On the contrary those objects that are part of Object Properties APIs can be found
-// in the table here https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
-var ObjectsWithoutPropertiesAPISupport = datautils.NewSet( //nolint:gochecknoglobals
-	"lists",
+//nolint:gochecknoglobals
+var (
+
+	// CRMObjectsWithoutPropertiesAPISupport contains HubSpot CRM object names that
+	// belong to the CRM API namespace but are not supported by the Object Properties API.
+	//
+	// These objects are not accessible through endpoints under either:
+	//   /crm/v3/objects/{objectTypeId}/
+	//	 /crm/objects/2026-03/{objectType}/{objectId}
+	//
+	// Objects that do support the Object Properties API are listed here:
+	// https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
+	CRMObjectsWithoutPropertiesAPISupport = datautils.NewSet( //nolint:gochecknoglobals
+		"lists",
+	)
+
+	// MarketingObjects contains object names that belong to the HubSpot Marketing API.
+	//
+	// The Marketing API is separate from the CRM API and is not related to the Objects API.
+	MarketingObjects = datautils.NewSet(
+		"campaigns",
+	)
 )

--- a/providers/hubspot/internal/metadata/metadata.go
+++ b/providers/hubspot/internal/metadata/metadata.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 
 	"github.com/amp-labs/connectors/internal/staticschema"
-	"github.com/amp-labs/connectors/tools/fileconv"
 	"github.com/amp-labs/connectors/tools/scrapper"
 )
 
@@ -14,9 +13,8 @@ var (
 	//go:embed schemas.json
 	schemas []byte
 
-	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV2]( // nolint:gochecknoglobals
-		schemas, fileconv.NewSiblingFileLocator())
+	FileManager = scrapper.NewReader[staticschema.FieldMetadataMapV2](schemas) // nolint:gochecknoglobals
 
-	// Schemas is cached Object schemas.
+	// Schemas are cached Object schemas.
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 )

--- a/providers/hubspot/internal/metadata/schemas.json
+++ b/providers/hubspot/internal/metadata/schemas.json
@@ -1,12 +1,12 @@
 {
   "modules": {
-    "CRM": {
-      "id": "CRM",
-      "path": "/crm/v3",
+    "root": {
+      "id": "root",
+      "path": "",
       "objects": {
         "lists": {
           "displayName": "Lists",
-          "path": "/lists/search",
+          "description": "This object lives outside of Hubspot Objects API: /crm/v3/lists/search",
           "responseKey": "data",
           "fields": {
             "additionalProperties": {
@@ -56,6 +56,105 @@
             "updatedById": {
               "displayName": "updatedById",
               "valueType": "other"
+            }
+          }
+        },
+        "campaigns": {
+          "displayName": "Campaigns",
+          "description": "Object does not belong to CRM: /marketing/campaigns",
+          "responseKey": "results",
+          "fields": {
+            "hs_name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "String"
+            },
+            "hs_start_date": {
+              "displayName": "Start Date",
+              "valueType": "date",
+              "providerType": "Date (YYYY-MM-DD)"
+            },
+            "hs_end_date": {
+              "displayName": "End Date",
+              "valueType": "date",
+              "providerType": "Date (YYYY-MM-DD)"
+            },
+            "hs_notes": {
+              "displayName": "Notes",
+              "valueType": "string",
+              "providerType": "String"
+            },
+            "hs_audience": {
+              "displayName": "Audience",
+              "valueType": "string",
+              "providerType": "String"
+            },
+            "hs_currency_code": {
+              "displayName": "Currency Code",
+              "valueType": "string",
+              "providerType": "ISO currency code"
+            },
+            "hs_campaign_status": {
+              "displayName": "Campaign Status",
+              "valueType": "singleSelect",
+              "providerType": "Enumeration",
+              "values": [
+                {
+                  "value": "planned",
+                  "displayValue": "planned"
+                },
+                {
+                  "value": "in_progress",
+                  "displayValue": "in_progress"
+                },
+                {
+                  "value": "active",
+                  "displayValue": "active"
+                },
+                {
+                  "value": "paused",
+                  "displayValue": "paused"
+                },
+                {
+                  "value": "completed",
+                  "displayValue": "completed"
+                }
+              ]
+            },
+            "hs_utm": {
+              "displayName": "UTM",
+              "valueType": "string",
+              "providerType": "String"
+            },
+            "hs_owner": {
+              "displayName": "Owner",
+              "valueType": "string",
+              "providerType": "User ID"
+            },
+            "hs_color_hex": {
+              "displayName": "Color Hex",
+              "valueType": "string",
+              "providerType": "Hex code"
+            },
+            "hs_created_by_user_id": {
+              "displayName": "Creator User ID",
+              "valueType": "string",
+              "providerType": "User ID"
+            },
+            "hs_object_id": {
+              "displayName": "Object ID",
+              "valueType": "string",
+              "providerType": "String"
+            },
+            "hs_budget_items_sum_amount": {
+              "displayName": "The sum of all budget items",
+              "valueType": "string",
+              "providerType": "Monetary value"
+            },
+            "hs_spend_items_sum_amount": {
+              "displayName": "The sum of all spend items",
+              "valueType": "string",
+              "providerType": "Monetary value"
             }
           }
         }

--- a/providers/hubspot/internal/search/search.go
+++ b/providers/hubspot/internal/search/search.go
@@ -39,7 +39,7 @@ func (s Strategy) Search(ctx context.Context, params *common.SearchParams) (*com
 	// Search has two execution paths:
 	// - ObjectAPI: for core CRM objects supported by the canonical ObjectAPI endpoint.
 	// - Non-ObjectAPI: for CRM objects not supported by ObjectAPI, which use separate endpoints (e.g., Lists).
-	if core.ObjectsWithoutPropertiesAPISupport.Has(params.ObjectName) {
+	if core.CRMObjectsWithoutPropertiesAPISupport.Has(params.ObjectName) {
 		return s.searchViaNonstandardSearchAPI(ctx, params)
 	}
 

--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -110,11 +110,17 @@ func (c *Connector) ListObjectMetadata( // nolint:cyclop,funlen
 
 // getObjectMetadata returns object metadata for the given object name.
 func (c *Connector) getObjectMetadata(ctx context.Context, objectName string) (*common.ObjectMetadata, error) {
-	if core.ObjectsWithoutPropertiesAPISupport.Has(objectName) {
+	switch {
+	case core.CRMObjectsWithoutPropertiesAPISupport.Has(objectName):
 		return c.getObjectMetadataFromCRMSearch(ctx, objectName)
+	case core.MarketingObjects.Has(objectName):
+		// Object is part of Hubspot Marketing API.
+		// There is no discovery endpoint. Using local file with schema definition.
+		return metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
+	default:
+		// Otherwise object belongs to Hubspot Objects API (sub-category of CRM namespace).
+		return c.getObjectMetadataFromPropertyAPI(ctx, objectName)
 	}
-
-	return c.getObjectMetadataFromPropertyAPI(ctx, objectName)
 }
 
 // This method describes objects that are part of Objects API using properties endpoint.
@@ -170,12 +176,12 @@ func (c *Connector) getObjectMetadataFromCRMSearch(
 	})
 	if err != nil {
 		// Ignore an error and fallback to static schema.
-		return metadata.Schemas.SelectOne(c.Module(), objectName)
+		return metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
 	}
 
 	if len(readResult.Data) == 0 {
 		// Read returned no rows.
-		return metadata.Schemas.SelectOne(c.Module(), objectName)
+		return metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
 	}
 
 	fields := make(map[string]common.FieldMetadata)

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -370,6 +370,49 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			},
 			ExpectedErrs: nil,
 		},
+		{
+			Name:       "Successfully describe marketing campaigns",
+			Input:      []string{"campaigns"},
+			Server:     mockserver.Dummy(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"campaigns": {
+						DisplayName: "Campaigns",
+						Fields: map[string]common.FieldMetadata{
+							"hs_campaign_status": {
+								DisplayName:  "Campaign Status",
+								ValueType:    "singleSelect",
+								ProviderType: "Enumeration",
+								Values: common.FieldValues{{
+									Value:        "planned",
+									DisplayValue: "planned",
+								}, {
+									Value:        "in_progress",
+									DisplayValue: "in_progress",
+								}, {
+									Value:        "active",
+									DisplayValue: "active",
+								}, {
+									Value:        "paused",
+									DisplayValue: "paused",
+								}, {
+									Value:        "completed",
+									DisplayValue: "completed",
+								}},
+							},
+							"hs_name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "String",
+							},
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -3,9 +3,12 @@ package hubspot
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers/hubspot/internal/associations"
 	"github.com/amp-labs/connectors/providers/hubspot/internal/core"
 )
@@ -16,25 +19,36 @@ import (
 // search endpoint. If Since is not set, it will use the read endpoint.
 // In case Deleted objects won’t appear in any search results.
 // Deleted objects can only be read by using this endpoint.
-func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { //nolint:funlen
+func (c *Connector) Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) { //nolint:funlen
 	ctx = logging.With(ctx, "connector", "hubspot")
 
-	if err := config.ValidateParams(true); err != nil {
+	if err := params.ValidateParams(true); err != nil {
 		return nil, err
 	}
 
-	if core.ObjectsWithoutPropertiesAPISupport.Has(config.ObjectName) {
-		// Objects outside ObjectAPI have different endpoint while both are part of CRM module.
-		// For instance Lists are fully returned only via Search endpoint.
+	switch {
+	case core.CRMObjectsWithoutPropertiesAPISupport.Has(params.ObjectName):
+		// Object is part of CRM namespace but outside ObjectAPI.
+		// For instance object "lists" is returned only via CRM Search endpoint.
 		return c.searchCRM(ctx, searchCRMParams{
 			SearchParams: SearchParams{
-				ObjectName: config.ObjectName,
-				NextPage:   config.NextPage,
-				Fields:     config.Fields,
+				ObjectName: params.ObjectName,
+				NextPage:   params.NextPage,
+				Fields:     params.Fields,
 			},
 		})
+	case core.MarketingObjects.Has(params.ObjectName):
+		// Object is part of Hubspot Marketing API.
+		return c.readMarketing(ctx, params)
+	default:
+		// Otherwise object belongs to Hubspot Objects API (sub-category of CRM namespace).
+		return c.readCRMObjectsAPI(ctx, params)
 	}
+}
 
+func (c *Connector) readCRMObjectsAPI(
+	ctx context.Context, config common.ReadParams,
+) (*common.ReadResult, error) { //nolint:funlen
 	// If filtering is required, then we have to use the search endpoint.
 	// The Search endpoint has a 10K record limit. In case this limit is reached,
 	// the sorting allows the caller to continue in another call by offsetting
@@ -114,4 +128,69 @@ func (c *Connector) buildReadURL(params common.ReadParams) (string, error) {
 	url.WithQueryParam("limit", core.DefaultPageSize)
 
 	return url.String(), nil
+}
+
+func (c *Connector) readMarketing(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
+	url, err := c.buildMarketingReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResultFiltered(
+		params,
+		resp,
+		common.MakeRecordsFunc("results"),
+		makeIncrementalFilterFunc(params),
+		readhelper.MakeMarshaledDataFuncWithId(
+			common.FlattenNestedFields("properties"),
+			readhelper.IdFieldQuery{Field: "id"},
+		),
+		params.Fields,
+	)
+}
+
+// When reading objects in Hubspot you must explicitly request the fields.
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/guide#campaign-properties
+//
+// Reading campaigns object:
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/get-campaigns
+//   - Incremental reading is not available.
+//   - Sorting is applied using "updatedAt" field from newest to oldest.
+func (c *Connector) buildMarketingReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	// First page
+	url, err := c.getMarketingURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("properties", strings.Join(params.Fields.List(), ","))
+	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, core.DefaultPageSize))
+	url.WithQueryParam("sort", "-updatedAt") // newest first
+
+	return url, nil
+}
+
+// makeIncrementalFilterFunc embodies connector-side filtering.
+// ReverseOrder is used because we request Campaigns sorted from newest to oldest.
+func makeIncrementalFilterFunc(params common.ReadParams) common.RecordsFilterFunc {
+	if params.Since.IsZero() && params.Until.IsZero() {
+		return readhelper.MakeIdentityFilterFunc(core.GetNextRecordsURL)
+	}
+
+	return readhelper.MakeTimeFilterFunc(
+		readhelper.ReverseOrder,
+		readhelper.NewTimeBoundary(),
+		"updatedAt", time.RFC3339,
+		core.GetNextRecordsURL,
+	)
 }

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -22,6 +22,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContacts := testutils.DataFromFile(t, "read/objects-api/contacts-response.json")
 	responseListsFirst := testutils.DataFromFile(t, "read-lists-1-first-page.json")
 	responseListsLast := testutils.DataFromFile(t, "read-lists-2-second-page.json")
+	responseCampaignsFirst := testutils.DataFromFile(t, "read/campaigns/1-first-page.json")
+	responseCampaignsLast := testutils.DataFromFile(t, "read/campaigns/2-last-page.json")
 
 	tests := []testroutines.Read{
 		{
@@ -242,6 +244,131 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Done:     true,
 			},
 			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read marketing campaigns first page",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("hs_name", "hs_notes", "hs_budget_items_sum_amount"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/marketing/campaigns/2026-03"),
+					mockcond.QueryParam("limit", "100"),
+					mockcond.QueryParam("sort", "-updatedAt"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCampaignsFirst),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"hs_name":                    "Nurture",
+						"hs_notes":                   "Creating campaign from the Dashboard",
+						"hs_budget_items_sum_amount": "2.0",
+					},
+					Raw: map[string]any{
+						"id": "84f199fa-beb7-4dca-ad94-3d778cdce157",
+						"properties": map[string]any{
+							"hs_name":                    "Nurture",
+							"hs_notes":                   "Creating campaign from the Dashboard",
+							"hs_budget_items_sum_amount": "2.0",
+						},
+						"createdAt": "2026-05-05T23:41:20.330Z",
+						"updatedAt": "2026-05-05T23:45:04.200Z",
+					},
+					Id: "84f199fa-beb7-4dca-ad94-3d778cdce157",
+				}, {
+					Fields: map[string]any{
+						"hs_name": "Kiwi",
+					},
+					Raw: map[string]any{
+						"id": "fc4583f7-5cfc-4773-8fa4-076cd4f4ae6d",
+						"properties": map[string]any{
+							"hs_name": "Kiwi",
+						},
+						"createdAt": "2026-05-05T23:09:27.549Z",
+						"updatedAt": "2026-05-05T23:09:27.713Z",
+					},
+					Id: "fc4583f7-5cfc-4773-8fa4-076cd4f4ae6d",
+				}},
+				NextPage: "https://api.hubapi.com/marketing/campaigns/2026-03?limit=2&sort=-updatedAt&properties=hs_name%2Chs_notes%2Chs_budget_items_sum_amount&after=Mg%3D%3D",
+				Done:     false,
+			},
+		},
+		{
+			Name: "Read marketing campaigns with connector side filtering",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("hs_name"),
+				// The first item will be returned, last filtered out.
+				// Due to the sort order there will be no next page.
+				// The record which is excluded has this timestamp: 2026-05-05T23:09:27.713Z
+				Since: time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/marketing/campaigns/2026-03"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCampaignsFirst),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"hs_name": "Nurture",
+						},
+						Raw: map[string]any{
+							"updatedAt": "2026-05-05T23:45:04.200Z",
+						},
+						Id: "84f199fa-beb7-4dca-ad94-3d778cdce157",
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+		},
+		{
+			Name: "Read marketing campaigns last page",
+			Input: common.ReadParams{
+				ObjectName: "campaigns",
+				Fields:     connectors.Fields("hs_name"),
+				NextPage:   testroutines.URLTestServer + "/marketing/campaigns/2026-03?limit=2&sort=-updatedAt&properties=hs_name%2Chs_notes%2Chs_budget_items_sum_amount&after=Mg%3D%3D",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/marketing/campaigns/2026-03"),
+					mockcond.QueryParam("after", "Mg=="),
+				},
+				Then: mockserver.Response(http.StatusOK, responseCampaignsLast),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"hs_name": "Inbound",
+						},
+						Raw: map[string]any{
+							"createdAt": "2026-05-05T23:07:11.797Z",
+							"updatedAt": "2026-05-05T23:07:12.040Z",
+						},
+						Id: "5f7bff76-193f-43af-968b-f13c6576ca76",
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
 		},
 	}
 

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -53,7 +53,7 @@ func (c *Connector) ReadUsingSearchAPI(ctx context.Context, config SearchParams)
 		)
 	}
 
-	if core.ObjectsWithoutPropertiesAPISupport.Has(config.ObjectName) {
+	if core.CRMObjectsWithoutPropertiesAPISupport.Has(config.ObjectName) {
 		// Objects outside ObjectAPI have different endpoint while both are part of CRM module.
 		// For instance such object is Lists.
 		return c.searchCRM(ctx, searchCRMParams{

--- a/providers/hubspot/test/read/campaigns/1-first-page.json
+++ b/providers/hubspot/test/read/campaigns/1-first-page.json
@@ -1,0 +1,39 @@
+{
+  "total": 3,
+  "results": [
+    {
+      "id": "84f199fa-beb7-4dca-ad94-3d778cdce157",
+      "properties": {
+        "hs_budget_items_sum_amount": "2.0",
+        "hs_name": "Nurture",
+        "hs_notes": "Creating campaign from the Dashboard"
+      },
+      "createdAt": "2026-05-05T23:41:20.330Z",
+      "updatedAt": "2026-05-05T23:45:04.200Z",
+      "businessUnits": [
+        {
+          "id": 0
+        }
+      ]
+    },
+    {
+      "id": "fc4583f7-5cfc-4773-8fa4-076cd4f4ae6d",
+      "properties": {
+        "hs_name": "Kiwi"
+      },
+      "createdAt": "2026-05-05T23:09:27.549Z",
+      "updatedAt": "2026-05-05T23:09:27.713Z",
+      "businessUnits": [
+        {
+          "id": 0
+        }
+      ]
+    }
+  ],
+  "paging": {
+    "next": {
+      "after": "Mg%3D%3D",
+      "link": "https://api.hubapi.com/marketing/campaigns/2026-03?limit=2&sort=-updatedAt&properties=hs_name%2Chs_notes%2Chs_budget_items_sum_amount&after=Mg%3D%3D"
+    }
+  }
+}

--- a/providers/hubspot/test/read/campaigns/2-last-page.json
+++ b/providers/hubspot/test/read/campaigns/2-last-page.json
@@ -1,0 +1,18 @@
+{
+  "total": 3,
+  "results": [
+    {
+      "id": "5f7bff76-193f-43af-968b-f13c6576ca76",
+      "properties": {
+        "hs_name": "Inbound"
+      },
+      "createdAt": "2026-05-05T23:07:11.797Z",
+      "updatedAt": "2026-05-05T23:07:12.040Z",
+      "businessUnits": [
+        {
+          "id": 0
+        }
+      ]
+    }
+  ]
+}

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -111,6 +111,18 @@ func (c *Connector) getCRMSearchURL(objectName string) (*urlbuilder.URL, error) 
 	return c.crmURL(core.APIVersion3, objectName, "search")
 }
 
+// Returns the base HubSpot Marketing API endpoint for CRUD operations.
+//
+// This URL shape is shared by CRUD operations.
+//
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/get-campaigns
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/create-campaign
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/update-campaign
+// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/delete-campaign
+func (c *Connector) getMarketingURL(objectName string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, "marketing", objectName, core.APIVersion2026March)
+}
+
 func (c *Connector) crmURL(paths ...string) (*urlbuilder.URL, error) {
 	parts := append([]string{"crm"}, paths...)
 

--- a/test/hubspot/metadata/read/campaings/main.go
+++ b/test/hubspot/metadata/read/campaings/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"campaigns",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/test/hubspot/read/campaigns/main.go
+++ b/test/hubspot/read/campaigns/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "campaigns",
+		Fields:     connectors.Fields("hs_name", "hs_notes", "hs_budget_items_sum_amount"),
+		// Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Descirption

Add support of `marketing/campaigns`.


# Changes

* Marketing read uses connector-side filtering. See unit tests.
* ListObjectMetadata and Read now have switch to direct objects by 3 categories:

<img width="818" height="287" alt="image" src="https://github.com/user-attachments/assets/b10f2c98-0431-4514-be3f-b75ba8a7d30a" />

<img width="809" height="486" alt="image" src="https://github.com/user-attachments/assets/61f46bb4-7813-4984-a69b-f95e8ae8d313" />


# Live Tests

Campaigns metadata:
<img width="475" height="947" alt="image" src="https://github.com/user-attachments/assets/e089c4bd-e39d-4085-af78-af0fd29e41d7" />


Campaigns read:
<img width="480" height="999" alt="image" src="https://github.com/user-attachments/assets/e49a92ba-27a0-407a-a9ea-54034f07004a" />

Campaigns read with since to demonstrate incremental read:
<img width="940" height="974" alt="image" src="https://github.com/user-attachments/assets/33d6ebe1-507e-479a-96ec-20eaf3ae3ae3" />
