### PR TITLE
[Customer Support] Add checking for object existent before deleting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,8 +145,8 @@ destructive.zip
 output/
 
 # Salesforce test binaries
-apex
+/apex
 test/salesforce/apex/apex
-subscribe
+/subscribe
 subscriber
 test/salesforce/subscribe/subscribe

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -2,7 +2,9 @@ package salesforce
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/logging"
@@ -362,6 +364,19 @@ func (c *Connector) deleteToSFAPI(ctx context.Context, path string, entity strin
 	location, err := c.getRestApiURL(path)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check the entity exists before deleting. If it's already gone (404),
+	// treat the delete as a no-op so callers can retry safely.
+	if _, err := c.Client.Get(ctx, location.String()); err != nil {
+		var httpErr *common.HTTPError
+		if errors.As(err, &httpErr) && httpErr.Status == http.StatusNotFound {
+			logging.Logger(ctx).Info("skipping delete, entity not found", "entity", entity)
+
+			return nil, nil //nolint:nilnil
+		}
+
+		return nil, fmt.Errorf("error checking %s before delete: %w", entity, err)
 	}
 
 	resp, err := c.Client.Delete(ctx, location.String())

--- a/test/salesforce/subscribe/delete-nonexisting/main.go
+++ b/test/salesforce/subscribe/delete-nonexisting/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// Random ID with the PlatformEventChannelMember key prefix (0u3) — guaranteed
+// not to match any real record in the org, so the GET inside deleteToSFAPI
+// returns 404 and the DELETE is skipped.
+const nonExistingMemberId = "0u3000000000000AAA"
+
+// This script verifies that DeleteEventChannelMember is idempotent for
+// non-existing records: passing an ID that doesn't exist should succeed (no
+// error) because deleteToSFAPI now does an existence check first and treats a
+// 404 as a no-op.
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	resp, err := conn.DeleteEventChannelMember(ctx, nonExistingMemberId)
+	if err != nil {
+		logging.Logger(ctx).Error("DeleteEventChannelMember on non-existing record returned error", "error", err)
+		return
+	}
+
+	fmt.Printf("DeleteEventChannelMember on non-existing record succeeded. resp=%v (expected nil)\n", resp)
+}


### PR DESCRIPTION
Salesforce returns 400 Bad Request when we try to delete a record, when the object does not exist. So we are adding this check to make sure the field exists. 

## Test run

```
jlim@Mac connectors % go run ./test/salesforce/subscribe/delete-nonexisting/main.go 
time=2026-05-07T19:14:49.201-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-07T19:14:49.201-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-07T19:14:49.203-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-07T19:14:49.203-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-07T19:14:49.205-07:00 level=DEBUG msg="HTTP request" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannelMember/0u3000000000000AAA correlationId=59acd5dd-54b4-4c14-84b2-158c97138a97 headers.Accept=application/json
time=2026-05-07T19:14:49.521-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:59acd5dd-54b4-4c14-84b2-158c97138a97 headers:[Server: sfdcedge Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Sfdc-Request-Id: 94aaab5be6a1a2c108de0037e46bcafc X-Request-Id: 94aaab5be6a1a2c108de0037e46bcafc Date: Fri, 08 May 2026 02:14:49 GMT Sforce-Limit-Info: api-usage=5/15000 X-Robots-Tag: none X-Content-Type-Options: nosniff Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Strict-Transport-Security: max-age=63072000; includeSubDomains] method:GET status:404 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannelMember/0u3000000000000AAA]"
time=2026-05-07T19:14:49.521-07:00 level=ERROR msg="HTTP request failed" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannelMember/0u3000000000000AAA correlationId=59acd5dd-54b4-4c14-84b2-158c97138a97 error="HTTP status 404: retryable error: [{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]"
time=2026-05-07T19:14:49.521-07:00 level=INFO msg="skipping delete, entity not found" entity=EventChannelMember
DeleteEventChannelMember on non-existing record succeeded. resp=<nil> (expected nil)
```