### PR TITLE
fix(salesforce): clear filter expressions on UpdateSubscription rollback

### DIFF
--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -257,6 +257,11 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 type updateSubscriptionProgress struct {
 	quotaFieldsUpserted bool
 	newQuotaFields      map[common.ObjectName]string
+	// recreatedMembers tracks PlatformEventChannelMembers freshly created by
+	// recreateKeptChannelMembers. On rollback we PATCH each to clear its
+	// FilterExpression and EnrichedFields so the new quota fields it would
+	// otherwise pin can be deleted.
+	recreatedMembers map[common.ObjectName]*EventChannelMember
 }
 
 // UpdateSubscription will update the subscription by:
@@ -321,7 +326,9 @@ func (c *Connector) executeUpdateSubscription(
 	prevState *SubscribeResult,
 	req *SubscriptionRequest,
 ) (*common.SubscriptionResult, *updateSubscriptionProgress, error) {
-	progress := &updateSubscriptionProgress{}
+	progress := &updateSubscriptionProgress{
+		recreatedMembers: make(map[common.ObjectName]*EventChannelMember),
+	}
 
 	if err := c.upsertQuotaOptimizationFields(ctx, params, req); err != nil {
 		return nil, progress, err
@@ -346,7 +353,7 @@ func (c *Connector) executeUpdateSubscription(
 	}
 
 	// Update channel members and redeploy apex triggers for kept objects.
-	if err := c.updateKeptSubscriptions(ctx, req, diff); err != nil {
+	if err := c.updateKeptSubscriptions(ctx, req, diff, progress); err != nil {
 		return nil, progress, err
 	}
 
@@ -640,12 +647,13 @@ func (c *Connector) updateKeptSubscriptions(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
+	progress *updateSubscriptionProgress,
 ) error {
 	if req == nil {
 		return nil
 	}
 
-	if err := c.recreateKeptChannelMembers(ctx, req, diff); err != nil {
+	if err := c.recreateKeptChannelMembers(ctx, req, diff, progress); err != nil {
 		return err
 	}
 
@@ -655,10 +663,15 @@ func (c *Connector) updateKeptSubscriptions(
 // recreateKeptChannelMembers deletes and recreates channel members for kept objects
 // with updated filter expressions and enriched fields. Salesforce doesn't support
 // PATCH on selectedEntity, so delete+recreate is required.
+//
+// Each successful or partially successful delete+recreate cycle is recorded in
+// progress.recreatedMembers so rollbackUpdateSubscription can restore the
+// original members before deleting the quota fields the new ones reference.
 func (c *Connector) recreateKeptChannelMembers(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
+	progress *updateSubscriptionProgress,
 ) error {
 	for objName, member := range diff.channelMembersToKeep {
 		filterExpr := buildQuotaFilterExpression(req.QuotaOptimizationObjectFields, objName)
@@ -679,6 +692,10 @@ func (c *Connector) recreateKeptChannelMembers(
 			return fmt.Errorf("failed to recreate event channel member for object %s: %w", objName, err)
 		}
 
+		// Track the new member so rollback can clear its FilterExpression and
+		// EnrichedFields, releasing the metadata reference that would otherwise
+		// pin the new quota fields.
+		progress.recreatedMembers[objName] = newMember
 		diff.channelMembersToKeep[objName] = newMember
 	}
 

--- a/providers/salesforce/subscribe_rollback.go
+++ b/providers/salesforce/subscribe_rollback.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 )
 
 // rollbackSubscribe reverses completed operations in reverse order based on progress.
@@ -72,17 +73,67 @@ func (c *Connector) rollbackSubscribe(
 }
 
 // rollbackUpdateSubscription reverses completed operations based on progress.
+//
+// Filter expressions on the recreated members are cleared FIRST so the new
+// members no longer hold a metadata reference to the new quota fields. The
+// quota field delete that follows is best-effort: if Salesforce still blocks
+// it (for example because a redeployed apex trigger references the field),
+// we log and continue rather than fail the rollback — leaving the orphan
+// custom field is acceptable.
 func (c *Connector) rollbackUpdateSubscription(
 	ctx context.Context,
 	progress *updateSubscriptionProgress,
 ) error {
-	if !progress.quotaFieldsUpserted || len(progress.newQuotaFields) == 0 {
+	var rollbackErr error
+
+	if err := c.clearRecreatedChannelMemberFilters(ctx, progress); err != nil {
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+
+	if progress.quotaFieldsUpserted && len(progress.newQuotaFields) > 0 {
+		req := &SubscriptionRequest{QuotaOptimizationObjectFields: progress.newQuotaFields}
+		if err := c.rollbackQuotaOptimizationFields(ctx, req); err != nil {
+			// Intentionally not joined into rollbackErr: leaving an orphan
+			// quota field is preferable to surfacing a rollback failure that
+			// the caller can't easily act on.
+			logging.Logger(ctx).Warn("rollback: leaving quota optimization fields undeleted",
+				"error", err)
+		}
+	}
+
+	return rollbackErr
+}
+
+// clearRecreatedChannelMemberFilters PATCHes each recreated channel member to
+// drop its FilterExpression and EnrichedFields. This releases the metadata
+// reference on the new quota fields so the field delete in the next rollback
+// step can succeed. Members are left in place with a no-op filter; the user
+// can re-run UpdateSubscription to restore quota optimization.
+func (c *Connector) clearRecreatedChannelMemberFilters(
+	ctx context.Context,
+	progress *updateSubscriptionProgress,
+) error {
+	if len(progress.recreatedMembers) == 0 {
 		return nil
 	}
 
-	req := &SubscriptionRequest{QuotaOptimizationObjectFields: progress.newQuotaFields}
+	var clearErr error
 
-	return c.rollbackQuotaOptimizationFields(ctx, req)
+	for objName, member := range progress.recreatedMembers {
+		member.Metadata.FilterExpression = ""
+		member.Metadata.EnrichedFields = nil
+
+		if _, err := c.UpdateEventChannelMember(ctx, member); err != nil {
+			clearErr = errors.Join(clearErr,
+				fmt.Errorf("failed to clear filter expression on channel member for object %s: %w", objName, err))
+
+			continue
+		}
+
+		delete(progress.recreatedMembers, objName)
+	}
+
+	return clearErr
 }
 
 func (c *Connector) rollbackQuotaOptimizationFields(ctx context.Context, req *SubscriptionRequest) error {

--- a/providers/salesforce/subscribe_test.go
+++ b/providers/salesforce/subscribe_test.go
@@ -329,14 +329,18 @@ func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
 		apexTriggersToKeep: map[common.ObjectName]*ApexTrigger{},
 	}
 
+	progress := &updateSubscriptionProgress{
+		recreatedMembers: make(map[common.ObjectName]*EventChannelMember),
+	}
+
 	// Nil request should be a no-op
-	err = conn.updateKeptSubscriptions(t.Context(), nil, diff)
+	err = conn.updateKeptSubscriptions(t.Context(), nil, diff, progress)
 	if err != nil {
 		t.Errorf("expected nil error for nil request, got %v", err)
 	}
 
 	// Request with no quota fields should be a no-op
-	err = conn.updateKeptSubscriptions(t.Context(), &SubscriptionRequest{}, diff)
+	err = conn.updateKeptSubscriptions(t.Context(), &SubscriptionRequest{}, diff, progress)
 	if err != nil {
 		t.Errorf("expected nil error for empty request, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- On a failed `UpdateSubscription`, recreated `PlatformEventChannelMember`s were left holding `filterExpression`s referencing the freshly-upserted quota fields. Salesforce then refused the field-delete step of rollback ("can't delete the field because it's referenced in the filter expression in PlatformEventChannelMember").
- Rollback now PATCHes each recreated member to drop `FilterExpression` and `EnrichedFields` before attempting to delete the quota fields.
- The field delete itself is best-effort: if SF still blocks it (e.g. because a redeployed apex trigger references the field), we log a warning and continue. Leaving an orphan custom field is preferable to surfacing a rollback failure the caller can't easily act on.

## Trade-offs
- Recreated members survive rollback with empty filter/enriched fields. Quota optimization is silently off for those objects until the user re-runs `UpdateSubscription`.
- Quota fields can be left orphaned in the org if the delete is blocked by another reference (e.g. apex trigger). Logged at WARN with the underlying SF error.

## Test plan
- [x] `go build ./providers/salesforce/...`
- [x] `go vet ./providers/salesforce/...`
- [x] `go test ./providers/salesforce/...` (existing tests pass)
- [x] `make fix` (0 issues)
- [ ] Manual: trigger a failure during apex redeploy and confirm rollback no longer errors out on field deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)