### PR TITLE
fix(salesforce): subscribe/update/delete API call ordering and correctness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-test/deep v1.1.1
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.13.0
@@ -76,7 +77,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.19.0 // indirect

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -485,28 +485,28 @@ func toApexTriggers(
 	return triggers
 }
 
-// redeployKeptApexTriggers updates apex triggers for kept objects in place via
+// redeployExistingApexTriggers updates apex triggers for existing objects in place via
 // Metadata API deploy, which is an upsert keyed by the trigger's fullName. No
 // destructive prelude is needed for objects that still have a quota field — the
 // new deploy atomically replaces the existing trigger and its companion test
 // class in a single transaction. Triggers whose object no longer has a quota
 // field configured (orphaned) are destructively deleted.
 //
-// Operates only on kept objects: anything in diff.objectsToAdd is excluded
+// Operates only on existing objects: anything in diff.objectsToAdd is excluded
 // because the inner Subscribe call in executeUpdateSubscription will deploy
 // triggers for new objects. Without this exclusion, each new-object trigger
 // would deploy twice (once here, once in inner Subscribe), doubling the
 // metadata-deploy time per added object.
 //
 //nolint:cyclop
-func (c *Connector) redeployKeptApexTriggers(
+func (c *Connector) redeployExistingApexTriggers(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
 ) error {
-	keptParams := common.SubscribeParams{SubscriptionEvents: diff.allObjectEvents}
+	existingParams := common.SubscribeParams{SubscriptionEvents: diff.allObjectEvents}
 
-	triggerParams, err := buildApexTriggerParamsForSubscribe(keptParams, req)
+	triggerParams, err := buildApexTriggerParamsForSubscribe(existingParams, req)
 	if err != nil {
 		return err
 	}
@@ -515,7 +515,7 @@ func (c *Connector) redeployKeptApexTriggers(
 	// contains all subscription events (kept and new), so triggerParams as
 	// returned by buildApexTriggerParamsForSubscribe includes new objects too.
 	// Inner Subscribe handles new-object trigger deployment; this function
-	// must restrict itself to kept objects only.
+	// must restrict itself to existing objects only.
 	for _, addObj := range diff.objectsToAdd {
 		delete(triggerParams, addObj)
 	}
@@ -523,7 +523,7 @@ func (c *Connector) redeployKeptApexTriggers(
 	// Destructively remove triggers for objects that previously had a quota
 	// field but no longer do. Objects still in triggerParams are left alone —
 	// the deploy below will upsert them in place.
-	for objName, trigger := range diff.apexTriggersToKeep {
+	for objName, trigger := range diff.apexTriggersExisting {
 		if _, willRedeploy := triggerParams[objName]; willRedeploy {
 			continue
 		}
@@ -541,7 +541,7 @@ func (c *Connector) redeployKeptApexTriggers(
 			return fmt.Errorf("failed to delete orphaned apex trigger for object %s: %w", objName, err)
 		}
 
-		delete(diff.apexTriggersToKeep, objName)
+		delete(diff.apexTriggersExisting, objName)
 	}
 
 	triggerCodeMap := make(map[common.ObjectName]string, len(triggerParams))
@@ -560,7 +560,7 @@ func (c *Connector) redeployKeptApexTriggers(
 			return fmt.Errorf("failed to redeploy apex trigger for object %s: %w", objName, err)
 		}
 
-		diff.apexTriggersToKeep[objName] = &ApexTrigger{
+		diff.apexTriggersExisting[objName] = &ApexTrigger{
 			ObjectName:     objName,
 			TriggerName:    result.TriggerName,
 			IndicatorField: result.IndicatorField,

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -38,15 +38,14 @@ const (
 // itself (per the Metadata API DeployOptions docs).
 const apexDeployTestLevel = metadata.TestLevelRunSpecifiedTests
 
-// ApexTrigger represents a deployed apex trigger in the SubscribeResult.
+// ApexTrigger represents a deployed apex trigger that exists in Salesforce.
+// Only successfully deployed triggers are recorded here; deploy failures are
+// surfaced through the error returned from Subscribe / UpdateSubscription.
 type ApexTrigger struct {
 	ObjectName     common.ObjectName
 	TriggerName    string
 	IndicatorField common.FieldDefinition
 	WatchFields    []string
-	// Errors contains deployment error messages for this trigger.
-	// Empty when deployment succeeded.
-	Errors []string
 
 	// Deprecated: CheckboxField is kept for backwards compatibility with
 	// previously serialized SubscribeResults. New code should use IndicatorField.
@@ -460,52 +459,89 @@ func filterSuccessfulTriggers(
 	return successful
 }
 
-// toApexTriggers converts deploy results to the ApexTrigger type stored in SubscribeResult,
-// including per-object error details for failed deployments.
+// toApexTriggers converts deploy results to the ApexTrigger type stored in
+// SubscribeResult. Only successfully deployed triggers (non-empty DeployID) are
+// emitted, so the returned map faithfully describes triggers that exist in
+// Salesforce. Per-object deploy errors are conveyed via out.Errors and surfaced
+// through the error chain returned from Subscribe / UpdateSubscription.
 func toApexTriggers(
 	out *DeployApexTriggersResult,
 ) map[common.ObjectName]*ApexTrigger {
 	triggers := make(map[common.ObjectName]*ApexTrigger, len(out.Results))
 
 	for objName, result := range out.Results {
-		trigger := &ApexTrigger{
+		if result.DeployID == "" {
+			continue
+		}
+
+		triggers[objName] = &ApexTrigger{
 			ObjectName:     objName,
 			TriggerName:    result.TriggerName,
 			IndicatorField: result.IndicatorField,
 			WatchFields:    result.WatchFields,
 		}
-
-		if err, ok := out.Errors[objName]; ok {
-			trigger.Errors = []string{err.Error()}
-		}
-
-		triggers[objName] = trigger
 	}
 
 	return triggers
 }
 
-// redeployKeptApexTriggers deletes old apex triggers for kept objects and redeploys
-// them with updated watch fields from keptObjectEvents.
+// redeployKeptApexTriggers updates apex triggers for kept objects in place via
+// Metadata API deploy, which is an upsert keyed by the trigger's fullName. No
+// destructive prelude is needed for objects that still have a quota field — the
+// new deploy atomically replaces the existing trigger and its companion test
+// class in a single transaction. Triggers whose object no longer has a quota
+// field configured (orphaned) are destructively deleted.
+//
+// Operates only on kept objects: anything in diff.objectsToAdd is excluded
+// because the inner Subscribe call in executeUpdateSubscription will deploy
+// triggers for new objects. Without this exclusion, each new-object trigger
+// would deploy twice (once here, once in inner Subscribe), doubling the
+// metadata-deploy time per added object.
+//
+//nolint:cyclop
 func (c *Connector) redeployKeptApexTriggers(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
 ) error {
-	for objName, trigger := range diff.apexTriggersToKeep {
-		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
-			return fmt.Errorf("failed to delete old apex trigger for object %s: %w", objName, err)
-		}
-
-		delete(diff.apexTriggersToKeep, objName)
-	}
-
-	// Build trigger params from the kept objects' events (saved before diff mutation).
-	keptParams := common.SubscribeParams{SubscriptionEvents: diff.keptObjectEvents}
+	keptParams := common.SubscribeParams{SubscriptionEvents: diff.allObjectEvents}
 
 	triggerParams, err := buildApexTriggerParamsForSubscribe(keptParams, req)
 	if err != nil {
 		return err
+	}
+
+	// Filter out objects-to-add from triggerParams. diff.allObjectEvents
+	// contains all subscription events (kept and new), so triggerParams as
+	// returned by buildApexTriggerParamsForSubscribe includes new objects too.
+	// Inner Subscribe handles new-object trigger deployment; this function
+	// must restrict itself to kept objects only.
+	for _, addObj := range diff.objectsToAdd {
+		delete(triggerParams, addObj)
+	}
+
+	// Destructively remove triggers for objects that previously had a quota
+	// field but no longer do. Objects still in triggerParams are left alone —
+	// the deploy below will upsert them in place.
+	for objName, trigger := range diff.apexTriggersToKeep {
+		if _, willRedeploy := triggerParams[objName]; willRedeploy {
+			continue
+		}
+
+		if trigger == nil {
+			slog.Warn("orphan apex trigger entry is nil, skipping delete",
+				"object", objName,
+			)
+
+			continue
+		}
+
+		// TODO: check existence before delete
+		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+			return fmt.Errorf("failed to delete orphaned apex trigger for object %s: %w", objName, err)
+		}
+
+		delete(diff.apexTriggersToKeep, objName)
 	}
 
 	triggerCodeMap := make(map[common.ObjectName]string, len(triggerParams))

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -462,8 +462,11 @@ func filterSuccessfulTriggers(
 // toApexTriggers converts deploy results to the ApexTrigger type stored in
 // SubscribeResult. Only successfully deployed triggers (non-empty DeployID) are
 // emitted, so the returned map faithfully describes triggers that exist in
-// Salesforce. Per-object deploy errors are conveyed via out.Errors and surfaced
-// through the error chain returned from Subscribe / UpdateSubscription.
+// Salesforce. Per-object deploy errors are aggregated into out.Errors and
+// surfaced through the error chain returned from Subscribe / UpdateSubscription;
+// they are also logged here per object so that, even if the caller swallows the
+// aggregate error, a failed-deploy entry has a corresponding warn log keyed to
+// the object name.
 func toApexTriggers(
 	out *DeployApexTriggersResult,
 ) map[common.ObjectName]*ApexTrigger {
@@ -471,6 +474,11 @@ func toApexTriggers(
 
 	for objName, result := range out.Results {
 		if result.DeployID == "" {
+			slog.Warn("apex trigger deploy failed; entry omitted from sfRes.ApexTriggers",
+				"object", objName,
+				"error", out.Errors[objName],
+			)
+
 			continue
 		}
 

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -69,10 +69,15 @@ type EventChannelMember struct {
 }
 
 type EventChannelMemberMetadata struct {
-	EventChannel     string           `json:"eventChannel"`
-	SelectedEntity   string           `json:"selectedEntity,omitempty"`
-	EnrichedFields   []*EnrichedField `json:"enrichedFields,omitempty"`
-	FilterExpression string           `json:"filterExpression,omitempty"`
+	EventChannel   string `json:"eventChannel"`
+	SelectedEntity string `json:"selectedEntity,omitempty"`
+	// EnrichedFields is sent on the wire even when empty so PATCH can clear
+	// previously-configured enrichments (Salesforce treats an omitted field
+	// as "leave alone," but treats an explicit empty array as "clear").
+	EnrichedFields []*EnrichedField `json:"enrichedFields"`
+	// FilterExpression is sent on the wire even when empty for the same
+	// PATCH-clear reason as EnrichedFields above.
+	FilterExpression string `json:"filterExpression"`
 }
 
 type EnrichedField struct {

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -208,18 +208,65 @@ func (c *Connector) CreateEventChannelMember(
 // UpdateEventChannelMember updates an existing PlatformEventChannelMember via PATCH.
 // nolint: lll
 // https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_platformeventchannelmember.htm
+//
+// Salesforce's Tooling API treats the PATCH body as a full Metadata replacement:
+// EventChannel and SelectedEntity are REQUIRED (a body without them returns
+// "Required field is missing: selectedEntity") but also IMMUTABLE (a body
+// whose value differs from what Salesforce has stored returns "Update is not
+// supported for the selectedEntity field on platform event channel members.").
+//
+// To avoid the case-mismatch hazard — Salesforce normalizes the stored
+// SelectedEntity / EventChannel (e.g. "account" → "Account__ChangeEvent")
+// while our locally-cached prevState may still hold the caller's original
+// casing — we first GET the live record to pick up its canonical immutable
+// fields, then PATCH using those values plus the caller-supplied mutable
+// fields (FilterExpression and EnrichedFields). The extra round trip is
+// worth it: passing a stale SelectedEntity tanks the whole UpdateSubscription
+// with a 400 even though the value didn't semantically change.
 func (c *Connector) UpdateEventChannelMember(
 	ctx context.Context,
 	member *EventChannelMember,
 ) (*EventChannelMember, error) {
-	// Salesforce Tooling API expects the Metadata wrapper and FullName in the PATCH body.
-	body := &EventChannelMember{FullName: member.FullName, Metadata: member.Metadata}
+	if member == nil || member.Metadata == nil {
+		return nil, errEventChannelMemberNilInput
+	}
 
-	_, err := c.patchToSFAPI(ctx, body,
+	current, err := getToolingEntityByID[EventChannelMember](
+		ctx, c, "PlatformEventChannelMember", member.Id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch current EventChannelMember %s before PATCH: %w", member.Id, err)
+	}
+
+	if current == nil || current.Metadata == nil {
+		return nil, fmt.Errorf("%w: id=%s", errEventChannelMemberMissingMD, member.Id)
+	}
+
+	// Build the PATCH body using Salesforce's canonical immutable values for
+	// EventChannel and SelectedEntity, plus the caller's intended new values
+	// for the mutable fields.
+	body := &EventChannelMember{
+		FullName: current.FullName,
+		Metadata: &EventChannelMemberMetadata{
+			EventChannel:     current.Metadata.EventChannel,
+			SelectedEntity:   current.Metadata.SelectedEntity,
+			FilterExpression: member.Metadata.FilterExpression,
+			EnrichedFields:   member.Metadata.EnrichedFields,
+		},
+	}
+
+	_, err = c.patchToSFAPI(ctx, body,
 		"tooling/sobjects/PlatformEventChannelMember/"+member.Id, "EventChannelMember")
 	if err != nil {
 		return nil, err
 	}
+
+	// Reflect the canonical immutable values back into the caller's member so
+	// downstream consumers (e.g. diff.channelMembersExisting) see the
+	// authoritative casing.
+	member.FullName = current.FullName
+	member.Metadata.EventChannel = current.Metadata.EventChannel
+	member.Metadata.SelectedEntity = current.Metadata.SelectedEntity
 
 	return member, nil
 }
@@ -413,9 +460,11 @@ func (c *Connector) deleteToSFAPI(ctx context.Context, path string, entity strin
 const errCodeDuplicateDeveloperName = "DUPLICATE_DEVELOPER_NAME"
 
 var (
-	errToolingQueryNoRecordsField = errors.New("tooling/query response missing 'records' field")
-	errToolingEntityNotFound      = errors.New("no tooling entity found by FullName")
-	errToolingRecordMissingID     = errors.New("tooling/query record missing 'Id' field")
+	errToolingQueryNoRecordsField  = errors.New("tooling/query response missing 'records' field")
+	errToolingEntityNotFound       = errors.New("no tooling entity found by FullName")
+	errToolingRecordMissingID      = errors.New("tooling/query record missing 'Id' field")
+	errEventChannelMemberNilInput  = errors.New("UpdateEventChannelMember: member or metadata is nil")
+	errEventChannelMemberMissingMD = errors.New("UpdateEventChannelMember: GET returned empty metadata")
 )
 
 // sfAPIError is a single entry in a Salesforce API error response array.

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -71,12 +71,9 @@ type EventChannelMember struct {
 type EventChannelMemberMetadata struct {
 	EventChannel   string `json:"eventChannel"`
 	SelectedEntity string `json:"selectedEntity,omitempty"`
-	// EnrichedFields is sent on the wire even when empty so PATCH can clear
-	// previously-configured enrichments (Salesforce treats an omitted field
-	// as "leave alone," but treats an explicit empty array as "clear").
+	// EnrichedFields are the fields are list of fields that are used in filter expression
 	EnrichedFields []*EnrichedField `json:"enrichedFields"`
-	// FilterExpression is sent on the wire even when empty for the same
-	// PATCH-clear reason as EnrichedFields above.
+	// Filter expression is used to filter COC events to reduce the number of events
 	FilterExpression string `json:"filterExpression"`
 }
 

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -53,11 +53,25 @@ type subscribeProgress struct {
 	deployedTriggers    map[common.ObjectName]*ApexTriggerResult
 }
 
-// Subscribe subscribes to the events for the given objects.
-// It creates event channel members for each object in the subscription.
-// If any of the event channel members fail to be created, it will rollback the operation.
-// If the rollback fails, it will return the partial result along with the error.
-// If the rollback is successful, it will return the original error on object.
+// Subscribe creates a Salesforce CDC subscription for the given objects, performing
+// up to three operations in order:
+//
+//  1. Upsert quota optimization custom fields — only when the request configures
+//     them via SubscriptionRequest.QuotaOptimizationObjectFields. Skipped entirely
+//     when no quota config is provided.
+//  2. Deploy apex triggers that maintain those fields per object — only for
+//     objects that have both a quota field configured (step 1) and WatchFields
+//     set in SubscriptionEvents. Skipped when no objects qualify.
+//  3. Create PlatformEventChannelMember records bound to the registered channel.
+//     The filter expression and enriched fields are populated only for objects
+//     with a quota field configured; otherwise the member is created without them.
+//
+// Any failure triggers a rollback that reverses completed steps in inverse order.
+// On success, returns a SubscriptionResult with Status = Success. On failure with
+// successful rollback, returns post-rollback state with Status = Failed. On failure
+// with failed rollback, returns the partial state with Status = FailedToRollback;
+// the caller should inspect Result to see what survived.
+//
 // Registration is required prior to subscribing.
 func (c *Connector) Subscribe(
 	ctx context.Context,
@@ -141,8 +155,11 @@ func (c *Connector) executeSubscribe(
 
 	progress.quotaFieldsUpserted = true
 
+	// Clone instead of aliasing so subsequent mutations of
+	// sfRes.QuotaOptimizationObjectFields (e.g. clear() in DeleteSubscription
+	// or rollback paths) do not silently mutate the caller's req map.
 	if req != nil && req.QuotaOptimizationObjectFields != nil {
-		sfRes.QuotaOptimizationObjectFields = req.QuotaOptimizationObjectFields
+		sfRes.QuotaOptimizationObjectFields = maps.Clone(req.QuotaOptimizationObjectFields)
 	}
 
 	// Deploy apex triggers before creating event channel members. Both reference
@@ -206,8 +223,29 @@ func (c *Connector) createEventChannelMembers(
 	return nil
 }
 
-// DeleteSubscription deletes the subscription by deleting all the event channel members.
-// If any of the event channel members fail to be deleted, it will return an error.
+// DeleteSubscription tears down a Salesforce CDC subscription by removing the
+// artifacts created by Subscribe / UpdateSubscription, in the inverse of creation
+// order:
+//
+//  1. Delete event channel members. The first failure aborts and returns an error;
+//     remaining triggers and fields are not touched.
+//  2. Delete apex triggers (and their companion Test_<TriggerName> classes via
+//     destructive deploy). Same fail-fast behavior as members.
+//  3. Delete quota optimization custom fields. Best-effort: a failure here is
+//     logged as a warning and the function returns nil. Common cause is that the
+//     field is still referenced by other metadata (e.g. PlatformEventChannelMembers
+//     on channels we don't manage).
+//
+// As each artifact is successfully removed, the corresponding entry is deleted
+// from params.Result so the surviving entries faithfully describe what is still
+// in Salesforce. Callers can inspect params.Result after the call (success or
+// failure) to see what remains.
+//
+// The dependency-removal rule is reflected in the order: filter expressions and
+// triggers (which reference the custom fields) are removed before the fields
+// they reference, so field deletion is not blocked by stale references.
+//
+//nolint:cyclop,funlen
 func (c *Connector) DeleteSubscription(ctx context.Context, params common.SubscriptionResult) error {
 	if params.Result == nil {
 		return fmt.Errorf("%w: missing SubscriptionResult.Result", errMissingParams)
@@ -229,16 +267,59 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 	// Tear down in reverse of creation: event channel members first to stop CDC
 	// traffic, then apex triggers. Both reference the quota optimization fields
 	// and must be removed before the custom fields can be deleted.
+	//
+	// Each successful per-object delete is removed from sfRes so that, if a later
+	// step fails and the caller retries or inspects sfRes, the surviving entries
+	// faithfully describe what is still in Salesforce.
 	for objectName, member := range sfRes.EventChannelMembers {
+		if member == nil {
+			slog.Warn("event channel member entry is nil, skipping delete",
+				"object", objectName,
+			)
+
+			continue
+		}
+
+		// TODO: check existence before delete
 		if _, err := c.DeleteEventChannelMember(ctx, member.Id); err != nil {
+			slog.Warn(
+				"event channel member delete failed mid-teardown; aborting before remaining "+
+					"members, triggers, and quota fields are touched",
+				"failedObject", objectName,
+				"error", err,
+				"remainingChannelMembers", datautils.FromMap(sfRes.EventChannelMembers).Keys(),
+				"remainingApexTriggers", datautils.FromMap(sfRes.ApexTriggers).Keys(),
+				"remainingQuotaFields", datautils.FromMap(sfRes.QuotaOptimizationObjectFields).Keys(),
+			)
+
 			return fmt.Errorf("failed to delete event channel member '%s': %w", objectName, err)
 		}
+
+		delete(sfRes.EventChannelMembers, objectName)
 	}
 
 	for objName, trigger := range sfRes.ApexTriggers {
+		if trigger == nil {
+			slog.Warn("apex trigger entry is nil, skipping delete",
+				"object", objName,
+			)
+
+			continue
+		}
+
+		// TODO: check existence before delete
 		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+			slog.Warn("apex trigger delete failed mid-teardown; aborting before remaining triggers and quota fields are touched",
+				"failedObject", objName,
+				"error", err,
+				"remainingApexTriggers", datautils.FromMap(sfRes.ApexTriggers).Keys(),
+				"remainingQuotaFields", datautils.FromMap(sfRes.QuotaOptimizationObjectFields).Keys(),
+			)
+
 			return fmt.Errorf("failed to delete apex trigger for object '%s': %w", objName, err)
 		}
+
+		delete(sfRes.ApexTriggers, objName)
 	}
 
 	if len(sfRes.QuotaOptimizationObjectFields) > 0 {
@@ -253,6 +334,7 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 		// Best-effort: a quota-field delete can fail when the field is still referenced by
 		// other metadata (e.g. PlatformEventChannelMember filter expressions on channels we
 		// don't manage). Log and continue so the rest of the subscription teardown succeeds.
+		// TODO: check existence before delete
 		if _, err := c.DeleteMetadata(ctx, &common.DeleteMetadataParams{
 			Fields: deleteFields,
 		}); err != nil {
@@ -261,6 +343,10 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 				"fields", deleteFields,
 			)
 		}
+		// Clear regardless of error: residual checkbox fields left in Salesforce
+		// are inert once the trigger and channel member referencing them are gone,
+		// and sfRes must not advertise fields this teardown attempted to remove.
+		clear(sfRes.QuotaOptimizationObjectFields)
 	}
 
 	return nil
@@ -273,15 +359,56 @@ type updateSubscriptionProgress struct {
 	newQuotaFields      map[common.ObjectName]string
 }
 
-// UpdateSubscription will update the subscription by:
-// 1. Removing objects from the previous subscription that are not in the new subscription.
-// 2. Adding new objects to the subscription that are in the new subscription but not in the previous subscription.
-// 3. Returning the updated subscription result.
+// UpdateSubscription reconciles an existing subscription against the new request,
+// performing four operations in order:
+//
+//  1. Upsert any quota optimization custom fields that the new request configures.
+//     Idempotent for fields that already exist.
+//  2. Update kept objects (those subscribed in both prevState and the new request):
+//     redeploy apex triggers via Metadata API upsert, and PATCH PlatformEventChannelMember
+//     filter expressions / enriched fields. Both operations are atomic from
+//     Salesforce's side, so per-object failure leaves the prior state intact.
+//  3. Delete objects that were in prevState but are not in the new request, via
+//     DeleteSubscription. Quota fields whose kept-object references were just
+//     cleared in step 2 are also cleaned up here.
+//  4. Subscribe newly-added objects (in the new request but not in prevState),
+//     via an inner Subscribe call with a narrowed SubscribeParams.
+//
+// Step 2 runs before step 3 so that filter / enriched references to quota fields
+// are cleared before DeleteSubscription tries to remove those fields, satisfying
+// the dependency-removal rule (dependents removed before dependency).
+//
+// On success, returns SubscriptionResult with Status = Success and Result reflecting
+// the merged state (kept + new − removed). On failure, returns a partial result
+// representing what is currently in Salesforce, with Status = Failed (rollback
+// succeeded) or Status = FailedToRollback (rollback also errored). The rollback
+// only undoes truly-new quota fields; kept-object updates and removals are not
+// undone, but their per-object atomicity means each artifact is in a consistent
+// state — a retry of the same UpdateSubscription is idempotent and converges.
+//
+//nolint:cyclop,nestif,funlen
 func (c *Connector) UpdateSubscription(
 	ctx context.Context,
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
+	// Validate params up-front (mirrors Subscribe) so a malformed input is
+	// rejected before any Salesforce-side mutation happens. Without this, a
+	// missing or invalid params would only be caught later by the inner
+	// Subscribe call — after upsertQuotaOptimizationFields, updateKeptSubscriptions,
+	// and DeleteSubscription have already run.
+	if params.RegistrationResult == nil {
+		return nil, fmt.Errorf("%w: missing RegistrationResult", errMissingParams)
+	}
+
+	if params.RegistrationResult.Result == nil {
+		return nil, fmt.Errorf("%w: missing RegistrationResult.Result", errMissingParams)
+	}
+
+	if err := validator.New().Struct(params); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
 	// validate the previous result
 	if previousResult.Result == nil {
 		return nil, fmt.Errorf("%w: missing previousResult.Result", errMissingParams)
@@ -318,16 +445,38 @@ func (c *Connector) UpdateSubscription(
 	if execErr != nil {
 		rollbackErr := c.rollbackUpdateSubscription(ctx, progress)
 
-		return nil, errors.Join(execErr, rollbackErr)
+		// Reflect post-rollback state in the partial result:
+		//   - Prune the truly-new quota fields that rollback attempted to remove.
+		//     Per project policy, residuals on the Salesforce side are tolerable
+		//     and the result must not advertise fields we tried to remove.
+		//   - Escalate the status to FailedToRollback when rollback errored, so
+		//     the caller can distinguish a clean teardown from a partial one.
+		if result != nil {
+			if state, ok := result.Result.(*SubscribeResult); ok && progress.quotaFieldsUpserted {
+				for objName := range progress.newQuotaFields {
+					delete(state.QuotaOptimizationObjectFields, objName)
+				}
+			}
+
+			if rollbackErr != nil {
+				result.Status = common.SubscriptionStatusFailedToRollback
+			}
+		}
+
+		return result, errors.Join(execErr, rollbackErr)
 	}
 
 	return result, nil
 }
 
 // executeUpdateSubscription performs the forward-path logic of UpdateSubscription.
-// It returns partial progress on error, without performing any rollback.
+// It returns a SubscriptionResult that reflects current Salesforce state at the
+// point of return (success or failure) along with partial progress for the
+// rollback path. The caller (UpdateSubscription) is responsible for invoking
+// rollbackUpdateSubscription on error and adjusting the returned result's
+// status accordingly.
 //
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (c *Connector) executeUpdateSubscription(
 	ctx context.Context,
 	params common.SubscribeParams,
@@ -338,7 +487,9 @@ func (c *Connector) executeUpdateSubscription(
 	progress := &updateSubscriptionProgress{}
 
 	if err := c.upsertQuotaOptimizationFields(ctx, params, req); err != nil {
-		return nil, progress, err
+		// No mutation has occurred yet; prevState still describes Salesforce.
+		return buildPartialUpdateResult(prevState, nil, nil, req, common.SubscriptionStatusFailed),
+			progress, err
 	}
 
 	progress.quotaFieldsUpserted = true
@@ -349,38 +500,77 @@ func (c *Connector) executeUpdateSubscription(
 
 	diff := computeSubscriptionDiff(params, prevState)
 
+	// Update kept-object channel members and triggers FIRST so that any
+	// filter / enriched-field references to quota custom fields are either
+	// re-pointed (rename case) or cleared (quota-config-removed case) before
+	// DeleteSubscription tries to delete those fields. The dependency rule:
+	// the field is the dependency, the filter/enriched and trigger are
+	// dependents — dependents must be removed first when removing the field.
+	if err := c.updateKeptSubscriptions(ctx, req, diff); err != nil {
+		return buildPartialUpdateResult(prevState, &diff, nil, req, common.SubscriptionStatusFailed),
+			progress, err
+	}
+
 	deleteParams := *previousResult
 	deleteParams.Result = prevState
 	deleteParams.Objects = diff.objectsToDelete
 
-	// Delete only objects that were selected for removal, preserving objects
-	// that need to remain in the subscription.
+	// Delete objects selected for removal. Their ECMs and triggers come from
+	// prevState; prevState.QuotaOptimizationObjectFields includes (a) fields
+	// owned by objects-to-delete and (b) quota fields whose kept-object
+	// references were just cleared above by updateKeptSubscriptions, so the
+	// field deletion can now succeed for both classes.
 	if err := c.DeleteSubscription(ctx, deleteParams); err != nil {
-		return nil, progress, fmt.Errorf("failed to delete previous subscription: %w", err)
+		return buildPartialUpdateResult(prevState, &diff, nil, req, common.SubscriptionStatusFailed),
+			progress, fmt.Errorf("failed to delete previous subscription: %w", err)
 	}
 
-	// Update channel members and redeploy apex triggers for kept objects.
-	if err := c.updateKeptSubscriptions(ctx, req, diff); err != nil {
-		return nil, progress, err
+	// Build a narrowed SubscribeParams for the inner Subscribe so it operates
+	// only on objects-to-add. We use a fresh SubscriptionEvents map (built from
+	// diff.objectsToAdd against the upfront snapshot in diff.allObjectEvents)
+	// instead of relying on a side-effecting mutation of the caller's
+	// params.SubscriptionEvents.
+	//
+	// The Request is also a fresh SubscriptionRequest carrying only the new
+	// objects' quota field configuration, so upsertQuotaOptimizationFields
+	// inside Subscribe can prune without disturbing the outer req's kept-object
+	// entries. Salesforce's UpsertMetadata is idempotent, so re-upserting the
+	// new-object fields (already done at the outer level) is a wasted call but
+	// not a correctness issue.
+	innerParams := params
+
+	innerEvents := make(map[common.ObjectName]common.ObjectEvents, len(diff.objectsToAdd))
+	for _, objName := range diff.objectsToAdd {
+		if events, ok := diff.allObjectEvents[objName]; ok {
+			innerEvents[objName] = events
+		}
 	}
 
-	// Temporarily clear QuotaOptimizationObjectFields from the request before calling Subscribe,
-	// since we already upserted them above. This avoids a duplicate UpsertMetadata call.
-	var savedQuotaOptimizationObjectFields map[common.ObjectName]string
+	innerParams.SubscriptionEvents = innerEvents
+
 	if req != nil {
-		savedQuotaOptimizationObjectFields = req.QuotaOptimizationObjectFields
-		req.QuotaOptimizationObjectFields = nil
+		innerFields := make(map[common.ObjectName]string)
+
+		for _, objName := range diff.objectsToAdd {
+			if fieldName, ok := lookupQuotaField(req.QuotaOptimizationObjectFields, objName); ok {
+				innerFields[objName] = fieldName
+			}
+		}
+
+		innerParams.Request = &SubscriptionRequest{QuotaOptimizationObjectFields: innerFields}
 	}
 
-	// create new subscription
-	createRes, err := c.Subscribe(ctx, params)
-	if err != nil {
-		return nil, progress, fmt.Errorf("failed to subscribe to new objects: %w", err)
-	}
+	createRes, subscribeErr := c.Subscribe(ctx, innerParams)
+	if subscribeErr != nil {
+		// Subscribe always returns a non-nil result even on failure, with status
+		// indicating whether its rollback succeeded; propagate that escalation.
+		status := common.SubscriptionStatusFailed
+		if createRes != nil && createRes.Status == common.SubscriptionStatusFailedToRollback {
+			status = common.SubscriptionStatusFailedToRollback
+		}
 
-	// Restore QuotaOptimizationObjectFields so it can be saved in the new state.
-	if req != nil {
-		req.QuotaOptimizationObjectFields = savedQuotaOptimizationObjectFields
+		return buildPartialUpdateResult(prevState, &diff, createRes, req, status),
+			progress, fmt.Errorf("failed to subscribe to new objects: %w", subscribeErr)
 	}
 
 	newState := buildUpdatedSubscribeResult(prevState, createRes, diff, req)
@@ -397,33 +587,68 @@ func (c *Connector) executeUpdateSubscription(
 	}, progress, nil
 }
 
+// buildPartialUpdateResult assembles a SubscriptionResult that describes the
+// current Salesforce state at the point an error was hit during UpdateSubscription.
+// diff is nil when computeSubscriptionDiff has not yet run; createRes is nil when
+// the inner Subscribe was not reached.
+func buildPartialUpdateResult(
+	prevState *SubscribeResult,
+	diff *subscriptionDiff,
+	createRes *common.SubscriptionResult,
+	req *SubscriptionRequest,
+	status common.SubscriptionStatus,
+) *common.SubscriptionResult {
+	var state *SubscribeResult
+
+	if diff == nil {
+		// No work has begun; prevState already reflects Salesforce.
+		state = prevState
+	} else {
+		state = buildUpdatedSubscribeResult(prevState, createRes, *diff, req)
+	}
+
+	return &common.SubscriptionResult{
+		Status: status,
+		Result: state,
+		Events: []common.SubscriptionEventType{
+			common.SubscriptionEventTypeCreate,
+			common.SubscriptionEventTypeUpdate,
+			common.SubscriptionEventTypeDelete,
+		},
+		Objects: datautils.FromMap(state.EventChannelMembers).Keys(),
+	}
+}
+
 // subscriptionDiff holds the result of diffing current subscription events against previous state.
 type subscriptionDiff struct {
 	channelMembersToKeep map[common.ObjectName]*EventChannelMember
 	apexTriggersToKeep   map[common.ObjectName]*ApexTrigger
-	keptObjectEvents     map[common.ObjectName]common.ObjectEvents
+	allObjectEvents      map[common.ObjectName]common.ObjectEvents
 	objectsToDelete      []common.ObjectName
+	// objectsToAdd lists objects present in the new params but not in prevState.
+	// Tracked explicitly so callers can iterate the new-object set without
+	// relying on the side-effecting mutation of params.SubscriptionEvents that
+	// computeSubscriptionDiff also performs.
+	objectsToAdd []common.ObjectName
 }
 
 // computeSubscriptionDiff determines which objects to add, keep, and delete.
-// It mutates params.SubscriptionEvents (removes already-subscribed objects) and
-// prevState.EventChannelMembers (removes objects being kept) as side effects.
+// It mutates prevState.EventChannelMembers (removes objects being kept) as a
+// side effect; this is load-bearing for the subsequent DeleteSubscription call,
+// which scopes its work via prevState.EventChannelMembers.
+//
+// params.SubscriptionEvents is NOT mutated. Callers needing the new-object
+// subset should iterate diff.objectsToAdd.
 func computeSubscriptionDiff(
 	params common.SubscribeParams,
 	prevState *SubscribeResult,
 ) subscriptionDiff {
-	// Save all subscription events upfront before mutation removes kept objects.
+	// Snapshot all subscription events for downstream consumers (e.g. building
+	// a new-objects-only map for the inner Subscribe call).
 	allObjectEvents := make(map[common.ObjectName]common.ObjectEvents, len(params.SubscriptionEvents))
 	maps.Copy(allObjectEvents, params.SubscriptionEvents)
 
-	objectsToExcludeFromSubscription := []common.ObjectName{}
 	objectsExcludeFromDelete := []common.ObjectName{}
-
-	for objName := range params.SubscriptionEvents {
-		if _, ok := prevState.EventChannelMembers[objName]; ok {
-			objectsToExcludeFromSubscription = append(objectsToExcludeFromSubscription, objName)
-		}
-	}
 
 	for objName := range prevState.EventChannelMembers {
 		if _, ok := params.SubscriptionEvents[objName]; ok {
@@ -431,8 +656,11 @@ func computeSubscriptionDiff(
 		}
 	}
 
-	for _, objName := range objectsToExcludeFromSubscription {
-		delete(params.SubscriptionEvents, objName)
+	objectsToAdd := make([]common.ObjectName, 0, len(params.SubscriptionEvents))
+	for objName := range params.SubscriptionEvents {
+		if _, ok := prevState.EventChannelMembers[objName]; !ok {
+			objectsToAdd = append(objectsToAdd, objName)
+		}
 	}
 
 	channelMembersToKeep := make(map[common.ObjectName]*EventChannelMember)
@@ -456,40 +684,74 @@ func computeSubscriptionDiff(
 	return subscriptionDiff{
 		channelMembersToKeep: channelMembersToKeep,
 		apexTriggersToKeep:   apexTriggersToKeep,
-		keptObjectEvents:     allObjectEvents,
+		allObjectEvents:      allObjectEvents,
 		objectsToDelete:      objectsToDelete,
+		objectsToAdd:         objectsToAdd,
 	}
 }
 
-// buildUpdatedSubscribeResult merges the kept members with newly created members
-// and applies quota optimization fields from the request.
+// buildUpdatedSubscribeResult merges three sources into a single SubscribeResult
+// reflecting current Salesforce state:
+//
+//   - prevState's residual ECMs/Triggers — entries that DeleteSubscription either
+//     hasn't deleted yet (early-failure paths) or failed to delete (partial-failure).
+//     The corruption-A fix in DeleteSubscription removes successfully-deleted
+//     entries from prevState as it goes, so what remains here is exactly what is
+//     still in Salesforce among the objects-to-delete set.
+//   - diff.channelMembersToKeep / diff.apexTriggersToKeep — kept objects in
+//     their post-update state (or pre-update if updateKeptSubscriptions failed
+//     before reaching them).
+//   - createRes from the inner Subscribe (when non-nil) — newly added objects,
+//     reflecting post-rollback state on Subscribe failure.
+//
+// createRes may be nil when called on a partial-failure path before the inner
+// Subscribe ran (or when the inner Subscribe returned a result without a typed
+// *SubscribeResult).
 func buildUpdatedSubscribeResult(
 	prevState *SubscribeResult,
 	createRes *common.SubscriptionResult,
 	diff subscriptionDiff,
 	req *SubscriptionRequest,
 ) *SubscribeResult {
-	//nolint:forcetypeassert
-	newCreateRes := createRes.Result.(*SubscribeResult)
+	var newCreateRes *SubscribeResult
+
+	if createRes != nil {
+		if val, ok := createRes.Result.(*SubscribeResult); ok {
+			newCreateRes = val
+		}
+	}
+
+	// Capture prevState's current ECMs/Triggers before the field reassignments
+	// below replace prevState's pointers. After corruption-A handling in
+	// DeleteSubscription, these contain only objects-to-delete entries that are
+	// still in Salesforce (either DeleteSubscription hasn't run yet or failed
+	// for those entries). Including them ensures the partial result accurately
+	// reflects "what's still in Salesforce" rather than over-claiming deletion.
+	residualECMs := prevState.EventChannelMembers
+	residualTriggers := prevState.ApexTriggers
 
 	newState := prevState
-	newState.EventChannelMembers = diff.channelMembersToKeep
-	maps.Copy(newState.EventChannelMembers, newCreateRes.EventChannelMembers)
+
+	newState.EventChannelMembers = make(map[common.ObjectName]*EventChannelMember)
+	maps.Copy(newState.EventChannelMembers, residualECMs)
+	maps.Copy(newState.EventChannelMembers, diff.channelMembersToKeep)
+
+	if newCreateRes != nil {
+		maps.Copy(newState.EventChannelMembers, newCreateRes.EventChannelMembers)
+	}
 
 	newState.ApexTriggers = make(map[common.ObjectName]*ApexTrigger)
+	maps.Copy(newState.ApexTriggers, residualTriggers)
 	maps.Copy(newState.ApexTriggers, diff.apexTriggersToKeep)
 
-	if len(newCreateRes.ApexTriggers) > 0 {
+	if newCreateRes != nil && len(newCreateRes.ApexTriggers) > 0 {
 		maps.Copy(newState.ApexTriggers, newCreateRes.ApexTriggers)
 	}
 
-	for _, objName := range diff.objectsToDelete {
-		delete(newState.EventChannelMembers, objName)
-		delete(newState.ApexTriggers, objName)
-	}
-
+	// Clone so post-processing (e.g. pruning rolled-back fields in the
+	// UpdateSubscription error path) doesn't mutate the caller's req map.
 	if req != nil && req.QuotaOptimizationObjectFields != nil {
-		newState.QuotaOptimizationObjectFields = req.QuotaOptimizationObjectFields
+		newState.QuotaOptimizationObjectFields = maps.Clone(req.QuotaOptimizationObjectFields)
 	}
 
 	return newState
@@ -586,11 +848,23 @@ func prepareQuotaOptimizationObjectFieldsForUpdate(
 // for each object that the caller has both (a) subscribed to via params.SubscriptionEvents
 // and (b) configured a quota field for via req.QuotaOptimizationObjectFields.
 //
-// Quota-field entries that don't correspond to any subscribed object are dropped from
-// req.QuotaOptimizationObjectFields in place so the rest of the subscribe flow (state
-// persistence at sfRes.QuotaOptimizationObjectFields, rollback via progress.req,
-// prepareQuotaOptimizationObjectFieldsForUpdate) operates on the same filtered view
-// and never references fields that were never created in the org.
+// As an intentional side effect, drops entries from req.QuotaOptimizationObjectFields
+// in place when the corresponding object is not in params.SubscriptionEvents. Those
+// entries are phantoms — their fields would never be created in Salesforce — and the
+// in-place filtering ensures they don't propagate to:
+//   - sfRes.QuotaOptimizationObjectFields (cloned post-mutation in executeSubscribe,
+//     so it captures only the actually-upserted set);
+//   - progress.req (still the same pointer, so rollback iterates the post-mutation
+//     view and only attempts to delete what was actually created);
+//   - prepareQuotaOptimizationObjectFieldsForUpdate (sees the post-mutation view
+//     when computing newQuotaFields for UpdateSubscription).
+//
+// The mutation is expected and produces no inconsistency: the returned result
+// advertises exactly the fields that exist in Salesforce, rollback targets exactly
+// those fields, and DeleteSubscription later cleans up exactly those fields. The
+// only observable effect on callers is that their req.QuotaOptimizationObjectFields
+// map is silently shrunk; callers that reuse the same req pointer across multiple
+// calls should construct a fresh req per call to avoid observing the mutation.
 func (c *Connector) upsertQuotaOptimizationFields(
 	ctx context.Context, params common.SubscribeParams, req *SubscriptionRequest,
 ) error {
@@ -663,37 +937,61 @@ func (c *Connector) updateKeptSubscriptions(
 		return err
 	}
 
-	return c.recreateKeptChannelMembers(ctx, req, diff)
+	return c.updateKeptChannelMembers(ctx, req, diff)
 }
 
-// recreateKeptChannelMembers deletes and recreates channel members for kept objects
-// with updated filter expressions and enriched fields. Salesforce doesn't support
-// PATCH on selectedEntity, so delete+recreate is required.
-func (c *Connector) recreateKeptChannelMembers(
+// updateKeptChannelMembers updates filter expressions and enriched fields on
+// existing PlatformEventChannelMember records via Tooling API PATCH. selectedEntity
+// is unchanged for kept objects (still <ObjectName>ChangeEvent), so PATCH suffices —
+// no delete-and-recreate window where CDC traffic is interrupted, and the member's
+// Id is preserved. The PATCH is also atomic from Salesforce's side, so a failure
+// leaves the prior FilterExpression / EnrichedFields intact.
+//
+// When the new request has no quota config for an object, buildQuotaFilterExpression
+// and buildQuotaEnrichedFields return empty values; the PATCH then explicitly
+// clears the existing filter / enriched fields on Salesforce. This frees the
+// quota custom field's reference so the subsequent DeleteSubscription can
+// successfully remove it (the dependency-removal ordering rule: filter and
+// enriched fields are removed before the field they reference).
+func (c *Connector) updateKeptChannelMembers(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
 ) error {
 	for objName, member := range diff.channelMembersToKeep {
-		filterExpr := buildQuotaFilterExpression(req.QuotaOptimizationObjectFields, objName)
-		if filterExpr == "" {
+		// Defensive: a malformed previousResult (e.g. corrupted by a storage
+		// roundtrip) could carry a nil member or nil Metadata. Skip and log so
+		// one bad entry doesn't crash the call for every other kept object.
+		if member == nil || member.Metadata == nil {
+			slog.Warn("kept channel member entry is malformed, skipping update",
+				"object", objName,
+				"memberNil", member == nil,
+				"metadataNil", member != nil && member.Metadata == nil,
+			)
+
 			continue
 		}
 
-		if _, err := c.DeleteEventChannelMember(ctx, member.Id); err != nil {
-			return fmt.Errorf("failed to delete event channel member for object %s: %w", objName, err)
+		// Build the PATCH body in a fresh struct so the existing diff entry is
+		// not mutated until Salesforce has acknowledged the update. On PATCH
+		// failure the prior state is preserved both in Salesforce (PATCH is
+		// atomic) and in diff.channelMembersToKeep — the two stay in sync.
+		updated := &EventChannelMember{
+			Id:       member.Id,
+			FullName: member.FullName,
+			Metadata: &EventChannelMemberMetadata{
+				EventChannel:     member.Metadata.EventChannel,
+				SelectedEntity:   member.Metadata.SelectedEntity,
+				FilterExpression: buildQuotaFilterExpression(req.QuotaOptimizationObjectFields, objName),
+				EnrichedFields:   buildQuotaEnrichedFields(req.QuotaOptimizationObjectFields, objName),
+			},
 		}
 
-		member.Id = ""
-		member.Metadata.FilterExpression = filterExpr
-		member.Metadata.EnrichedFields = buildQuotaEnrichedFields(req.QuotaOptimizationObjectFields, objName)
-
-		newMember, err := c.CreateEventChannelMember(ctx, member)
-		if err != nil {
-			return fmt.Errorf("failed to recreate event channel member for object %s: %w", objName, err)
+		if _, err := c.UpdateEventChannelMember(ctx, updated); err != nil {
+			return fmt.Errorf("failed to update event channel member for object %s: %w", objName, err)
 		}
 
-		diff.channelMembersToKeep[objName] = newMember
+		diff.channelMembersToKeep[objName] = updated
 	}
 
 	return nil

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -141,20 +141,26 @@ func (c *Connector) executeSubscribe(
 
 	progress.quotaFieldsUpserted = true
 
-	if err := c.createEventChannelMembers(ctx, params, registrationParams, req, sfRes); err != nil {
-		return sfRes, progress, err
-	}
-
 	if req != nil && req.QuotaOptimizationObjectFields != nil {
 		sfRes.QuotaOptimizationObjectFields = req.QuotaOptimizationObjectFields
 	}
 
+	// Deploy apex triggers before creating event channel members. Both reference
+	// the quota optimization field, but neither references the other, so the order
+	// is free. Doing triggers first means: (a) if the failure-prone trigger deploy
+	// fails, rollback only has to drop the custom field — no ECMs to tear down;
+	// (b) once ECMs go live, the trigger is already maintaining the indicator,
+	// so no UPDATE events get silently filtered out during the setup window.
 	deployOut, err := c.deployApexTriggersForCDC(ctx, params, req)
 
 	progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
 	sfRes.ApexTriggers = toApexTriggers(deployOut)
 
 	if err != nil {
+		return sfRes, progress, err
+	}
+
+	if err := c.createEventChannelMembers(ctx, params, registrationParams, req, sfRes); err != nil {
 		return sfRes, progress, err
 	}
 
@@ -220,17 +226,18 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 	// Migrate old CheckboxField to IndicatorField for backwards compatibility.
 	migrateApexTriggers(sfRes.ApexTriggers)
 
-	// Delete apex triggers first — they reference the quota optimization fields,
-	// so they must be removed before the custom fields can be deleted.
-	for objName, trigger := range sfRes.ApexTriggers {
-		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
-			return fmt.Errorf("failed to delete apex trigger for object '%s': %w", objName, err)
-		}
-	}
-
+	// Tear down in reverse of creation: event channel members first to stop CDC
+	// traffic, then apex triggers. Both reference the quota optimization fields
+	// and must be removed before the custom fields can be deleted.
 	for objectName, member := range sfRes.EventChannelMembers {
 		if _, err := c.DeleteEventChannelMember(ctx, member.Id); err != nil {
 			return fmt.Errorf("failed to delete event channel member '%s': %w", objectName, err)
+		}
+	}
+
+	for objName, trigger := range sfRes.ApexTriggers {
+		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+			return fmt.Errorf("failed to delete apex trigger for object '%s': %w", objName, err)
 		}
 	}
 
@@ -652,11 +659,11 @@ func (c *Connector) updateKeptSubscriptions(
 		return nil
 	}
 
-	if err := c.recreateKeptChannelMembers(ctx, req, diff); err != nil {
+	if err := c.redeployKeptApexTriggers(ctx, req, diff); err != nil {
 		return err
 	}
 
-	return c.redeployKeptApexTriggers(ctx, req, diff)
+	return c.recreateKeptChannelMembers(ctx, req, diff)
 }
 
 // recreateKeptChannelMembers deletes and recreates channel members for kept objects

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -364,12 +364,12 @@ type updateSubscriptionProgress struct {
 //
 //  1. Upsert any quota optimization custom fields that the new request configures.
 //     Idempotent for fields that already exist.
-//  2. Update kept objects (those subscribed in both prevState and the new request):
+//  2. Update existing objects (those subscribed in both prevState and the new request):
 //     redeploy apex triggers via Metadata API upsert, and PATCH PlatformEventChannelMember
 //     filter expressions / enriched fields. Both operations are atomic from
 //     Salesforce's side, so per-object failure leaves the prior state intact.
 //  3. Delete objects that were in prevState but are not in the new request, via
-//     DeleteSubscription. Quota fields whose kept-object references were just
+//     DeleteSubscription. Quota fields whose existing-object references were just
 //     cleared in step 2 are also cleaned up here.
 //  4. Subscribe newly-added objects (in the new request but not in prevState),
 //     via an inner Subscribe call with a narrowed SubscribeParams.
@@ -382,7 +382,7 @@ type updateSubscriptionProgress struct {
 // the merged state (kept + new − removed). On failure, returns a partial result
 // representing what is currently in Salesforce, with Status = Failed (rollback
 // succeeded) or Status = FailedToRollback (rollback also errored). The rollback
-// only undoes truly-new quota fields; kept-object updates and removals are not
+// only undoes truly-new quota fields; existing-object updates and removals are not
 // undone, but their per-object atomicity means each artifact is in a consistent
 // state — a retry of the same UpdateSubscription is idempotent and converges.
 //
@@ -395,7 +395,7 @@ func (c *Connector) UpdateSubscription(
 	// Validate params up-front (mirrors Subscribe) so a malformed input is
 	// rejected before any Salesforce-side mutation happens. Without this, a
 	// missing or invalid params would only be caught later by the inner
-	// Subscribe call — after upsertQuotaOptimizationFields, updateKeptSubscriptions,
+	// Subscribe call — after upsertQuotaOptimizationFields, updateExistingSubscriptions,
 	// and DeleteSubscription have already run.
 	if params.RegistrationResult == nil {
 		return nil, fmt.Errorf("%w: missing RegistrationResult", errMissingParams)
@@ -500,13 +500,13 @@ func (c *Connector) executeUpdateSubscription(
 
 	diff := computeSubscriptionDiff(params, prevState)
 
-	// Update kept-object channel members and triggers FIRST so that any
+	// Update existing-object channel members and triggers FIRST so that any
 	// filter / enriched-field references to quota custom fields are either
 	// re-pointed (rename case) or cleared (quota-config-removed case) before
 	// DeleteSubscription tries to delete those fields. The dependency rule:
 	// the field is the dependency, the filter/enriched and trigger are
 	// dependents — dependents must be removed first when removing the field.
-	if err := c.updateKeptSubscriptions(ctx, req, diff); err != nil {
+	if err := c.updateExistingSubscriptions(ctx, req, diff); err != nil {
 		return buildPartialUpdateResult(prevState, &diff, nil, req, common.SubscriptionStatusFailed),
 			progress, err
 	}
@@ -517,8 +517,8 @@ func (c *Connector) executeUpdateSubscription(
 
 	// Delete objects selected for removal. Their ECMs and triggers come from
 	// prevState; prevState.QuotaOptimizationObjectFields includes (a) fields
-	// owned by objects-to-delete and (b) quota fields whose kept-object
-	// references were just cleared above by updateKeptSubscriptions, so the
+	// owned by objects-to-delete and (b) quota fields whose existing-object
+	// references were just cleared above by updateExistingSubscriptions, so the
 	// field deletion can now succeed for both classes.
 	if err := c.DeleteSubscription(ctx, deleteParams); err != nil {
 		return buildPartialUpdateResult(prevState, &diff, nil, req, common.SubscriptionStatusFailed),
@@ -533,7 +533,7 @@ func (c *Connector) executeUpdateSubscription(
 	//
 	// The Request is also a fresh SubscriptionRequest carrying only the new
 	// objects' quota field configuration, so upsertQuotaOptimizationFields
-	// inside Subscribe can prune without disturbing the outer req's kept-object
+	// inside Subscribe can prune without disturbing the outer req's existing-object
 	// entries. Salesforce's UpsertMetadata is idempotent, so re-upserting the
 	// new-object fields (already done at the outer level) is a wasted call but
 	// not a correctness issue.
@@ -621,10 +621,10 @@ func buildPartialUpdateResult(
 
 // subscriptionDiff holds the result of diffing current subscription events against previous state.
 type subscriptionDiff struct {
-	channelMembersToKeep map[common.ObjectName]*EventChannelMember
-	apexTriggersToKeep   map[common.ObjectName]*ApexTrigger
-	allObjectEvents      map[common.ObjectName]common.ObjectEvents
-	objectsToDelete      []common.ObjectName
+	channelMembersExisting map[common.ObjectName]*EventChannelMember
+	apexTriggersExisting   map[common.ObjectName]*ApexTrigger
+	allObjectEvents        map[common.ObjectName]common.ObjectEvents
+	objectsToDelete        []common.ObjectName
 	// objectsToAdd lists objects present in the new params but not in prevState.
 	// Tracked explicitly so callers can iterate the new-object set without
 	// relying on the side-effecting mutation of params.SubscriptionEvents that
@@ -648,11 +648,11 @@ func computeSubscriptionDiff(
 	allObjectEvents := make(map[common.ObjectName]common.ObjectEvents, len(params.SubscriptionEvents))
 	maps.Copy(allObjectEvents, params.SubscriptionEvents)
 
-	objectsExcludeFromDelete := []common.ObjectName{}
+	objectsExisting := []common.ObjectName{}
 
 	for objName := range prevState.EventChannelMembers {
 		if _, ok := params.SubscriptionEvents[objName]; ok {
-			objectsExcludeFromDelete = append(objectsExcludeFromDelete, objName)
+			objectsExisting = append(objectsExisting, objName)
 		}
 	}
 
@@ -663,15 +663,15 @@ func computeSubscriptionDiff(
 		}
 	}
 
-	channelMembersToKeep := make(map[common.ObjectName]*EventChannelMember)
-	apexTriggersToKeep := make(map[common.ObjectName]*ApexTrigger)
+	channelMembersExisting := make(map[common.ObjectName]*EventChannelMember)
+	apexTriggersExisting := make(map[common.ObjectName]*ApexTrigger)
 
-	for _, objName := range objectsExcludeFromDelete {
-		channelMembersToKeep[objName] = prevState.EventChannelMembers[objName]
+	for _, objName := range objectsExisting {
+		channelMembersExisting[objName] = prevState.EventChannelMembers[objName]
 		delete(prevState.EventChannelMembers, objName)
 
 		if trigger, ok := prevState.ApexTriggers[objName]; ok {
-			apexTriggersToKeep[objName] = trigger
+			apexTriggersExisting[objName] = trigger
 			delete(prevState.ApexTriggers, objName)
 		}
 	}
@@ -682,11 +682,11 @@ func computeSubscriptionDiff(
 	}
 
 	return subscriptionDiff{
-		channelMembersToKeep: channelMembersToKeep,
-		apexTriggersToKeep:   apexTriggersToKeep,
-		allObjectEvents:      allObjectEvents,
-		objectsToDelete:      objectsToDelete,
-		objectsToAdd:         objectsToAdd,
+		channelMembersExisting: channelMembersExisting,
+		apexTriggersExisting:   apexTriggersExisting,
+		allObjectEvents:        allObjectEvents,
+		objectsToDelete:        objectsToDelete,
+		objectsToAdd:           objectsToAdd,
 	}
 }
 
@@ -698,8 +698,8 @@ func computeSubscriptionDiff(
 //     The corruption-A fix in DeleteSubscription removes successfully-deleted
 //     entries from prevState as it goes, so what remains here is exactly what is
 //     still in Salesforce among the objects-to-delete set.
-//   - diff.channelMembersToKeep / diff.apexTriggersToKeep — kept objects in
-//     their post-update state (or pre-update if updateKeptSubscriptions failed
+//   - diff.channelMembersExisting / diff.apexTriggersExisting — existing objects in
+//     their post-update state (or pre-update if updateExistingSubscriptions failed
 //     before reaching them).
 //   - createRes from the inner Subscribe (when non-nil) — newly added objects,
 //     reflecting post-rollback state on Subscribe failure.
@@ -734,7 +734,7 @@ func buildUpdatedSubscribeResult(
 
 	newState.EventChannelMembers = make(map[common.ObjectName]*EventChannelMember)
 	maps.Copy(newState.EventChannelMembers, residualECMs)
-	maps.Copy(newState.EventChannelMembers, diff.channelMembersToKeep)
+	maps.Copy(newState.EventChannelMembers, diff.channelMembersExisting)
 
 	if newCreateRes != nil {
 		maps.Copy(newState.EventChannelMembers, newCreateRes.EventChannelMembers)
@@ -742,7 +742,7 @@ func buildUpdatedSubscribeResult(
 
 	newState.ApexTriggers = make(map[common.ObjectName]*ApexTrigger)
 	maps.Copy(newState.ApexTriggers, residualTriggers)
-	maps.Copy(newState.ApexTriggers, diff.apexTriggersToKeep)
+	maps.Copy(newState.ApexTriggers, diff.apexTriggersExisting)
 
 	if newCreateRes != nil && len(newCreateRes.ApexTriggers) > 0 {
 		maps.Copy(newState.ApexTriggers, newCreateRes.ApexTriggers)
@@ -922,9 +922,35 @@ func isObjectSubscribed(
 	return false
 }
 
-// updateKeptSubscriptions updates channel members and redeploys apex triggers for
-// objects that are kept across an UpdateSubscription call.
-func (c *Connector) updateKeptSubscriptions(
+// updateExistingSubscriptions reconciles the per-object Salesforce configuration
+// for objects that remain subscribed across an UpdateSubscription call (i.e. the
+// overlap of prevState and the new request — neither newly added nor being
+// removed). Even though the subscription itself isn't being added or removed,
+// the new request can change how that subscription is configured, and those
+// changes need to be pushed to Salesforce:
+//
+//   - WatchFields may differ from the previous request, which changes which
+//     record-field updates fire the apex trigger. The trigger code is generated
+//     from WatchFields, so a change here requires redeploying the trigger.
+//   - QuotaOptimizationObjectFields[obj] may be added, removed, or renamed.
+//     Adding requires deploying a trigger and setting the channel member's
+//     filter expression / enriched fields. Removing requires destructively
+//     deleting the trigger (handled by the orphan branch in
+//     redeployExistingApexTriggers) and clearing the filter / enriched fields.
+//     Renaming requires both: point trigger and filter at the new field name.
+//
+// We don't diff old vs new configuration before acting — both Metadata API
+// deploy (used for triggers) and Tooling API PATCH (used for channel members)
+// are idempotent on Salesforce, so unconditional reconciliation converges to
+// the desired state at the cost of one round trip per existing object when
+// nothing has changed. Diffing per-object config would be more complex than
+// that round trip is expensive.
+//
+// Order: triggers first, then channel members. Both reference the quota
+// custom field; the order between them is free, but doing triggers first
+// keeps the indicator field maintained while the new channel-member filter
+// goes live.
+func (c *Connector) updateExistingSubscriptions(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
@@ -933,16 +959,16 @@ func (c *Connector) updateKeptSubscriptions(
 		return nil
 	}
 
-	if err := c.redeployKeptApexTriggers(ctx, req, diff); err != nil {
+	if err := c.redeployExistingApexTriggers(ctx, req, diff); err != nil {
 		return err
 	}
 
-	return c.updateKeptChannelMembers(ctx, req, diff)
+	return c.updateExistingChannelMembers(ctx, req, diff)
 }
 
-// updateKeptChannelMembers updates filter expressions and enriched fields on
+// updateExistingChannelMembers updates filter expressions and enriched fields on
 // existing PlatformEventChannelMember records via Tooling API PATCH. selectedEntity
-// is unchanged for kept objects (still <ObjectName>ChangeEvent), so PATCH suffices —
+// is unchanged for existing objects (still <ObjectName>ChangeEvent), so PATCH suffices —
 // no delete-and-recreate window where CDC traffic is interrupted, and the member's
 // Id is preserved. The PATCH is also atomic from Salesforce's side, so a failure
 // leaves the prior FilterExpression / EnrichedFields intact.
@@ -953,15 +979,15 @@ func (c *Connector) updateKeptSubscriptions(
 // quota custom field's reference so the subsequent DeleteSubscription can
 // successfully remove it (the dependency-removal ordering rule: filter and
 // enriched fields are removed before the field they reference).
-func (c *Connector) updateKeptChannelMembers(
+func (c *Connector) updateExistingChannelMembers(
 	ctx context.Context,
 	req *SubscriptionRequest,
 	diff subscriptionDiff,
 ) error {
-	for objName, member := range diff.channelMembersToKeep {
+	for objName, member := range diff.channelMembersExisting {
 		// Defensive: a malformed previousResult (e.g. corrupted by a storage
 		// roundtrip) could carry a nil member or nil Metadata. Skip and log so
-		// one bad entry doesn't crash the call for every other kept object.
+		// one bad entry doesn't crash the call for every other existing object.
 		if member == nil || member.Metadata == nil {
 			slog.Warn("kept channel member entry is malformed, skipping update",
 				"object", objName,
@@ -975,7 +1001,7 @@ func (c *Connector) updateKeptChannelMembers(
 		// Build the PATCH body in a fresh struct so the existing diff entry is
 		// not mutated until Salesforce has acknowledged the update. On PATCH
 		// failure the prior state is preserved both in Salesforce (PATCH is
-		// atomic) and in diff.channelMembersToKeep — the two stay in sync.
+		// atomic) and in diff.channelMembersExisting — the two stay in sync.
 		updated := &EventChannelMember{
 			Id:       member.Id,
 			FullName: member.FullName,
@@ -991,7 +1017,7 @@ func (c *Connector) updateKeptChannelMembers(
 			return fmt.Errorf("failed to update event channel member for object %s: %w", objName, err)
 		}
 
-		diff.channelMembersToKeep[objName] = updated
+		diff.channelMembersExisting[objName] = updated
 	}
 
 	return nil

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -500,12 +500,8 @@ func (c *Connector) executeUpdateSubscription(
 
 	diff := computeSubscriptionDiff(params, prevState)
 
-	// Update existing-object channel members and triggers FIRST so that any
-	// filter / enriched-field references to quota custom fields are either
-	// re-pointed (rename case) or cleared (quota-config-removed case) before
-	// DeleteSubscription tries to delete those fields. The dependency rule:
-	// the field is the dependency, the filter/enriched and trigger are
-	// dependents — dependents must be removed first when removing the field.
+	// Try updating existing subscriptions with filter expressions and enriched fields.
+	// If this fails, we simply return so minimal state change is done.
 	if err := c.updateExistingSubscriptions(ctx, req, diff); err != nil {
 		return buildPartialUpdateResult(prevState, &diff, nil, req, common.SubscriptionStatusFailed),
 			progress, err
@@ -985,9 +981,6 @@ func (c *Connector) updateExistingChannelMembers(
 	diff subscriptionDiff,
 ) error {
 	for objName, member := range diff.channelMembersExisting {
-		// Defensive: a malformed previousResult (e.g. corrupted by a storage
-		// roundtrip) could carry a nil member or nil Metadata. Skip and log so
-		// one bad entry doesn't crash the call for every other existing object.
 		if member == nil || member.Metadata == nil {
 			slog.Warn("kept channel member entry is malformed, skipping update",
 				"object", objName,

--- a/providers/salesforce/subscribe_rollback.go
+++ b/providers/salesforce/subscribe_rollback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -11,6 +12,8 @@ import (
 // rollbackSubscribe reverses completed operations in reverse order based on progress.
 // It removes successfully rolled-back members from the shared createdMembers map
 // and returns a SubscriptionResult reflecting the post-rollback state.
+//
+//nolint:cyclop,funlen
 func (c *Connector) rollbackSubscribe(
 	ctx context.Context,
 	sfRes *SubscribeResult,
@@ -22,7 +25,21 @@ func (c *Connector) rollbackSubscribe(
 	// Members are torn down first to stop CDC traffic, then triggers, then the
 	// custom fields they both reference.
 	for objName, member := range progress.createdMembers {
+		if member == nil {
+			slog.Warn("event channel member entry is nil during rollback, skipping",
+				"object", objName,
+			)
+
+			continue
+		}
+
+		// TODO: check existence before delete
 		if _, err := c.DeleteEventChannelMember(ctx, member.Id); err != nil {
+			slog.Warn("event channel member rollback failed; entry retained in sfRes for operator visibility",
+				"object", objName,
+				"error", err,
+			)
+
 			rollbackErr = errors.Join(
 				rollbackErr,
 				fmt.Errorf("failed to delete event channel member for object %s: %w", objName, err),
@@ -33,20 +50,53 @@ func (c *Connector) rollbackSubscribe(
 	}
 
 	for objName, trigger := range progress.deployedTriggers {
+		if trigger == nil {
+			slog.Warn("apex trigger entry is nil during rollback, skipping",
+				"object", objName,
+			)
+
+			continue
+		}
+
+		// TODO: check existence before delete
 		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+			slog.Warn("apex trigger rollback failed; entry retained in sfRes for operator visibility",
+				"object", objName,
+				"error", err,
+			)
+
 			rollbackErr = errors.Join(
 				rollbackErr,
 				fmt.Errorf("failed to rollback apex trigger for object %s: %w", objName, err),
 			)
 		} else {
 			delete(progress.deployedTriggers, objName)
+			delete(sfRes.ApexTriggers, objName)
 		}
 	}
 
 	if progress.quotaFieldsUpserted {
+		// TODO: check existence before delete
 		if err := c.rollbackQuotaOptimizationFields(ctx, progress.req); err != nil {
+			// Residual fields left in Salesforce are tolerable: they are inert
+			// custom checkbox fields with no behavioral side effects once the
+			// referencing apex trigger and channel member are gone. We log the
+			// snapshot so an admin can clean them up manually if desired, then
+			// continue — sfRes must not keep advertising fields we believe
+			// (best-effort) we removed.
+			slog.Warn(
+				"quota optimization field rollback failed; clearing tracked fields anyway, "+
+					"residual fields may remain in Salesforce but are tolerable",
+				"error", err,
+				"fields", sfRes.QuotaOptimizationObjectFields,
+			)
+
 			rollbackErr = errors.Join(rollbackErr, err)
 		}
+		// Clear regardless of error: any residual fields on the Salesforce side
+		// are tolerable, and sfRes should not advertise fields that this rollback
+		// attempted to remove.
+		clear(sfRes.QuotaOptimizationObjectFields)
 	}
 
 	res := &common.SubscriptionResult{
@@ -82,6 +132,7 @@ func (c *Connector) rollbackUpdateSubscription(
 
 	req := &SubscriptionRequest{QuotaOptimizationObjectFields: progress.newQuotaFields}
 
+	// TODO: check existence before delete
 	return c.rollbackQuotaOptimizationFields(ctx, req)
 }
 
@@ -98,6 +149,7 @@ func (c *Connector) rollbackQuotaOptimizationFields(ctx context.Context, req *Su
 		)
 	}
 
+	// TODO: check existence before delete
 	res, err := c.DeleteMetadata(ctx, &common.DeleteMetadataParams{
 		Fields: deleteFields,
 	})

--- a/providers/salesforce/subscribe_rollback.go
+++ b/providers/salesforce/subscribe_rollback.go
@@ -18,19 +18,9 @@ func (c *Connector) rollbackSubscribe(
 ) (*common.SubscriptionResult, error) {
 	var rollbackErr error
 
-	// Reverse deployed apex triggers (last completed, first to rollback).
-	for objName, trigger := range progress.deployedTriggers {
-		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
-			rollbackErr = errors.Join(
-				rollbackErr,
-				fmt.Errorf("failed to rollback apex trigger for object %s: %w", objName, err),
-			)
-		} else {
-			delete(progress.deployedTriggers, objName)
-		}
-	}
-
-	// Reverse created event channel members.
+	// Reverse in the inverse of creation order (fields → triggers → members).
+	// Members are torn down first to stop CDC traffic, then triggers, then the
+	// custom fields they both reference.
 	for objName, member := range progress.createdMembers {
 		if _, err := c.DeleteEventChannelMember(ctx, member.Id); err != nil {
 			rollbackErr = errors.Join(
@@ -42,7 +32,17 @@ func (c *Connector) rollbackSubscribe(
 		}
 	}
 
-	// Reverse quota optimization fields.
+	for objName, trigger := range progress.deployedTriggers {
+		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+			rollbackErr = errors.Join(
+				rollbackErr,
+				fmt.Errorf("failed to rollback apex trigger for object %s: %w", objName, err),
+			)
+		} else {
+			delete(progress.deployedTriggers, objName)
+		}
+	}
+
 	if progress.quotaFieldsUpserted {
 		if err := c.rollbackQuotaOptimizationFields(ctx, progress.req); err != nil {
 			rollbackErr = errors.Join(rollbackErr, err)

--- a/providers/salesforce/subscribe_rollback.go
+++ b/providers/salesforce/subscribe_rollback.go
@@ -9,9 +9,70 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// rollbackSubscribe reverses completed operations in reverse order based on progress.
-// It removes successfully rolled-back members from the shared createdMembers map
-// and returns a SubscriptionResult reflecting the post-rollback state.
+// rollbackSubscribe is the failure-path counterpart to executeSubscribe. It runs
+// only when executeSubscribe returned an error, and its job is to undo whatever
+// completed steps left state in Salesforce so the caller is not left with a
+// half-built subscription.
+//
+// What it undoes (and the order)
+//
+// The forward path creates artifacts in this order:
+//
+//	(A) quota optimization custom fields  →  (C) apex triggers  →  (B) channel members
+//
+// Both apex triggers and channel members reference the quota custom fields,
+// while neither references the other. Cleanup follows the dependency-removal
+// rule — dependents are removed before the dependency:
+//
+//	(B) channel members  →  (C) apex triggers  →  (A) quota custom fields
+//
+// Tearing channel members down first also stops CDC traffic before the trigger
+// that maintains the indicator field is removed, avoiding a window where the
+// pipeline emits events with a stale indicator value.
+//
+// # Progress tracking
+//
+// rollbackSubscribe consults subscribeProgress (populated by executeSubscribe)
+// to know which steps actually completed:
+//   - progress.createdMembers   — channel members successfully created
+//     (this is the same map as sfRes.EventChannelMembers — they share a
+//     reference, so deleting from one updates the other)
+//   - progress.deployedTriggers — apex triggers whose Metadata API deploy
+//     reported success (filtered from the bulk deploy result)
+//   - progress.quotaFieldsUpserted — bool flag set after a successful
+//     UpsertMetadata; rollback then iterates progress.req's
+//     QuotaOptimizationObjectFields (already filtered by upsert to only
+//     subscribed objects)
+//
+// # Best-effort across the loops
+//
+// Each per-object delete is independent. Failures don't abort — the function
+// joins errors via errors.Join and continues, so the maximum number of
+// artifacts get cleaned up even when one fails. Successful deletes are removed
+// from progress (and from sfRes for ECMs/triggers) so the returned result
+// reflects what is actually still in Salesforce. Failed deletes are retained
+// in both progress and sfRes for operator visibility, with a per-object
+// slog.Warn so the operator sees which objects need manual cleanup.
+//
+// Quota-field cleanup is bulk (one DeleteMetadata call). On error we still
+// clear sfRes.QuotaOptimizationObjectFields (per project policy: residual
+// inert custom fields in Salesforce are tolerable, and sfRes must not
+// advertise fields this rollback attempted to remove). The error is recorded
+// in rollbackErr and a warn log captures the snapshot for forensic cleanup.
+//
+// # Returned result
+//
+// The returned *common.SubscriptionResult wraps sfRes (which has been mutated
+// throughout this function to mirror Salesforce). The Status field encodes
+// whether the rollback itself succeeded:
+//   - SubscriptionStatusFailed            — original Subscribe failed AND
+//     rollback successfully undid every completed step.
+//   - SubscriptionStatusFailedToRollback  — original Subscribe failed AND
+//     rollback could not fully undo. The returned Result lists what's still
+//     stranded in Salesforce so the caller can drive a follow-up cleanup.
+//
+// Subscribe (the public entry point) uses errors.Join to combine execErr and
+// rollbackErr before returning to the caller.
 //
 //nolint:cyclop,funlen
 func (c *Connector) rollbackSubscribe(

--- a/providers/salesforce/subscribe_test.go
+++ b/providers/salesforce/subscribe_test.go
@@ -308,7 +308,7 @@ func TestUpsertQuotaOptimizationFieldsFiltersUnsubscribedObjects(t *testing.T) {
 	}
 }
 
-func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
+func TestUpdateExistingSubscriptionsNoWork(t *testing.T) {
 	t.Parallel()
 
 	conn, err := constructTestConnector("http://example.com")
@@ -316,7 +316,9 @@ func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
 		t.Fatalf("failed to construct test connector: %v", err)
 	}
 
-	diff := subscriptionDiff{
+	// Nil request short-circuits regardless of diff contents — the function
+	// returns nil before iterating any existing objects.
+	diffWithMember := subscriptionDiff{
 		channelMembersExisting: map[common.ObjectName]*EventChannelMember{
 			"Account": {
 				Id:       "member-1",
@@ -329,16 +331,23 @@ func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
 		apexTriggersExisting: map[common.ObjectName]*ApexTrigger{},
 	}
 
-	// Nil request should be a no-op
-	err = conn.updateExistingSubscriptions(t.Context(), nil, diff)
-	if err != nil {
+	if err := conn.updateExistingSubscriptions(t.Context(), nil, diffWithMember); err != nil {
 		t.Errorf("expected nil error for nil request, got %v", err)
 	}
 
-	// Request with no quota fields should be a no-op
-	err = conn.updateExistingSubscriptions(t.Context(), &SubscriptionRequest{}, diff)
-	if err != nil {
-		t.Errorf("expected nil error for empty request, got %v", err)
+	// A non-nil request with an empty diff (no existing objects to reconcile)
+	// is also a no-op — the iteration loops have nothing to operate on. Note
+	// that a non-nil request with non-empty diff is NOT a no-op even if the
+	// request has no quota fields: the design unconditionally PATCHes existing
+	// channel members to converge their state to the desired config (which
+	// includes "no filter" when quota config has been removed).
+	emptyDiff := subscriptionDiff{
+		channelMembersExisting: map[common.ObjectName]*EventChannelMember{},
+		apexTriggersExisting:   map[common.ObjectName]*ApexTrigger{},
+	}
+
+	if err := conn.updateExistingSubscriptions(t.Context(), &SubscriptionRequest{}, emptyDiff); err != nil {
+		t.Errorf("expected nil error for empty request and empty diff, got %v", err)
 	}
 }
 

--- a/providers/salesforce/subscribe_test.go
+++ b/providers/salesforce/subscribe_test.go
@@ -317,7 +317,7 @@ func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
 	}
 
 	diff := subscriptionDiff{
-		channelMembersToKeep: map[common.ObjectName]*EventChannelMember{
+		channelMembersExisting: map[common.ObjectName]*EventChannelMember{
 			"Account": {
 				Id:       "member-1",
 				FullName: "test",
@@ -326,17 +326,17 @@ func TestUpdateKeptSubscriptionsNilRequest(t *testing.T) {
 				},
 			},
 		},
-		apexTriggersToKeep: map[common.ObjectName]*ApexTrigger{},
+		apexTriggersExisting: map[common.ObjectName]*ApexTrigger{},
 	}
 
 	// Nil request should be a no-op
-	err = conn.updateKeptSubscriptions(t.Context(), nil, diff)
+	err = conn.updateExistingSubscriptions(t.Context(), nil, diff)
 	if err != nil {
 		t.Errorf("expected nil error for nil request, got %v", err)
 	}
 
 	// Request with no quota fields should be a no-op
-	err = conn.updateKeptSubscriptions(t.Context(), &SubscriptionRequest{}, diff)
+	err = conn.updateExistingSubscriptions(t.Context(), &SubscriptionRequest{}, diff)
 	if err != nil {
 		t.Errorf("expected nil error for empty request, got %v", err)
 	}

--- a/test/salesforce/subscribe/kept-quota-removed/main.go
+++ b/test/salesforce/subscribe/kept-quota-removed/main.go
@@ -28,8 +28,7 @@ import (
 //
 // Without these, the object would silently lose UPDATE events: the ECM filter
 // would still reference an indicator field that no trigger maintains, so the
-// filter always evaluates to false for UPDATE changeType. That's the bug we
-// called out as 🔴 #2 during the audit.
+// filter always evaluates to false for UPDATE changeType.
 //
 // Run with:
 //

--- a/test/salesforce/subscribe/kept-quota-removed/main.go
+++ b/test/salesforce/subscribe/kept-quota-removed/main.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/tools/debug"
+)
+
+// This script verifies that when UpdateSubscription keeps an object subscribed
+// but removes its quota config (omitting the object from
+// SubscriptionRequest.QuotaOptimizationObjectFields), the connector:
+//
+//  1. Clears the FilterExpression on the kept object's PlatformEventChannelMember
+//     (sends an empty filter via PATCH so Salesforce drops the prior reference)
+//  2. Clears the EnrichedFields on the kept object's PlatformEventChannelMember
+//  3. Removes the kept object's entry from SubscribeResult.ApexTriggers
+//     (because its trigger is destructively deleted by the orphan-handling branch)
+//
+// Without these, the object would silently lose UPDATE events: the ECM filter
+// would still reference an indicator field that no trigger maintains, so the
+// filter always evaluates to false for UPDATE changeType. That's the bug we
+// called out as 🔴 #2 during the audit.
+//
+// Run with:
+//
+//	go run ./test/salesforce/subscribe/kept-quota-removed/main.go \
+//	  -unique <unique string> -arn <AWS Named Credential ARN>
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	var uniqueString, namedCredArn string
+
+	flag.StringVar(&uniqueString, "unique", "", "Unique string to append to the registration label")
+	flag.StringVar(&namedCredArn, "arn", "", "AWS Named Credential ARN")
+	flag.Parse()
+
+	if uniqueString == "" || namedCredArn == "" {
+		log.Fatalf("missing flags: -unique <unique string> -arn <AWS Named Credential ARN>")
+	}
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	registration, err := conn.Register(ctx, common.SubscriptionRegistrationParams{
+		Request: &salesforce.RegistrationParams{
+			UniqueRef:             "Amp" + uniqueString,
+			Label:                 "Amp" + uniqueString,
+			AwsNamedCredentialArn: namedCredArn,
+		},
+	})
+	if err != nil {
+		logging.Logger(ctx).Error("registration failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Registration:", debug.PrettyFormatStringJSON(registration))
+
+	const quotaField = "amp_cdc_optimized"
+
+	// Initial subscription: Account WITH quota config.
+	subscribeParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				"Account": quotaField,
+			},
+		},
+	}
+
+	subscribeResult, err := conn.Subscribe(ctx, subscribeParams)
+	if err != nil {
+		logging.Logger(ctx).Error("subscribe failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Subscribe:", debug.PrettyFormatStringJSON(subscribeResult))
+
+	// Sanity check the initial state has filter + trigger so we can show they
+	// were cleared after the update.
+	initialState, ok := subscribeResult.Result.(*salesforce.SubscribeResult)
+	if !ok {
+		logging.Logger(ctx).Error("subscribe result has unexpected type")
+
+		return
+	}
+
+	initialMember, ok := initialState.EventChannelMembers["Account"]
+	if !ok || initialMember == nil || initialMember.Metadata == nil {
+		logging.Logger(ctx).Error("subscribe did not produce a usable Account channel member")
+
+		return
+	}
+
+	if initialMember.Metadata.FilterExpression == "" {
+		logging.Logger(ctx).Error("precondition violated: Account FilterExpression is empty after initial Subscribe")
+
+		return
+	}
+
+	if _, hasTrigger := initialState.ApexTriggers["Account"]; !hasTrigger {
+		logging.Logger(ctx).Error("precondition violated: Account apex trigger missing after initial Subscribe")
+
+		return
+	}
+
+	fmt.Printf("Initial Account FilterExpression: %q\n", initialMember.Metadata.FilterExpression)
+	fmt.Printf("Initial Account trigger present: %s\n", initialState.ApexTriggers["Account"].TriggerName)
+
+	// UpdateSubscription: keep Account subscribed but REMOVE its quota config.
+	// The Request still exists, but its QuotaOptimizationObjectFields no longer
+	// contains an entry for Account.
+	updateParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				// Account intentionally omitted to remove its quota config.
+			},
+		},
+	}
+
+	updateResult, err := conn.UpdateSubscription(ctx, updateParams, subscribeResult)
+	if err != nil {
+		logging.Logger(ctx).Error("update subscription failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Update:", debug.PrettyFormatStringJSON(updateResult))
+
+	state, ok := updateResult.Result.(*salesforce.SubscribeResult)
+	if !ok {
+		logging.Logger(ctx).Error("update result has unexpected type", "result", updateResult.Result)
+
+		return
+	}
+
+	// Assertion 1: Account's ECM still exists but its FilterExpression is empty.
+	updatedMember, ok := state.EventChannelMembers["Account"]
+	if !ok || updatedMember == nil {
+		logging.Logger(ctx).Error("FAIL: Account channel member is missing after update — the kept object should still be subscribed")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	if updatedMember.Metadata == nil {
+		logging.Logger(ctx).Error("FAIL: Account channel member has nil Metadata after update")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	if updatedMember.Metadata.FilterExpression != "" {
+		logging.Logger(ctx).Error("FAIL: Account FilterExpression was not cleared",
+			"filter", updatedMember.Metadata.FilterExpression,
+		)
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Println("PASS (1/3): Account FilterExpression is empty after quota config removed")
+
+	// Assertion 2: Account's EnrichedFields are also cleared.
+	if len(updatedMember.Metadata.EnrichedFields) != 0 {
+		logging.Logger(ctx).Error("FAIL: Account EnrichedFields were not cleared",
+			"count", len(updatedMember.Metadata.EnrichedFields),
+		)
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Println("PASS (2/3): Account EnrichedFields are empty after quota config removed")
+
+	// Assertion 3: Account's apex trigger has been removed from the result.
+	if _, hasTrigger := state.ApexTriggers["Account"]; hasTrigger {
+		logging.Logger(ctx).Error("FAIL: Account apex trigger still present in result — orphan-handling branch should have destructively deleted it")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Println("PASS (3/3): Account apex trigger removed from result (destructively deleted as orphan)")
+
+	fmt.Println("All assertions passed. Removing quota config from a kept object correctly clears its filter, enriched fields, and trigger.")
+
+	cleanup(ctx, conn, updateResult, registration)
+}
+
+func cleanup(
+	ctx context.Context,
+	conn *salesforce.Connector,
+	subscriptionResult *common.SubscriptionResult,
+	registration *common.RegistrationResult,
+) {
+	if subscriptionResult != nil && subscriptionResult.Status == common.SubscriptionStatusSuccess {
+		if err := conn.DeleteSubscription(ctx, *subscriptionResult); err != nil {
+			logging.Logger(ctx).Error("cleanup DeleteSubscription failed", "error", err)
+		} else {
+			fmt.Println("Cleanup DeleteSubscription successful")
+		}
+	}
+
+	if err := conn.DeleteRegistration(ctx, *registration); err != nil {
+		logging.Logger(ctx).Error("cleanup DeleteRegistration failed", "error", err)
+	} else {
+		fmt.Println("Cleanup DeleteRegistration successful")
+	}
+}

--- a/test/salesforce/subscribe/new-object-trigger-filter/main.go
+++ b/test/salesforce/subscribe/new-object-trigger-filter/main.go
@@ -23,10 +23,6 @@ import (
 //  2. A non-empty EnrichedFields list on its PlatformEventChannelMember
 //  3. An entry in SubscribeResult.ApexTriggers
 //
-// Without all three, quota optimization for the newly-added object is broken
-// (the bug we called out as 🔴 #1 during the audit). This test would have
-// caught that bug at the time and now locks in the fix.
-//
 // Run with:
 //
 //	go run ./test/salesforce/subscribe/new-object-trigger-filter/main.go \

--- a/test/salesforce/subscribe/new-object-trigger-filter/main.go
+++ b/test/salesforce/subscribe/new-object-trigger-filter/main.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/tools/debug"
+)
+
+// This script verifies that when UpdateSubscription adds a new object with
+// quota config, that object gets:
+//
+//  1. A non-empty FilterExpression on its PlatformEventChannelMember
+//  2. A non-empty EnrichedFields list on its PlatformEventChannelMember
+//  3. An entry in SubscribeResult.ApexTriggers
+//
+// Without all three, quota optimization for the newly-added object is broken
+// (the bug we called out as 🔴 #1 during the audit). This test would have
+// caught that bug at the time and now locks in the fix.
+//
+// Run with:
+//
+//	go run ./test/salesforce/subscribe/new-object-trigger-filter/main.go \
+//	  -unique <unique string> -arn <AWS Named Credential ARN>
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	var uniqueString, namedCredArn string
+
+	flag.StringVar(&uniqueString, "unique", "", "Unique string to append to the registration label")
+	flag.StringVar(&namedCredArn, "arn", "", "AWS Named Credential ARN")
+	flag.Parse()
+
+	if uniqueString == "" || namedCredArn == "" {
+		log.Fatalf("missing flags: -unique <unique string> -arn <AWS Named Credential ARN>")
+	}
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	registration, err := conn.Register(ctx, common.SubscriptionRegistrationParams{
+		Request: &salesforce.RegistrationParams{
+			UniqueRef:             "Amp" + uniqueString,
+			Label:                 "Amp" + uniqueString,
+			AwsNamedCredentialArn: namedCredArn,
+		},
+	})
+	if err != nil {
+		logging.Logger(ctx).Error("registration failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Registration:", debug.PrettyFormatStringJSON(registration))
+
+	const quotaField = "amp_cdc_optimized"
+
+	// Initial subscription: Account only.
+	subscribeParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				"Account": quotaField,
+			},
+		},
+	}
+
+	subscribeResult, err := conn.Subscribe(ctx, subscribeParams)
+	if err != nil {
+		logging.Logger(ctx).Error("subscribe failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Subscribe:", debug.PrettyFormatStringJSON(subscribeResult))
+
+	// UpdateSubscription: keep Account, add Contact (the newly-added object).
+	updateParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+			"Contact": {WatchFields: []string{"Email"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				"Account": quotaField,
+				"Contact": quotaField,
+			},
+		},
+	}
+
+	updateResult, err := conn.UpdateSubscription(ctx, updateParams, subscribeResult)
+	if err != nil {
+		logging.Logger(ctx).Error("update subscription failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Update:", debug.PrettyFormatStringJSON(updateResult))
+
+	state, ok := updateResult.Result.(*salesforce.SubscribeResult)
+	if !ok {
+		logging.Logger(ctx).Error("update result has unexpected type", "result", updateResult.Result)
+
+		return
+	}
+
+	// Assertion 1: Contact's PlatformEventChannelMember exists and has a
+	// non-empty FilterExpression.
+	contactMember, ok := state.EventChannelMembers["Contact"]
+	if !ok || contactMember == nil {
+		logging.Logger(ctx).Error("FAIL: update result is missing newly-added Contact channel member")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	if contactMember.Metadata == nil {
+		logging.Logger(ctx).Error("FAIL: Contact channel member has nil Metadata")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	if contactMember.Metadata.FilterExpression == "" {
+		logging.Logger(ctx).Error("FAIL: Contact channel member has empty FilterExpression — quota optimization not configured for the newly-added object")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Printf("PASS (1/3): Contact FilterExpression is non-empty: %q\n", contactMember.Metadata.FilterExpression)
+
+	// Assertion 2: Contact's PlatformEventChannelMember has at least one
+	// EnrichedField.
+	if len(contactMember.Metadata.EnrichedFields) == 0 {
+		logging.Logger(ctx).Error("FAIL: Contact channel member has empty EnrichedFields — quota optimization filter cannot evaluate without the indicator field enriched")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Printf("PASS (2/3): Contact EnrichedFields has %d entries\n", len(contactMember.Metadata.EnrichedFields))
+
+	// Assertion 3: Contact's apex trigger was deployed.
+	contactTrigger, ok := state.ApexTriggers["Contact"]
+	if !ok || contactTrigger == nil {
+		logging.Logger(ctx).Error("FAIL: update result is missing newly-added Contact apex trigger — the indicator field would never be set, so all UPDATE events would be filtered out")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	if contactTrigger.TriggerName == "" {
+		logging.Logger(ctx).Error("FAIL: Contact apex trigger has empty TriggerName")
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Printf("PASS (3/3): Contact apex trigger was deployed: TriggerName=%s\n", contactTrigger.TriggerName)
+
+	fmt.Println("All assertions passed. The newly-added Contact has a complete quota optimization setup (filter, enriched fields, and trigger).")
+
+	cleanup(ctx, conn, updateResult, registration)
+}
+
+func cleanup(
+	ctx context.Context,
+	conn *salesforce.Connector,
+	subscriptionResult *common.SubscriptionResult,
+	registration *common.RegistrationResult,
+) {
+	if subscriptionResult != nil && subscriptionResult.Status == common.SubscriptionStatusSuccess {
+		if err := conn.DeleteSubscription(ctx, *subscriptionResult); err != nil {
+			logging.Logger(ctx).Error("cleanup DeleteSubscription failed", "error", err)
+		} else {
+			fmt.Println("Cleanup DeleteSubscription successful")
+		}
+	}
+
+	if err := conn.DeleteRegistration(ctx, *registration); err != nil {
+		logging.Logger(ctx).Error("cleanup DeleteRegistration failed", "error", err)
+	} else {
+		fmt.Println("Cleanup DeleteRegistration successful")
+	}
+}

--- a/test/salesforce/subscribe/patch-kept-member/main.go
+++ b/test/salesforce/subscribe/patch-kept-member/main.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/tools/debug"
+)
+
+// This script verifies that UpdateSubscription updates kept-object channel
+// members in place via Tooling API PATCH (UpdateEventChannelMember) rather
+// than the previous delete-and-recreate pattern.
+//
+// The proof is identity preservation: a PATCH leaves the
+// PlatformEventChannelMember's Salesforce-assigned Id untouched, while a
+// delete-and-recreate would mint a new Id. The script subscribes once,
+// captures the kept member's Id, runs an UpdateSubscription that exercises
+// the kept-object path, and asserts the Id is unchanged.
+//
+// Run with:
+//
+//	go run ./test/salesforce/subscribe/patch-kept-member/main.go \
+//	  -unique <unique string> -arn <AWS Named Credential ARN>
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	var uniqueString, namedCredArn string
+
+	flag.StringVar(&uniqueString, "unique", "", "Unique string to append to the registration label")
+	flag.StringVar(&namedCredArn, "arn", "", "AWS Named Credential ARN")
+	flag.Parse()
+
+	if uniqueString == "" || namedCredArn == "" {
+		log.Fatalf("missing flags: -unique <unique string> -arn <AWS Named Credential ARN>")
+	}
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	registration, err := conn.Register(ctx, common.SubscriptionRegistrationParams{
+		Request: &salesforce.RegistrationParams{
+			UniqueRef:             "Amp" + uniqueString,
+			Label:                 "Amp" + uniqueString,
+			AwsNamedCredentialArn: namedCredArn,
+		},
+	})
+	if err != nil {
+		logging.Logger(ctx).Error("registration failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Registration:", debug.PrettyFormatStringJSON(registration))
+
+	const quotaField = "amp_cdc_optimized"
+
+	subscribeParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				"Account": quotaField,
+			},
+		},
+	}
+
+	subscribeResult, err := conn.Subscribe(ctx, subscribeParams)
+	if err != nil {
+		logging.Logger(ctx).Error("subscribe failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Subscribe:", debug.PrettyFormatStringJSON(subscribeResult))
+
+	initialState, ok := subscribeResult.Result.(*salesforce.SubscribeResult)
+	if !ok {
+		logging.Logger(ctx).Error("subscribe result has unexpected type", "result", subscribeResult.Result)
+
+		return
+	}
+
+	initialMember, ok := initialState.EventChannelMembers["Account"]
+	if !ok || initialMember == nil {
+		logging.Logger(ctx).Error("subscribe did not produce an Account channel member")
+
+		return
+	}
+
+	initialID := initialMember.Id
+	if initialID == "" {
+		logging.Logger(ctx).Error("Account channel member has empty Id after subscribe")
+
+		return
+	}
+
+	fmt.Printf("Initial Account PlatformEventChannelMember Id: %s\n", initialID)
+
+	// Add Contact as a new object so UpdateSubscription has work to do; Account
+	// stays as a kept object whose channel member should be PATCHed in place.
+	updateParams := common.SubscribeParams{
+		RegistrationResult: registration,
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"Account": {WatchFields: []string{"Name", "Phone"}},
+			"Contact": {WatchFields: []string{"Email"}},
+		},
+		Request: &salesforce.SubscriptionRequest{
+			QuotaOptimizationObjectFields: map[common.ObjectName]string{
+				"Account": quotaField,
+				"Contact": quotaField,
+			},
+		},
+	}
+
+	updateResult, err := conn.UpdateSubscription(ctx, updateParams, subscribeResult)
+	if err != nil {
+		logging.Logger(ctx).Error("update subscription failed", "error", err)
+
+		return
+	}
+
+	fmt.Println("Update:", debug.PrettyFormatStringJSON(updateResult))
+
+	updatedState, ok := updateResult.Result.(*salesforce.SubscribeResult)
+	if !ok {
+		logging.Logger(ctx).Error("update result has unexpected type", "result", updateResult.Result)
+
+		return
+	}
+
+	updatedMember, ok := updatedState.EventChannelMembers["Account"]
+	if !ok || updatedMember == nil {
+		logging.Logger(ctx).Error("update result is missing the kept Account channel member")
+
+		return
+	}
+
+	updatedID := updatedMember.Id
+
+	fmt.Printf("Updated Account PlatformEventChannelMember Id: %s\n", updatedID)
+
+	if updatedID != initialID {
+		logging.Logger(ctx).Error("kept channel member Id changed across UpdateSubscription — PATCH did not happen",
+			"before", initialID,
+			"after", updatedID,
+		)
+
+		cleanup(ctx, conn, updateResult, registration)
+
+		return
+	}
+
+	fmt.Println("PASS: kept Account channel member Id preserved across UpdateSubscription (PATCH used).")
+
+	cleanup(ctx, conn, updateResult, registration)
+}
+
+func cleanup(
+	ctx context.Context,
+	conn *salesforce.Connector,
+	subscriptionResult *common.SubscriptionResult,
+	registration *common.RegistrationResult,
+) {
+	if subscriptionResult != nil && subscriptionResult.Status == common.SubscriptionStatusSuccess {
+		if err := conn.DeleteSubscription(ctx, *subscriptionResult); err != nil {
+			logging.Logger(ctx).Error("cleanup DeleteSubscription failed", "error", err)
+		} else {
+			fmt.Println("Cleanup DeleteSubscription successful")
+		}
+	}
+
+	if err := conn.DeleteRegistration(ctx, *registration); err != nil {
+		logging.Logger(ctx).Error("cleanup DeleteRegistration failed", "error", err)
+	} else {
+		fmt.Println("Cleanup DeleteRegistration successful")
+	}
+}


### PR DESCRIPTION
## Summary

End-to-end correctness pass on `Subscribe`, `UpdateSubscription`, and `DeleteSubscription` so the returned `SubscriptionResult` faithfully reflects Salesforce state at every return point, and the dependency-removal rule (filter/trigger references must be cleared before the field they reference) is honored across all paths.

The dependency tree this PR enforces:

```
EventChannel (from Registration)
    │
    └── PlatformEventChannelMember
            │ FilterExpression / EnrichedFields ─┐
            │                                    ▼
            │                           QuotaOptimization CustomField (__c)
            │                                    ▲
            │                                    │ IndicatorField
            │                              ApexTrigger
```

Create order: field → trigger → channel member. Delete/rollback order: member → trigger → field.

## API call sequence

### Subscribe

```
Subscribe(params)
  │
  ├─[1]─► UpsertMetadata                  ── quota custom fields
  │       (skipped when no quota config)
  │
  ├─[2]─► DeployMetadataZipWithTests      ── apex triggers (parallel per object)
  │       (skipped when no quota config / no WatchFields)
  │
  └─[3]─► CreateEventChannelMember        ── per subscribed object
          (filter / enriched populated only when quota config exists)
```

### DeleteSubscription

```
DeleteSubscription(params)
  │
  ├─[1]─► DeleteEventChannelMember        ── per ECM (fail-fast)
  │
  ├─[2]─► DeployMetadataZipWithTests      ── destructive: trigger + Test_<TriggerName>
  │       (per trigger, fail-fast)
  │
  └─[3]─► DeleteMetadata                  ── quota custom fields (best-effort, log-and-continue)
```

### UpdateSubscription

```
UpdateSubscription(params, previousResult)
  │
  ├─[1]─► UpsertMetadata                  ── quota fields for ALL subscribed objects
  │       (idempotent for fields that already exist)
  │
  ├─[2]─► updateExistingSubscriptions
  │       │
  │       ├─► DeployMetadataZipWithTests  ── destructive: orphan triggers
  │       │   (existing objects whose quota config was removed)
  │       │
  │       ├─► DeployMetadataZipWithTests  ── upsert: existing-object triggers
  │       │   (atomic in-place replacement)
  │       │
  │       └─► UpdateEventChannelMember    ── PATCH: existing-object members
  │           (filter / enriched cleared if quota config removed)
  │
  ├─[3]─► DeleteSubscription              ── scoped to objectsToDelete
  │       │                                  (uses the inner sequence above)
  │       │
  │       ├─► DeleteEventChannelMember    ── ECMs of objects-to-delete
  │       │
  │       ├─► DeployMetadataZipWithTests  ── destructive: triggers of objects-to-delete
  │       │
  │       └─► DeleteMetadata              ── quota fields for objects-to-delete
  │                                          + fields whose existing-object refs
  │                                          were just cleared in step 2
  │
  └─[4]─► Subscribe (inner)               ── scoped to diff.objectsToAdd
          │                                  (fresh SubscribeParams; no overlap
          │                                   with kept/removed objects)
          │
          ├─► UpsertMetadata              ── new objects' quota fields
          ├─► DeployMetadataZipWithTests  ── new objects' triggers
          └─► CreateEventChannelMember    ── new objects' channel members
```

Note: step 2 runs **before** step 3 so the dependency-removal rule is satisfied (existing-object filter/trigger refs to quota fields are cleared before step 3 tries to delete those fields).

## What changed

**State consistency**
- `DeleteSubscription` mutates `sfRes` per successful per-object delete so partial-failure no longer over-claims.
- `rollbackSubscribe` prunes `sfRes.ApexTriggers` and clears `sfRes.QuotaOptimizationObjectFields` to mirror Salesforce.
- `toApexTriggers` filters failed deploys out of `sfRes.ApexTriggers` and logs each failed deploy per object.
- `UpdateSubscription` returns a partial `SubscriptionResult` on failure (was `nil`), with rolled-back quota fields pruned and `Status` escalated to `FailedToRollback` when rollback errored.
- `buildUpdatedSubscribeResult` merges `prevState` residual entries rather than replacing, so the partial result reflects to-delete entries that `DeleteSubscription` has not yet removed or failed to remove. Closes a pre-existing partial-failure mismatch.

**Atomic in-place updates**
- Existing-object `PlatformEventChannelMember` updates via `UpdateEventChannelMember` PATCH instead of delete-and-recreate. Preserves the member `Id`, avoids the CDC-traffic gap, atomic.
- Existing-object apex triggers upsert via Metadata API deploy in place. Destructive prelude only runs for orphans (existing objects whose quota config was removed).
- `updateExistingSubscriptions` now runs before `DeleteSubscription` so filter / enriched / trigger references to quota fields are cleared before `DeleteSubscription` tries to remove the fields.
- `updateExistingChannelMembers` PATCHes with empty filter / enriched when an object's quota config is removed (instead of skipping). Prevents UPDATE events from being silently dropped.
- `redeployExistingApexTriggers` excludes `diff.objectsToAdd` so new-object triggers deploy exactly once (in inner `Subscribe`) rather than twice.

**Caller-input purity**
- `sfRes.QuotaOptimizationObjectFields` cloned from `req` instead of aliased, so DeleteSubscription / rollback mutations don't silently mutate the caller's `req`.
- `computeSubscriptionDiff` no longer mutates `params.SubscriptionEvents`; `diff.objectsToAdd` is added so callers don't depend on the side-effecting filter.
- `UpdateSubscription` mirrors `Subscribe`'s up-front validation (RegistrationResult nil checks + `validator.Struct`).

**Defensive guards**
- Nil-safety guards (`slog.Warn` + `continue`) at every map iteration that dereferences `*EventChannelMember` / `*ApexTrigger`. Corrupted `previousResult` is logged and skipped instead of panicking.
- `TODO: check existence before delete` placed at every rollback / delete site. Once implemented, double-rollback at the inner-Subscribe-fails path becomes idempotent.

**JSON tags**
- `EnrichedFields` and `FilterExpression` on `EventChannelMemberMetadata` drop `omitempty` so PATCH sends empty values to clear prior config (Salesforce treats omitted fields as no-change).

**Renames**
- `diff.keptObjectEvents` → `diff.allObjectEvents`. The field always contained all events (kept + new); the misleading name was the trap that caused a double-deploy bug.
- `updateKeptSubscriptions` → `updateExistingSubscriptions` (and the same pattern applied to `redeployKept...`, `updateKept...`, `apexTriggersToKeep`, `channelMembersToKeep`, `keptParams`, `objectsExcludeFromDelete`). "Existing" is more accessible than "kept" jargon.

**Documentation**
- `Subscribe`, `DeleteSubscription`, `UpdateSubscription`, `updateExistingSubscriptions`, `upsertQuotaOptimizationFields`, `buildUpdatedSubscribeResult`, `computeSubscriptionDiff` doc comments updated to describe current behavior, ordering rationale, and `Status` conventions.

## Integration Tests

### Updates with fiels removed and added in different objects succeeds

<img width="1369" height="1028" alt="Screenshot 2026-05-08 at 10 41 20 PM" src="https://github.com/user-attachments/assets/a7d4cd7c-ad34-4b97-b473-9973d63e8248" />
<img width="1112" height="490" alt="Screenshot 2026-05-08 at 10 41 36 PM" src="https://github.com/user-attachments/assets/256276fe-761b-47f2-ba8a-1049565e0ca2" />


Create Installation with 1 object Opted in
<img width="1752" height="890" alt="Screenshot 2026-05-08 at 8 59 38 PM" src="https://github.com/user-attachments/assets/ac974493-9ac7-4aff-b3fa-4607d8b67b2f" />

<img width="1546" height="973" alt="Screenshot 2026-05-08 at 8 41 04 PM" src="https://github.com/user-attachments/assets/628e7ea6-ee8a-4329-b05f-1e81cc65ea22" />


```
[{"RegistrationResult":{"RegistrationRef":"7k2gK000001BF9dQAG","Result":{"eventChannel":{"Id":"0YLgK000000TdnZWAS","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","Metadata":{"channelType":"data","label":"amp_10446aca4b6344aca8a2b202623c5fc3"}},"namedCredential":{"FullName":"amp_10446aca4b6344aca8a2b202623c5fc3","Metadata":{"generateAuthorizationHeader":true,"label":"Ampersand_10446aca4b6344aca8a2b202623c5fc3","endpoint":"arn:aws:US-EAST-1:471112904037","principalType":"NamedUser","protocol":"NoAuthentication"},"Id":"0XAgK000000PnlVWAS"},"eventRelayConfig":{"Id":"7k2gK000001BF9dQAG","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3","Metadata":{"destinationResourceName":"callout:amp_10446aca4b6344aca8a2b202623c5fc3","eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","state":"RUN"}}},"Status":"success"},"Registration":{"Id":"26fe9d79-9a03-4216-abed-3940a2977955","ProjectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","ProviderAppId":"5f63c569-1d03-4274-8153-4306cc011dd8","IntegrationId":"69abe611-b007-464f-8917-84a4d5f792d7","InstallationId":"10446aca-4b63-44ac-a8a2-b202623c5fc3","ProviderRef":"7k2gK000001BF9dQAG","Result":{"eventChannel":{"Id":"0YLgK000000TdnZWAS","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","Metadata":{"channelType":"data","label":"amp_10446aca4b6344aca8a2b202623c5fc3"}},"namedCredential":{"FullName":"amp_10446aca4b6344aca8a2b202623c5fc3","Metadata":{"generateAuthorizationHeader":true,"label":"Ampersand_10446aca4b6344aca8a2b202623c5fc3","endpoint":"arn:aws:US-EAST-1:471112904037","principalType":"NamedUser","protocol":"NoAuthentication"},"Id":"0XAgK000000PnlVWAS"},"eventRelayConfig":{"Id":"7k2gK000001BF9dQAG","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3","Metadata":{"destinationResourceName":"callout:amp_10446aca4b6344aca8a2b202623c5fc3","eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","state":"RUN"}}},"Status":"active"},"SubscriptionResult":{"Result":{"EventChannelMembers":{"account":{"Id":"0v8gK0000008vabQAA","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3_chn_accountChangeEvent","Metadata":{"eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","selectedEntity":"accountChangeEvent","enrichedFields":[{"name":"test_local_sub_cdc_event_flag__c"}],"filterExpression":"ChangeEventHeader.changeType != 'UPDATE' OR test_local_sub_cdc_event_flag__c = true"}},"contact":{"Id":"0v8gK0000008vcDQAQ","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3_chn_contactChangeEvent","Metadata":{"eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","selectedEntity":"contactChangeEvent","enrichedFields":null,"filterExpression":""}}},"QuotaOptimizationObjectFields":{"Account":"test_local_sub_cdc_event_flag__c"},"ApexTriggers":{"account":{"ObjectName":"account","TriggerName":"CDC_account","IndicatorField":{"fieldName":"test_local_sub_cdc_event_flag__c","displayName":"","valueType":"boolean"},"WatchFields":["name","phone"]}}},"ObjectEvents":null,"Status":"success","Objects":["account","contact"],"Events":["create","update","delete"],"UpdateFields":null,"PassThroughEvents":null},"Subscription":{"Id":"aae4fc2d-c366-4671-ab44-4e4b9bc278da","ProviderRef":"","Result":{"EventChannelMembers":{"account":{"Id":"0v8gK0000008vabQAA","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3_chn_accountChangeEvent","Metadata":{"eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","selectedEntity":"accountChangeEvent","enrichedFields":[{"name":"test_local_sub_cdc_event_flag__c"}],"filterExpression":"ChangeEventHeader.changeType != 'UPDATE' OR test_local_sub_cdc_event_flag__c = true"}},"contact":{"Id":"0v8gK0000008vcDQAQ","FullName":"amp_10446aca4b6344aca8a2b202623c5fc3_chn_contactChangeEvent","Metadata":{"eventChannel":"amp_10446aca4b6344aca8a2b202623c5fc3__chn","selectedEntity":"contactChangeEvent","enrichedFields":null,"filterExpression":""}}},"QuotaOptimizationObjectFields":{"Account":"test_local_sub_cdc_event_flag__c"},"ApexTriggers":{"account":{"ObjectName":"account","TriggerName":"CDC_account","IndicatorField":{"fieldName":"test_local_sub_cdc_event_flag__c","displayName":"","valueType":"boolean"},"WatchFields":["name","phone"]}}},"Status":"active"},"PostProcessResult":{"Bus":{"DeadLetterConfig":null,"Description":null,"EventBusArn":"arn:aws:events:us-east-1:471112904037:event-bus/aws.partner/salesforce.com/00DgK000007AxqnUAC/0YLgK000000TdnZWAS","KmsKeyIdentifier":null,"LogConfig":null,"ResultMetadata":{}},"ApiDestination":{"ApiDestinationArn":"arn:aws:events:us-east-1:471112904037:api-destination/10446aca4b6344aca8a2b202623c5fc3/1eae0565-a863-442c-87fd-39a51660e12c","ApiDestinationState":"ACTIVE","CreationTime":"2026-05-09T03:31:31Z","LastModifiedTime":"2026-05-09T03:31:31Z","ResultMetadata":{}},"Rule":{"RuleArn":"arn:aws:events:us-east-1:471112904037:rule/aws.partner/salesforce.com/00DgK000007AxqnUAC/0YLgK000000TdnZWAS/10446aca4b6344aca8a2b202623c5fc3","ResultMetadata":{}},"Targets":{"FailedEntries":[],"FailedEntryCount":0,"ResultMetadata":{}}},"UnsubscribeSkipped":false}]
```

### UpdateInstallation Removing subscribe
<img width="1792" height="1047" alt="Screenshot 2026-05-08 at 9 14 25 PM" src="https://github.com/user-attachments/assets/75864051-a15e-466a-b028-2b9494b6835b" />

```
jlim@Mac server % >....                                                                                                                                                                                                       
          "read": {
            "objects": {
              "contact": {
                "objectName": "contact",
                "destination": "revWebhook",
                "selectedFields": {
                  "id": true,
                  "firstName": true,
                  "lastName": true,
                  "ownerId": true
                }
              }
            }
          },
          "subscribe": {
            "objects": {
              "contact": {
                "objectName": "contact",
                "createEvent": { "enabled": "never" },
                "deleteEvent": { "enabled": "never" },
                "updateEvent": { "enabled": "never" },
                "otherEvents": []
              },
              "account": {
                "objectName": "account",
                "createEvent": { "enabled": "never" },
                "deleteEvent": { "enabled": "never" },
                "updateEvent": { "enabled": "never" },
                "otherEvents": []
              }
            }
          }
        }
      }
    }
  }'

{"id":"10446aca-4b63-44ac-a8a2-b202623c5fc3","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","integrationId":"69abe611-b007-464f-8917-84a4d5f792d7","groupRef":"testexistingfieldandapex","group":{"groupRef":"testexistingfieldandapex","groupName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.253126Z","updateTime":"2026-05-09T02:48:24.450245Z"},"connectionId":"b42f1473-ee51-49de-8e88-fb0af0ede9e0","connection":{"id":"b42f1473-ee51-49de-8e88-fb0af0ede9e0","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","provider":"salesforce","authScheme":"oauth2/authorizationCode","group":{"groupRef":"testexistingfieldandapex","groupName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.253126Z","updateTime":"2026-05-09T02:48:24.450245Z"},"consumer":{"consumerRef":"testexistingfieldandapex","consumerName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.248717Z","updateTime":"2026-05-09T02:48:24.447843Z"},"providerWorkspaceRef":"orgfarm-c270e93339-dev-ed.develop","providerConsumerRef":"https://login.salesforce.com/id/00DgK000007AxqnUAC/005gK00003UwoSDQAZ","status":"working","createTime":"2026-05-09T02:48:24.451898Z","updateTime":"2026-05-09T02:49:08.164948Z","providerMetadata":{"workspace":{"displayName":"","value":"orgfarm-c270e93339-dev-ed.develop","source":"input"}}},"createdBy":"api:create-installation","config":{"id":"45df2295-9f9a-44d1-bf13-38c380f8ec6e","revisionId":"bfd8403c-eb7e-498f-9617-22e05aab4733","createdBy":"api:create-installation","content":{"provider":"salesforce","read":{"objects":{"account":{"disabled":false,"objectName":"account","selectedFieldMappings":{"notes":"photourl"},"selectedFields":{"annualrevenue":true,"website":true}},"contact":{"destination":"revWebhook","objectName":"contact","selectedFieldMappings":{},"selectedFields":{"firstName":true,"id":true,"lastName":true,"ownerId":true}}}},"subscribe":{"objects":{"account":{"createEvent":{"enabled":"never"},"deleteEvent":{"enabled":"never"},"destination":"","inheritFieldsAndMappings":false,"objectName":"account","otherEvents":[],"updateEvent":{"enabled":"never"}},"contact":{"createEvent":{"enabled":"never"},"deleteEvent":{"enabled":"never"},"destination":"","inheritFieldsAndMappings":false,"objectName":"contact","otherEvents":[],"updateEvent":{"enabled":"never"}}}}},"installationId":"10446aca-4b63-44ac-a8a2-b202623c5fc3","createTime":"2026-05-09T04:13:54.11167Z"},"createTime":"2026-05-09T03:30:43.949929Z","updateTime":"2026-05-09T04:13:54.112915Z","healthStatus":"healthy","consumerRef":"testexistingfieldandapex"}%  
```

<img width="578" height="930" alt="Screenshot 2026-05-08 at 9 16 12 PM" src="https://github.com/user-attachments/assets/dc145376-205c-47a1-8cf6-c3e3b25e3e4e" />
<img width="1725" height="290" alt="Screenshot 2026-05-08 at 9 17 12 PM" src="https://github.com/user-attachments/assets/c80f680c-4def-45d3-aeca-3ac6de100e23" />

### UpdateInstallation again with more object added - Triggered create because it was removed earlier


```
jlim@Mac server % >....                                                                                                                                                                                                       
                "deleteEvent": { "enabled": "always" },
                "updateEvent": {
                  "enabled": "always",
                  "requiredWatchFields": [
                    "name",
                    "website",
                    "ownerId",
                    "linkedInUrl",
                    "domain"
                  ]
                },
                "destination": "salesforceLiveWebhook",
                "otherEvents": ["UNDELETE"],
                "inheritFieldsAndMappings": true
              },
              "contact": {
                "objectName": "contact",
                "createEvent": { "enabled": "always" },
                "deleteEvent": { "enabled": "always" },
                "updateEvent": {
                  "enabled": "always",
                  "requiredWatchFields": [
                    "firstname",
                    "phone",
                    "lastname"
                  ]
                },
                "destination": "salesforceLiveWebhook",
                "inheritFieldsAndMappings": true
              }
            }
          }
        }
      }
    }
  }'

{"id":"10446aca-4b63-44ac-a8a2-b202623c5fc3","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","integrationId":"69abe611-b007-464f-8917-84a4d5f792d7","groupRef":"testexistingfieldandapex","group":{"groupRef":"testexistingfieldandapex","groupName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.253126Z","updateTime":"2026-05-09T02:48:24.450245Z"},"connectionId":"b42f1473-ee51-49de-8e88-fb0af0ede9e0","connection":{"id":"b42f1473-ee51-49de-8e88-fb0af0ede9e0","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","provider":"salesforce","authScheme":"oauth2/authorizationCode","group":{"groupRef":"testexistingfieldandapex","groupName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.253126Z","updateTime":"2026-05-09T02:48:24.450245Z"},"consumer":{"consumerRef":"testexistingfieldandapex","consumerName":"testexistingfieldandapex","projectId":"04bbc51e-7b5e-43c4-a453-e6d77ee55cb2","createTime":"2026-05-08T04:36:07.248717Z","updateTime":"2026-05-09T02:48:24.447843Z"},"providerWorkspaceRef":"orgfarm-c270e93339-dev-ed.develop","providerConsumerRef":"https://login.salesforce.com/id/00DgK000007AxqnUAC/005gK00003UwoSDQAZ","status":"working","createTime":"2026-05-09T02:48:24.451898Z","updateTime":"2026-05-09T02:49:08.164948Z","providerMetadata":{"workspace":{"displayName":"","value":"orgfarm-c270e93339-dev-ed.develop","source":"input"}}},"createdBy":"api:create-installation","config":{"id":"574fce83-d385-4f87-9455-d8fc2ffded52","revisionId":"bfd8403c-eb7e-498f-9617-22e05aab4733","createdBy":"api:create-installation","content":{"provider":"salesforce","read":{"objects":{"account":{"disabled":false,"objectName":"account","selectedFieldMappings":{"notes":"photourl"},"selectedFields":{"annualrevenue":true,"website":true}},"contact":{"destination":"revWebhook","objectName":"contact","selectedFieldMappings":{},"selectedFields":{"firstName":true,"id":true,"lastName":true,"ownerId":true}}}},"subscribe":{"objects":{"account":{"createEvent":{"enabled":"always"},"deleteEvent":{"enabled":"always"},"destination":"salesforceLiveWebhook","inheritFieldsAndMappings":true,"objectName":"account","otherEvents":["UNDELETE"],"updateEvent":{"enabled":"always","requiredWatchFields":["name","website","ownerId","linkedInUrl","domain"]}},"contact":{"createEvent":{"enabled":"always"},"deleteEvent":{"enabled":"always"},"destination":"salesforceLiveWebhook","inheritFieldsAndMappings":true,"objectName":"contact","updateEvent":{"enabled":"always","requiredWatchFields":["firstname","phone","lastname"]}}}}},"installationId":"10446aca-4b63-44ac-a8a2-b202623c5fc3","createTime":"2026-05-09T04:19:28.574512Z"},"createTime":"2026-05-09T03:30:43.949929Z","updateTime":"2026-05-09T04:19:28.575347Z","healthStatus":"healthy","consumerRef":"testexistingfieldandapex"}



```
## Tests

Three new test scripts under `test/salesforce/subscribe/`:

- **`patch-kept-member/`** — verifies the existing member's `Id` is preserved across `UpdateSubscription` (proves PATCH was used, not delete+create).
- **`new-object-trigger-filter/`** — verifies newly-added objects via `UpdateSubscription` get a non-empty `FilterExpression`, `EnrichedFields`, and an `ApexTrigger` entry. Locks in the new-object correctness fix.
- **`kept-quota-removed/`** — verifies removing quota config from an existing object clears its filter, enriched fields, and removes its trigger as orphan. Locks in the existing-object correctness fix.

Each is its own runnable `package main`, following the convention of `delete-nonexisting/` and `duplicate-create/`.

## Knowingly skipped (residuals tolerable per project policy)

- Field-rename leak (caller-pattern; old field is inert custom checkbox)
- `UpsertMetadata` / `DeleteMetadata` partial-failure orphans (inert)
- Async / cache propagation (CDC pipeline, PATCH late events, Tooling SOQL stale) — platform-level, uncloseable in code
- Existing-object partial-failure rollback — per-artifact atomicity + idempotent retry covers it
- Wasted inner Subscribe call when no new objects — microsecond cost

## Test plan

All five tests run end-to-end against a live Salesforce dev org. Logs attached as a secret gist: 📎 https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa (also referenced in the run-summary comment on this PR). Each log includes the full HTTP trace at DEBUG level (auth tokens / cookies redacted by the slog setup) plus the test's stdout assertions, terminated by `EXIT_CODE=0`.

- [x] `go run ./test/salesforce/subscribe/register.go -unique 12340000000000 -arn arn:aws:US-EAST-1:471112904037` — happy path Subscribe → UpdateSubscription (add) → UpdateSubscription (remove) → DeleteSubscription. **Result:** clean cleanup, `Delete registration successful`. → [`01-register.txt`](https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa#file-01-register-txt)
- [x] `go run ./test/salesforce/subscribe/patch-kept-member -unique 12340000000001 -arn arn:aws:US-EAST-1:471112904037` — kept member Id preserved. **Result:** `PASS: kept Account channel member Id preserved across UpdateSubscription (PATCH used).` → [`02-patch-kept-member.txt`](https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa#file-02-patch-kept-member-txt)
- [x] `go run ./test/salesforce/subscribe/new-object-trigger-filter -unique 12340000000002 -arn arn:aws:US-EAST-1:471112904037` — newly-added object has trigger + filter + enriched fields. **Result:** PASS 3/3 — `Contact FilterExpression: "ChangeEventHeader.changeType != 'UPDATE' OR amp_cdc_optimized__c = true"`, `EnrichedFields has 1 entries`, `TriggerName=CDC_Contact`. → [`03-new-object-trigger-filter.txt`](https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa#file-03-new-object-trigger-filter-txt)
- [x] `go run ./test/salesforce/subscribe/kept-quota-removed -unique 12340000000003 -arn arn:aws:US-EAST-1:471112904037` — removing quota from a kept object clears filter and trigger. **Result:** PASS 3/3 — `FilterExpression is empty after quota config removed`, `EnrichedFields are empty`, `apex trigger removed (destructively deleted as orphan)`. → [`04-kept-quota-removed.txt`](https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa#file-04-kept-quota-removed-txt)
- [x] `go run ./test/salesforce/subscribe/duplicate-create` — duplicate-name recovery still works (regression check). **Result:** `IDs match — duplicate recovery returned the existing record.` → [`05-duplicate-create.txt`](https://gist.github.com/jlimatampersand/47d8eba83303a4de3e518a4a220976aa#file-05-duplicate-create-txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


