### PR TITLE
handle duplicate developer name

### DIFF
--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -2,9 +2,11 @@ package salesforce
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/logging"
@@ -161,6 +163,10 @@ func (n *NamedCredential) DestinationResourceName() string {
 func (c *Connector) CreateEventChannel(ctx context.Context, channel *EventChannel) (*EventChannel, error) {
 	res, err := c.postToSFAPI(ctx, channel, "tooling/sobjects/PlatformEventChannel", "PlatformEventChannel")
 	if err != nil {
+		if isDuplicateDeveloperName(err) {
+			return recoverDuplicateByFullName[EventChannel](ctx, c, "PlatformEventChannel", channel.FullName)
+		}
+
 		return nil, err
 	}
 
@@ -182,6 +188,10 @@ func (c *Connector) CreateEventChannelMember(
 ) (*EventChannelMember, error) {
 	res, err := c.postToSFAPI(ctx, member, "tooling/sobjects/PlatformEventChannelMember", "EventChannelMember")
 	if err != nil {
+		if isDuplicateDeveloperName(err) {
+			return recoverDuplicateByFullName[EventChannelMember](ctx, c, "PlatformEventChannelMember", member.FullName)
+		}
+
 		return nil, err
 	}
 
@@ -222,6 +232,10 @@ func (c *Connector) CreateEventRelayConfig(
 ) (*EventRelayConfig, error) {
 	res, err := c.postToSFAPI(ctx, cfg, "/tooling/sobjects/EventRelayConfig", "EventRelayConfig")
 	if err != nil {
+		if isDuplicateDeveloperName(err) {
+			return recoverDuplicateByFullName[EventRelayConfig](ctx, c, "EventRelayConfig", cfg.FullName)
+		}
+
 		return nil, err
 	}
 
@@ -301,6 +315,10 @@ func GetRemoteResource(orgId, channelId string) string {
 func (c *Connector) CreateNamedCredential(ctx context.Context, creds *NamedCredential) (*NamedCredential, error) {
 	res, err := c.postToSFAPI(ctx, creds, "/tooling/sobjects/NamedCredential", "NamedCredential")
 	if err != nil {
+		if isDuplicateDeveloperName(err) {
+			return recoverDuplicateByFullName[NamedCredential](ctx, c, "NamedCredential", creds.FullName)
+		}
+
 		return nil, err
 	}
 
@@ -385,4 +403,150 @@ func (c *Connector) deleteToSFAPI(ctx context.Context, path string, entity strin
 	}
 
 	return resp, nil
+}
+
+const errCodeDuplicateDeveloperName = "DUPLICATE_DEVELOPER_NAME"
+
+var (
+	errToolingQueryNoRecordsField = errors.New("tooling/query response missing 'records' field")
+	errToolingEntityNotFound      = errors.New("no tooling entity found by FullName")
+	errToolingRecordMissingID     = errors.New("tooling/query record missing 'Id' field")
+)
+
+// sfAPIError is a single entry in a Salesforce API error response array.
+// nolint:tagliatelle
+type sfAPIError struct {
+	Message   string   `json:"message"`
+	ErrorCode string   `json:"errorCode"`
+	Fields    []string `json:"fields"`
+}
+
+// isDuplicateDeveloperName reports whether err is a 400 response whose body
+// contains the DUPLICATE_DEVELOPER_NAME Salesforce error code.
+func isDuplicateDeveloperName(err error) bool {
+	var httpErr *common.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusBadRequest {
+		return false
+	}
+
+	var entries []sfAPIError
+	if jsonErr := json.Unmarshal(httpErr.Body, &entries); jsonErr != nil {
+		return false
+	}
+
+	for _, e := range entries {
+		if e.ErrorCode == errCodeDuplicateDeveloperName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// recoverDuplicateByFullName looks up a tooling entity by FullName and returns
+// the full record. Used to make Create* idempotent when Salesforce reports
+// DUPLICATE_DEVELOPER_NAME — the SOQL query yields the existing Id, and the
+// follow-up GET returns the same shape a successful Create would have.
+func recoverDuplicateByFullName[T any](
+	ctx context.Context, conn *Connector, objectType, fullName string,
+) (*T, error) {
+	logging.Logger(ctx).Info("create returned duplicate, fetching existing record",
+		"objectType", objectType, "fullName", fullName)
+
+	id, err := conn.findToolingEntityIdByFullName(ctx, objectType, fullName)
+	if err != nil {
+		return nil, fmt.Errorf("%s duplicate detected, but SOQL lookup by FullName failed: %w",
+			objectType, err)
+	}
+
+	existing, err := getToolingEntityByID[T](ctx, conn, objectType, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s duplicate detected, found id=%s but GET failed: %w",
+			objectType, id, err)
+	}
+
+	return existing, nil
+}
+
+// findToolingEntityIdByFullName runs a Tooling API SOQL query to find the Id
+// of the given object type by FullName.
+func (c *Connector) findToolingEntityIdByFullName(
+	ctx context.Context, objectType, fullName string,
+) (string, error) {
+	location, err := c.getRestApiURL("tooling/query")
+	if err != nil {
+		return "", err
+	}
+
+	soql := fmt.Sprintf("SELECT Id FROM %s WHERE FullName = '%s'",
+		objectType, escapeSOQLString(fullName))
+	location.WithQueryParam("q", soql)
+
+	resp, err := c.Client.Get(ctx, location.String())
+	if err != nil {
+		return "", err
+	}
+
+	body, ok := resp.Body()
+	if !ok {
+		return "", common.ErrEmptyJSONHTTPResponse
+	}
+
+	obj, err := body.GetObject()
+	if err != nil {
+		return "", err
+	}
+
+	recordsNode, exists := obj["records"]
+	if !exists {
+		return "", fmt.Errorf("%w: objectType=%s", errToolingQueryNoRecordsField, objectType)
+	}
+
+	records, err := recordsNode.GetArray()
+	if err != nil {
+		return "", err
+	}
+
+	if len(records) == 0 {
+		return "", fmt.Errorf("%w: objectType=%s, fullName=%s", errToolingEntityNotFound, objectType, fullName)
+	}
+
+	rec, err := records[0].GetObject()
+	if err != nil {
+		return "", err
+	}
+
+	idNode, exists := rec["Id"]
+	if !exists {
+		return "", fmt.Errorf("%w: objectType=%s", errToolingRecordMissingID, objectType)
+	}
+
+	return idNode.MustString(), nil
+}
+
+// getToolingEntityByID fetches an entity by Id from the Tooling API and
+// unmarshals into T.
+func getToolingEntityByID[T any](
+	ctx context.Context, conn *Connector, objectType, id string,
+) (*T, error) {
+	location, err := conn.getRestApiURL(fmt.Sprintf("tooling/sobjects/%s/%s", objectType, id))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := conn.Client.Get(ctx, location.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.UnmarshalJSON[T](resp)
+}
+
+// escapeSOQLString escapes a value for safe inclusion in a SOQL string
+// literal. Backslashes must be escaped before single quotes.
+func escapeSOQLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+
+	return s
 }

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -164,7 +164,10 @@ func (c *Connector) CreateEventChannel(ctx context.Context, channel *EventChanne
 	res, err := c.postToSFAPI(ctx, channel, "tooling/sobjects/PlatformEventChannel", "PlatformEventChannel")
 	if err != nil {
 		if isDuplicateDeveloperName(err) {
-			return recoverDuplicateByFullName[EventChannel](ctx, c, "PlatformEventChannel", channel.FullName)
+			// PlatformEventChannel.DeveloperName is FullName without the "__chn" suffix.
+			developerName := strings.TrimSuffix(channel.FullName, "__chn")
+
+			return recoverDuplicateByDeveloperName[EventChannel](ctx, c, "PlatformEventChannel", developerName)
 		}
 
 		return nil, err
@@ -189,7 +192,7 @@ func (c *Connector) CreateEventChannelMember(
 	res, err := c.postToSFAPI(ctx, member, "tooling/sobjects/PlatformEventChannelMember", "EventChannelMember")
 	if err != nil {
 		if isDuplicateDeveloperName(err) {
-			return recoverDuplicateByFullName[EventChannelMember](ctx, c, "PlatformEventChannelMember", member.FullName)
+			return recoverDuplicateByDeveloperName[EventChannelMember](ctx, c, "PlatformEventChannelMember", member.FullName)
 		}
 
 		return nil, err
@@ -233,7 +236,7 @@ func (c *Connector) CreateEventRelayConfig(
 	res, err := c.postToSFAPI(ctx, cfg, "/tooling/sobjects/EventRelayConfig", "EventRelayConfig")
 	if err != nil {
 		if isDuplicateDeveloperName(err) {
-			return recoverDuplicateByFullName[EventRelayConfig](ctx, c, "EventRelayConfig", cfg.FullName)
+			return recoverDuplicateByDeveloperName[EventRelayConfig](ctx, c, "EventRelayConfig", cfg.FullName)
 		}
 
 		return nil, err
@@ -316,7 +319,7 @@ func (c *Connector) CreateNamedCredential(ctx context.Context, creds *NamedCrede
 	res, err := c.postToSFAPI(ctx, creds, "/tooling/sobjects/NamedCredential", "NamedCredential")
 	if err != nil {
 		if isDuplicateDeveloperName(err) {
-			return recoverDuplicateByFullName[NamedCredential](ctx, c, "NamedCredential", creds.FullName)
+			return recoverDuplicateByDeveloperName[NamedCredential](ctx, c, "NamedCredential", creds.FullName)
 		}
 
 		return nil, err
@@ -443,19 +446,23 @@ func isDuplicateDeveloperName(err error) bool {
 	return false
 }
 
-// recoverDuplicateByFullName looks up a tooling entity by FullName and returns
-// the full record. Used to make Create* idempotent when Salesforce reports
-// DUPLICATE_DEVELOPER_NAME — the SOQL query yields the existing Id, and the
-// follow-up GET returns the same shape a successful Create would have.
-func recoverDuplicateByFullName[T any](
-	ctx context.Context, conn *Connector, objectType, fullName string,
+// recoverDuplicateByDeveloperName looks up a tooling entity by DeveloperName
+// and returns the full record. Used to make Create* idempotent when Salesforce
+// reports DUPLICATE_DEVELOPER_NAME — the SOQL query yields the existing Id,
+// and the follow-up GET returns the same shape a successful Create would have.
+//
+// Salesforce does not allow FullName in a SOQL WHERE clause for these metadata
+// objects, so callers must pass a DeveloperName. For most entities here that
+// equals the FullName, but PlatformEventChannel strips its "__chn" suffix.
+func recoverDuplicateByDeveloperName[T any](
+	ctx context.Context, conn *Connector, objectType, developerName string,
 ) (*T, error) {
 	logging.Logger(ctx).Info("create returned duplicate, fetching existing record",
-		"objectType", objectType, "fullName", fullName)
+		"objectType", objectType, "developerName", developerName)
 
-	id, err := conn.findToolingEntityIdByFullName(ctx, objectType, fullName)
+	id, err := conn.findToolingEntityIDByDeveloperName(ctx, objectType, developerName)
 	if err != nil {
-		return nil, fmt.Errorf("%s duplicate detected, but SOQL lookup by FullName failed: %w",
+		return nil, fmt.Errorf("%s duplicate detected, but SOQL lookup failed: %w",
 			objectType, err)
 	}
 
@@ -468,18 +475,18 @@ func recoverDuplicateByFullName[T any](
 	return existing, nil
 }
 
-// findToolingEntityIdByFullName runs a Tooling API SOQL query to find the Id
-// of the given object type by FullName.
-func (c *Connector) findToolingEntityIdByFullName(
-	ctx context.Context, objectType, fullName string,
+// findToolingEntityIDByDeveloperName runs a Tooling API SOQL query to find
+// the Id of the given object type by DeveloperName.
+func (c *Connector) findToolingEntityIDByDeveloperName(
+	ctx context.Context, objectType, developerName string,
 ) (string, error) {
 	location, err := c.getRestApiURL("tooling/query")
 	if err != nil {
 		return "", err
 	}
 
-	soql := fmt.Sprintf("SELECT Id FROM %s WHERE FullName = '%s'",
-		objectType, escapeSOQLString(fullName))
+	soql := fmt.Sprintf("SELECT Id FROM %s WHERE DeveloperName = '%s'",
+		objectType, escapeSOQLString(developerName))
 	location.WithQueryParam("q", soql)
 
 	resp, err := c.Client.Get(ctx, location.String())
@@ -508,7 +515,7 @@ func (c *Connector) findToolingEntityIdByFullName(
 	}
 
 	if len(records) == 0 {
-		return "", fmt.Errorf("%w: objectType=%s, fullName=%s", errToolingEntityNotFound, objectType, fullName)
+		return "", fmt.Errorf("%w: objectType=%s, developerName=%s", errToolingEntityNotFound, objectType, developerName)
 	}
 
 	rec, err := records[0].GetObject()

--- a/test/salesforce/subscribe/duplicate-create/main.go
+++ b/test/salesforce/subscribe/duplicate-create/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/tools/debug"
+)
+
+// Hardcoded FullName used to provoke a DUPLICATE_DEVELOPER_NAME on the second
+// CreateEventChannel call. Stable across runs so the script is repeatable —
+// the trailing cleanup deletes the channel after each run. The "__chn" suffix
+// is required for custom PlatformEventChannel records; without it Salesforce
+// treats the request as targeting a standard channel and rejects Create.
+const duplicateChannelFullName = "amp_duplicate_create_test__chn"
+
+// This script verifies that CreateEventChannel is idempotent on
+// DUPLICATE_DEVELOPER_NAME: calling Create twice with the same FullName
+// should succeed both times and return the same record (the second call
+// recovers via SOQL+GET instead of erroring out).
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	channel := &salesforce.EventChannel{
+		FullName: duplicateChannelFullName,
+		Metadata: &salesforce.EventChannelMetadata{
+			ChannelType: "data",
+			Label:       duplicateChannelFullName,
+		},
+	}
+
+	first, err := conn.CreateEventChannel(ctx, channel)
+	if err != nil {
+		logging.Logger(ctx).Error("first CreateEventChannel failed", "error", err)
+		return
+	}
+
+	fmt.Printf("First CreateEventChannel succeeded. id=%s\n", first.Id)
+
+	// Second call with the same FullName should hit DUPLICATE_DEVELOPER_NAME
+	// and recover by looking up the existing record.
+	second, err := conn.CreateEventChannel(ctx, &salesforce.EventChannel{
+		FullName: duplicateChannelFullName,
+		Metadata: &salesforce.EventChannelMetadata{
+			ChannelType: "data",
+			Label:       duplicateChannelFullName,
+		},
+	})
+	if err != nil {
+		logging.Logger(ctx).Error("second CreateEventChannel (duplicate) failed", "error", err)
+		return
+	}
+
+	fmt.Printf("Second CreateEventChannel (duplicate) recovered. id=%s\n", second.Id)
+
+	if first.Id != second.Id {
+		logging.Logger(ctx).Error("recovered record id mismatch",
+			"firstId", first.Id, "secondId", second.Id)
+		return
+	}
+
+	fmt.Println("First: ", debug.PrettyFormatStringJSON(first))
+	fmt.Println("Second: ", debug.PrettyFormatStringJSON(second))
+
+	fmt.Println("IDs match — duplicate recovery returned the existing record.")
+
+	// Clean up so the script is repeatable.
+	if _, err := conn.DeleteEventChannel(ctx, first.Id); err != nil {
+		logging.Logger(ctx).Error("cleanup DeleteEventChannel failed", "error", err)
+		return
+	}
+
+	fmt.Println("Cleanup successful")
+}


### PR DESCRIPTION
When creating Subscribe-related entities, sometimes we get `DUPLICATE_DEVELOPER_ERROR` which blocks creation. 

Since that means the record exists, we should just bypass creation and then move on. This PR enables this

Test Result

```
jlim@Mac connectors % go run ./test/salesforce/subscribe/duplicate-create/main.go
time=2026-05-07T21:16:39.920-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-07T21:16:39.920-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-07T21:16:39.923-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-07T21:16:39.923-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-07T21:16:39.925-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel correlationId=becef1d9-b6d9-405c-baf9-2bde57ab504a headers.Accept=application/json headers.Content-Type=application/json
time=2026-05-07T21:16:40.319-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:becef1d9-b6d9-405c-baf9-2bde57ab504a headers:[Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Request-Id: c156b9345a57f3fa40b0467dca88573e X-Content-Type-Options: nosniff Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Robots-Tag: none Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding Location: /services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO Server: sfdcedge X-Sfdc-Edge-Cache: none Sforce-Limit-Info: api-usage=24/15000 X-Sfdc-Request-Id: c156b9345a57f3fa40b0467dca88573e Date: Fri, 08 May 2026 04:16:40 GMT Strict-Transport-Security: max-age=63072000; includeSubDomains] method:POST status:201 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel]"
First CreateEventChannel succeeded. id=0YLgK000000TZK9WAO
time=2026-05-07T21:16:40.319-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel correlationId=77cfcf62-00af-4819-9eb0-aef923d411b8 headers.Accept=application/json headers.Content-Type=application/json
time=2026-05-07T21:16:40.495-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:77cfcf62-00af-4819-9eb0-aef923d411b8 headers:[Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Content-Type-Options: nosniff Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Strict-Transport-Security: max-age=63072000; includeSubDomains X-Request-Id: f777d7da225fa33461d81c7480fd6ac3 Date: Fri, 08 May 2026 04:16:40 GMT Sforce-Limit-Info: api-usage=26/15000 Vary: Accept-Encoding X-Robots-Tag: none Server: sfdcedge X-Sfdc-Request-Id: f777d7da225fa33461d81c7480fd6ac3 Content-Type: application/json;charset=UTF-8] method:POST status:400 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel]"
time=2026-05-07T21:16:40.495-07:00 level=ERROR msg="HTTP request failed" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel correlationId=77cfcf62-00af-4819-9eb0-aef923d411b8 error="HTTP status 400: caller error: [{\"message\":\"A PlatformEventChannel record with full name amp_duplicate_create_test__chn already exists. Try using another full name for the channel.\",\"errorCode\":\"DUPLICATE_DEVELOPER_NAME\",\"fields\":[]}]"
time=2026-05-07T21:16:40.495-07:00 level=INFO msg="create returned duplicate, fetching existing record" objectType=PlatformEventChannel developerName=amp_duplicate_create_test
time=2026-05-07T21:16:40.495-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+PlatformEventChannel+WHERE+DeveloperName+%3D+%27amp_duplicate_create_test%27" correlationId=13e8fada-3fcf-40b9-9079-6955a18219c3 headers.Accept=application/json
time=2026-05-07T21:16:40.656-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:13e8fada-3fcf-40b9-9079-6955a18219c3 headers:[Content-Type: application/json;charset=UTF-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Sforce-Limit-Info: api-usage=24/15000 X-Content-Type-Options: nosniff Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Strict-Transport-Security: max-age=63072000; includeSubDomains Vary: Accept-Encoding X-Sfdc-Request-Id: a3f3e5abf524cbad5db1796a83618739 X-Sfdc-Edge-Cache: none Date: Fri, 08 May 2026 04:16:40 GMT X-Robots-Tag: none Server: sfdcedge X-Request-Id: a3f3e5abf524cbad5db1796a83618739] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+PlatformEventChannel+WHERE+DeveloperName+%3D+%27amp_duplicate_create_test%27]"
time=2026-05-07T21:16:40.656-07:00 level=DEBUG msg="HTTP request" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO correlationId=5a25326c-ad81-428b-b313-0cf4a6d1fd79 headers.Accept=application/json
time=2026-05-07T21:16:40.843-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:5a25326c-ad81-428b-b313-0cf4a6d1fd79 headers:[X-Content-Type-Options: nosniff Last-Modified: Fri, 08 May 2026 04:16:40 GMT Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Sfdc-Request-Id: d3fa469b50b368534c035c53770e3b9c X-Request-Id: d3fa469b50b368534c035c53770e3b9c Strict-Transport-Security: max-age=63072000; includeSubDomains Vary: Accept-Encoding Server: sfdcedge X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Robots-Tag: none Sforce-Limit-Info: api-usage=24/15000 Date: Fri, 08 May 2026 04:16:40 GMT Content-Type: application/json;charset=UTF-8] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO]"
Second CreateEventChannel (duplicate) recovered. id=0YLgK000000TZK9WAO
First:  {
  "Id": "0YLgK000000TZK9WAO",
  "FullName": "amp_duplicate_create_test__chn",
  "Metadata": {
    "channelType": "data",
    "label": "amp_duplicate_create_test__chn"
  }
}
Second:  {
  "Id": "0YLgK000000TZK9WAO",
  "FullName": "amp_duplicate_create_test__chn",
  "Metadata": {
    "channelType": "data",
    "label": "amp_duplicate_create_test__chn"
  }
}
IDs match — duplicate recovery returned the existing record.
time=2026-05-07T21:16:40.843-07:00 level=DEBUG msg="HTTP request" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO correlationId=47939fe0-9d7e-4c43-8f7b-206403edc16d headers.Accept=application/json
time=2026-05-07T21:16:40.985-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:47939fe0-9d7e-4c43-8f7b-206403edc16d headers:[X-Sfdc-Edge-Cache: none Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Request-Id: d6b28c78dbe5a5d654863d44da5c4e05 Date: Fri, 08 May 2026 04:16:40 GMT X-Content-Type-Options: nosniff Vary: Accept-Encoding X-Robots-Tag: none Content-Type: application/json;charset=UTF-8 Strict-Transport-Security: max-age=63072000; includeSubDomains Sforce-Limit-Info: api-usage=26/15000 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Last-Modified: Fri, 08 May 2026 04:16:40 GMT X-Sfdc-Request-Id: d6b28c78dbe5a5d654863d44da5c4e05 Server: sfdcedge] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO]"
time=2026-05-07T21:16:40.985-07:00 level=DEBUG msg="HTTP request" method=DELETE url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO correlationId=619d3658-a7f2-491d-b894-44d2cf67c41b headers.Accept=application/json
time=2026-05-07T21:16:41.236-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:619d3658-a7f2-491d-b894-44d2cf67c41b headers:[Date: Fri, 08 May 2026 04:16:41 GMT Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Robots-Tag: none X-Content-Type-Options: nosniff Server: sfdcedge X-Sfdc-Request-Id: 436354703f72dbb443b57757ae337798 X-Request-Id: 436354703f72dbb443b57757ae337798 Content-Security-Policy: upgrade-insecure-requests Strict-Transport-Security: max-age=63072000; includeSubDomains Sforce-Limit-Info: api-usage=24/15000 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Sfdc-Edge-Cache: none] method:DELETE status:204 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/sobjects/PlatformEventChannel/0YLgK000000TZK9WAO]"
Cleanup successful
```