### PR TITLE
fix(salesforce): always run tests on apex trigger deploys

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -205,6 +205,27 @@ func (c *Connector) DeployMetadataZipWithTests(
 	return "", common.ErrNotImplemented
 }
 
+// deployApexTriggerZipWithTests is the entry point for every apex-trigger deploy
+// (constructive and destructive). It enforces the invariant that apex-trigger
+// deploys never run with testLevel=NoTestRun: NoTestRun would silently bypass
+// Salesforce's 75% Apex production coverage gate. If the caller passes
+// NoTestRun, upgrade to RunLocalTests and clear runTests (RunLocalTests does
+// not consume it). The same upgrade is also performed in metadata.deploy()
+// based on zip introspection so external callers of DeployMetadataZip* get the
+// same protection.
+func (c *Connector) deployApexTriggerZipWithTests(
+	ctx context.Context, zipData []byte, testLevel metadata.TestLevel, runTests []string,
+) (string, error) {
+	if testLevel == metadata.TestLevelNoTestRun {
+		slog.WarnContext(ctx, "apex trigger deploy: testLevel NoTestRun upgraded to RunLocalTests")
+
+		testLevel = metadata.TestLevelRunLocalTests
+		runTests = nil
+	}
+
+	return c.DeployMetadataZipWithTests(ctx, zipData, testLevel, runTests)
+}
+
 // CheckDeployStatus checks the status of an async deployment once and returns the result.
 // The caller is responsible for polling in a loop until DeployResult.Done is true.
 func (c *Connector) CheckDeployStatus(ctx context.Context, deployID string) (*DeployResult, error) {
@@ -323,7 +344,7 @@ func (c *Connector) deployApexTrigger(
 	runTests := []string{testClassName}
 
 	for attempt := range apexDeployMaxAttempts {
-		deployID, err := c.DeployMetadataZipWithTests(ctx, zipData, apexDeployTestLevel, runTests)
+		deployID, err := c.deployApexTriggerZipWithTests(ctx, zipData, apexDeployTestLevel, runTests)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deploy apex trigger for %s: %w", params.ObjectName, err)
 		}
@@ -393,7 +414,7 @@ func (c *Connector) rollbackApexTrigger(ctx context.Context, triggerName string)
 		return fmt.Errorf("failed to construct destructive apex trigger zip for %s: %w", triggerName, err)
 	}
 
-	deployID, err := c.DeployMetadataZipWithTests(ctx, zipData, metadata.TestLevelRunLocalTests, nil)
+	deployID, err := c.deployApexTriggerZipWithTests(ctx, zipData, metadata.TestLevelRunLocalTests, nil)
 	if err != nil {
 		return fmt.Errorf("failed to deploy destructive apex trigger for %s: %w", triggerName, err)
 	}

--- a/providers/salesforce/internal/crm/metadata/apextrigger.go
+++ b/providers/salesforce/internal/crm/metadata/apextrigger.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -571,6 +572,51 @@ func createTriggerDestructiveZip(triggerName, handlerClassName, testClassName st
 	}
 
 	return buf.Bytes(), nil
+}
+
+// ZipContainsApexTrigger reports whether a deploy zip contains an Apex
+// trigger artifact, either as a constructive deploy (a triggers/<Name>.trigger
+// entry) or as a destructive deploy (a destructiveChanges.xml referencing the
+// ApexTrigger metadata type).
+//
+// Used by deploy() to decide whether to upgrade testLevel=NoTestRun to
+// RunLocalTests: NoTestRun would silently bypass Salesforce's 75% Apex
+// production-coverage gate, which is unsafe for trigger deploys. A malformed
+// or unreadable zip returns false rather than an error so the actual deploy
+// surfaces the more specific Salesforce error instead of being short-circuited
+// here.
+func ZipContainsApexTrigger(zipData []byte) bool {
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return false
+	}
+
+	for _, f := range reader.File {
+		if strings.HasPrefix(f.Name, "triggers/") && strings.HasSuffix(f.Name, ".trigger") {
+			return true
+		}
+
+		if f.Name == "destructiveChanges.xml" && zipEntryContains(f, "<name>ApexTrigger</name>") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func zipEntryContains(f *zip.File, needle string) bool {
+	rc, err := f.Open()
+	if err != nil {
+		return false
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(data), needle)
 }
 
 func addTriggerToZip(zw *zip.Writer, name string, content []byte) error {

--- a/providers/salesforce/internal/crm/metadata/apextrigger_test.go
+++ b/providers/salesforce/internal/crm/metadata/apextrigger_test.go
@@ -637,6 +637,112 @@ func TestConstructDestructiveApexTrigger(t *testing.T) { //nolint:funlen
 	}
 }
 
+func TestZipContainsApexTrigger(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	constructiveParams := ApexTriggerParams{
+		ObjectName:  "Lead",
+		TriggerName: "CDC_Lead",
+		IndicatorField: common.FieldDefinition{
+			FieldName: "AmpTriggerSubscription__c",
+			ValueType: common.FieldTypeBoolean,
+		},
+		WatchFields: []string{"Email"},
+	}
+
+	constructiveZip, err := ConstructApexTrigger(constructiveParams)
+	if err != nil {
+		t.Fatalf("unexpected error building constructive zip: %v", err)
+	}
+
+	destructiveZip, err := ConstructDestructiveApexTrigger("CDC_Lead")
+	if err != nil {
+		t.Fatalf("unexpected error building destructive zip: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		zipData  []byte
+		expected bool
+	}{
+		{
+			name:     "constructive deploy zip with trigger file is detected",
+			zipData:  constructiveZip,
+			expected: true,
+		},
+		{
+			name:     "destructive deploy zip referencing ApexTrigger is detected",
+			zipData:  destructiveZip,
+			expected: true,
+		},
+		{
+			name:     "zip with only ApexClass entries is not detected",
+			zipData:  buildZip(t, map[string]string{"classes/MyClass.cls": "public class MyClass {}"}),
+			expected: false,
+		},
+		{
+			name: "destructiveChanges.xml referencing only ApexClass is not detected",
+			zipData: buildZip(t, map[string]string{
+				"destructiveChanges.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types><members>MyClass</members><name>ApexClass</name></types>
+</Package>`,
+			}),
+			expected: false,
+		},
+		{
+			name:     "empty zip is not detected",
+			zipData:  buildZip(t, map[string]string{}),
+			expected: false,
+		},
+		{
+			name:     "malformed bytes are not detected",
+			zipData:  []byte("not a zip"),
+			expected: false,
+		},
+		{
+			name:     "nil bytes are not detected",
+			zipData:  nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ZipContainsApexTrigger(tt.zipData); got != tt.expected {
+				t.Errorf("ZipContainsApexTrigger() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// buildZip writes the given file map into an in-memory zip and returns its bytes.
+func buildZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
 // assertZipContainsFiles verifies that the zip data contains exactly the expected files.
 func assertZipContainsFiles(t *testing.T, zipData []byte, expectedFiles []string) {
 	t.Helper()

--- a/providers/salesforce/internal/crm/metadata/deploy.go
+++ b/providers/salesforce/internal/crm/metadata/deploy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -167,6 +168,17 @@ func (a *Adapter) deploy(
 
 	if testLevel == "" {
 		testLevel = TestLevelNoTestRun
+	}
+
+	// Apex trigger deploys must run tests so production deploys can clear
+	// Salesforce's 75% Apex coverage gate. NoTestRun would silently bypass
+	// that gate, so upgrade to RunLocalTests when the zip carries trigger
+	// metadata. RunLocalTests doesn't consume runTests, so clear it.
+	if testLevel == TestLevelNoTestRun && ZipContainsApexTrigger(zipData) {
+		slog.WarnContext(ctx, "apex trigger deploy: testLevel NoTestRun upgraded to RunLocalTests")
+
+		testLevel = TestLevelRunLocalTests
+		runTests = nil
 	}
 
 	var runTestsXML strings.Builder


### PR DESCRIPTION
## Summary

- Apex trigger deploys (constructive and destructive) now always run tests; `testLevel=NoTestRun` is upgraded to `RunLocalTests` so deploys cannot silently bypass Salesforce's 75% Apex production-coverage gate.
- The upgrade is enforced in two places:
  - A new `deployApexTriggerZipWithTests` wrapper in `providers/salesforce/apex.go` used by both `deployApexTrigger` (constructive) and `rollbackApexTrigger` (destructive).
  - Inside `metadata.deploy()` itself via the new `ZipContainsApexTrigger` zip-introspection helper, so external callers of `DeployMetadataZip*` get the same protection.
- `ZipContainsApexTrigger` detects either `triggers/<Name>.trigger` (constructive) or `destructiveChanges.xml` referencing `<name>ApexTrigger</name>` (destructive). Malformed zips return false rather than erroring so the actual deploy surfaces the better error.

## Test plan

- [x] `go test ./providers/salesforce/internal/crm/metadata/...` — passes
- [x] `make fix` — 0 issues
- [x] New `TestZipContainsApexTrigger` covers: constructive zip, destructive zip, ApexClass-only zip (constructive and destructive), empty zip, malformed bytes, nil bytes
- [ ] Manual: confirm a destructive deploy in a customer org no longer bypasses tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)