### PR TITLE
[CON-3237] feat(livestorm): Read implementation

### DIFF
--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -50,12 +50,21 @@ func New(base string, path ...string) (*URL, error) {
 	return u, nil
 }
 
-// FromRawURL converts a core Go `url.URL` into `urlbuilder.URL`,
-// providing better control over query parameters and encoding.
+// FromRawURL creates an independent copy of a net/url.URL as *urlbuilder.URL.
 //
-// The input URL is not stored by pointer: a copy is made so mutating this
-// urlbuilder.URL (including String(), which updates the delegate's RawQuery)
-// never changes the original *url.URL (for example http.Request.URL).
+// Unlike direct pointer use, mutations to the returned URL—including path
+// changes via AddPath(), query updates via WithQueryParam()/RemoveQueryParam(),
+// and String() which regenerates RawQuery—do not modify the original *url.URL.
+//
+// This safety is critical when wrapping http.Request.URL or parsed endpoints,
+// as urlbuilder.URL provides immutable query keys, proper percent-encoding,
+// and builder-style modifications for robust API construction.
+//
+// Example:
+//
+//	u, _ := url.Parse("https://api.example.com?existing=1")
+//	b, _ := FromRawURL(u)
+//	b.WithQueryParam("new", "value") // Original u unchanged
 func FromRawURL(rawURL *url.URL) (*URL, error) {
 	if rawURL == nil {
 		return nil, ErrInvalidURL

--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -52,14 +52,27 @@ func New(base string, path ...string) (*URL, error) {
 
 // FromRawURL converts a core Go `url.URL` into `urlbuilder.URL`,
 // providing better control over query parameters and encoding.
+//
+// The input URL is not stored by pointer: a copy is made so mutating this
+// urlbuilder.URL (including String(), which updates the delegate's RawQuery)
+// never changes the original *url.URL (for example http.Request.URL).
 func FromRawURL(rawURL *url.URL) (*URL, error) {
-	values, err := url.ParseQuery(rawURL.RawQuery)
+	if rawURL == nil {
+		return nil, ErrInvalidURL
+	}
+
+	delegate, err := url.Parse(rawURL.String())
+	if err != nil {
+		return nil, errors.Join(err, ErrInvalidURL)
+	}
+
+	values, err := url.ParseQuery(delegate.RawQuery)
 	if err != nil {
 		return nil, errors.Join(err, ErrInvalidURL)
 	}
 
 	return &URL{
-		delegate:             rawURL,
+		delegate:             delegate,
 		queryParams:          values,
 		unencodedQueryParams: url.Values{},
 		encodingExceptions:   make(map[string]string),

--- a/common/urlbuilder/url_test.go
+++ b/common/urlbuilder/url_test.go
@@ -295,6 +295,74 @@ func TestFromRawURL(t *testing.T) { // nolint:funlen
 	}
 }
 
+func TestFromRawURLDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	original, err := url.Parse("https://api.example.com/v1/items?page[number]=0&page[size]=100")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := original.String()
+	beforeRawQuery := original.RawQuery
+
+	wrapped, err := FromRawURL(original)
+	if err != nil {
+		t.Fatalf("FromRawURL: %v", err)
+	}
+
+	wrapped.WithQueryParam("page[number]", "5")
+	_ = wrapped.String()
+
+	if got := original.String(); got != before {
+		t.Fatalf("source URL changed after builder.String(): before %q after %q", before, got)
+	}
+
+	if original.RawQuery != beforeRawQuery {
+		t.Fatalf("source RawQuery changed: before %q after %q", beforeRawQuery, original.RawQuery)
+	}
+}
+
+func TestFromRawURLIndependentOfLaterSourceMutation(t *testing.T) {
+	t.Parallel()
+
+	original, err := url.Parse("https://example.com/path?keep=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapped, err := FromRawURL(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original.RawQuery = "tampered=1"
+
+	wrapped.WithQueryParam("keep", "2")
+	out := wrapped.String()
+
+	if strings.Contains(out, "tampered") {
+		t.Fatalf("output should not reflect post-wrap mutation of source URL: %q", out)
+	}
+
+	if !strings.Contains(out, "keep=2") {
+		t.Fatalf("expected keep=2 in %q", out)
+	}
+}
+
+func TestFromRawURLNilInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromRawURL(nil)
+	if err == nil {
+		t.Fatal("expected error for nil *url.URL")
+	}
+
+	if !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL, got %v", err)
+	}
+}
+
 func TestEquality(t *testing.T) { // nolint:funlen
 	t.Parallel()
 

--- a/common/urlbuilder/url_test.go
+++ b/common/urlbuilder/url_test.go
@@ -306,13 +306,13 @@ func TestFromRawURLDoesNotMutateInput(t *testing.T) {
 	before := original.String()
 	beforeRawQuery := original.RawQuery
 
-	wrapped, err := FromRawURL(original)
+	built, err := FromRawURL(original)
 	if err != nil {
 		t.Fatalf("FromRawURL: %v", err)
 	}
 
-	wrapped.WithQueryParam("page[number]", "5")
-	_ = wrapped.String()
+	built.WithQueryParam("page[number]", "5")
+	_ = built.String()
 
 	if got := original.String(); got != before {
 		t.Fatalf("source URL changed after builder.String(): before %q after %q", before, got)
@@ -331,18 +331,18 @@ func TestFromRawURLIndependentOfLaterSourceMutation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wrapped, err := FromRawURL(original)
+	built, err := FromRawURL(original)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	original.RawQuery = "tampered=1"
 
-	wrapped.WithQueryParam("keep", "2")
-	out := wrapped.String()
+	built.WithQueryParam("keep", "2")
+	out := built.String()
 
 	if strings.Contains(out, "tampered") {
-		t.Fatalf("output should not reflect post-wrap mutation of source URL: %q", out)
+		t.Fatalf("output should not reflect mutation of source *url.URL after FromRawURL: %q", out)
 	}
 
 	if !strings.Contains(out, "keep=2") {

--- a/providers/fastspring/read.go
+++ b/providers/fastspring/read.go
@@ -226,14 +226,7 @@ func nextPageFromIntegerCounter(previousRequestURL *url.URL) common.NextPageFunc
 			return "", err
 		}
 
-		// Re-parse from string so we do not mutate the live request URL when the builder
-		// serializes (it sets RawQuery on the delegate).
-		cloned, err := url.Parse(previousRequestURL.String())
-		if err != nil {
-			return "", err
-		}
-
-		u, err := urlbuilder.FromRawURL(cloned)
+		u, err := urlbuilder.FromRawURL(previousRequestURL)
 		if err != nil {
 			return "", err
 		}

--- a/providers/livestorm/README.md
+++ b/providers/livestorm/README.md
@@ -1,0 +1,6 @@
+# Livestorm connector
+
+This directory contains the deep connector implementation for Livestorm.
+
+- `connector.go` wires the metadata provider.
+- `metadata/schemas.json` contains static object metadata.

--- a/providers/livestorm/README.md
+++ b/providers/livestorm/README.md
@@ -1,6 +1,0 @@
-# Livestorm connector
-
-This directory contains the deep connector implementation for Livestorm.
-
-- `connector.go` wires the metadata provider.
-- `metadata/schemas.json` contains static object metadata.

--- a/providers/livestorm/connector.go
+++ b/providers/livestorm/connector.go
@@ -3,6 +3,8 @@ package livestorm
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/livestorm/metadata"
@@ -13,6 +15,7 @@ type Connector struct {
 
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -25,6 +28,17 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
 		connector.ProviderContext.Module(),
 		metadata.Schemas,
+	)
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
 	)
 
 	return connector, nil

--- a/providers/livestorm/errors.go
+++ b/providers/livestorm/errors.go
@@ -1,0 +1,11 @@
+package livestorm
+
+import "errors"
+
+var (
+	// ErrSessionIDRequired is returned when reading session_chat_messages without a session id in ReadParams.Filter.
+	ErrSessionIDRequired = errors.New("read session_chat_messages requires a non-empty ReadParams.Filter (session id)")
+
+	// ErrJobIDRequired is returned when reading jobs without a job id in ReadParams.Filter.
+	ErrJobIDRequired = errors.New("read jobs requires a non-empty ReadParams.Filter (job id)")
+)

--- a/providers/livestorm/jsonapi.go
+++ b/providers/livestorm/jsonapi.go
@@ -1,0 +1,84 @@
+package livestorm
+
+import (
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// extractJSONAPIDataRecords returns flattened records from a JSON:API body.
+// The "data" property may be an array of resources or a single resource object.
+func extractJSONAPIDataRecords(root *ajson.Node) ([]map[string]any, error) {
+	items, arrErr := jsonquery.New(root).ArrayOptional("data")
+	if arrErr == nil {
+		return flattenJSONAPIResourceList(items)
+	}
+
+	obj, objErr := jsonquery.New(root).ObjectOptional("data")
+	if objErr == nil && obj != nil {
+		flat, err := flattenJSONAPIResource(obj)
+		if err != nil {
+			return nil, err
+		}
+
+		return []map[string]any{flat}, nil
+	}
+
+	if arrErr != nil && objErr != nil {
+		return nil, arrErr
+	}
+
+	return []map[string]any{}, nil
+}
+
+func flattenJSONAPIResourceList(items []*ajson.Node) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(items))
+
+	for _, n := range items {
+		if n == nil {
+			continue
+		}
+
+		if !n.IsObject() {
+			continue
+		}
+
+		m, err := flattenJSONAPIResource(n)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, m)
+	}
+
+	return out, nil
+}
+
+// flattenJSONAPIResource merges resource id and attributes into one map (JSON:API style).
+func flattenJSONAPIResource(n *ajson.Node) (map[string]any, error) {
+	id, err := jsonquery.New(n).StringRequired("id")
+	if err != nil {
+		return nil, err
+	}
+
+	attrs, err := jsonquery.New(n).ObjectOptional("attributes")
+	if err != nil {
+		return nil, err
+	}
+
+	merged := map[string]any{"id": id}
+
+	if attrs == nil {
+		return merged, nil
+	}
+
+	attrMap, err := jsonquery.Convertor.ObjectToMap(attrs)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range attrMap {
+		merged[k] = v
+	}
+
+	return merged, nil
+}

--- a/providers/livestorm/jsonapi.go
+++ b/providers/livestorm/jsonapi.go
@@ -5,56 +5,47 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// extractJSONAPIDataRecords returns flattened records from a JSON:API body.
-// The "data" property may be an array of resources or a single resource object.
-func extractJSONAPIDataRecords(root *ajson.Node) ([]map[string]any, error) {
+// extractJSONAPIResourceNodes returns JSON:API primary `data` resource nodes only (no flattening).
+// `data` may be an array of resources or a single resource object.
+func extractJSONAPIResourceNodes(root *ajson.Node) ([]*ajson.Node, error) {
 	items, arrErr := jsonquery.New(root).ArrayOptional("data")
 	if arrErr == nil {
-		return flattenJSONAPIResourceList(items)
+		return jsonAPIDataArrayToObjectNodes(items), nil
 	}
 
 	obj, objErr := jsonquery.New(root).ObjectOptional("data")
 	if objErr == nil && obj != nil {
-		flat, err := flattenJSONAPIResource(obj)
-		if err != nil {
-			return nil, err
+		if !obj.IsObject() {
+			return []*ajson.Node{}, nil
 		}
 
-		return []map[string]any{flat}, nil
+		return []*ajson.Node{obj}, nil
 	}
 
 	if arrErr != nil && objErr != nil {
 		return nil, arrErr
 	}
 
-	return []map[string]any{}, nil
+	return []*ajson.Node{}, nil
 }
 
-func flattenJSONAPIResourceList(items []*ajson.Node) ([]map[string]any, error) {
-	out := make([]map[string]any, 0, len(items))
+func jsonAPIDataArrayToObjectNodes(items []*ajson.Node) []*ajson.Node {
+	out := make([]*ajson.Node, 0, len(items))
 
 	for _, n := range items {
-		if n == nil {
+		if n == nil || !n.IsObject() {
 			continue
 		}
 
-		if !n.IsObject() {
-			continue
-		}
-
-		m, err := flattenJSONAPIResource(n)
-		if err != nil {
-			return nil, err
-		}
-
-		out = append(out, m)
+		out = append(out, n)
 	}
 
-	return out, nil
+	return out
 }
 
-// flattenJSONAPIResource merges resource id and attributes into one map (JSON:API style).
-func flattenJSONAPIResource(n *ajson.Node) (map[string]any, error) {
+// flattenJSONAPIResourceForFields merges JSON:API `id` and `attributes` into one map for
+// readhelper.MakeMarshaledDataFuncWithId field selection only. Raw rows use the full node map.
+func flattenJSONAPIResourceForFields(n *ajson.Node) (map[string]any, error) {
 	id, err := jsonquery.New(n).StringRequired("id")
 	if err != nil {
 		return nil, err

--- a/providers/livestorm/jsonapi.go
+++ b/providers/livestorm/jsonapi.go
@@ -6,7 +6,10 @@ import (
 )
 
 // extractJSONAPIResourceNodes returns JSON:API primary `data` resource nodes only (no flattening).
-// `data` may be an array of resources or a single resource object.
+// List endpoints use `data` as an array (the usual Read path). Livestorm also returns `data` as a
+// single resource object for GET /v1/jobs/{id}; that yields one row. If Read is narrowed to
+// collections-only later, drop jobs (or similar singleton reads) from read routing instead of
+// changing this extractor.
 func extractJSONAPIResourceNodes(root *ajson.Node) ([]*ajson.Node, error) {
 	items, arrErr := jsonquery.New(root).ArrayOptional("data")
 	if arrErr == nil {

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -1,0 +1,192 @@
+package livestorm
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/livestorm/metadata"
+	"github.com/spyzhov/ajson"
+)
+
+// Default page size for list endpoints (page[size]). https://developers.livestorm.co/
+const defaultPageSize = "100"
+
+// nolint:gochecknoglobals
+var readSupportedObjects = datautils.NewStringSet(
+	"events",
+	"people",
+	"people_attributes",
+	"session_chat_messages",
+	"jobs",
+)
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	if !readSupportedObjects.Has(params.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	u, err := c.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.api+json")
+
+	return req, nil
+}
+
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	if params.ObjectName == "" {
+		return nil, common.ErrMissingObjects
+	}
+
+	switch params.ObjectName {
+	case objectSessionChatMessages:
+		sessionID := strings.TrimSpace(params.Filter)
+		if sessionID == "" {
+			return nil, ErrSessionIDRequired
+		}
+
+		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "sessions", sessionID, "chat_messages")
+		if err != nil {
+			return nil, err
+		}
+
+		u.WithQueryParam("page[number]", "0")
+		u.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+		return u, nil
+	case objectJobs:
+		jobID := strings.TrimSpace(params.Filter)
+		if jobID == "" {
+			return nil, ErrJobIDRequired
+		}
+
+		return urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "jobs", jobID)
+	default:
+		path, err := metadata.Schemas.FindURLPath(c.ProviderContext.Module(), params.ObjectName)
+		if err != nil {
+			return nil, err
+		}
+
+		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+		if err != nil {
+			return nil, err
+		}
+
+		u.WithQueryParam("page[number]", "0")
+		u.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+		if params.ObjectName == objectEvents {
+			applyEventTimeFilters(u, params)
+		}
+
+		return u, nil
+	}
+}
+
+const (
+	objectEvents              = "events"
+	objectSessionChatMessages = "session_chat_messages"
+	objectJobs                = "jobs"
+)
+
+func applyEventTimeFilters(u *urlbuilder.URL, params common.ReadParams) {
+	if !params.Since.IsZero() {
+		u.WithQueryParam("filter[updated_since]", strconv.FormatInt(params.Since.Unix(), 10))
+	}
+
+	if !params.Until.IsZero() {
+		u.WithQueryParam("filter[updated_until]", strconv.FormatInt(params.Until.Unix(), 10))
+	}
+}
+
+func (c *Connector) parseReadResponse(
+	_ context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	return common.ParseResult(
+		resp,
+		func(root *ajson.Node) ([]map[string]any, error) {
+			return extractJSONAPIDataRecords(root)
+		},
+		nextPageLivestorm(request),
+		readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id")),
+		params.Fields,
+	)
+}
+
+func nextPageLivestorm(previous *http.Request) common.NextPageFunc {
+	return func(root *ajson.Node) (string, error) {
+		if previous == nil || previous.URL == nil {
+			return "", nil
+		}
+
+		nextStr, err := jsonquery.New(root, "meta").StringOptional("next_page")
+		if err != nil {
+			return "", err
+		}
+
+		if nextStr != nil && *nextStr != "" {
+			return *nextStr, nil
+		}
+
+		pageCount, err := jsonquery.New(root, "meta").IntegerOptional("page_count")
+		if err != nil {
+			return "", err
+		}
+
+		current, err := jsonquery.New(root, "meta").IntegerOptional("current_page")
+		if err != nil {
+			return "", err
+		}
+
+		if pageCount == nil || current == nil {
+			return "", nil
+		}
+
+		pc := *pageCount
+		cur := *current
+
+		if pc <= 0 || cur+1 >= pc {
+			return "", nil
+		}
+
+		cloned, err := url.Parse(previous.URL.String())
+		if err != nil {
+			return "", err
+		}
+
+		u, err := urlbuilder.FromRawURL(cloned)
+		if err != nil {
+			return "", err
+		}
+
+		u.WithQueryParam("page[number]", strconv.FormatInt(cur+1, 10))
+
+		return u.String(), nil
+	}
+}

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -129,8 +129,6 @@ func buildVersionedPathURL(baseURL string, path string) (*urlbuilder.URL, error)
 		return urlbuilder.New(baseURL, apiVersion)
 	}
 
-	path = strings.TrimPrefix(path, "/")
-
 	return urlbuilder.New(baseURL, apiVersion, path)
 }
 

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -61,49 +61,62 @@ func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, err
 		return nil, common.ErrMissingObjects
 	}
 
-	switch params.ObjectName {
-	case objectSessionChatMessages:
-		sessionID := strings.TrimSpace(params.Filter)
-		if sessionID == "" {
-			return nil, ErrSessionIDRequired
-		}
-
-		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "sessions", sessionID, "chat_messages")
-		if err != nil {
-			return nil, err
-		}
-
-		u.WithQueryParam("page[number]", "0")
-		u.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
-
-		return u, nil
-	case objectJobs:
-		jobID := strings.TrimSpace(params.Filter)
-		if jobID == "" {
-			return nil, ErrJobIDRequired
-		}
-
-		return urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "jobs", jobID)
-	default:
-		path, err := metadata.Schemas.FindURLPath(c.ProviderContext.Module(), params.ObjectName)
-		if err != nil {
-			return nil, err
-		}
-
-		u, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
-		if err != nil {
-			return nil, err
-		}
-
-		u.WithQueryParam("page[number]", "0")
-		u.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
-
-		if params.ObjectName == objectEvents {
-			applyEventTimeFilters(u, params)
-		}
-
-		return u, nil
+	if params.ObjectName == objectSessionChatMessages {
+		return c.buildSessionChatMessagesReadURL(params)
 	}
+
+	if params.ObjectName == objectJobs {
+		return c.buildJobReadURL(params)
+	}
+
+	return c.buildGenericReadURL(params)
+}
+
+func (c *Connector) buildSessionChatMessagesReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	sessionID := strings.TrimSpace(params.Filter)
+	if sessionID == "" {
+		return nil, ErrSessionIDRequired
+	}
+
+	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "sessions", sessionID, "chat_messages")
+	if err != nil {
+		return nil, err
+	}
+
+	endpointURL.WithQueryParam("page[number]", "0")
+	endpointURL.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+	return endpointURL, nil
+}
+
+func (c *Connector) buildJobReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	jobID := strings.TrimSpace(params.Filter)
+	if jobID == "" {
+		return nil, ErrJobIDRequired
+	}
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "jobs", jobID)
+}
+
+func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	path, err := metadata.Schemas.FindURLPath(c.ProviderContext.Module(), params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointURL.WithQueryParam("page[number]", "0")
+	endpointURL.WithQueryParam("page[size]", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+	if params.ObjectName == objectEvents {
+		applyEventTimeFilters(endpointURL, params)
+	}
+
+	return endpointURL, nil
 }
 
 const (
@@ -130,9 +143,7 @@ func (c *Connector) parseReadResponse(
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
 		resp,
-		func(root *ajson.Node) ([]map[string]any, error) {
-			return extractJSONAPIDataRecords(root)
-		},
+		extractJSONAPIDataRecords,
 		nextPageLivestorm(request),
 		readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id")),
 		params.Fields,
@@ -145,48 +156,74 @@ func nextPageLivestorm(previous *http.Request) common.NextPageFunc {
 			return "", nil
 		}
 
-		nextStr, err := jsonquery.New(root, "meta").StringOptional("next_page")
+		nextPage, err := readNextPageFromMeta(root)
 		if err != nil {
 			return "", err
 		}
 
-		if nextStr != nil && *nextStr != "" {
-			return *nextStr, nil
+		if nextPage != "" {
+			return nextPage, nil
 		}
 
-		pageCount, err := jsonquery.New(root, "meta").IntegerOptional("page_count")
-		if err != nil {
-			return "", err
-		}
-
-		current, err := jsonquery.New(root, "meta").IntegerOptional("current_page")
-		if err != nil {
-			return "", err
-		}
-
-		if pageCount == nil || current == nil {
-			return "", nil
-		}
-
-		pc := *pageCount
-		cur := *current
-
-		if pc <= 0 || cur+1 >= pc {
-			return "", nil
-		}
-
-		cloned, err := url.Parse(previous.URL.String())
-		if err != nil {
-			return "", err
-		}
-
-		u, err := urlbuilder.FromRawURL(cloned)
-		if err != nil {
-			return "", err
-		}
-
-		u.WithQueryParam("page[number]", strconv.FormatInt(cur+1, 10))
-
-		return u.String(), nil
+		return buildNextPageFromCounters(previous, root)
 	}
+}
+
+func readNextPageFromMeta(root *ajson.Node) (string, error) {
+	nextStr, err := jsonquery.New(root, "meta").StringOptional("next_page")
+	if err != nil {
+		return "", err
+	}
+
+	if nextStr == nil || *nextStr == "" {
+		return "", nil
+	}
+
+	return *nextStr, nil
+}
+
+func buildNextPageFromCounters(previous *http.Request, root *ajson.Node) (string, error) {
+	pageCount, current, err := readPageCounters(root)
+	if err != nil {
+		return "", err
+	}
+
+	if pageCount == nil || current == nil {
+		return "", nil
+	}
+
+	pc := *pageCount
+	cur := *current
+
+	if pc <= 0 || cur+1 >= pc {
+		return "", nil
+	}
+
+	cloned, err := url.Parse(previous.URL.String())
+	if err != nil {
+		return "", err
+	}
+
+	u, err := urlbuilder.FromRawURL(cloned)
+	if err != nil {
+		return "", err
+	}
+
+	u.WithQueryParam("page[number]", strconv.FormatInt(cur+1, 10))
+
+	return u.String(), nil
+}
+
+func readPageCounters(root *ajson.Node) (*int64, *int64, error) {
+	pageCount, err := jsonquery.New(root, "meta").IntegerOptional("page_count")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	current, err := jsonquery.New(root, "meta").IntegerOptional("current_page")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pageCount, current, nil
 }

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -155,9 +155,9 @@ func (c *Connector) parseReadResponse(
 ) (*common.ReadResult, error) {
 	return common.ParseResult(
 		resp,
-		extractJSONAPIDataRecords,
+		extractJSONAPIResourceNodes,
 		nextPageLivestorm(request),
-		readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id")),
+		readhelper.MakeMarshaledDataFuncWithId(flattenJSONAPIResourceForFields, readhelper.NewIdField("id")),
 		params.Fields,
 	)
 }

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -78,7 +78,7 @@ func (c *Connector) buildSessionChatMessagesReadURL(params common.ReadParams) (*
 		return nil, ErrSessionIDRequired
 	}
 
-	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "sessions", sessionID, "chat_messages")
+	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, "sessions", sessionID, "chat_messages")
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (c *Connector) buildJobReadURL(params common.ReadParams) (*urlbuilder.URL, 
 		return nil, ErrJobIDRequired
 	}
 
-	return urlbuilder.New(c.ProviderInfo().BaseURL, "v1", "jobs", jobID)
+	return urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, "jobs", jobID)
 }
 
 func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
@@ -104,7 +104,7 @@ func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.U
 		return nil, err
 	}
 
-	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+	endpointURL, err := buildVersionedPathURL(c.ProviderInfo().BaseURL, path)
 	if err != nil {
 		return nil, err
 	}
@@ -120,10 +120,22 @@ func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.U
 }
 
 const (
+	apiVersion                = "v1"
 	objectEvents              = "events"
 	objectSessionChatMessages = "session_chat_messages"
 	objectJobs                = "jobs"
 )
+
+func buildVersionedPathURL(baseURL string, path string) (*urlbuilder.URL, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return urlbuilder.New(baseURL, apiVersion)
+	}
+
+	path = strings.TrimPrefix(path, "/")
+
+	return urlbuilder.New(baseURL, apiVersion, path)
+}
 
 func applyEventTimeFilters(u *urlbuilder.URL, params common.ReadParams) {
 	if !params.Since.IsZero() {

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -3,7 +3,6 @@ package livestorm
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -206,12 +205,7 @@ func buildNextPageFromCounters(previous *http.Request, root *ajson.Node) (string
 		return "", nil
 	}
 
-	cloned, err := url.Parse(previous.URL.String())
-	if err != nil {
-		return "", err
-	}
-
-	u, err := urlbuilder.FromRawURL(cloned)
+	u, err := urlbuilder.FromRawURL(previous.URL)
 	if err != nil {
 		return "", err
 	}

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -64,19 +64,16 @@ func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, err
 		return urlbuilder.New(params.NextPage.String())
 	}
 
-	if params.ObjectName == "" {
+	switch params.ObjectName {
+	case "":
 		return nil, common.ErrMissingObjects
-	}
-
-	if params.ObjectName == objectSessionChatMessages {
+	case objectSessionChatMessages:
 		return c.buildSessionChatMessagesReadURL(params)
-	}
-
-	if params.ObjectName == objectJobs {
+	case objectJobs:
 		return c.buildJobReadURL(params)
+	default:
+		return c.buildGenericReadURL(params)
 	}
-
-	return c.buildGenericReadURL(params)
 }
 
 func (c *Connector) buildSessionChatMessagesReadURL(params common.ReadParams) (*urlbuilder.URL, error) {

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -16,8 +16,15 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// Default page size for list endpoints (page[size]). https://developers.livestorm.co/
-const defaultPageSize = "100"
+const (
+	// Default page size for list endpoints (page[size]). https://developers.livestorm.co/
+	defaultPageSize = "100"
+
+	apiVersion                = "v1"
+	objectEvents              = "events"
+	objectSessionChatMessages = "session_chat_messages"
+	objectJobs                = "jobs"
+)
 
 // nolint:gochecknoglobals
 var readSupportedObjects = datautils.NewStringSet(
@@ -118,13 +125,6 @@ func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.U
 
 	return endpointURL, nil
 }
-
-const (
-	apiVersion                = "v1"
-	objectEvents              = "events"
-	objectSessionChatMessages = "session_chat_messages"
-	objectJobs                = "jobs"
-)
 
 func buildVersionedPathURL(baseURL string, path string) (*urlbuilder.URL, error) {
 	path = strings.TrimSpace(path)

--- a/providers/livestorm/read.go
+++ b/providers/livestorm/read.go
@@ -123,12 +123,7 @@ func (c *Connector) buildGenericReadURL(params common.ReadParams) (*urlbuilder.U
 }
 
 func buildVersionedPathURL(baseURL string, path string) (*urlbuilder.URL, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return urlbuilder.New(baseURL, apiVersion)
-	}
-
-	return urlbuilder.New(baseURL, apiVersion, path)
+	return urlbuilder.New(baseURL, apiVersion, strings.TrimSpace(path))
 }
 
 func applyEventTimeFilters(u *urlbuilder.URL, params common.ReadParams) {

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			},
 		},
 		{
-			Name: "Read people uses next_page token from response",
+			Name: "Read people offset pagination via meta.next_page absolute URL",
 			Input: common.ReadParams{
 				ObjectName: "people",
 				NextPage:   testroutines.URLTestServer + "/v1/people?page[number]=2&page[size]=100",
@@ -192,6 +192,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 
+				// Connector path: readNextPageFromMeta reads meta.next_page and returns it as the next
+				// page token (offset-style pagination with an absolute URL). The mock must use r.Host so
+				// that URL matches the httptest origin expected after {{testServerURL}} resolution.
 				body := fmt.Sprintf(
 					`{"data":[{"id":"person_1","type":"people","attributes":{"email":"a@example.com"}}],"meta":{"next_page":"http://%s/v1/people?page[number]=3&page[size]=100"}}`,
 					r.Host,

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -11,56 +11,21 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-func TestRead(t *testing.T) { //nolint:funlen
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
 	since := time.Unix(1735689600, 0).UTC()
 	until := time.Unix(1735776000, 0).UTC()
 
-	eventsResponse := []byte(`{
-		"data": [
-			{
-				"id": "evt_1",
-				"type": "events",
-				"attributes": {
-					"title": "Launch Webinar",
-					"updated_at": "2025-01-01T12:00:00Z"
-				}
-			}
-		],
-		"meta": {
-			"current_page": 0,
-			"page_count": 2
-		}
-	}`)
-
-	chatMessagesResponse := []byte(`{
-		"data": [
-			{
-				"id": "chat_1",
-				"type": "session_chat_messages",
-				"attributes": {
-					"text": "hello"
-				}
-			}
-		],
-		"meta": {
-			"current_page": 0,
-			"page_count": 1
-		}
-	}`)
-
-	jobResponse := []byte(`{
-		"data": {
-			"id": "job_1",
-			"type": "jobs",
-			"attributes": {
-				"status": "done"
-			}
-		}
-	}`)
+	eventsBody := testutils.DataFromFile(t, "read-events.json")
+	eventsMultipageBody := testutils.DataFromFile(t, "read-events-multipage.json")
+	peopleFirstPageBody := testutils.DataFromFile(t, "read-people-first-page.json")
+	chatMessagesBody := testutils.DataFromFile(t, "read-session-chat-messages.json")
+	jobBody := testutils.DataFromFile(t, "read-job.json")
+	peopleAttributesBody := testutils.DataFromFile(t, "read-people-attributes.json")
 
 	tests := []testroutines.Read{
 		{
@@ -111,7 +76,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockcond.QueryParam("filter[updated_since]", fmt.Sprintf("%d", since.Unix())),
 					mockcond.QueryParam("filter[updated_until]", fmt.Sprintf("%d", until.Unix())),
 				},
-				Then: mockserver.Response(http.StatusOK, eventsResponse),
+				Then: mockserver.Response(http.StatusOK, eventsBody),
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
@@ -127,6 +92,78 @@ func TestRead(t *testing.T) { //nolint:funlen
 							"id":         "evt_1",
 							"title":      "Launch Webinar",
 							"updated_at": "2025-01-01T12:00:00Z",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read events advances page from meta when next_page absent",
+			Input: common.ReadParams{
+				ObjectName: objectEvents,
+				Fields:     connectors.Fields("title"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/events"),
+					mockcond.QueryParam("page[number]", "0"),
+					mockcond.QueryParam("page[size]", "100"),
+					mockcond.QueryParamsMissing("filter[updated_since]", "filter[updated_until]"),
+				},
+				Then: mockserver.Response(http.StatusOK, eventsMultipageBody),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Done:     false,
+				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"title": "Paged Event",
+						},
+						Raw: map[string]any{
+							"id":         "evt_1",
+							"title":      "Paged Event",
+							"updated_at": "2025-01-02T12:00:00Z",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read people first page",
+			Input: common.ReadParams{
+				ObjectName: "people",
+				Fields:     connectors.Fields("email", "first_name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/people"),
+					mockcond.QueryParam("page[number]", "0"),
+					mockcond.QueryParam("page[size]", "100"),
+				},
+				Then: mockserver.Response(http.StatusOK, peopleFirstPageBody),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Done: true,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"email":      "alpha@example.com",
+							"first_name": "Alpha",
+						},
+						Raw: map[string]any{
+							"id":         "person_a",
+							"email":      "alpha@example.com",
+							"first_name": "Alpha",
+							"last_name":  "User",
 						},
 					},
 				},
@@ -183,7 +220,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockcond.QueryParam("page[number]", "0"),
 					mockcond.QueryParam("page[size]", "100"),
 				},
-				Then: mockserver.Response(http.StatusOK, chatMessagesResponse),
+				Then: mockserver.Response(http.StatusOK, chatMessagesBody),
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
@@ -215,7 +252,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockcond.MethodGET(),
 					mockcond.Path("/v1/jobs/job_1"),
 				},
-				Then: mockserver.Response(http.StatusOK, jobResponse),
+				Then: mockserver.Response(http.StatusOK, jobBody),
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
@@ -248,19 +285,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockcond.QueryParam("page[number]", "0"),
 					mockcond.QueryParam("page[size]", "100"),
 				},
-				Then: mockserver.ResponseString(http.StatusOK, `{
-					"data": [{
-						"id": "attr_1",
-						"type": "people_attributes",
-						"attributes": {
-							"slug": "company"
-						}
-					}],
-					"meta": {
-						"current_page": 0,
-						"page_count": 1
-					}
-				}`),
+				Then: mockserver.Response(http.StatusOK, peopleAttributesBody),
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
@@ -294,7 +319,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockcond.QueryParam("page[number]", "5"),
 					mockcond.QueryParam("page[size]", "100"),
 				},
-				Then: mockserver.Response(http.StatusOK, eventsResponse),
+				Then: mockserver.Response(http.StatusOK, eventsBody),
 			}.Server(),
 			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
@@ -309,6 +334,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
+
 			tt.Run(t, func() (connectors.ReadConnector, error) {
 				return constructTestConnector(tt.Server.URL)
 			})

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -89,9 +89,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 							"title": "Launch Webinar",
 						},
 						Raw: map[string]any{
-							"id":         "evt_1",
-							"title":      "Launch Webinar",
-							"updated_at": "2025-01-01T12:00:00Z",
+							"id":   "evt_1",
+							"type": "events",
+							"attributes": map[string]any{
+								"title":      "Launch Webinar",
+								"updated_at": "2025-01-01T12:00:00Z",
+							},
 						},
 					},
 				},
@@ -125,9 +128,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 							"title": "Paged Event",
 						},
 						Raw: map[string]any{
-							"id":         "evt_1",
-							"title":      "Paged Event",
-							"updated_at": "2025-01-02T12:00:00Z",
+							"id":   "evt_1",
+							"type": "events",
+							"attributes": map[string]any{
+								"title":      "Paged Event",
+								"updated_at": "2025-01-02T12:00:00Z",
+							},
 						},
 					},
 				},
@@ -160,10 +166,13 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 							"first_name": "Alpha",
 						},
 						Raw: map[string]any{
-							"id":         "person_a",
-							"email":      "alpha@example.com",
-							"first_name": "Alpha",
-							"last_name":  "User",
+							"id":   "person_a",
+							"type": "people",
+							"attributes": map[string]any{
+								"email":      "alpha@example.com",
+								"first_name": "Alpha",
+								"last_name":  "User",
+							},
 						},
 					},
 				},
@@ -198,8 +207,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 							"email": "a@example.com",
 						},
 						Raw: map[string]any{
-							"id":    "person_1",
-							"email": "a@example.com",
+							"id":   "person_1",
+							"type": "people",
+							"attributes": map[string]any{
+								"email": "a@example.com",
+							},
 						},
 					},
 				},
@@ -233,7 +245,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						},
 						Raw: map[string]any{
 							"id":   "chat_1",
-							"text": "hello",
+							"type": "session_chat_messages",
+							"attributes": map[string]any{
+								"text": "hello",
+							},
 						},
 					},
 				},
@@ -264,8 +279,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 							"status": "done",
 						},
 						Raw: map[string]any{
-							"id":     "job_1",
-							"status": "done",
+							"id":   "job_1",
+							"type": "jobs",
+							"attributes": map[string]any{
+								"status": "done",
+							},
 						},
 					},
 				},
@@ -298,7 +316,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						},
 						Raw: map[string]any{
 							"id":   "attr_1",
-							"slug": "company",
+							"type": "people_attributes",
+							"attributes": map[string]any{
+								"slug": "company",
+							},
 						},
 					},
 				},

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -148,7 +148,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					r.Host,
 				)
 
-				_, _ = w.Write([]byte(body)) // nolint:errcheck
+				_, _ = w.Write([]byte(body)) // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
 			}),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -1,0 +1,317 @@
+package livestorm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	since := time.Unix(1735689600, 0).UTC()
+	until := time.Unix(1735776000, 0).UTC()
+
+	eventsResponse := []byte(`{
+		"data": [
+			{
+				"id": "evt_1",
+				"type": "events",
+				"attributes": {
+					"title": "Launch Webinar",
+					"updated_at": "2025-01-01T12:00:00Z"
+				}
+			}
+		],
+		"meta": {
+			"current_page": 0,
+			"page_count": 2
+		}
+	}`)
+
+	chatMessagesResponse := []byte(`{
+		"data": [
+			{
+				"id": "chat_1",
+				"type": "session_chat_messages",
+				"attributes": {
+					"text": "hello"
+				}
+			}
+		],
+		"meta": {
+			"current_page": 0,
+			"page_count": 1
+		}
+	}`)
+
+	jobResponse := []byte(`{
+		"data": {
+			"id": "job_1",
+			"type": "jobs",
+			"attributes": {
+				"status": "done"
+			}
+		}
+	}`)
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: objectEvents},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:         "Unknown object name is not supported",
+			Input:        common.ReadParams{ObjectName: "unknown", Fields: connectors.Fields("id")},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name:         "Session chat messages require session id in filter",
+			Input:        common.ReadParams{ObjectName: objectSessionChatMessages, Fields: connectors.Fields("id")},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrSessionIDRequired},
+		},
+		{
+			Name:         "Jobs require job id in filter",
+			Input:        common.ReadParams{ObjectName: objectJobs, Fields: connectors.Fields("id")},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrJobIDRequired},
+		},
+		{
+			Name: "Read events applies v1 path and incremental time filters",
+			Input: common.ReadParams{
+				ObjectName: objectEvents,
+				Fields:     connectors.Fields("title"),
+				Since:      since,
+				Until:      until,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/events"),
+					mockcond.QueryParam("page[number]", "0"),
+					mockcond.QueryParam("page[size]", "100"),
+					mockcond.QueryParam("filter[updated_since]", fmt.Sprintf("%d", since.Unix())),
+					mockcond.QueryParam("filter[updated_until]", fmt.Sprintf("%d", until.Unix())),
+				},
+				Then: mockserver.Response(http.StatusOK, eventsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Done:     false,
+				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100&filter[updated_since]=1735689600&filter[updated_until]=1735776000",
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"title": "Launch Webinar",
+						},
+						Raw: map[string]any{
+							"id":         "evt_1",
+							"title":      "Launch Webinar",
+							"updated_at": "2025-01-01T12:00:00Z",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read people uses next_page token from response",
+			Input: common.ReadParams{
+				ObjectName: "people",
+				NextPage:   testroutines.URLTestServer + "/v1/people?page[number]=2&page[size]=100",
+				Fields:     connectors.Fields("email"),
+			},
+			Server: mockserver.NewServer(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				body := fmt.Sprintf(
+					`{"data":[{"id":"person_1","type":"people","attributes":{"email":"a@example.com"}}],"meta":{"next_page":"http://%s/v1/people?page[number]=3&page[size]=100"}}`,
+					r.Host,
+				)
+
+				_, _ = w.Write([]byte(body)) // nolint:errcheck
+			}),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Done:     false,
+				NextPage: testroutines.URLTestServer + "/v1/people?page[number]=3&page[size]=100",
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"email": "a@example.com",
+						},
+						Raw: map[string]any{
+							"id":    "person_1",
+							"email": "a@example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read session chat messages by session id",
+			Input: common.ReadParams{
+				ObjectName: objectSessionChatMessages,
+				Filter:     "sess_1",
+				Fields:     connectors.Fields("text"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/sessions/sess_1/chat_messages"),
+					mockcond.QueryParam("page[number]", "0"),
+					mockcond.QueryParam("page[size]", "100"),
+				},
+				Then: mockserver.Response(http.StatusOK, chatMessagesResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Done: true,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"text": "hello",
+						},
+						Raw: map[string]any{
+							"id":   "chat_1",
+							"text": "hello",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read job by id",
+			Input: common.ReadParams{
+				ObjectName: objectJobs,
+				Filter:     "job_1",
+				Fields:     connectors.Fields("status"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/jobs/job_1"),
+				},
+				Then: mockserver.Response(http.StatusOK, jobResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Done: true,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"status": "done",
+						},
+						Raw: map[string]any{
+							"id":     "job_1",
+							"status": "done",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read people attributes via generic object metadata path",
+			Input: common.ReadParams{
+				ObjectName: "people_attributes",
+				Fields:     connectors.Fields("slug"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/people_attributes"),
+					mockcond.QueryParam("page[number]", "0"),
+					mockcond.QueryParam("page[size]", "100"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{
+					"data": [{
+						"id": "attr_1",
+						"type": "people_attributes",
+						"attributes": {
+							"slug": "company"
+						}
+					}],
+					"meta": {
+						"current_page": 0,
+						"page_count": 1
+					}
+				}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Done: true,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"slug": "company",
+						},
+						Raw: map[string]any{
+							"id":   "attr_1",
+							"slug": "company",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Read events from NextPage token uses provided URL as-is",
+			Input: common.ReadParams{
+				ObjectName: objectEvents,
+				NextPage:   testroutines.URLTestServer + "/v1/events?page[number]=5&page[size]=100",
+				Fields:     connectors.Fields("title"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/events"),
+					mockcond.QueryParam("page[number]", "5"),
+					mockcond.QueryParam("page[size]", "100"),
+				},
+				Then: mockserver.Response(http.StatusOK, eventsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     1,
+				Done:     false,
+				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -3,6 +3,8 @@ package livestorm
 import (
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 	"github.com/amp-labs/connectors/test/utils/testutils"
+	"github.com/go-test/deep"
 )
 
 func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
@@ -360,5 +363,73 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
+	}
+}
+
+// TestRead_fieldsFlattenedRawPreservesJSONAPI asserts the read contract: Fields holds a flat map
+// suitable for field projection (id + attributes merged for extraction only), while Raw is the
+// full JSON:API resource object. Full equality (not subset matching) shows the two shapes differ
+// and Raw is not flattened to match Fields.
+func TestRead_fieldsFlattenedRawPreservesJSONAPI(t *testing.T) {
+	t.Parallel()
+
+	body := testutils.DataFromFile(t, "read-people-first-page.json")
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/v1/people"),
+			mockcond.QueryParam("page[number]", "0"),
+			mockcond.QueryParam("page[size]", "100"),
+		},
+		Then: mockserver.Response(http.StatusOK, body),
+	}.Server()
+	t.Cleanup(srv.Close)
+
+	conn, err := constructTestConnector(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := conn.Read(t.Context(), common.ReadParams{
+		ObjectName: "people",
+		Fields:     connectors.Fields("email", "first_name"),
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	want := &common.ReadResult{
+		Rows:     1,
+		Done:     true,
+		NextPage: "",
+		Data: []common.ReadResultRow{
+			{
+				Fields: map[string]any{
+					"email":      "alpha@example.com",
+					"first_name": "Alpha",
+				},
+				Raw: map[string]any{
+					"id":   "person_a",
+					"type": "people",
+					"attributes": map[string]any{
+						"email":      "alpha@example.com",
+						"first_name": "Alpha",
+						"last_name":  "User",
+					},
+				},
+				Id: "person_a",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("ReadResult not equal to expected (full match, not subset):\n%s",
+			strings.Join(deep.Equal(want, got), "\n"))
+	}
+
+	if _, has := got.Data[0].Fields["attributes"]; has {
+		t.Fatal("Fields must be flat for projection; must not include JSON:API \"attributes\" object")
 	}
 }

--- a/providers/livestorm/test/read-events-multipage.json
+++ b/providers/livestorm/test/read-events-multipage.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "id": "evt_1",
+      "type": "events",
+      "attributes": {
+        "title": "Paged Event",
+        "updated_at": "2025-01-02T12:00:00Z"
+      }
+    }
+  ],
+  "meta": {
+    "current_page": 0,
+    "page_count": 3
+  }
+}

--- a/providers/livestorm/test/read-events.json
+++ b/providers/livestorm/test/read-events.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "id": "evt_1",
+      "type": "events",
+      "attributes": {
+        "title": "Launch Webinar",
+        "updated_at": "2025-01-01T12:00:00Z"
+      }
+    }
+  ],
+  "meta": {
+    "current_page": 0,
+    "page_count": 2
+  }
+}

--- a/providers/livestorm/test/read-job.json
+++ b/providers/livestorm/test/read-job.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "id": "job_1",
+    "type": "jobs",
+    "attributes": {
+      "status": "done"
+    }
+  }
+}

--- a/providers/livestorm/test/read-people-attributes.json
+++ b/providers/livestorm/test/read-people-attributes.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "id": "attr_1",
+      "type": "people_attributes",
+      "attributes": {
+        "slug": "company"
+      }
+    }
+  ],
+  "meta": {
+    "current_page": 0,
+    "page_count": 1
+  }
+}

--- a/providers/livestorm/test/read-people-first-page.json
+++ b/providers/livestorm/test/read-people-first-page.json
@@ -1,0 +1,17 @@
+{
+  "data": [
+    {
+      "id": "person_a",
+      "type": "people",
+      "attributes": {
+        "email": "alpha@example.com",
+        "first_name": "Alpha",
+        "last_name": "User"
+      }
+    }
+  ],
+  "meta": {
+    "current_page": 0,
+    "page_count": 1
+  }
+}

--- a/providers/livestorm/test/read-session-chat-messages.json
+++ b/providers/livestorm/test/read-session-chat-messages.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "id": "chat_1",
+      "type": "session_chat_messages",
+      "attributes": {
+        "text": "hello"
+      }
+    }
+  ],
+  "meta": {
+    "current_page": 0,
+    "page_count": 1
+  }
+}

--- a/test/livestorm/read/main.go
+++ b/test/livestorm/read/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	livestormprovider "github.com/amp-labs/connectors/providers/livestorm"
+	connTest "github.com/amp-labs/connectors/test/livestorm"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetLivestormConnector(ctx)
+
+	slog.Info("=== Basic paginated read: events ===")
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "events",
+		Fields: connectors.Fields(
+			"title",
+			"updated_at",
+		),
+	})
+
+	slog.Info("=== Incremental read with Since: events ===")
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "events",
+		Fields: connectors.Fields(
+			"title",
+			"updated_at",
+		),
+		Since: time.Now().UTC().AddDate(0, -1, 0),
+	})
+
+	slog.Info("=== Basic paginated read: people ===")
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "people",
+		Fields: connectors.Fields(
+			"email",
+			"first_name",
+			"last_name",
+		),
+	})
+
+	slog.Info("=== Basic paginated read: people_attributes ===")
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "people_attributes",
+		Fields: connectors.Fields(
+			"slug",
+			"name",
+			"type",
+		),
+	})
+
+	slog.Info("=== Metadata vs Read validation: events ===")
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "events", nil)
+
+	slog.Info("=== Metadata vs Read validation: people ===")
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "people", nil)
+
+	slog.Info("=== Metadata vs Read validation: people_attributes ===")
+	testscenario.ValidateMetadataContainsRead(ctx, conn, "people_attributes", nil)
+
+	if sessionID := os.Getenv("LIVESTORM_SESSION_ID"); sessionID != "" {
+		slog.Info("=== Read session_chat_messages (requires LIVESTORM_SESSION_ID) ===")
+		readSessionChatMessages(ctx, conn, sessionID)
+	}
+
+	if jobID := os.Getenv("LIVESTORM_JOB_ID"); jobID != "" {
+		slog.Info("=== Read jobs by id (requires LIVESTORM_JOB_ID) ===")
+		readJob(ctx, conn, jobID)
+	}
+
+	slog.Info("Livestorm read tests completed successfully!")
+}
+
+func readSessionChatMessages(ctx context.Context, conn *livestormprovider.Connector, sessionID string) {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "session_chat_messages",
+		Filter:     sessionID,
+		Fields: connectors.Fields(
+			"text",
+			"created_at",
+		),
+	})
+	if err != nil {
+		utils.Fail("error reading session_chat_messages from Livestorm", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func readJob(ctx context.Context, conn *livestormprovider.Connector, jobID string) {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "jobs",
+		Filter:     jobID,
+		Fields: connectors.Fields(
+			"status",
+			"updated_at",
+		),
+	})
+	if err != nil {
+		utils.Fail("error reading jobs from Livestorm", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
## Summary

This PR delivers the Livestorm deep connector: schema-backed `ListObjectMetadata`, OAuth-based HTTP read against Livestorm’s JSON:API (application/vnd.api+json), factory wiring in connector/new.go, and provider catalog updates so Livestorm exposes Read in addition to Proxy. Reads cover list endpoints (events, people, people_attributes), paginated session chat messages (session id via ReadParams.Filter), and single job fetch by id (ReadParams.Filter). Incremental reads for events use filter[updated_since] / filter[updated_until] mapped from Since / Until. Pagination uses meta.next_page when present, otherwise meta.current_page / meta.page_count with page[number] / page[size].

## Key Features

- `Embedded metadata`: providers/livestorm/metadata/schemas.json + schema.NewOpenAPISchemaProvider for ListObjectMetadata.
- `JSON`:API read parsing: Flattens data[] / single data resources (id + attributes) into flat records; IDs surfaced via readhelper.MakeGetMarshaledDataWithId.
-` Multi-object reads`: Lists for standard objects; nested routes require Filter: session_chat_messages → session UUID, jobs → job UUID.
- `Incremental events`: Since/Until → filter[updated_since] / filter[updated_until] (Unix).
- `Pagination`: Next URL from meta.next_page or computed page index from meta.
- `Factory & catalog`: providers.Livestorm registered in connector/new.go; providers/livestorm.go sets Support.Read: true.
- `Tests`: Metadata unit tests (metadata_test.go); integration harness under test/livestorm/ (extend with read/live scripts as you finish them).

## Testing
```bash
# Unit tests
go test ./providers/livestorm -v

go test ./providers/livestorm -cover

# Integration-style scripts
go run ./test/livestorm/metadata/main.go
```