### PR TITLE
fix(salesforce): only upsert quota fields for subscribed objects

### DIFF
--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -134,7 +134,7 @@ func (c *Connector) executeSubscribe(
 		createdMembers: sfRes.EventChannelMembers,
 	}
 
-	if err := c.upsertQuotaOptimizationFields(ctx, req); err != nil {
+	if err := c.upsertQuotaOptimizationFields(ctx, params, req); err != nil {
 		return sfRes, progress, fmt.Errorf("failed to upsert quota optimization fields: %w", err)
 	}
 
@@ -323,7 +323,7 @@ func (c *Connector) executeUpdateSubscription(
 ) (*common.SubscriptionResult, *updateSubscriptionProgress, error) {
 	progress := &updateSubscriptionProgress{}
 
-	if err := c.upsertQuotaOptimizationFields(ctx, req); err != nil {
+	if err := c.upsertQuotaOptimizationFields(ctx, params, req); err != nil {
 		return nil, progress, err
 	}
 
@@ -568,8 +568,17 @@ func prepareQuotaOptimizationObjectFieldsForUpdate(
 	return newQuotaFields
 }
 
+// upsertQuotaOptimizationFields creates the quota-optimization checkbox custom field
+// for each object that the caller has both (a) subscribed to via params.SubscriptionEvents
+// and (b) configured a quota field for via req.QuotaOptimizationObjectFields.
+//
+// Quota-field entries that don't correspond to any subscribed object are dropped from
+// req.QuotaOptimizationObjectFields in place so the rest of the subscribe flow (state
+// persistence at sfRes.QuotaOptimizationObjectFields, rollback via progress.req,
+// prepareQuotaOptimizationObjectFieldsForUpdate) operates on the same filtered view
+// and never references fields that were never created in the org.
 func (c *Connector) upsertQuotaOptimizationFields(
-	ctx context.Context, req *SubscriptionRequest,
+	ctx context.Context, params common.SubscribeParams, req *SubscriptionRequest,
 ) error {
 	if req == nil || len(req.QuotaOptimizationObjectFields) == 0 {
 		return nil
@@ -578,6 +587,12 @@ func (c *Connector) upsertQuotaOptimizationFields(
 	fields := make(map[string][]common.FieldDefinition)
 
 	for objectName, fieldName := range req.QuotaOptimizationObjectFields {
+		if !isObjectSubscribed(params.SubscriptionEvents, objectName) {
+			delete(req.QuotaOptimizationObjectFields, objectName)
+
+			continue
+		}
+
 		fields[string(objectName)] = []common.FieldDefinition{
 			{
 				FieldName:   customFieldAPIName(fieldName),
@@ -592,6 +607,10 @@ func (c *Connector) upsertQuotaOptimizationFields(
 		}
 	}
 
+	if len(fields) == 0 {
+		return nil
+	}
+
 	if _, err := c.UpsertMetadata(ctx, &common.UpsertMetadataParams{
 		Fields: fields,
 	}); err != nil {
@@ -599,6 +618,20 @@ func (c *Connector) upsertQuotaOptimizationFields(
 	}
 
 	return nil
+}
+
+// isObjectSubscribed reports whether objName matches any key in events using the
+// same case-and-plurality-insensitive comparison as lookupQuotaField.
+func isObjectSubscribed(
+	events map[common.ObjectName]common.ObjectEvents, objName common.ObjectName,
+) bool {
+	for key := range events {
+		if naming.PluralityAndCaseIgnoreEqual(string(key), string(objName)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // updateKeptSubscriptions updates channel members and redeploys apex triggers for

--- a/providers/salesforce/subscribe_test.go
+++ b/providers/salesforce/subscribe_test.go
@@ -259,15 +259,52 @@ func TestUpsertQuotaOptimizationFieldsNilRequest(t *testing.T) {
 	}
 
 	// Nil request should be a no-op
-	err = conn.upsertQuotaOptimizationFields(t.Context(), nil)
+	err = conn.upsertQuotaOptimizationFields(t.Context(), common.SubscribeParams{}, nil)
 	if err != nil {
 		t.Errorf("expected nil error for nil request, got %v", err)
 	}
 
 	// Request with nil QuotaOptimizationObjectFields should be a no-op
-	err = conn.upsertQuotaOptimizationFields(t.Context(), &SubscriptionRequest{})
+	err = conn.upsertQuotaOptimizationFields(t.Context(), common.SubscribeParams{}, &SubscriptionRequest{})
 	if err != nil {
 		t.Errorf("expected nil error for empty request, got %v", err)
+	}
+}
+
+func TestUpsertQuotaOptimizationFieldsFiltersUnsubscribedObjects(t *testing.T) {
+	t.Parallel()
+
+	req := &SubscriptionRequest{
+		QuotaOptimizationObjectFields: map[common.ObjectName]string{
+			"Lead":    "amp_lead_field",
+			"Account": "amp_account_field",
+			"Contact": "amp_contact_field",
+		},
+	}
+
+	params := common.SubscribeParams{
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Lead":    {},
+			"contact": {},
+		},
+	}
+
+	for objectName := range req.QuotaOptimizationObjectFields {
+		if !isObjectSubscribed(params.SubscriptionEvents, objectName) {
+			delete(req.QuotaOptimizationObjectFields, objectName)
+		}
+	}
+
+	if _, ok := req.QuotaOptimizationObjectFields["Lead"]; !ok {
+		t.Error("expected Lead to remain (exact match)")
+	}
+
+	if _, ok := req.QuotaOptimizationObjectFields["Contact"]; !ok {
+		t.Error("expected Contact to remain (case-insensitive match)")
+	}
+
+	if _, ok := req.QuotaOptimizationObjectFields["Account"]; ok {
+		t.Error("expected Account to be removed (not in SubscriptionEvents)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `upsertQuotaOptimizationFields` previously iterated every entry in `req.QuotaOptimizationObjectFields` and created a checkbox custom field on the Salesforce object even when that object wasn't part of `params.SubscriptionEvents`. This left orphan custom fields on unrelated objects and made saved subscription state diverge from actual org schema (rollback then tried to delete fields that were never created on those objects).
- The fix takes `params` and skips entries whose object isn't subscribed, also dropping them from `req.QuotaOptimizationObjectFields` in place so the rest of the subscribe flow (state persistence at `sfRes.QuotaOptimizationObjectFields`, `prepareQuotaOptimizationObjectFieldsForUpdate`, `rollbackQuotaOptimizationFields` via `progress.req`) operates on the same filtered view.
- Matching uses the existing `naming.PluralityAndCaseIgnoreEqual` (same comparison `lookupQuotaField` uses), via a new `isObjectSubscribed` helper.

## Test plan
- [x] `go build ./providers/salesforce/...`
- [x] `go test ./providers/salesforce/...` — all unit tests pass; existing `TestUpsertQuotaOptimizationFieldsNilRequest` updated for new signature
- [x] Added `TestUpsertQuotaOptimizationFieldsFiltersUnsubscribedObjects` covering exact-match, case-insensitive match, and unsubscribed-object removal
- [x] Pre-commit `make fix` (gci + golangci-lint v2.7.1 + typos) passes
- [ ] Manual: subscribe with `QuotaOptimizationObjectFields={Lead, Account}` but `SubscriptionEvents={Lead}` and confirm only the Lead checkbox field is created in Salesforce
- [ ] Manual: rollback the same subscription and confirm only the Lead field is deleted (no 404 for Account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)