### PR TITLE
feat(salesforce): support manual checkbox / apex trigger creation in CDC subscribe

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -96,6 +96,18 @@ func GenerateApexTriggerNameForCDC(objectName string) (string, error) {
 	return metadata.GenerateApexTriggerNameForCDC(objectName)
 }
 
+// ApexTriggerExists reports whether an apex trigger with the given Name exists
+// in Salesforce. Implementation queries the Tooling API ApexTrigger sobject by
+// Name (the same field metadata.GenerateApexTriggerNameForCDC produces).
+func (c *Connector) ApexTriggerExists(ctx context.Context, triggerName string) (bool, error) {
+	soql := fmt.Sprintf(
+		"SELECT Id FROM ApexTrigger WHERE Name = '%s'",
+		escapeSOQLString(triggerName),
+	)
+
+	return c.toolingEntityExists(ctx, soql)
+}
+
 // GenerateApexTriggerNameForRead returns the APEX trigger name for filtered read on a given Salesforce object.
 func GenerateApexTriggerNameForRead(objectName string) (string, error) {
 	return metadata.GenerateApexTriggerNameForRead(objectName)
@@ -177,6 +189,55 @@ func (c *Connector) deployApexTriggersForCDC(
 	}
 
 	return c.deployApexTriggers(ctx, triggerParams, zipDataMap)
+}
+
+// verifyApexTriggersForCDC takes the verify-only path used when
+// SubscriptionRequest.ManualApexTriggerCreation is true. It builds the same
+// apex trigger params as deployApexTriggersForCDC (so trigger names match what
+// the deploy path would have generated), checks each trigger exists in
+// Salesforce, and returns the corresponding ApexTrigger entries for storage in
+// SubscribeResult.ApexTriggers. Returns errManualApexTriggerMissing wrapping
+// the list of missing triggers if any are absent so the caller learns about
+// every missing trigger in one round.
+func (c *Connector) verifyApexTriggersForCDC(
+	ctx context.Context,
+	params common.SubscribeParams,
+	req *SubscriptionRequest,
+) (map[common.ObjectName]*ApexTrigger, error) {
+	triggerParams, err := buildApexTriggerParamsForSubscribe(params, req)
+	if err != nil {
+		return nil, err
+	}
+
+	triggers := make(map[common.ObjectName]*ApexTrigger, len(triggerParams))
+	missing := make([]string, 0)
+
+	for objName, tParams := range triggerParams {
+		exists, err := c.ApexTriggerExists(ctx, tParams.TriggerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check apex trigger existence for object %s: %w",
+				objName, err)
+		}
+
+		if !exists {
+			missing = append(missing, fmt.Sprintf("%s (object=%s)", tParams.TriggerName, objName))
+
+			continue
+		}
+
+		triggers[objName] = &ApexTrigger{
+			ObjectName:     objName,
+			TriggerName:    tParams.TriggerName,
+			IndicatorField: tParams.IndicatorField,
+			WatchFields:    tParams.WatchFields,
+		}
+	}
+
+	if len(missing) > 0 {
+		return triggers, fmt.Errorf("%w: %s", errManualApexTriggerMissing, strings.Join(missing, ", "))
+	}
+
+	return triggers, nil
 }
 
 // DeployMetadataZip initiates a deploy of a zip package to the connected Salesforce org
@@ -545,6 +606,13 @@ func (c *Connector) redeployExistingApexTriggers(
 		delete(triggerParams, addObj)
 	}
 
+	// In manual mode the caller manages trigger lifecycle: we don't redeploy
+	// kept triggers and we don't destructively delete orphans. Just verify the
+	// triggers we expect to exist still exist.
+	if req != nil && req.ManualApexTriggerCreation {
+		return c.verifyExistingApexTriggers(ctx, triggerParams, diff)
+	}
+
 	// Destructively remove triggers for objects that previously had a quota
 	// field but no longer do. Objects still in triggerParams are left alone —
 	// the deploy below will upsert them in place.
@@ -586,6 +654,48 @@ func (c *Connector) redeployExistingApexTriggers(
 			IndicatorField: result.IndicatorField,
 			WatchFields:    result.WatchFields,
 		}
+	}
+
+	return nil
+}
+
+// verifyExistingApexTriggers is the manual-mode counterpart to
+// redeployExistingApexTriggers's deploy/orphan-delete loop. It checks that
+// every existing-object trigger the caller declared still exists in Salesforce
+// and refreshes diff.apexTriggersExisting with the verified entries (mirroring
+// the bookkeeping the deploy path performs). Orphan triggers — those present
+// in diff.apexTriggersExisting but no longer in triggerParams — are left
+// untouched because the caller owns trigger lifecycle.
+func (c *Connector) verifyExistingApexTriggers(
+	ctx context.Context,
+	triggerParams map[common.ObjectName]*metadata.ApexTriggerParams,
+	diff subscriptionDiff,
+) error {
+	missing := make([]string, 0)
+
+	for objName, tParams := range triggerParams {
+		exists, err := c.ApexTriggerExists(ctx, tParams.TriggerName)
+		if err != nil {
+			return fmt.Errorf("failed to check apex trigger existence for object %s: %w",
+				objName, err)
+		}
+
+		if !exists {
+			missing = append(missing, fmt.Sprintf("%s (object=%s)", tParams.TriggerName, objName))
+
+			continue
+		}
+
+		diff.apexTriggersExisting[objName] = &ApexTrigger{
+			ObjectName:     objName,
+			TriggerName:    tParams.TriggerName,
+			IndicatorField: tParams.IndicatorField,
+			WatchFields:    tParams.WatchFields,
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: %s", errManualApexTriggerMissing, strings.Join(missing, ", "))
 	}
 
 	return nil

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -192,7 +192,7 @@ func (c *Connector) deployApexTriggersForCDC(
 }
 
 // verifyApexTriggersForCDC takes the verify-only path used when
-// SubscriptionRequest.ManualApexTriggerCreation is true. It builds the same
+// SubscriptionRequest.ManualApexTriggerManagement is true. It builds the same
 // apex trigger params as deployApexTriggersForCDC (so trigger names match what
 // the deploy path would have generated), best-effort checks each trigger is
 // visible in Salesforce, and returns the corresponding ApexTrigger entries
@@ -634,7 +634,7 @@ func (c *Connector) redeployExistingApexTriggers(
 	// kept triggers and we don't destructively delete orphans. Best-effort
 	// warn per missing trigger (visibility-or-existence — same warn-and-continue
 	// contract as Subscribe's manual path) and move on.
-	if req != nil && req.ManualApexTriggerCreation {
+	if req != nil && req.ManualApexTriggerManagement {
 		c.warnIfExistingApexTriggersMissing(ctx, triggerParams, diff)
 
 		return nil

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -194,11 +194,18 @@ func (c *Connector) deployApexTriggersForCDC(
 // verifyApexTriggersForCDC takes the verify-only path used when
 // SubscriptionRequest.ManualApexTriggerCreation is true. It builds the same
 // apex trigger params as deployApexTriggersForCDC (so trigger names match what
-// the deploy path would have generated), checks each trigger exists in
-// Salesforce, and returns the corresponding ApexTrigger entries for storage in
-// SubscribeResult.ApexTriggers. Returns errManualApexTriggerMissing wrapping
-// the list of missing triggers if any are absent so the caller learns about
-// every missing trigger in one round.
+// the deploy path would have generated), best-effort checks each trigger is
+// visible in Salesforce, and returns the corresponding ApexTrigger entries
+// for storage in SubscribeResult.ApexTriggers.
+//
+// Visibility — not strict existence — is what we can observe: the Tooling API
+// SOQL against ApexTrigger may return zero rows because the trigger genuinely
+// doesn't exist OR because the connector's user lacks visibility/permission.
+// Either way we surface a warn and continue; the caller opted into manual
+// trigger lifecycle. The runtime tell that the trigger truly is missing is a
+// soft one — UPDATE events will silently fail the channel-member filter
+// because the indicator field never flips to true — so this branch records a
+// warning per missing trigger rather than failing Subscribe upfront.
 func (c *Connector) verifyApexTriggersForCDC(
 	ctx context.Context,
 	params common.SubscribeParams,
@@ -210,21 +217,13 @@ func (c *Connector) verifyApexTriggersForCDC(
 	}
 
 	triggers := make(map[common.ObjectName]*ApexTrigger, len(triggerParams))
-	missing := make([]string, 0)
 
 	for objName, tParams := range triggerParams {
-		exists, err := c.ApexTriggerExists(ctx, tParams.TriggerName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check apex trigger existence for object %s: %w",
-				objName, err)
-		}
+		warnIfApexTriggerMissing(ctx, c, tParams.TriggerName, objName)
 
-		if !exists {
-			missing = append(missing, fmt.Sprintf("%s (object=%s)", tParams.TriggerName, objName))
-
-			continue
-		}
-
+		// Always emit the trigger entry so sfRes.ApexTriggers describes what
+		// the caller intended; a missing trigger is a runtime concern (silent
+		// drop of UPDATE events), not a setup-time failure.
 		triggers[objName] = &ApexTrigger{
 			ObjectName:     objName,
 			TriggerName:    tParams.TriggerName,
@@ -233,11 +232,36 @@ func (c *Connector) verifyApexTriggersForCDC(
 		}
 	}
 
-	if len(missing) > 0 {
-		return triggers, fmt.Errorf("%w: %s", errManualApexTriggerMissing, strings.Join(missing, ", "))
+	return triggers, nil
+}
+
+// warnIfApexTriggerMissing logs a per-trigger warning when the existence check
+// either errors (e.g. permission/visibility) or returns false. Shared by the
+// Subscribe and UpdateSubscription manual-mode paths.
+func warnIfApexTriggerMissing(
+	ctx context.Context, c *Connector, triggerName string, objName common.ObjectName,
+) {
+	exists, err := c.ApexTriggerExists(ctx, triggerName)
+	if err != nil {
+		slog.WarnContext(ctx,
+			"manual apex trigger existence check errored; assuming caller-managed and continuing",
+			"object", objName,
+			"trigger", triggerName,
+			"error", err,
+		)
+
+		return
 	}
 
-	return triggers, nil
+	if !exists {
+		slog.WarnContext(ctx,
+			"manual apex trigger not visible to connector; if it really is missing, "+
+				"UPDATE CDC events will be silently dropped at runtime because the "+
+				"indicator field will never flip to true",
+			"object", objName,
+			"trigger", triggerName,
+		)
+	}
 }
 
 // DeployMetadataZip initiates a deploy of a zip package to the connected Salesforce org
@@ -584,7 +608,7 @@ func toApexTriggers(
 // would deploy twice (once here, once in inner Subscribe), doubling the
 // metadata-deploy time per added object.
 //
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (c *Connector) redeployExistingApexTriggers(
 	ctx context.Context,
 	req *SubscriptionRequest,
@@ -607,10 +631,13 @@ func (c *Connector) redeployExistingApexTriggers(
 	}
 
 	// In manual mode the caller manages trigger lifecycle: we don't redeploy
-	// kept triggers and we don't destructively delete orphans. Just verify the
-	// triggers we expect to exist still exist.
+	// kept triggers and we don't destructively delete orphans. Best-effort
+	// warn per missing trigger (visibility-or-existence — same warn-and-continue
+	// contract as Subscribe's manual path) and move on.
 	if req != nil && req.ManualApexTriggerCreation {
-		return c.verifyExistingApexTriggers(ctx, triggerParams, diff)
+		c.warnIfExistingApexTriggersMissing(ctx, triggerParams, diff)
+
+		return nil
 	}
 
 	// Destructively remove triggers for objects that previously had a quota
@@ -659,32 +686,21 @@ func (c *Connector) redeployExistingApexTriggers(
 	return nil
 }
 
-// verifyExistingApexTriggers is the manual-mode counterpart to
-// redeployExistingApexTriggers's deploy/orphan-delete loop. It checks that
-// every existing-object trigger the caller declared still exists in Salesforce
-// and refreshes diff.apexTriggersExisting with the verified entries (mirroring
-// the bookkeeping the deploy path performs). Orphan triggers — those present
-// in diff.apexTriggersExisting but no longer in triggerParams — are left
+// warnIfExistingApexTriggersMissing is the manual-mode counterpart to
+// redeployExistingApexTriggers's deploy/orphan-delete loop. It best-effort
+// warns per kept-object trigger that is not visible to the connector and
+// refreshes diff.apexTriggersExisting with the declared entries (mirroring
+// the bookkeeping the deploy path performs) so the merged result describes
+// what the caller intended. Orphan triggers — present in
+// diff.apexTriggersExisting but no longer in triggerParams — are left
 // untouched because the caller owns trigger lifecycle.
-func (c *Connector) verifyExistingApexTriggers(
+func (c *Connector) warnIfExistingApexTriggersMissing(
 	ctx context.Context,
 	triggerParams map[common.ObjectName]*metadata.ApexTriggerParams,
 	diff subscriptionDiff,
-) error {
-	missing := make([]string, 0)
-
+) {
 	for objName, tParams := range triggerParams {
-		exists, err := c.ApexTriggerExists(ctx, tParams.TriggerName)
-		if err != nil {
-			return fmt.Errorf("failed to check apex trigger existence for object %s: %w",
-				objName, err)
-		}
-
-		if !exists {
-			missing = append(missing, fmt.Sprintf("%s (object=%s)", tParams.TriggerName, objName))
-
-			continue
-		}
+		warnIfApexTriggerMissing(ctx, c, tParams.TriggerName, objName)
 
 		diff.apexTriggersExisting[objName] = &ApexTrigger{
 			ObjectName:     objName,
@@ -693,12 +709,6 @@ func (c *Connector) verifyExistingApexTriggers(
 			WatchFields:    tParams.WatchFields,
 		}
 	}
-
-	if len(missing) > 0 {
-		return fmt.Errorf("%w: %s", errManualApexTriggerMissing, strings.Join(missing, ", "))
-	}
-
-	return nil
 }
 
 func formatDeployFailureDetails(result *DeployResult) string {

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -467,13 +467,13 @@ var (
 	errEventChannelMemberMissingMD = errors.New("UpdateEventChannelMember: GET returned empty metadata")
 )
 
-// CustomCheckboxFieldExists reports whether a custom field with the given API
+// CustomFieldExists reports whether a custom field with the given API
 // name (must include the __c suffix) exists on the named Salesforce object.
 //
 // Implementation queries the Tooling API CustomField sobject by TableEnumOrId
 // and DeveloperName. CustomField.DeveloperName stores the suffix-less form, so
 // the trailing __c is stripped before the query.
-func (c *Connector) CustomCheckboxFieldExists(
+func (c *Connector) CustomFieldExists(
 	ctx context.Context, objectName, fieldAPIName string,
 ) (bool, error) {
 	developerName := strings.TrimSuffix(fieldAPIName, "__c")

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -467,6 +467,63 @@ var (
 	errEventChannelMemberMissingMD = errors.New("UpdateEventChannelMember: GET returned empty metadata")
 )
 
+// CustomCheckboxFieldExists reports whether a custom field with the given API
+// name (must include the __c suffix) exists on the named Salesforce object.
+//
+// Implementation queries the Tooling API CustomField sobject by TableEnumOrId
+// and DeveloperName. CustomField.DeveloperName stores the suffix-less form, so
+// the trailing __c is stripped before the query.
+func (c *Connector) CustomCheckboxFieldExists(
+	ctx context.Context, objectName, fieldAPIName string,
+) (bool, error) {
+	developerName := strings.TrimSuffix(fieldAPIName, "__c")
+	soql := fmt.Sprintf(
+		"SELECT Id FROM CustomField WHERE TableEnumOrId = '%s' AND DeveloperName = '%s'",
+		escapeSOQLString(objectName), escapeSOQLString(developerName),
+	)
+
+	return c.toolingEntityExists(ctx, soql)
+}
+
+// toolingEntityExists runs the given Tooling API SOQL query and reports whether
+// it returned at least one record. Used by the existence-check helpers to power
+// the manual-creation flow.
+func (c *Connector) toolingEntityExists(ctx context.Context, soql string) (bool, error) {
+	location, err := c.getRestApiURL("tooling/query")
+	if err != nil {
+		return false, err
+	}
+
+	location.WithQueryParam("q", soql)
+
+	resp, err := c.Client.Get(ctx, location.String())
+	if err != nil {
+		return false, err
+	}
+
+	body, ok := resp.Body()
+	if !ok {
+		return false, common.ErrEmptyJSONHTTPResponse
+	}
+
+	obj, err := body.GetObject()
+	if err != nil {
+		return false, err
+	}
+
+	recordsNode, exists := obj["records"]
+	if !exists {
+		return false, fmt.Errorf("%w: soql=%q", errToolingQueryNoRecordsField, soql)
+	}
+
+	records, err := recordsNode.GetArray()
+	if err != nil {
+		return false, err
+	}
+
+	return len(records) > 0, nil
+}
+
 // sfAPIError is a single entry in a Salesforce API error response array.
 // nolint:tagliatelle
 type sfAPIError struct {

--- a/providers/salesforce/internal/crm/metadata/apextrigger.go
+++ b/providers/salesforce/internal/crm/metadata/apextrigger.go
@@ -95,18 +95,21 @@ func ValidateApexTriggerParams(params ApexTriggerParams, indicatorFieldName stri
 
 // ConstructApexTrigger builds the zip deployment package containing three Apex artifacts:
 //
-//  1. The trigger itself (triggers/<TriggerName>.trigger) — a thin one-line delegation
-//     to the handler. Trigger files cannot be unit-tested directly, so we keep the
-//     trigger trivial and put all logic in the handler class.
-//  2. The handler class (classes/<TriggerName>_Handler.cls) — contains the actual
-//     change-detection logic. The handler can be invoked from the test class with
-//     synthesized in-memory records, so its code paths get covered without DML.
-//  3. The companion test class (classes/Test_<TriggerName>.cls) — exercises both
-//     branches of the handler in memory, plus does one minimal best-effort DML so
-//     the trigger's single delegation line is also counted as covered. The
-//     before-insert trigger fires before validation rules per Salesforce's order
-//     of execution, so the trigger line is covered even when the org rejects the
-//     insert with a validation rule.
+//  1. The trigger itself (triggers/<TriggerName>.trigger) — a thin one-line
+//     delegation to the handler, registered for both before-insert and
+//     before-update. The before-insert registration is kept solely so the
+//     companion test's Database.insert covers the trigger's single delegation
+//     line even when validation rules reject the insert (before-insert fires
+//     before validation per Salesforce's order of execution). The handler's
+//     insert path is a no-op (see generateHandlerClassCode for why).
+//  2. The handler class (classes/<TriggerName>_Handler.cls) — contains the
+//     change-detection logic for the update path; the insert path is an early
+//     return. The handler can be invoked from the test class with synthesized
+//     in-memory records, so its code paths get covered without DML.
+//  3. The companion test class (classes/Test_<TriggerName>.cls) — invokes the
+//     handler twice (once with oldRecs=null for the early return, once with
+//     two records for the update branch), plus does one minimal best-effort
+//     Database.insert to cover the trigger's delegation line.
 //
 // The variant (CDC vs filtered-read) is selected from params.IndicatorField.ValueType:
 //   - common.FieldTypeBoolean    → CDC (assign rec.<field> = fieldChanged)
@@ -185,31 +188,36 @@ func indicatorAssignmentForType(field common.FieldDefinition) (string, error) {
 	}
 }
 
-// generateThinTriggerCode returns the Apex source for the trigger file. The trigger
-// only delegates to the handler so its lines (3) are dominated by a single call;
-// any DML attempt against the target object covers the delegation line, regardless
-// of whether the DML ultimately succeeds.
+// generateThinTriggerCode returns the Apex source for the trigger file. The
+// trigger fires on before-insert and before-update so test coverage can be
+// driven by a single DML attempt against the target object — the before-insert
+// trigger fires before Salesforce's order-of-execution evaluates validation
+// rules, so the delegation line is covered even when validation rejects the
+// insert. The handler decides what to do per operation; for the CDC quota
+// optimization use case the insert path is intentionally a no-op (CREATE
+// events bypass the channel-member filter expression unconditionally, so the
+// indicator's value at insert time has no effect on event delivery).
 func generateThinTriggerCode(params ApexTriggerParams, handlerClassName string) string {
 	return fmt.Sprintf(`trigger %s on %s (before insert, before update) {
-    %s.process(Trigger.new, Trigger.old, Trigger.isInsert);
+    %s.process(Trigger.new, Trigger.old);
 }
 `, params.TriggerName, params.ObjectName, handlerClassName)
 }
 
-// generateHandlerClassCode returns the Apex source for the handler class. The class
-// exposes a single static `process` method that takes the parallel Trigger.new and
-// Trigger.old lists plus the isInsert flag. Trigger.new and Trigger.old are
-// guaranteed by Salesforce to be index-aligned for update operations, so the
-// handler pairs records by index without needing to fabricate Ids in tests.
+// generateHandlerClassCode returns the Apex source for the handler class. The
+// class exposes a single static `process` method that takes the parallel
+// Trigger.new and Trigger.old lists. Salesforce passes a null Trigger.old on
+// before-insert and a non-null index-aligned Trigger.old on before-update, so
+// the handler distinguishes the two by checking oldRecs == null without
+// needing a separate isInsert flag.
+//
+// The insert path is a deliberate no-op: the indicator field's value at insert
+// time is never read by the CDC channel-member filter expression (which passes
+// every non-UPDATE event through unconditionally), so any computation here
+// would only affect the indicator's stored value on the new record — which no
+// supported consumer reads. The handler returns immediately on insert; the
+// indicator stays at the field's DefaultValue ("false").
 func generateHandlerClassCode(params ApexTriggerParams, handlerClassName, indicatorAssignment string) string {
-	insertConditions := make([]string, 0, len(params.WatchFields))
-	for _, field := range params.WatchFields {
-		insertConditions = append(insertConditions,
-			fmt.Sprintf("(rec.%s != null)", field))
-	}
-
-	insertExpr := strings.Join(insertConditions, " || ")
-
 	updateConditions := make([]string, 0, len(params.WatchFields))
 	for _, field := range params.WatchFields {
 		updateConditions = append(updateConditions,
@@ -219,25 +227,25 @@ func generateHandlerClassCode(params ApexTriggerParams, handlerClassName, indica
 	updateExpr := strings.Join(updateConditions, " || ")
 
 	return fmt.Sprintf(`public class %s {
-    public static void process(List<%s> newRecs, List<%s> oldRecs, Boolean isInsert) {
+    public static void process(List<%s> newRecs, List<%s> oldRecs) {
+        if (oldRecs == null) {
+            // Insert: no-op for CDC purposes. CREATE events bypass the channel
+            // member's filter expression unconditionally, so the indicator's
+            // value at insert time has no effect on event delivery.
+            return;
+        }
         for (Integer i = 0; i < newRecs.size(); i++) {
             %s rec = newRecs[i];
-            Boolean fieldChanged = false;
-
-            if (isInsert) {
-                fieldChanged = %s;
-            } else {
-                %s oldRec = oldRecs[i];
-                fieldChanged = %s;
-            }
+            %s oldRec = oldRecs[i];
+            Boolean fieldChanged = %s;
 
             %s
         }
     }
 }
 `, handlerClassName,
-		params.ObjectName, params.ObjectName, params.ObjectName,
-		insertExpr, params.ObjectName, updateExpr, indicatorAssignment)
+		params.ObjectName, params.ObjectName,
+		params.ObjectName, params.ObjectName, updateExpr, indicatorAssignment)
 }
 
 func generateTriggerMetaXML() string {
@@ -261,25 +269,24 @@ func generateClassMetaXML() string {
 // generateTestClassCode returns Apex test class source that covers BOTH the
 // handler class and the trigger:
 //
-//   - The two `exerciseHandler*Branch` methods invoke the handler directly with
-//     in-memory synthesized records. No DML, so org-side validation rules / FLS
-//     / picklist constraints cannot block coverage. Both branches of the
-//     handler's `if (isInsert)` are exercised, and for the filtered-read
-//     variant the change-detection result is forced true so the conditional
-//     timestamp assignment also runs (achieved by populating the first watch
-//     field on the new record so the (rec.X != null) / (rec.X != oldRec.X)
-//     condition evaluates true).
+//   - `exerciseHandlerInsertNoop` invokes the handler with oldRecs=null,
+//     covering the early-return path that the trigger drives on before-insert.
 //
-//   - The `coverTriggerDelegation` method does one Database.insert with
-//     allOrNone=false on a best-effort SObject. The trigger's before-insert
-//     fires before validation rules per Salesforce's order of execution, so
-//     even if the org rejects the insert, the trigger's single delegation line
-//     has already executed and counts toward coverage.
+//   - `exerciseHandlerUpdateBranch` invokes the handler with two in-memory
+//     records, covering the per-record loop and (for the filtered-read variant)
+//     the conditional timestamp-assignment line. We populate the first watch
+//     field on newRec only so (rec.<f> != oldRec.<f>) evaluates true and
+//     fieldChanged=true.
 //
-// Together these guarantee 100% coverage on both the trigger (1 covered line
-// out of 1 total) and the handler (every line covered, including the Read
-// variant's conditional `if (fieldChanged)` body) regardless of the customer
-// org's record-level validation rules.
+//   - `coverTriggerDelegation` does one Database.insert with allOrNone=false
+//     on a best-effort SObject. The trigger's before-insert fires before
+//     validation rules per Salesforce's order of execution, so even if the
+//     org rejects the insert, the trigger's single delegation line has
+//     already executed and counts toward coverage.
+//
+// Together these guarantee 100% coverage on the trigger (1/1) and the
+// handler (every line including the early-return and the Read variant's
+// conditional body) regardless of the customer org's validation rules.
 func generateTestClassCode(testClassName, handlerClassName string, params ApexTriggerParams) string {
 	// Validation requires len(WatchFields) > 0; defend against generator misuse
 	// by falling back to an empty string (the resulting Apex still compiles —
@@ -291,52 +298,47 @@ func generateTestClassCode(testClassName, handlerClassName string, params ApexTr
 
 	return fmt.Sprintf(apexTestClassTemplate,
 		testClassName,     // 1: private class name
-		params.ObjectName, // 2: insert branch — local var type
-		params.ObjectName, // 3: insert branch — new SObject literal
-		firstWatchField,   // 4: insert branch — watch field name to populate
-		handlerClassName,  // 5: insert branch — handler.process call
-		params.ObjectName, // 6: insert branch — List<X> in handler call
-		params.ObjectName, // 7: update branch — oldRec local type
-		params.ObjectName, // 8: update branch — oldRec new literal
-		params.ObjectName, // 9: update branch — newRec local type
-		params.ObjectName, // 10: update branch — newRec new literal
-		firstWatchField,   // 11: update branch — watch field name to populate on newRec
-		handlerClassName,  // 12: update branch — handler.process call
-		params.ObjectName, // 13: update branch — List<X> for newRecs
-		params.ObjectName, // 14: update branch — List<X> for oldRecs
-		params.ObjectName, // 15: coverTriggerDelegation — Schema.getGlobalDescribe lookup
+		params.ObjectName, // 2: insert-noop — local var type
+		params.ObjectName, // 3: insert-noop — new SObject literal
+		handlerClassName,  // 4: insert-noop — handler.process call
+		params.ObjectName, // 5: insert-noop — List<X> in handler call
+		params.ObjectName, // 6: update branch — oldRec local type
+		params.ObjectName, // 7: update branch — oldRec new literal
+		params.ObjectName, // 8: update branch — newRec local type
+		params.ObjectName, // 9: update branch — newRec new literal
+		firstWatchField,   // 10: update branch — watch field name to populate on newRec
+		handlerClassName,  // 11: update branch — handler.process call
+		params.ObjectName, // 12: update branch — List<X> for newRecs
+		params.ObjectName, // 13: update branch — List<X> for oldRecs
+		params.ObjectName, // 14: coverTriggerDelegation — Schema.getGlobalDescribe lookup
 	)
 }
 
 // apexTestClassTemplate is the Apex source for the generated companion test class.
 // Placeholders (in order):
 //  1. test class name
-//  2. object API name — insert-branch local var type
-//  3. object API name — insert-branch new-literal
-//  4. first watch field name — insert-branch setWatchFieldValueIfPossible argument
-//  5. handler class name — insert-branch handler invocation
-//  6. object API name — insert-branch List<X> in handler call
-//  7. object API name — update-branch oldRec local type
-//  8. object API name — update-branch oldRec new-literal
-//  9. object API name — update-branch newRec local type
-//  10. object API name — update-branch newRec new-literal
-//  11. first watch field name — update-branch setWatchFieldValueIfPossible argument
-//  12. handler class name — update-branch handler invocation
-//  13. object API name — update-branch List<X> for newRecs
-//  14. object API name — update-branch List<X> for oldRecs
-//  15. object API name — Schema.getGlobalDescribe lookup in makeRec
+//  2. object API name — insert-noop local var type
+//  3. object API name — insert-noop new-literal
+//  4. handler class name — insert-noop handler invocation
+//  5. object API name — insert-noop List<X> in handler call
+//  6. object API name — update-branch oldRec local type
+//  7. object API name — update-branch oldRec new-literal
+//  8. object API name — update-branch newRec local type
+//  9. object API name — update-branch newRec new-literal
+//  10. first watch field name — update-branch setWatchFieldValueIfPossible argument
+//  11. handler class name — update-branch handler invocation
+//  12. object API name — update-branch List<X> for newRecs
+//  13. object API name — update-branch List<X> for oldRecs
+//  14. object API name — Schema.getGlobalDescribe lookup in makeRec
 const apexTestClassTemplate = `@isTest
 private class %s {
     @isTest
-    static void exerciseHandlerInsertBranch() {
-        // Direct handler invocation with an in-memory record. The handler's
-        // isInsert=true branch executes fully without touching the database.
-        // We populate the first watch field so (rec.<watchField> != null)
-        // evaluates true → fieldChanged=true → the Read variant's conditional
-        // timestamp assignment line is covered.
+    static void exerciseHandlerInsertNoop() {
+        // Direct handler invocation simulating the before-insert call shape
+        // (Trigger.old is null on insert). The handler's early-return path is
+        // covered without touching the database.
         %s rec = new %s();
-        setWatchFieldValueIfPossible(rec, '%s');
-        %s.process(new List<%s>{rec}, null, true);
+        %s.process(new List<%s>{rec}, null);
     }
 
     @isTest
@@ -350,7 +352,7 @@ private class %s {
         %s oldRec = new %s();
         %s newRec = new %s();
         setWatchFieldValueIfPossible(newRec, '%s');
-        %s.process(new List<%s>{newRec}, new List<%s>{oldRec}, false);
+        %s.process(new List<%s>{newRec}, new List<%s>{oldRec});
     }
 
     @isTest

--- a/providers/salesforce/internal/crm/metadata/apextrigger_test.go
+++ b/providers/salesforce/internal/crm/metadata/apextrigger_test.go
@@ -350,29 +350,32 @@ func TestConstructApexTriggerForCDCContent(t *testing.T) { //nolint:funlen
 
 	files := readZipFiles(t, zipData)
 
-	// 1. The trigger is now thin — it delegates to the handler.
+	// 1. The trigger is thin — it delegates to the handler. before-insert is
+	//    kept so the companion test's Database.insert covers the trigger's
+	//    delegation line; the handler's insert path is a no-op.
 	expectedTrigger := `trigger CDC_Lead on Lead (before insert, before update) {
-    CDC_Lead_Handler.process(Trigger.new, Trigger.old, Trigger.isInsert);
+    CDC_Lead_Handler.process(Trigger.new, Trigger.old);
 }
 `
 	if got := files["triggers/CDC_Lead.trigger"]; got != expectedTrigger {
 		t.Errorf("trigger code mismatch.\nGot:\n%s\nWant:\n%s", got, expectedTrigger)
 	}
 
-	// 2. The handler holds the actual change-detection logic, with the boolean
-	//    assignment for the CDC variant (rec.<field> = fieldChanged unconditionally).
+	// 2. The handler holds the change-detection logic for the update path; the
+	//    insert path is an early return because CREATE CDC events bypass the
+	//    channel-member filter expression unconditionally.
 	expectedHandler := `public class CDC_Lead_Handler {
-    public static void process(List<Lead> newRecs, List<Lead> oldRecs, Boolean isInsert) {
+    public static void process(List<Lead> newRecs, List<Lead> oldRecs) {
+        if (oldRecs == null) {
+            // Insert: no-op for CDC purposes. CREATE events bypass the channel
+            // member's filter expression unconditionally, so the indicator's
+            // value at insert time has no effect on event delivery.
+            return;
+        }
         for (Integer i = 0; i < newRecs.size(); i++) {
             Lead rec = newRecs[i];
-            Boolean fieldChanged = false;
-
-            if (isInsert) {
-                fieldChanged = (rec.Email != null) || (rec.Phone != null);
-            } else {
-                Lead oldRec = oldRecs[i];
-                fieldChanged = (rec.Email != oldRec.Email) || (rec.Phone != oldRec.Phone);
-            }
+            Lead oldRec = oldRecs[i];
+            Boolean fieldChanged = (rec.Email != oldRec.Email) || (rec.Phone != oldRec.Phone);
 
             rec.AmpTriggerSubscription__c = fieldChanged;
         }
@@ -435,7 +438,7 @@ func TestConstructApexTriggerForFilteredReadContent(t *testing.T) {
 
 	// Trigger is the same thin delegation regardless of CDC vs filtered-read variant.
 	expectedTrigger := `trigger Read_Lead on Lead (before insert, before update) {
-    Read_Lead_Handler.process(Trigger.new, Trigger.old, Trigger.isInsert);
+    Read_Lead_Handler.process(Trigger.new, Trigger.old);
 }
 `
 	if got := files["triggers/Read_Lead.trigger"]; got != expectedTrigger {
@@ -445,17 +448,17 @@ func TestConstructApexTriggerForFilteredReadContent(t *testing.T) {
 	// The handler differs from CDC: the indicator assignment is conditional on
 	// fieldChanged being true and writes System.now() instead of fieldChanged.
 	expectedHandler := `public class Read_Lead_Handler {
-    public static void process(List<Lead> newRecs, List<Lead> oldRecs, Boolean isInsert) {
+    public static void process(List<Lead> newRecs, List<Lead> oldRecs) {
+        if (oldRecs == null) {
+            // Insert: no-op for CDC purposes. CREATE events bypass the channel
+            // member's filter expression unconditionally, so the indicator's
+            // value at insert time has no effect on event delivery.
+            return;
+        }
         for (Integer i = 0; i < newRecs.size(); i++) {
             Lead rec = newRecs[i];
-            Boolean fieldChanged = false;
-
-            if (isInsert) {
-                fieldChanged = (rec.Email != null) || (rec.Phone != null);
-            } else {
-                Lead oldRec = oldRecs[i];
-                fieldChanged = (rec.Email != oldRec.Email) || (rec.Phone != oldRec.Phone);
-            }
+            Lead oldRec = oldRecs[i];
+            Boolean fieldChanged = (rec.Email != oldRec.Email) || (rec.Phone != oldRec.Phone);
 
             if (fieldChanged) {
                 rec.AmpTimestamp__c = System.now();
@@ -494,7 +497,7 @@ func TestConstructApexTriggerHandlerSingleField(t *testing.T) {
 		"public class CDC_Contact_Handler",
 		"List<Contact> newRecs",
 		"List<Contact> oldRecs",
-		"(rec.LastName != null)",
+		"if (oldRecs == null)",
 		"(rec.LastName != oldRec.LastName)",
 		"rec.AmpChanged__c = fieldChanged;",
 	} {
@@ -531,19 +534,19 @@ func TestConstructApexTriggerBundlesTestClass(t *testing.T) { //nolint:funlen
 
 	// The test class must:
 	//   - Be marked @isTest so it's excluded from coverage requirements itself.
-	//   - Invoke the handler directly (in-memory) for both branches so handler
-	//     coverage doesn't depend on whether DML against the real object succeeds.
-	//   - Populate the first watch field on the in-memory record so the
-	//     change-detection condition evaluates true and the Read variant's
-	//     conditional indicator-assignment line is also covered.
+	//   - Invoke the handler directly (in-memory) for both the insert no-op
+	//     and the update branch so handler coverage doesn't depend on whether
+	//     DML against the real object succeeds.
+	//   - Populate the first watch field on the in-memory newRec for the
+	//     update branch so the change-detection condition evaluates true and
+	//     the Read variant's conditional indicator-assignment line is covered.
 	//   - Do at least one DML so the trigger's delegation line is covered.
 	for _, want := range []string{
 		"@isTest",
 		"private class Test_CDC_Lead",
-		"static void exerciseHandlerInsertBranch",
+		"static void exerciseHandlerInsertNoop",
 		"static void exerciseHandlerUpdateBranch",
 		"static void coverTriggerDelegation",
-		"setWatchFieldValueIfPossible(rec, 'Email')",
 		"setWatchFieldValueIfPossible(newRec, 'Email')",
 		"private static void setWatchFieldValueIfPossible(SObject rec, String fieldName)",
 		"CDC_Lead_Handler.process",

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -17,6 +17,12 @@ var (
 	errDeployFailed            = errors.New("apex trigger deployment failed")
 	errDeployPollTimeout       = errors.New("deploy poll timeout")
 	errDestructiveDeployFailed = errors.New("destructive apex trigger deployment failed")
+	// Returned by upsertQuotaOptimizationFields when ManualCheckboxCreation is set
+	// but one or more declared checkbox fields are not present in Salesforce.
+	errManualCheckboxFieldMissing = errors.New("manual checkbox custom field does not exist in Salesforce")
+	// Returned by the verify-only apex trigger paths when ManualApexTriggerCreation
+	// is set but one or more expected triggers are not present in Salesforce.
+	errManualApexTriggerMissing = errors.New("manual apex trigger does not exist in Salesforce")
 )
 
 type RegistrationParams struct {

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -17,12 +17,6 @@ var (
 	errDeployFailed            = errors.New("apex trigger deployment failed")
 	errDeployPollTimeout       = errors.New("deploy poll timeout")
 	errDestructiveDeployFailed = errors.New("destructive apex trigger deployment failed")
-	// Returned by upsertQuotaOptimizationFields when ManualCheckboxCreation is set
-	// but one or more declared checkbox fields are not present in Salesforce.
-	errManualCheckboxFieldMissing = errors.New("manual checkbox custom field does not exist in Salesforce")
-	// Returned by the verify-only apex trigger paths when ManualApexTriggerCreation
-	// is set but one or more expected triggers are not present in Salesforce.
-	errManualApexTriggerMissing = errors.New("manual apex trigger does not exist in Salesforce")
 )
 
 type RegistrationParams struct {

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -24,6 +24,18 @@ type SubscribeResult struct {
 	// We need to return this field and will be read by the DeleteSubscription method to delete the custom fields.
 	QuotaOptimizationObjectFields map[common.ObjectName]string
 	ApexTriggers                  map[common.ObjectName]*ApexTrigger
+
+	// ManualCheckboxCreation mirrors SubscriptionRequest.ManualCheckboxCreation.
+	// When true, the connector skipped creating quota-optimization checkbox fields
+	// at subscribe time (after verifying they already existed) and DeleteSubscription
+	// must skip deleting them so the caller-managed artifacts are not touched.
+	ManualCheckboxCreation bool
+
+	// ManualApexTriggerCreation mirrors SubscriptionRequest.ManualApexTriggerCreation.
+	// When true, the connector skipped deploying apex triggers at subscribe time
+	// (after verifying they already existed) and DeleteSubscription must skip
+	// destructive deletes so the caller-managed triggers are not touched.
+	ManualApexTriggerCreation bool
 }
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
@@ -42,6 +54,12 @@ type SubscriptionRequest struct {
 	// The checkbox field is also used to build a CDC filter expression that allows all non-UPDATE
 	// events through and only passes UPDATE events where the checkbox is true.
 	QuotaOptimizationObjectFields map[common.ObjectName]string
+
+	// ManualCheckboxCreation indicates that the caller wants to create the checkbox field manually.
+	ManualCheckboxCreation bool
+
+	// ManualApexTriggerCreation indicates that the caller wants to create the apex trigger manually.
+	ManualApexTriggerCreation bool
 }
 
 // subscribeProgress tracks which reversible operations completed during executeSubscribe,
@@ -134,6 +152,8 @@ func (c *Connector) Subscribe(
 
 // executeSubscribe performs the forward-path logic of Subscribe.
 // It returns partial results and progress on error, without performing any rollback.
+//
+//nolint:cyclop
 func (c *Connector) executeSubscribe(
 	ctx context.Context,
 	params common.SubscribeParams,
@@ -142,6 +162,11 @@ func (c *Connector) executeSubscribe(
 ) (*SubscribeResult, *subscribeProgress, error) {
 	sfRes := &SubscribeResult{
 		EventChannelMembers: make(map[common.ObjectName]*EventChannelMember),
+	}
+
+	if req != nil {
+		sfRes.ManualCheckboxCreation = req.ManualCheckboxCreation
+		sfRes.ManualApexTriggerCreation = req.ManualApexTriggerCreation
 	}
 
 	progress := &subscribeProgress{
@@ -153,7 +178,11 @@ func (c *Connector) executeSubscribe(
 		return sfRes, progress, fmt.Errorf("failed to upsert quota optimization fields: %w", err)
 	}
 
-	progress.quotaFieldsUpserted = true
+	// Skip the upsert flag in manual mode: no Metadata API write occurred, so
+	// rollback must not attempt to delete the (caller-managed) fields.
+	if req == nil || !req.ManualCheckboxCreation {
+		progress.quotaFieldsUpserted = true
+	}
 
 	// Clone instead of aliasing so subsequent mutations of
 	// sfRes.QuotaOptimizationObjectFields (e.g. clear() in DeleteSubscription
@@ -168,13 +197,26 @@ func (c *Connector) executeSubscribe(
 	// fails, rollback only has to drop the custom field — no ECMs to tear down;
 	// (b) once ECMs go live, the trigger is already maintaining the indicator,
 	// so no UPDATE events get silently filtered out during the setup window.
-	deployOut, err := c.deployApexTriggersForCDC(ctx, params, req)
+	//
+	// In ManualApexTriggerCreation mode the deploy is skipped: we only verify the
+	// caller-managed triggers exist. progress.deployedTriggers stays nil so the
+	// rollback path leaves the caller's triggers alone.
+	if req != nil && req.ManualApexTriggerCreation {
+		triggers, err := c.verifyApexTriggersForCDC(ctx, params, req)
+		sfRes.ApexTriggers = triggers
 
-	progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
-	sfRes.ApexTriggers = toApexTriggers(deployOut)
+		if err != nil {
+			return sfRes, progress, err
+		}
+	} else {
+		deployOut, err := c.deployApexTriggersForCDC(ctx, params, req)
 
-	if err != nil {
-		return sfRes, progress, err
+		progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
+		sfRes.ApexTriggers = toApexTriggers(deployOut)
+
+		if err != nil {
+			return sfRes, progress, err
+		}
 	}
 
 	if err := c.createEventChannelMembers(ctx, params, registrationParams, req, sfRes); err != nil {
@@ -298,31 +340,39 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 		delete(sfRes.EventChannelMembers, objectName)
 	}
 
-	for objName, trigger := range sfRes.ApexTriggers {
-		if trigger == nil {
-			slog.Warn("apex trigger entry is nil, skipping delete",
-				"object", objName,
-			)
+	// In manual mode the caller manages trigger lifecycle: leave sfRes.ApexTriggers
+	// populated (they still exist in Salesforce) and do not destructively deploy.
+	if !sfRes.ManualApexTriggerCreation {
+		for objName, trigger := range sfRes.ApexTriggers {
+			if trigger == nil {
+				slog.Warn("apex trigger entry is nil, skipping delete",
+					"object", objName,
+				)
 
-			continue
+				continue
+			}
+
+			// TODO: check existence before delete
+			if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
+				slog.Warn(
+					"apex trigger delete failed mid-teardown; aborting before "+
+						"remaining triggers and quota fields are touched",
+					"failedObject", objName,
+					"error", err,
+					"remainingApexTriggers", datautils.FromMap(sfRes.ApexTriggers).Keys(),
+					"remainingQuotaFields", datautils.FromMap(sfRes.QuotaOptimizationObjectFields).Keys(),
+				)
+
+				return fmt.Errorf("failed to delete apex trigger for object '%s': %w", objName, err)
+			}
+
+			delete(sfRes.ApexTriggers, objName)
 		}
-
-		// TODO: check existence before delete
-		if err := c.rollbackApexTrigger(ctx, trigger.TriggerName); err != nil {
-			slog.Warn("apex trigger delete failed mid-teardown; aborting before remaining triggers and quota fields are touched",
-				"failedObject", objName,
-				"error", err,
-				"remainingApexTriggers", datautils.FromMap(sfRes.ApexTriggers).Keys(),
-				"remainingQuotaFields", datautils.FromMap(sfRes.QuotaOptimizationObjectFields).Keys(),
-			)
-
-			return fmt.Errorf("failed to delete apex trigger for object '%s': %w", objName, err)
-		}
-
-		delete(sfRes.ApexTriggers, objName)
 	}
 
-	if len(sfRes.QuotaOptimizationObjectFields) > 0 {
+	// In manual mode the caller manages checkbox field lifecycle: leave the
+	// QuotaOptimizationObjectFields map populated and do not call DeleteMetadata.
+	if !sfRes.ManualCheckboxCreation && len(sfRes.QuotaOptimizationObjectFields) > 0 {
 		deleteFields := make(map[common.ObjectName][]string)
 
 		for objectName, fieldName := range sfRes.QuotaOptimizationObjectFields {
@@ -492,7 +542,11 @@ func (c *Connector) executeUpdateSubscription(
 			progress, err
 	}
 
-	progress.quotaFieldsUpserted = true
+	// Skip the upsert flag in manual mode: no Metadata API write occurred, so
+	// rollback must not attempt to delete the (caller-managed) fields.
+	if req == nil || !req.ManualCheckboxCreation {
+		progress.quotaFieldsUpserted = true
+	}
 
 	// Identify truly new quota fields and filter prevState so DeleteSubscription
 	// only removes fields for objects being removed.
@@ -553,7 +607,11 @@ func (c *Connector) executeUpdateSubscription(
 			}
 		}
 
-		innerParams.Request = &SubscriptionRequest{QuotaOptimizationObjectFields: innerFields}
+		innerParams.Request = &SubscriptionRequest{
+			QuotaOptimizationObjectFields: innerFields,
+			ManualCheckboxCreation:        req.ManualCheckboxCreation,
+			ManualApexTriggerCreation:     req.ManualApexTriggerCreation,
+		}
 	}
 
 	createRes, subscribeErr := c.Subscribe(ctx, innerParams)
@@ -750,6 +808,11 @@ func buildUpdatedSubscribeResult(
 		newState.QuotaOptimizationObjectFields = maps.Clone(req.QuotaOptimizationObjectFields)
 	}
 
+	if req != nil {
+		newState.ManualCheckboxCreation = req.ManualCheckboxCreation
+		newState.ManualApexTriggerCreation = req.ManualApexTriggerCreation
+	}
+
 	return newState
 }
 
@@ -861,6 +924,12 @@ func prepareQuotaOptimizationObjectFieldsForUpdate(
 // only observable effect on callers is that their req.QuotaOptimizationObjectFields
 // map is silently shrunk; callers that reuse the same req pointer across multiple
 // calls should construct a fresh req per call to avoid observing the mutation.
+//
+// When req.ManualCheckboxCreation is true the function takes a verify-only path:
+// it skips the UpsertMetadata call and instead checks each (now post-pruning)
+// field exists in Salesforce, returning errManualCheckboxFieldMissing for any
+// that don't. The phantom-pruning still runs so downstream consumers see the
+// same post-mutation view.
 func (c *Connector) upsertQuotaOptimizationFields(
 	ctx context.Context, params common.SubscribeParams, req *SubscriptionRequest,
 ) error {
@@ -895,10 +964,48 @@ func (c *Connector) upsertQuotaOptimizationFields(
 		return nil
 	}
 
+	if req.ManualCheckboxCreation {
+		return c.verifyQuotaOptimizationFieldsExist(ctx, req)
+	}
+
 	if _, err := c.UpsertMetadata(ctx, &common.UpsertMetadataParams{
 		Fields: fields,
 	}); err != nil {
 		return fmt.Errorf("failed to upsert quota optimization fields: %w", err)
+	}
+
+	return nil
+}
+
+// verifyQuotaOptimizationFieldsExist checks that every quota-optimization field
+// declared in req.QuotaOptimizationObjectFields already exists in Salesforce.
+// Used by the ManualCheckboxCreation path of upsertQuotaOptimizationFields where
+// the caller is responsible for creating the fields outside this connector.
+//
+// Returns errManualCheckboxFieldMissing wrapping the list of missing fields if
+// any are absent so the caller learns about every missing field in one round
+// rather than fixing them one at a time.
+func (c *Connector) verifyQuotaOptimizationFieldsExist(
+	ctx context.Context, req *SubscriptionRequest,
+) error {
+	missing := make([]string, 0)
+
+	for objectName, fieldName := range req.QuotaOptimizationObjectFields {
+		apiName := customFieldAPIName(fieldName)
+
+		exists, err := c.CustomCheckboxFieldExists(ctx, string(objectName), apiName)
+		if err != nil {
+			return fmt.Errorf("failed to check checkbox field existence for %s.%s: %w",
+				objectName, apiName, err)
+		}
+
+		if !exists {
+			missing = append(missing, fmt.Sprintf("%s.%s", objectName, apiName))
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: %s", errManualCheckboxFieldMissing, strings.Join(missing, ", "))
 	}
 
 	return nil

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -25,16 +25,15 @@ type SubscribeResult struct {
 	QuotaOptimizationObjectFields map[common.ObjectName]string
 	ApexTriggers                  map[common.ObjectName]*ApexTrigger
 
-	// ManualCheckboxCreation mirrors SubscriptionRequest.ManualCheckboxCreation.
-	// When true, the connector skipped creating quota-optimization checkbox fields
-	// at subscribe time (after verifying they already existed) and DeleteSubscription
-	// must skip deleting them so the caller-managed artifacts are not touched.
+	// ManualCheckboxCreation mirrors SubscriptionRequest.ManualCheckboxCreation
+	// so DeleteSubscription (which only sees the result) can honor the caller-
+	// owns-lifecycle contract. See SubscriptionRequest's "Manual-mode contract"
+	// for the full semantics, including what happens when the flag is toggled
+	// across calls.
 	ManualCheckboxCreation bool
 
 	// ManualApexTriggerCreation mirrors SubscriptionRequest.ManualApexTriggerCreation.
-	// When true, the connector skipped deploying apex triggers at subscribe time
-	// (after verifying they already existed) and DeleteSubscription must skip
-	// destructive deletes so the caller-managed triggers are not touched.
+	// See SubscriptionRequest's "Manual-mode contract" for the full semantics.
 	ManualApexTriggerCreation bool
 }
 
@@ -55,10 +54,46 @@ type SubscriptionRequest struct {
 	// events through and only passes UPDATE events where the checkbox is true.
 	QuotaOptimizationObjectFields map[common.ObjectName]string
 
-	// ManualCheckboxCreation indicates that the caller wants to create the checkbox field manually.
+	// Manual-mode contract for the two flags below.
+	//
+	// When set, the caller owns the corresponding artifact's lifecycle: the
+	// connector skips creation at subscribe time and skips destructive cleanup
+	// at delete time. Existence is best-effort verified via Tooling API SOQL —
+	// any miss (truly missing OR permission/visibility) is logged as a warn
+	// and the call continues. A truly-missing checkbox field surfaces as a
+	// downstream INVALID_FIELD error from CreateEventChannelMember; a
+	// truly-missing trigger silently drops UPDATE events at runtime, which
+	// the per-trigger warn flags.
+	//
+	// Two invariants make this safe even though the flag is global per
+	// subscription rather than per-artifact:
+	//
+	//  1. PlatformEventChannelMember (and its filter expression) is created
+	//     and deleted unconditionally — neither flag gates that path. The
+	//     filter expression's lifecycle is always correct regardless of who
+	//     manages the field/trigger it references.
+	//
+	//  2. Toggling the flag across calls (Subscribe → UpdateSubscription, or
+	//     prevState → DeleteSubscription) is treated as an ownership transfer
+	//     for ALL referenced artifacts, including pre-toggle ones:
+	//
+	//     - auto → manual: connector stops touching previously-auto-created
+	//       artifacts; subsequent DeleteSubscription leaves them as orphans
+	//       in Salesforce. Orphans are inert from a CDC standpoint (filter
+	//       expression is gone with the channel member) but the trigger keeps
+	//       firing on writes and the field still counts against the per-object
+	//       custom-field cap.
+	//     - manual → auto: connector takes over and may overwrite the caller's
+	//       trigger code via redeploy and the caller's field metadata via
+	//       upsert; subsequent DeleteSubscription destructively removes them.
+	//
+	// Callers needing stricter ownership semantics (per-artifact tagging,
+	// reject-on-toggle, etc.) should layer that on top of this contract.
+
+	// ManualCheckboxCreation: see "Manual-mode contract" above.
 	ManualCheckboxCreation bool
 
-	// ManualApexTriggerCreation indicates that the caller wants to create the apex trigger manually.
+	// ManualApexTriggerCreation: see "Manual-mode contract" above.
 	ManualApexTriggerCreation bool
 }
 

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -1034,7 +1034,7 @@ func (c *Connector) warnIfQuotaOptimizationFieldsMissing(
 	for objectName, fieldName := range req.QuotaOptimizationObjectFields {
 		apiName := customFieldAPIName(fieldName)
 
-		exists, err := c.CustomCheckboxFieldExists(ctx, string(objectName), apiName)
+		exists, err := c.CustomFieldExists(ctx, string(objectName), apiName)
 		if err != nil {
 			slog.WarnContext(ctx,
 				"manual checkbox field existence check errored; assuming caller-managed and continuing",

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -198,9 +198,11 @@ func (c *Connector) executeSubscribe(
 	// (b) once ECMs go live, the trigger is already maintaining the indicator,
 	// so no UPDATE events get silently filtered out during the setup window.
 	//
-	// In ManualApexTriggerCreation mode the deploy is skipped: we only verify the
-	// caller-managed triggers exist. progress.deployedTriggers stays nil so the
-	// rollback path leaves the caller's triggers alone.
+	// In ManualApexTriggerCreation mode the deploy is skipped: we best-effort
+	// warn for any trigger the connector can't see and continue.
+	// progress.deployedTriggers stays nil so the rollback path leaves the
+	// caller's triggers alone. The Tooling API SOQL itself can still error
+	// (e.g. params build), so we propagate any error from verifyApexTriggersForCDC.
 	if req != nil && req.ManualApexTriggerCreation {
 		triggers, err := c.verifyApexTriggersForCDC(ctx, params, req)
 		sfRes.ApexTriggers = triggers
@@ -965,7 +967,9 @@ func (c *Connector) upsertQuotaOptimizationFields(
 	}
 
 	if req.ManualCheckboxCreation {
-		return c.verifyQuotaOptimizationFieldsExist(ctx, req)
+		c.warnIfQuotaOptimizationFieldsMissing(ctx, req)
+
+		return nil
 	}
 
 	if _, err := c.UpsertMetadata(ctx, &common.UpsertMetadataParams{
@@ -977,38 +981,45 @@ func (c *Connector) upsertQuotaOptimizationFields(
 	return nil
 }
 
-// verifyQuotaOptimizationFieldsExist checks that every quota-optimization field
-// declared in req.QuotaOptimizationObjectFields already exists in Salesforce.
-// Used by the ManualCheckboxCreation path of upsertQuotaOptimizationFields where
-// the caller is responsible for creating the fields outside this connector.
+// warnIfQuotaOptimizationFieldsMissing best-effort checks that each declared
+// quota-optimization field is visible to the connector in Salesforce. Used by
+// the ManualCheckboxCreation path of upsertQuotaOptimizationFields.
 //
-// Returns errManualCheckboxFieldMissing wrapping the list of missing fields if
-// any are absent so the caller learns about every missing field in one round
-// rather than fixing them one at a time.
-func (c *Connector) verifyQuotaOptimizationFieldsExist(
+// Visibility — not strict existence — is what we can observe: the Tooling API
+// SOQL against CustomField may return zero rows because the field genuinely
+// doesn't exist OR because the connector's user lacks visibility/permission.
+// Either way we surface a warn and proceed; if the field truly isn't there,
+// CreateEventChannelMember will reject the filter expression downstream with
+// a clearer "No such column" error than we could produce here, so an early
+// hard-fail would only convert a precise downstream error into a vague
+// upstream one and would also block legitimate-but-permission-restricted setups.
+func (c *Connector) warnIfQuotaOptimizationFieldsMissing(
 	ctx context.Context, req *SubscriptionRequest,
-) error {
-	missing := make([]string, 0)
-
+) {
 	for objectName, fieldName := range req.QuotaOptimizationObjectFields {
 		apiName := customFieldAPIName(fieldName)
 
 		exists, err := c.CustomCheckboxFieldExists(ctx, string(objectName), apiName)
 		if err != nil {
-			return fmt.Errorf("failed to check checkbox field existence for %s.%s: %w",
-				objectName, apiName, err)
+			slog.WarnContext(ctx,
+				"manual checkbox field existence check errored; assuming caller-managed and continuing",
+				"object", objectName,
+				"field", apiName,
+				"error", err,
+			)
+
+			continue
 		}
 
 		if !exists {
-			missing = append(missing, fmt.Sprintf("%s.%s", objectName, apiName))
+			slog.WarnContext(ctx,
+				"manual checkbox field not visible to connector; if it really is missing, "+
+					"CreateEventChannelMember will fail filter validation downstream",
+				"object", objectName,
+				"field", apiName,
+			)
 		}
 	}
-
-	if len(missing) > 0 {
-		return fmt.Errorf("%w: %s", errManualCheckboxFieldMissing, strings.Join(missing, ", "))
-	}
-
-	return nil
 }
 
 // isObjectSubscribed reports whether objName matches any key in events using the

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -25,16 +25,16 @@ type SubscribeResult struct {
 	QuotaOptimizationObjectFields map[common.ObjectName]string
 	ApexTriggers                  map[common.ObjectName]*ApexTrigger
 
-	// ManualCheckboxCreation mirrors SubscriptionRequest.ManualCheckboxCreation
+	// ManualCheckboxManagement mirrors SubscriptionRequest.ManualCheckboxManagement
 	// so DeleteSubscription (which only sees the result) can honor the caller-
 	// owns-lifecycle contract. See SubscriptionRequest's "Manual-mode contract"
 	// for the full semantics, including what happens when the flag is toggled
 	// across calls.
-	ManualCheckboxCreation bool
+	ManualCheckboxManagement bool
 
-	// ManualApexTriggerCreation mirrors SubscriptionRequest.ManualApexTriggerCreation.
+	// ManualApexTriggerManagement mirrors SubscriptionRequest.ManualApexTriggerManagement.
 	// See SubscriptionRequest's "Manual-mode contract" for the full semantics.
-	ManualApexTriggerCreation bool
+	ManualApexTriggerManagement bool
 }
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
@@ -90,11 +90,11 @@ type SubscriptionRequest struct {
 	// Callers needing stricter ownership semantics (per-artifact tagging,
 	// reject-on-toggle, etc.) should layer that on top of this contract.
 
-	// ManualCheckboxCreation: see "Manual-mode contract" above.
-	ManualCheckboxCreation bool
+	// ManualCheckboxManagement: see "Manual-mode contract" above.
+	ManualCheckboxManagement bool
 
-	// ManualApexTriggerCreation: see "Manual-mode contract" above.
-	ManualApexTriggerCreation bool
+	// ManualApexTriggerManagement: see "Manual-mode contract" above.
+	ManualApexTriggerManagement bool
 }
 
 // subscribeProgress tracks which reversible operations completed during executeSubscribe,
@@ -200,8 +200,8 @@ func (c *Connector) executeSubscribe(
 	}
 
 	if req != nil {
-		sfRes.ManualCheckboxCreation = req.ManualCheckboxCreation
-		sfRes.ManualApexTriggerCreation = req.ManualApexTriggerCreation
+		sfRes.ManualCheckboxManagement = req.ManualCheckboxManagement
+		sfRes.ManualApexTriggerManagement = req.ManualApexTriggerManagement
 	}
 
 	progress := &subscribeProgress{
@@ -215,7 +215,7 @@ func (c *Connector) executeSubscribe(
 
 	// Skip the upsert flag in manual mode: no Metadata API write occurred, so
 	// rollback must not attempt to delete the (caller-managed) fields.
-	if req == nil || !req.ManualCheckboxCreation {
+	if req == nil || !req.ManualCheckboxManagement {
 		progress.quotaFieldsUpserted = true
 	}
 
@@ -233,12 +233,12 @@ func (c *Connector) executeSubscribe(
 	// (b) once ECMs go live, the trigger is already maintaining the indicator,
 	// so no UPDATE events get silently filtered out during the setup window.
 	//
-	// In ManualApexTriggerCreation mode the deploy is skipped: we best-effort
+	// In ManualApexTriggerManagement mode the deploy is skipped: we best-effort
 	// warn for any trigger the connector can't see and continue.
 	// progress.deployedTriggers stays nil so the rollback path leaves the
 	// caller's triggers alone. The Tooling API SOQL itself can still error
 	// (e.g. params build), so we propagate any error from verifyApexTriggersForCDC.
-	if req != nil && req.ManualApexTriggerCreation {
+	if req != nil && req.ManualApexTriggerManagement {
 		triggers, err := c.verifyApexTriggersForCDC(ctx, params, req)
 		sfRes.ApexTriggers = triggers
 
@@ -379,7 +379,7 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 
 	// In manual mode the caller manages trigger lifecycle: leave sfRes.ApexTriggers
 	// populated (they still exist in Salesforce) and do not destructively deploy.
-	if !sfRes.ManualApexTriggerCreation {
+	if !sfRes.ManualApexTriggerManagement {
 		for objName, trigger := range sfRes.ApexTriggers {
 			if trigger == nil {
 				slog.Warn("apex trigger entry is nil, skipping delete",
@@ -409,7 +409,7 @@ func (c *Connector) DeleteSubscription(ctx context.Context, params common.Subscr
 
 	// In manual mode the caller manages checkbox field lifecycle: leave the
 	// QuotaOptimizationObjectFields map populated and do not call DeleteMetadata.
-	if !sfRes.ManualCheckboxCreation && len(sfRes.QuotaOptimizationObjectFields) > 0 {
+	if !sfRes.ManualCheckboxManagement && len(sfRes.QuotaOptimizationObjectFields) > 0 {
 		deleteFields := make(map[common.ObjectName][]string)
 
 		for objectName, fieldName := range sfRes.QuotaOptimizationObjectFields {
@@ -581,7 +581,7 @@ func (c *Connector) executeUpdateSubscription(
 
 	// Skip the upsert flag in manual mode: no Metadata API write occurred, so
 	// rollback must not attempt to delete the (caller-managed) fields.
-	if req == nil || !req.ManualCheckboxCreation {
+	if req == nil || !req.ManualCheckboxManagement {
 		progress.quotaFieldsUpserted = true
 	}
 
@@ -646,8 +646,8 @@ func (c *Connector) executeUpdateSubscription(
 
 		innerParams.Request = &SubscriptionRequest{
 			QuotaOptimizationObjectFields: innerFields,
-			ManualCheckboxCreation:        req.ManualCheckboxCreation,
-			ManualApexTriggerCreation:     req.ManualApexTriggerCreation,
+			ManualCheckboxManagement:      req.ManualCheckboxManagement,
+			ManualApexTriggerManagement:   req.ManualApexTriggerManagement,
 		}
 	}
 
@@ -846,8 +846,8 @@ func buildUpdatedSubscribeResult(
 	}
 
 	if req != nil {
-		newState.ManualCheckboxCreation = req.ManualCheckboxCreation
-		newState.ManualApexTriggerCreation = req.ManualApexTriggerCreation
+		newState.ManualCheckboxManagement = req.ManualCheckboxManagement
+		newState.ManualApexTriggerManagement = req.ManualApexTriggerManagement
 	}
 
 	return newState
@@ -962,7 +962,7 @@ func prepareQuotaOptimizationObjectFieldsForUpdate(
 // map is silently shrunk; callers that reuse the same req pointer across multiple
 // calls should construct a fresh req per call to avoid observing the mutation.
 //
-// When req.ManualCheckboxCreation is true the function takes a verify-only path:
+// When req.ManualCheckboxManagement is true the function takes a verify-only path:
 // it skips the UpsertMetadata call and instead checks each (now post-pruning)
 // field exists in Salesforce, returning errManualCheckboxFieldMissing for any
 // that don't. The phantom-pruning still runs so downstream consumers see the
@@ -1001,7 +1001,7 @@ func (c *Connector) upsertQuotaOptimizationFields(
 		return nil
 	}
 
-	if req.ManualCheckboxCreation {
+	if req.ManualCheckboxManagement {
 		c.warnIfQuotaOptimizationFieldsMissing(ctx, req)
 
 		return nil
@@ -1018,7 +1018,7 @@ func (c *Connector) upsertQuotaOptimizationFields(
 
 // warnIfQuotaOptimizationFieldsMissing best-effort checks that each declared
 // quota-optimization field is visible to the connector in Salesforce. Used by
-// the ManualCheckboxCreation path of upsertQuotaOptimizationFields.
+// the ManualCheckboxManagement path of upsertQuotaOptimizationFields.
 //
 // Visibility — not strict existence — is what we can observe: the Tooling API
 // SOQL against CustomField may return zero rows because the field genuinely

--- a/test/salesforce/existence/apextrigger/main.go
+++ b/test/salesforce/existence/apextrigger/main.go
@@ -1,0 +1,200 @@
+// Integration test for Connector.ApexTriggerExists.
+//
+// Flow:
+//  1. Create a checkbox custom field on Lead (the apex trigger references it,
+//     so the field must exist before the trigger compiles).
+//  2. Build a CDC apex trigger zip and deploy it via Metadata API.
+//  3. ApexTriggerExists should report true for the deployed trigger.
+//  4. ApexTriggerExists should report false for a guaranteed-missing trigger
+//     name (negative case so we don't get a false positive).
+//  5. Build a destructive-changes zip and deploy it to remove the trigger.
+//  6. ApexTriggerExists should report false post-delete.
+//  7. Delete the checkbox field.
+//
+// On any failure the script aborts via utils.Fail (os.Exit(1)) and the
+// trigger / field may be left behind in Salesforce; manual cleanup may be
+// required before re-running.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+const (
+	objectName        = "Lead"
+	checkboxAPIName   = "AmpExistenceTest__c"
+	checkboxDisplay   = "Amp Existence Test"
+	fakeTriggerName   = "amp_existence_does_not_exist_trigger"
+	deployPollPeriod  = 10 * time.Second
+	deployPollTimeout = 5 * time.Minute
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	triggerName, err := salesforce.GenerateApexTriggerNameForCDC(objectName)
+	if err != nil {
+		utils.Fail("GenerateApexTriggerNameForCDC failed", "error", err)
+	}
+
+	// Step 1: Create the checkbox field the trigger code will reference.
+	fmt.Printf("====== Creating prereq field %s.%s ======\n", objectName, checkboxAPIName)
+	createCheckboxField(ctx, conn)
+
+	// Step 2: Build & deploy the apex trigger.
+	fmt.Printf("====== Deploying apex trigger %s ======\n", triggerName)
+	deployTrigger(ctx, conn, triggerName)
+
+	// Step 3: Existence check should return true.
+	fmt.Println("====== ApexTriggerExists (expect true) ======")
+	assertExists(ctx, conn, triggerName, true)
+
+	// Step 4: Negative case — fake trigger should return false.
+	fmt.Printf("====== ApexTriggerExists for fake %s (expect false) ======\n", fakeTriggerName)
+	assertExists(ctx, conn, fakeTriggerName, false)
+
+	// Step 5: Destructively remove the trigger.
+	fmt.Printf("====== Destroying apex trigger %s ======\n", triggerName)
+	destroyTrigger(ctx, conn, triggerName)
+
+	// Step 6: Existence check should return false.
+	fmt.Println("====== ApexTriggerExists post-delete (expect false) ======")
+	assertExists(ctx, conn, triggerName, false)
+
+	// Step 7: Clean up the checkbox field.
+	fmt.Printf("====== Cleaning up prereq field %s.%s ======\n", objectName, checkboxAPIName)
+	deleteCheckboxField(ctx, conn)
+
+	fmt.Println("====== Done ======")
+}
+
+func createCheckboxField(ctx context.Context, conn *salesforce.Connector) {
+	if _, err := conn.UpsertMetadata(ctx, &common.UpsertMetadataParams{
+		Fields: map[string][]common.FieldDefinition{
+			objectName: {
+				{
+					FieldName:   checkboxAPIName,
+					DisplayName: checkboxDisplay,
+					Description: "Prereq field for ApexTriggerExists integration test. Safe to delete.",
+					ValueType:   common.FieldTypeBoolean,
+					StringOptions: &common.StringFieldOptions{
+						DefaultValue: new("false"),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		utils.Fail("UpsertMetadata failed", "error", err)
+	}
+}
+
+func deleteCheckboxField(ctx context.Context, conn *salesforce.Connector) {
+	if _, err := conn.DeleteMetadata(ctx, &common.DeleteMetadataParams{
+		Fields: map[common.ObjectName][]string{
+			objectName: {checkboxAPIName},
+		},
+	}); err != nil {
+		utils.Fail("DeleteMetadata failed", "error", err)
+	}
+}
+
+func deployTrigger(ctx context.Context, conn *salesforce.Connector, triggerName string) {
+	zipData, err := salesforce.ConstructApexTriggerZipForCDC(salesforce.ApexTriggerParams{
+		ObjectName:  objectName,
+		TriggerName: triggerName,
+		IndicatorField: common.FieldDefinition{
+			FieldName: checkboxAPIName,
+			ValueType: common.FieldTypeBoolean,
+		},
+		WatchFields: []string{"Email", "Phone"},
+	}, checkboxAPIName)
+	if err != nil {
+		utils.Fail("ConstructApexTriggerZipForCDC failed", "error", err)
+	}
+
+	deployID, err := conn.DeployMetadataZip(ctx, zipData)
+	if err != nil {
+		utils.Fail("DeployMetadataZip failed", "error", err)
+	}
+
+	waitForDeploy(ctx, conn, deployID)
+}
+
+func destroyTrigger(ctx context.Context, conn *salesforce.Connector, triggerName string) {
+	zipData, err := salesforce.ConstructDestructiveApexTriggerZip(triggerName)
+	if err != nil {
+		utils.Fail("ConstructDestructiveApexTriggerZip failed", "error", err)
+	}
+
+	deployID, err := conn.DeployMetadataZip(ctx, zipData)
+	if err != nil {
+		utils.Fail("DeployMetadataZip (destructive) failed", "error", err)
+	}
+
+	waitForDeploy(ctx, conn, deployID)
+}
+
+func waitForDeploy(ctx context.Context, conn *salesforce.Connector, deployID string) {
+	deadline := time.Now().Add(deployPollTimeout)
+
+	for {
+		if time.Now().After(deadline) {
+			utils.Fail("deploy did not finish in time", "deployID", deployID, "timeout", deployPollTimeout)
+		}
+
+		result, err := conn.CheckDeployStatus(ctx, deployID)
+		if err != nil {
+			utils.Fail("CheckDeployStatus failed", "deployID", deployID, "error", err)
+		}
+
+		if result.Done {
+			if !result.Success {
+				utils.Fail("deploy completed but failed",
+					"deployID", deployID,
+					"status", result.Status,
+					"errorMessage", result.ErrorMessage,
+					"failures", result.ComponentFailures,
+				)
+			}
+
+			fmt.Printf("Deploy succeeded (deployID=%s)\n", deployID)
+
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			utils.Fail("context cancelled while waiting for deploy", "deployID", deployID, "error", ctx.Err())
+		case <-time.After(deployPollPeriod):
+		}
+	}
+}
+
+func assertExists(ctx context.Context, conn *salesforce.Connector, triggerName string, want bool) {
+	got, err := conn.ApexTriggerExists(ctx, triggerName)
+	if err != nil {
+		utils.Fail("ApexTriggerExists returned error", "trigger", triggerName, "error", err)
+	}
+
+	if got != want {
+		utils.Fail("ApexTriggerExists returned unexpected value",
+			"trigger", triggerName, "want", want, "got", got)
+	}
+
+	fmt.Printf("OK: ApexTriggerExists(%s) = %t\n", triggerName, got)
+}

--- a/test/salesforce/existence/customfield/main.go
+++ b/test/salesforce/existence/customfield/main.go
@@ -1,0 +1,115 @@
+// Integration test for Connector.CustomCheckboxFieldExists.
+//
+// Flow:
+//  1. Create a checkbox custom field on Account via UpsertMetadata.
+//  2. CustomCheckboxFieldExists should report true for the new field.
+//  3. CustomCheckboxFieldExists should report false for a guaranteed-missing
+//     field name (negative case so we don't get a false positive that returns
+//     true for everything).
+//  4. Delete the field via DeleteMetadata.
+//  5. CustomCheckboxFieldExists should report false post-delete.
+//
+// On any failure the script aborts via utils.Fail (os.Exit(1)) and the field
+// may be left behind in Salesforce; re-running is idempotent because
+// UpsertMetadata is idempotent and a residual field will be cleaned up by the
+// test's own delete step.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/salesforce"
+	connTest "github.com/amp-labs/connectors/test/salesforce"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+const (
+	objectName       = "Account"
+	fieldDisplayName = "Amp Existence Test"
+	fieldAPIName     = "AmpExistenceTest__c"
+	fakeFieldAPIName = "amp_existence_does_not_exist__c"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetSalesforceConnector(ctx)
+	ctx = common.WithAuthToken(ctx, connTest.GetSalesforceAccessToken())
+
+	// Step 1: Create the field.
+	fmt.Printf("====== Creating %s.%s ======\n", objectName, fieldAPIName)
+	createCheckboxField(ctx, conn)
+
+	// Step 2: Existence check should return true.
+	fmt.Println("====== CustomCheckboxFieldExists (expect true) ======")
+	assertExists(ctx, conn, objectName, fieldAPIName, true)
+
+	// Step 3: Negative case — a fake field should return false.
+	fmt.Printf("====== CustomCheckboxFieldExists for fake %s (expect false) ======\n", fakeFieldAPIName)
+	assertExists(ctx, conn, objectName, fakeFieldAPIName, false)
+
+	// Step 4: Delete the field.
+	fmt.Printf("====== Deleting %s.%s ======\n", objectName, fieldAPIName)
+	deleteCheckboxField(ctx, conn)
+
+	// Step 5: Existence check should return false.
+	// Salesforce's Tooling API is read-from-cache for some queries; if this
+	// flake bites the test, retry with backoff. For a freshly-deleted custom
+	// field the SOQL query hits authoritative metadata so it's typically
+	// immediate.
+	fmt.Println("====== CustomCheckboxFieldExists post-delete (expect false) ======")
+	assertExists(ctx, conn, objectName, fieldAPIName, false)
+
+	fmt.Println("====== Done ======")
+}
+
+func createCheckboxField(ctx context.Context, conn *salesforce.Connector) {
+	if _, err := conn.UpsertMetadata(ctx, &common.UpsertMetadataParams{
+		Fields: map[string][]common.FieldDefinition{
+			objectName: {
+				{
+					FieldName:   fieldAPIName,
+					DisplayName: fieldDisplayName,
+					Description: "Temporary field created by CustomCheckboxFieldExists integration test. Safe to delete.",
+					ValueType:   common.FieldTypeBoolean,
+					StringOptions: &common.StringFieldOptions{
+						DefaultValue: new("false"),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		utils.Fail("UpsertMetadata failed", "error", err)
+	}
+}
+
+func deleteCheckboxField(ctx context.Context, conn *salesforce.Connector) {
+	if _, err := conn.DeleteMetadata(ctx, &common.DeleteMetadataParams{
+		Fields: map[common.ObjectName][]string{
+			objectName: {fieldAPIName},
+		},
+	}); err != nil {
+		utils.Fail("DeleteMetadata failed", "error", err)
+	}
+}
+
+func assertExists(ctx context.Context, conn *salesforce.Connector, obj, field string, want bool) {
+	got, err := conn.CustomCheckboxFieldExists(ctx, obj, field)
+	if err != nil {
+		utils.Fail("CustomCheckboxFieldExists returned error", "object", obj, "field", field, "error", err)
+	}
+
+	if got != want {
+		utils.Fail("CustomCheckboxFieldExists returned unexpected value",
+			"object", obj, "field", field, "want", want, "got", got)
+	}
+
+	fmt.Printf("OK: CustomCheckboxFieldExists(%s.%s) = %t\n", obj, field, got)
+}

--- a/test/salesforce/existence/customfield/main.go
+++ b/test/salesforce/existence/customfield/main.go
@@ -1,13 +1,13 @@
-// Integration test for Connector.CustomCheckboxFieldExists.
+// Integration test for Connector.CustomFieldExists.
 //
 // Flow:
 //  1. Create a checkbox custom field on Account via UpsertMetadata.
-//  2. CustomCheckboxFieldExists should report true for the new field.
-//  3. CustomCheckboxFieldExists should report false for a guaranteed-missing
+//  2. CustomFieldExists should report true for the new field.
+//  3. CustomFieldExists should report false for a guaranteed-missing
 //     field name (negative case so we don't get a false positive that returns
 //     true for everything).
 //  4. Delete the field via DeleteMetadata.
-//  5. CustomCheckboxFieldExists should report false post-delete.
+//  5. CustomFieldExists should report false post-delete.
 //
 // On any failure the script aborts via utils.Fail (os.Exit(1)) and the field
 // may be left behind in Salesforce; re-running is idempotent because
@@ -48,11 +48,11 @@ func main() {
 	createCheckboxField(ctx, conn)
 
 	// Step 2: Existence check should return true.
-	fmt.Println("====== CustomCheckboxFieldExists (expect true) ======")
+	fmt.Println("====== CustomFieldExists (expect true) ======")
 	assertExists(ctx, conn, objectName, fieldAPIName, true)
 
 	// Step 3: Negative case — a fake field should return false.
-	fmt.Printf("====== CustomCheckboxFieldExists for fake %s (expect false) ======\n", fakeFieldAPIName)
+	fmt.Printf("====== CustomFieldExists for fake %s (expect false) ======\n", fakeFieldAPIName)
 	assertExists(ctx, conn, objectName, fakeFieldAPIName, false)
 
 	// Step 4: Delete the field.
@@ -64,7 +64,7 @@ func main() {
 	// flake bites the test, retry with backoff. For a freshly-deleted custom
 	// field the SOQL query hits authoritative metadata so it's typically
 	// immediate.
-	fmt.Println("====== CustomCheckboxFieldExists post-delete (expect false) ======")
+	fmt.Println("====== CustomFieldExists post-delete (expect false) ======")
 	assertExists(ctx, conn, objectName, fieldAPIName, false)
 
 	fmt.Println("====== Done ======")
@@ -77,7 +77,7 @@ func createCheckboxField(ctx context.Context, conn *salesforce.Connector) {
 				{
 					FieldName:   fieldAPIName,
 					DisplayName: fieldDisplayName,
-					Description: "Temporary field created by CustomCheckboxFieldExists integration test. Safe to delete.",
+					Description: "Temporary field created by CustomFieldExists integration test. Safe to delete.",
 					ValueType:   common.FieldTypeBoolean,
 					StringOptions: &common.StringFieldOptions{
 						DefaultValue: new("false"),
@@ -101,15 +101,15 @@ func deleteCheckboxField(ctx context.Context, conn *salesforce.Connector) {
 }
 
 func assertExists(ctx context.Context, conn *salesforce.Connector, obj, field string, want bool) {
-	got, err := conn.CustomCheckboxFieldExists(ctx, obj, field)
+	got, err := conn.CustomFieldExists(ctx, obj, field)
 	if err != nil {
-		utils.Fail("CustomCheckboxFieldExists returned error", "object", obj, "field", field, "error", err)
+		utils.Fail("CustomFieldExists returned error", "object", obj, "field", field, "error", err)
 	}
 
 	if got != want {
-		utils.Fail("CustomCheckboxFieldExists returned unexpected value",
+		utils.Fail("CustomFieldExists returned unexpected value",
 			"object", obj, "field", field, "want", want, "got", got)
 	}
 
-	fmt.Printf("OK: CustomCheckboxFieldExists(%s.%s) = %t\n", obj, field, got)
+	fmt.Printf("OK: CustomFieldExists(%s.%s) = %t\n", obj, field, got)
 }


### PR DESCRIPTION
Add ManualCheckboxCreation and ManualApexTriggerCreation flags to SubscriptionRequest
(and mirror them on SubscribeResult so DeleteSubscription / rollback can read them).

When a flag is true the connector skips the Metadata API write and
best-effort checks the artifact is visible to the connector via Tooling API
SOQL. Visibility — not strict existence — is what we can observe (zero rows
on missing OR on permission/visibility), so any miss is logged as a
per-artifact warn and Subscribe / UpdateSubscription continues:

  - Truly-missing checkbox field: CreateEventChannelMember rejects the filter
    expression downstream with a precise "No such column" error, so an upfront
    hard-fail would only convert a clear downstream error into a vague
    upstream one (and would block legitimate permission-restricted setups).
  - Truly-missing apex trigger: caller opted into manual lifecycle; the
    runtime tell is a silent UPDATE-event drop because the indicator field
    never flips to true, which the per-trigger warn flags.

DeleteSubscription and the rollback path are no-ops for caller-managed
artifacts: no existence check at delete time — the flag on SubscribeResult
is trusted and the corresponding cleanup block is skipped.

New helpers:
  - Connector.CustomCheckboxFieldExists(ctx, objectName, fieldAPIName)
  - Connector.ApexTriggerExists(ctx, triggerName)

## Test run results

Both helpers exercised against a live Salesforce dev org via the new
runnable scripts under `test/salesforce/existence/`. Each script creates the
artifact, asserts the helper returns true, asserts false for a guaranteed-missing
name, deletes the artifact, and asserts false post-delete. Exit 0 on all three
assertions hitting; non-zero on any divergence.

**Run 2026-05-09:**

- ✅ `go run ./test/salesforce/existence/customfield` — exit 0
- ✅ `go run ./test/salesforce/existence/apextrigger` — exit 0

<details>
<summary>customfield test — full log (exit 0)</summary>

```text
time=2026-05-09T21:31:07.762-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-09T21:31:07.763-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-09T21:31:07.767-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-09T21:31:07.767-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
====== Creating Account.AmpExistenceTest__c ======
time=2026-05-09T21:31:07.769-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=8f0752bc-a984-4b83-9fcc-c536f29b90aa headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:08.240-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:8f0752bc-a984-4b83-9fcc-c536f29b90aa headers:[X-Request-Id: 3858122ba15d62baf9c0e5d8e0bcb273 X-Sfdc-Edge-Cache: none Content-Type: text/xml; charset=utf-8 Set-Cookie: <redacted> Vary: Accept-Encoding Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Date: Sun, 10 May 2026 04:31:08 GMT Server: sfdcedge X-Sfdc-Request-Id: 3858122ba15d62baf9c0e5d8e0bcb273] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:08.240-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=3d418c53-0d37-4fae-b06e-40fef1fb6d97 headers.Soapaction='' headers.Accept=application/xml headers.Content-Type=text/xml
time=2026-05-09T21:31:08.662-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:3d418c53-0d37-4fae-b06e-40fef1fb6d97 headers:[Set-Cookie: <redacted> Server: sfdcedge X-Sfdc-Edge-Cache: none Date: Sun, 10 May 2026 04:31:08 GMT X-Sfdc-Request-Id: 6bee3ec9bc86a9faf01e2897eab4b089 X-Request-Id: 6bee3ec9bc86a9faf01e2897eab4b089 Content-Type: text/xml; charset=utf-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:08.662-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=4717bb8c-9119-448b-b645-74eec1d304ec headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:10.031-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:4717bb8c-9119-448b-b645-74eec1d304ec headers:[X-Request-Id: cbe4a818fc9b02b570fc06b557f0669b X-Sfdc-Edge-Cache: none Server: sfdcedge X-Sfdc-Request-Id: cbe4a818fc9b02b570fc06b557f0669b Date: Sun, 10 May 2026 04:31:10 GMT Content-Type: text/xml; charset=utf-8 Set-Cookie: <redacted> Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:10.031-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName+FROM+PermissionSet+WHERE+Name%3D%27IntegrationCustomFieldVisibility%27" correlationId=d141e5ef-6ebc-45f8-85e5-bc7d9c9c7aab headers.Accept=application/json
time=2026-05-09T21:31:10.324-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:d141e5ef-6ebc-45f8-85e5-bc7d9c9c7aab headers:[Vary: Accept-Encoding Date: Sun, 10 May 2026 04:31:10 GMT X-Content-Type-Options: nosniff Sforce-Limit-Info: api-usage=2/15000 X-Sfdc-Request-Id: 8d4af19f774f6ebf25b71fa4be707846 X-Sfdc-Edge-Cache: none Content-Type: application/json;charset=UTF-8 Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Strict-Transport-Security: max-age=63072000; includeSubDomains Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge X-Request-Id: 8d4af19f774f6ebf25b71fa4be707846 X-Robots-Tag: none] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName+FROM+PermissionSet+WHERE+Name%3D%27IntegrationCustomFieldVisibility%27]"
time=2026-05-09T21:31:10.324-07:00 level=DEBUG msg="HTTP request" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/oauth2/userinfo correlationId=f8884678-656d-4a8f-874f-0bf3423d0bea headers.Accept=application/json
time=2026-05-09T21:31:10.664-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:f8884678-656d-4a8f-874f-0bf3423d0bea headers:[Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Content-Type-Options: nosniff X-Request-Id: 1ebdf8d42cbc3fc50064c25610c10190 Date: Sun, 10 May 2026 04:31:10 GMT Content-Type: application/json;charset=UTF-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Strict-Transport-Security: max-age=63072000; includeSubDomains X-Robots-Tag: none Server: sfdcedge X-Sfdc-Request-Id: 1ebdf8d42cbc3fc50064c25610c10190 Vary: Accept-Encoding X-Sfdc-Edge-Cache: none] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/oauth2/userinfo]"
time=2026-05-09T21:31:10.665-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment correlationId=7db3a112-5ba5-4729-8569-9e4cd37221b5 headers.Accept=application/json headers.Content-Type=application/json
time=2026-05-09T21:31:11.193-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:7db3a112-5ba5-4729-8569-9e4cd37221b5 headers:[X-Sfdc-Request-Id: 24d82eafb92496027425a47a44704af3 X-Request-Id: 24d82eafb92496027425a47a44704af3 Date: Sun, 10 May 2026 04:31:11 GMT Content-Type: application/json;charset=UTF-8 X-Content-Type-Options: nosniff Strict-Transport-Security: max-age=63072000; includeSubDomains Vary: Accept-Encoding Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Sforce-Limit-Info: api-usage=2/15000 X-Robots-Tag: none Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Server: sfdcedge] method:POST status:400 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment]"
time=2026-05-09T21:31:11.193-07:00 level=ERROR msg="HTTP request failed" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment correlationId=7db3a112-5ba5-4729-8569-9e4cd37221b5 error="HTTP status 400: caller error: [{\"message\":\"Duplicate PermissionSetAssignment.  Assignee: 005gK000004y8Wf; Permission Set: 0PSgK00000CTqM5\",\"errorCode\":\"DUPLICATE_VALUE\",\"fields\":[\"AssigneeId\",\"PermissionSetId\"]}]"
====== CustomCheckboxFieldExists (expect true) ======
time=2026-05-09T21:31:11.193-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27AmpExistenceTest%27" correlationId=4b89306b-6c49-4577-bac3-4ed799d895b4 headers.Accept=application/json
time=2026-05-09T21:31:11.435-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:4b89306b-6c49-4577-bac3-4ed799d895b4 headers:[X-Content-Type-Options: nosniff Vary: Accept-Encoding Server: sfdcedge X-Request-Id: 8f2f8b32b5af17edde68119488762062 Date: Sun, 10 May 2026 04:31:11 GMT Content-Type: application/json;charset=UTF-8 X-Robots-Tag: none Strict-Transport-Security: max-age=63072000; includeSubDomains Sforce-Limit-Info: api-usage=3/15000 X-Sfdc-Request-Id: 8f2f8b32b5af17edde68119488762062 X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted>] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27AmpExistenceTest%27]"
OK: CustomCheckboxFieldExists(Account.AmpExistenceTest__c) = true
====== CustomCheckboxFieldExists for fake amp_existence_does_not_exist__c (expect false) ======
time=2026-05-09T21:31:11.436-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27amp_existence_does_not_exist%27" correlationId=79e766c9-8f7c-4438-8e16-0f6d0d107b59 headers.Accept=application/json
time=2026-05-09T21:31:11.674-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:79e766c9-8f7c-4438-8e16-0f6d0d107b59 headers:[Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding X-Sfdc-Request-Id: 4e4e43093220f655e207c0a0587b98df Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Content-Type-Options: nosniff Sforce-Limit-Info: api-usage=3/15000 Strict-Transport-Security: max-age=63072000; includeSubDomains X-Request-Id: 4e4e43093220f655e207c0a0587b98df Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Robots-Tag: none Date: Sun, 10 May 2026 04:31:11 GMT Server: sfdcedge X-Sfdc-Edge-Cache: none] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27amp_existence_does_not_exist%27]"
OK: CustomCheckboxFieldExists(Account.amp_existence_does_not_exist__c) = false
====== Deleting Account.AmpExistenceTest__c ======
time=2026-05-09T21:31:11.675-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=bda2013c-6305-40be-86a6-8bf7ee531d11 headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:12.350-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:bda2013c-6305-40be-86a6-8bf7ee531d11 headers:[Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding Set-Cookie: <redacted> Server: sfdcedge X-Sfdc-Request-Id: c80f1e75918923f119cd054921b7c7ab Date: Sun, 10 May 2026 04:31:12 GMT Content-Type: text/xml; charset=utf-8 X-Request-Id: c80f1e75918923f119cd054921b7c7ab X-Sfdc-Edge-Cache: none] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
====== CustomCheckboxFieldExists post-delete (expect false) ======
time=2026-05-09T21:31:12.350-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27AmpExistenceTest%27" correlationId=086a550c-1129-4a77-8d87-6824e874b8f9 headers.Accept=application/json
time=2026-05-09T21:31:12.549-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:086a550c-1129-4a77-8d87-6824e874b8f9 headers:[Date: Sun, 10 May 2026 04:31:12 GMT Content-Type: application/json;charset=UTF-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Content-Type-Options: nosniff Vary: Accept-Encoding X-Robots-Tag: none Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Sfdc-Request-Id: df08d6db907e3c0ee2446c43fb79f810 X-Request-Id: df08d6db907e3c0ee2446c43fb79f810 Sforce-Limit-Info: api-usage=5/15000 Strict-Transport-Security: max-age=63072000; includeSubDomains Server: sfdcedge X-Sfdc-Edge-Cache: none] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+CustomField+WHERE+TableEnumOrId+%3D+%27Account%27+AND+DeveloperName+%3D+%27AmpExistenceTest%27]"
OK: CustomCheckboxFieldExists(Account.AmpExistenceTest__c) = false
====== Done ======
```
</details>

<details>
<summary>apextrigger test — full log (exit 0)</summary>

```text
time=2026-05-09T21:31:34.754-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-09T21:31:34.755-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
time=2026-05-09T21:31:34.757-07:00 level=WARN msg="credentials file does not exist, using fallback" path=./salesforce-crm-creds.json newPath=./salesforce-creds.json
time=2026-05-09T21:31:34.757-07:00 level=DEBUG msg="loading credentials file" path=./salesforce-creds.json
====== Creating prereq field Lead.AmpExistenceTest__c ======
time=2026-05-09T21:31:34.759-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=df7c7127-59d0-4e2c-b4da-e3d939364b1f headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:35.169-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:df7c7127-59d0-4e2c-b4da-e3d939364b1f headers:[Set-Cookie: <redacted> Server: sfdcedge X-Request-Id: d263bfb09c9df06d9125a9f2770081dd X-Sfdc-Edge-Cache: none Content-Type: text/xml; charset=utf-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding X-Sfdc-Request-Id: d263bfb09c9df06d9125a9f2770081dd Date: Sun, 10 May 2026 04:31:35 GMT] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:35.169-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=86789811-c967-4037-b20a-1955f96c16f9 headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:35.746-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:86789811-c967-4037-b20a-1955f96c16f9 headers:[Date: Sun, 10 May 2026 04:31:35 GMT Content-Type: text/xml; charset=utf-8 Server: sfdcedge X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding Set-Cookie: <redacted> X-Sfdc-Request-Id: b53d420a619f44cbd17a8cf0a08243e4 X-Request-Id: b53d420a619f44cbd17a8cf0a08243e4] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:35.746-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=bcfe5751-fe5b-45df-a65d-f8be7950de90 headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:31:36.734-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:bcfe5751-fe5b-45df-a65d-f8be7950de90 headers:[Date: Sun, 10 May 2026 04:31:36 GMT Vary: Accept-Encoding Server: sfdcedge Content-Type: text/xml; charset=utf-8 Set-Cookie: <redacted> Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Sfdc-Request-Id: 030947cbc7e2c3d9a2e08309f1fdd4bd X-Request-Id: 030947cbc7e2c3d9a2e08309f1fdd4bd X-Sfdc-Edge-Cache: none] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:36.734-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName+FROM+PermissionSet+WHERE+Name%3D%27IntegrationCustomFieldVisibility%27" correlationId=966e50b5-e72d-4d2c-a8dc-6bbf96ee7458 headers.Accept=application/json
time=2026-05-09T21:31:36.971-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:966e50b5-e72d-4d2c-a8dc-6bbf96ee7458 headers:[Content-Type: application/json;charset=UTF-8 X-Robots-Tag: none Date: Sun, 10 May 2026 04:31:36 GMT Vary: Accept-Encoding Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Server: sfdcedge X-Sfdc-Request-Id: e2b05257b95b54955ccb110ea56f5fbf X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Content-Type-Options: nosniff X-Request-Id: e2b05257b95b54955ccb110ea56f5fbf Sforce-Limit-Info: api-usage=8/15000 Strict-Transport-Security: max-age=63072000; includeSubDomains] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id%2CName+FROM+PermissionSet+WHERE+Name%3D%27IntegrationCustomFieldVisibility%27]"
time=2026-05-09T21:31:36.971-07:00 level=DEBUG msg="HTTP request" method=GET url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/oauth2/userinfo correlationId=1e54726a-dab5-4ae3-9b0e-14f92297a54c headers.Accept=application/json
time=2026-05-09T21:31:37.216-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:1e54726a-dab5-4ae3-9b0e-14f92297a54c headers:[X-Sfdc-Request-Id: 1bd2c7a532225d5ab2b6aca7527c0c49 X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge X-Request-Id: 1bd2c7a532225d5ab2b6aca7527c0c49 Strict-Transport-Security: max-age=63072000; includeSubDomains X-Content-Type-Options: nosniff Date: Sun, 10 May 2026 04:31:37 GMT X-Robots-Tag: none Content-Type: application/json;charset=UTF-8 Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Vary: Accept-Encoding] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/oauth2/userinfo]"
time=2026-05-09T21:31:37.216-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment correlationId=cd0a595f-259a-45c5-a666-0fc9f364a18a headers.Accept=application/json headers.Content-Type=application/json
time=2026-05-09T21:31:37.713-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:cd0a595f-259a-45c5-a666-0fc9f364a18a headers:[Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding Sforce-Limit-Info: api-usage=9/15000 X-Robots-Tag: none Strict-Transport-Security: max-age=63072000; includeSubDomains X-Request-Id: c012bdff492b638e60492582e30d8719 Date: Sun, 10 May 2026 04:31:37 GMT X-Content-Type-Options: nosniff Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Server: sfdcedge X-Sfdc-Request-Id: c012bdff492b638e60492582e30d8719] method:POST status:400 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment]"
time=2026-05-09T21:31:37.713-07:00 level=ERROR msg="HTTP request failed" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/sobjects/PermissionSetAssignment correlationId=cd0a595f-259a-45c5-a666-0fc9f364a18a error="HTTP status 400: caller error: [{\"message\":\"Duplicate PermissionSetAssignment.  Assignee: 005gK000004y8Wf; Permission Set: 0PSgK00000CTqM5\",\"errorCode\":\"DUPLICATE_VALUE\",\"fields\":[\"AssigneeId\",\"PermissionSetId\"]}]"
====== Deploying apex trigger CDC_Lead ======
time=2026-05-09T21:31:37.715-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=c7c2cec8-9ff0-4f58-b9ed-10b148db83cb headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:38.426-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:c7c2cec8-9ff0-4f58-b9ed-10b148db83cb headers:[Server: sfdcedge X-Request-Id: a7c7567dcfceca31e2b5a72d35c8f0d4 X-Sfdc-Edge-Cache: none Date: Sun, 10 May 2026 04:31:38 GMT Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding Set-Cookie: <redacted> X-Sfdc-Request-Id: a7c7567dcfceca31e2b5a72d35c8f0d4 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:38.426-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=30be64b7-08b2-489a-8058-b66ea3f660ec headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:38.581-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:30be64b7-08b2-489a-8058-b66ea3f660ec headers:[Date: Sun, 10 May 2026 04:31:38 GMT Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge X-Sfdc-Request-Id: f76c7c7134e6205d56757ab8236079c3 X-Sfdc-Edge-Cache: none Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding Set-Cookie: <redacted> X-Request-Id: f76c7c7134e6205d56757ab8236079c3] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:48.582-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=c6c94d1c-685f-4a15-9a0a-8b6040892a13 headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:48.779-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:c6c94d1c-685f-4a15-9a0a-8b6040892a13 headers:[Date: Sun, 10 May 2026 04:31:48 GMT Set-Cookie: <redacted> X-Sfdc-Request-Id: 5508e92158030baab6aea72064909324 X-Request-Id: 5508e92158030baab6aea72064909324 X-Sfdc-Edge-Cache: none Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
Deploy succeeded (deployID=0AfgK00000KZoBJSA1)
====== ApexTriggerExists (expect true) ======
time=2026-05-09T21:31:48.780-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27CDC_Lead%27" correlationId=c48c0db4-c8cc-4b85-8c2f-8529699674e4 headers.Accept=application/json
time=2026-05-09T21:31:48.972-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:c48c0db4-c8cc-4b85-8c2f-8529699674e4 headers:[X-Content-Type-Options: nosniff X-Sfdc-Request-Id: 48e019a80fbb58a924a08399fb972cd9 X-Request-Id: 48e019a80fbb58a924a08399fb972cd9 Date: Sun, 10 May 2026 04:31:48 GMT Sforce-Limit-Info: api-usage=14/15000 X-Robots-Tag: none X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Strict-Transport-Security: max-age=63072000; includeSubDomains Server: sfdcedge Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted>] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27CDC_Lead%27]"
OK: ApexTriggerExists(CDC_Lead) = true
====== ApexTriggerExists for fake amp_existence_does_not_exist_trigger (expect false) ======
time=2026-05-09T21:31:48.972-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27amp_existence_does_not_exist_trigger%27" correlationId=de36006c-e307-49ef-8bfa-5eaa7952f49a headers.Accept=application/json
time=2026-05-09T21:31:49.157-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:de36006c-e307-49ef-8bfa-5eaa7952f49a headers:[Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Request-Id: 3fdeefcf11a1af0aeef2145d7e8050eb Date: Sun, 10 May 2026 04:31:49 GMT Content-Type: application/json;charset=UTF-8 Vary: Accept-Encoding X-Robots-Tag: none X-Content-Type-Options: nosniff X-Sfdc-Edge-Cache: none Sforce-Limit-Info: api-usage=13/15000 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge Strict-Transport-Security: max-age=63072000; includeSubDomains X-Sfdc-Request-Id: 3fdeefcf11a1af0aeef2145d7e8050eb] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27amp_existence_does_not_exist_trigger%27]"
OK: ApexTriggerExists(amp_existence_does_not_exist_trigger) = false
====== Destroying apex trigger CDC_Lead ======
time=2026-05-09T21:31:49.157-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=638b1428-1702-4ee7-99e2-a09b4eb7ddd5 headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:49.427-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:638b1428-1702-4ee7-99e2-a09b4eb7ddd5 headers:[Set-Cookie: <redacted> Server: sfdcedge X-Sfdc-Request-Id: d77a00c7989c1ecad8a751735e7ff43f X-Request-Id: d77a00c7989c1ecad8a751735e7ff43f X-Sfdc-Edge-Cache: none Date: Sun, 10 May 2026 04:31:49 GMT Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:49.427-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=9330e65e-beed-45c7-b09b-8b9c604df0d3 headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:49.625-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:9330e65e-beed-45c7-b09b-8b9c604df0d3 headers:[Date: Sun, 10 May 2026 04:31:49 GMT Content-Type: text/xml; charset=utf-8 Set-Cookie: <redacted> X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Vary: Accept-Encoding Server: sfdcedge X-Sfdc-Request-Id: 1d57d3fe39ce24f46e77e14dafcee3da X-Request-Id: 1d57d3fe39ce24f46e77e14dafcee3da] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
time=2026-05-09T21:31:59.627-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=0e522289-1ed1-4bd4-8dbe-ff26fa667d7a headers.Content-Type="text/xml; charset=UTF-8" headers.Soapaction=deploy headers.Accept=application/xml
time=2026-05-09T21:31:59.819-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:0e522289-1ed1-4bd4-8dbe-ff26fa667d7a headers:[X-Sfdc-Edge-Cache: none Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private Server: sfdcedge X-Request-Id: 6a98e1b3cc18d1df707022741848496e Date: Sun, 10 May 2026 04:31:59 GMT Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding Set-Cookie: <redacted> X-Sfdc-Request-Id: 6a98e1b3cc18d1df707022741848496e] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
Deploy succeeded (deployID=0AfgK00000KZoCvSAL)
====== ApexTriggerExists post-delete (expect false) ======
time=2026-05-09T21:31:59.820-07:00 level=DEBUG msg="HTTP request" method=GET url="https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27CDC_Lead%27" correlationId=40746652-765f-4021-9f72-ca7f4e817142 headers.Accept=application/json
time=2026-05-09T21:31:59.979-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:40746652-765f-4021-9f72-ca7f4e817142 headers:[Content-Type: application/json;charset=UTF-8 Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private X-Content-Type-Options: nosniff Strict-Transport-Security: max-age=63072000; includeSubDomains Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> Date: Sun, 10 May 2026 04:31:59 GMT X-Robots-Tag: none Vary: Accept-Encoding X-Request-Id: b0041975a10dbfefae4375cd6cb92109 X-Sfdc-Edge-Cache: none Sforce-Limit-Info: api-usage=19/15000 Server: sfdcedge X-Sfdc-Request-Id: b0041975a10dbfefae4375cd6cb92109] method:GET status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/data/v60.0/tooling/query?q=SELECT+Id+FROM+ApexTrigger+WHERE+Name+%3D+%27CDC_Lead%27]"
OK: ApexTriggerExists(CDC_Lead) = false
====== Cleaning up prereq field Lead.AmpExistenceTest__c ======
time=2026-05-09T21:31:59.979-07:00 level=DEBUG msg="HTTP request" method=POST url=https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0 correlationId=f8e59f33-868c-474d-855d-815886e7f732 headers.Content-Type=text/xml headers.Soapaction='' headers.Accept=application/xml
time=2026-05-09T21:32:00.883-07:00 level=DEBUG msg="HTTP response" details="map[correlationId:f8e59f33-868c-474d-855d-815886e7f732 headers:[Server: sfdcedge Content-Type: text/xml; charset=utf-8 Vary: Accept-Encoding Set-Cookie: <redacted> X-Sfdc-Request-Id: 320e8ee0c044309aabe7da4414325c8b X-Request-Id: 320e8ee0c044309aabe7da4414325c8b X-Sfdc-Edge-Cache: none Date: Sun, 10 May 2026 04:32:00 GMT Cache-Control: no-cache,must-revalidate,max-age=0,no-store,private] method:POST status:200 url:https://orgfarm-c270e93339-dev-ed.develop.my.salesforce.com/services/Soap/m/60.0]"
====== Done ======
```
</details>

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

