### PR TITLE
[CON-3243] feat: Add google calendar subscriber connector

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -155,6 +155,10 @@ func (c *Connector) Subscribe(
 	ctx context.Context,
 	params common.SubscribeParams,
 ) (*common.SubscriptionResult, error) {
+	if c.Calendar != nil {
+		return c.Calendar.Subscribe(ctx, params)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.Subscribe(ctx, params)
 	}
@@ -167,6 +171,10 @@ func (c *Connector) UpdateSubscription(
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
+	if c.Calendar != nil {
+		return c.Calendar.UpdateSubscription(ctx, params, previousResult)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.UpdateSubscription(ctx, params, previousResult)
 	}
@@ -178,6 +186,10 @@ func (c *Connector) DeleteSubscription(
 	ctx context.Context,
 	previousResult common.SubscriptionResult,
 ) error {
+	if c.Calendar != nil {
+		return c.Calendar.DeleteSubscription(ctx, previousResult)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.DeleteSubscription(ctx, previousResult)
 	}
@@ -186,6 +198,10 @@ func (c *Connector) DeleteSubscription(
 }
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
+	if c.Calendar != nil {
+		return c.Calendar.EmptySubscriptionParams()
+	}
+
 	if c.Mail != nil {
 		return c.Mail.EmptySubscriptionParams()
 	}
@@ -194,6 +210,10 @@ func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
 }
 
 func (c *Connector) EmptySubscriptionResult() *common.SubscriptionResult {
+	if c.Calendar != nil {
+		return c.Calendar.EmptySubscriptionResult()
+	}
+
 	if c.Mail != nil {
 		return c.Mail.EmptySubscriptionResult()
 	}
@@ -206,6 +226,10 @@ func (c *Connector) VerifyWebhookMessage(
 	request *common.WebhookRequest,
 	params *common.VerificationParams,
 ) (bool, error) {
+	if c.Calendar != nil {
+		return c.Calendar.VerifyWebhookMessage(ctx, request, params)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.VerifyWebhookMessage(ctx, request, params)
 	}
@@ -219,6 +243,10 @@ func (c *Connector) GetRecordsByIds(ctx context.Context, // nolint: revive
 	fields []string,
 	associations []string,
 ) ([]common.ReadResultRow, error) {
+	if c.Calendar != nil {
+		return c.Calendar.GetRecordsByIds(ctx, objectName, recordIds, fields, associations)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.GetRecordsByIds(ctx, objectName, recordIds, fields, associations)
 	}
@@ -231,12 +259,24 @@ func (c *Connector) RunScheduledMaintenance(
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
+	if c.Calendar != nil {
+		return c.Calendar.RunScheduledMaintenance(ctx, params, previousResult)
+	}
+
 	if c.Mail != nil {
 		return c.Mail.RunScheduledMaintenance(ctx, params, previousResult)
 	}
 
 	return nil, common.ErrNotImplemented
 }
+
+// Re-exports of Google Calendar subscribe types so external callers can use them
+// without importing the internal calendar package.
+type (
+	CalendarWatchRequest        = calendar.WatchRequest
+	CalendarWatchResponse       = calendar.WatchResponse
+	CalendarSubscriptionResult  = calendar.CalendarSubscriptionResult
+)
 
 // Re-exports of Gmail history.list types so external callers can use them
 // without importing the internal mail package.

--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -273,9 +273,9 @@ func (c *Connector) RunScheduledMaintenance(
 // Re-exports of Google Calendar subscribe types so external callers can use them
 // without importing the internal calendar package.
 type (
-	CalendarWatchRequest        = calendar.WatchRequest
-	CalendarWatchResponse       = calendar.WatchResponse
-	CalendarSubscriptionResult  = calendar.CalendarSubscriptionResult
+	CalendarWatchRequest       = calendar.WatchRequest
+	CalendarWatchResponse      = calendar.WatchResponse
+	CalendarSubscriptionResult = calendar.CalendarSubscriptionResult
 )
 
 // Re-exports of Gmail history.list types so external callers can use them

--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -226,10 +226,6 @@ func (c *Connector) VerifyWebhookMessage(
 	request *common.WebhookRequest,
 	params *common.VerificationParams,
 ) (bool, error) {
-	if c.Calendar != nil {
-		return c.Calendar.VerifyWebhookMessage(ctx, request, params)
-	}
-
 	if c.Mail != nil {
 		return c.Mail.VerifyWebhookMessage(ctx, request, params)
 	}
@@ -243,10 +239,6 @@ func (c *Connector) GetRecordsByIds(ctx context.Context, // nolint: revive
 	fields []string,
 	associations []string,
 ) ([]common.ReadResultRow, error) {
-	if c.Calendar != nil {
-		return c.Calendar.GetRecordsByIds(ctx, objectName, recordIds, fields, associations)
-	}
-
 	if c.Mail != nil {
 		return c.Mail.GetRecordsByIds(ctx, objectName, recordIds, fields, associations)
 	}

--- a/providers/google/internal/calendar/errors.go
+++ b/providers/google/internal/calendar/errors.go
@@ -2,12 +2,19 @@ package calendar
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var (
+	errMissingParams              = errors.New("missing required parameters")
+	errInvalidRequestType         = errors.New("invalid request type")
+	errUnsupportedSubscribeObject = errors.New("unsupported subscribe object")
 )
 
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals

--- a/providers/google/internal/calendar/operations.go
+++ b/providers/google/internal/calendar/operations.go
@@ -18,6 +18,8 @@ import (
 const (
 	objectNameCalendarList = "calendarList"
 	objectNameEvents       = "events"
+	objectNameSettings     = "settings"
+	objectNameAcl          = "acl"
 
 	// Page size references:
 	// https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/list

--- a/providers/google/internal/calendar/operations.go
+++ b/providers/google/internal/calendar/operations.go
@@ -19,7 +19,7 @@ const (
 	objectNameCalendarList = "calendarList"
 	objectNameEvents       = "events"
 	objectNameSettings     = "settings"
-	objectNameAcl          = "acl"
+	objectNameACL          = "acl"
 
 	// Page size references:
 	// https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/list

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -27,7 +28,7 @@ var objectWatchPaths = map[common.ObjectName]string{
 	objectNameEvents:       "calendars/primary/events/watch",
 	objectNameCalendarList: "users/me/calendarList/watch",
 	objectNameSettings:     "users/me/settings/watch",
-	objectNameAcl:          "calendars/primary/acl/watch",
+	objectNameACL:          "calendars/primary/acl/watch",
 }
 
 // WatchRequest is the caller-provided config for creating watch channels.
@@ -178,7 +179,7 @@ func (a *Adapter) Subscribe(
 // Objects present in prev but absent from params are stopped. Objects in params
 // but absent from prev are newly watched. Objects present in both are left untouched
 // (Google Calendar does not support mutating an existing channel).
-func (a *Adapter) UpdateSubscription(
+func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
 	ctx context.Context,
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
@@ -207,9 +208,7 @@ func (a *Adapter) UpdateSubscription(
 
 	// Start from a copy of the previous channels; we'll mutate it below.
 	updatedChannels := make(map[common.ObjectName]*WatchResponse, len(prevChannels))
-	for obj, ch := range prevChannels {
-		updatedChannels[obj] = ch
-	}
+	maps.Copy(updatedChannels, prevChannels)
 
 	// Stop removed channels.
 	var stopErr error
@@ -280,6 +279,7 @@ func (a *Adapter) DeleteSubscription(
 	result common.SubscriptionResult,
 ) error {
 	channels := extractChannels(&result)
+
 	return a.stopAllChannels(ctx, channels)
 }
 
@@ -388,7 +388,7 @@ func (a *Adapter) stopChannel(ctx context.Context, id, resourceID string) error 
 
 	// channels/stop returns 204 No Content on success with no body.
 	if response.Code != http.StatusNoContent && response.Code != http.StatusOK {
-		return fmt.Errorf("stopChannel: unexpected status %d", response.Code)
+		return fmt.Errorf("stopChannel: unexpected status %d", response.Code) //nolint: err113
 	}
 
 	return nil

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -151,12 +151,14 @@ func (a *Adapter) Subscribe(
 	for _, obj := range objects {
 		resp, err := a.watchObject(ctx, obj, baseID, watchReq)
 		if err != nil {
-			rollbackErr := a.stopAllChannels(ctx, result.Channels)
-			if rollbackErr != nil {
-				return &common.SubscriptionResult{
-					Status: common.SubscriptionStatusFailedToRollback,
-					Result: result,
-				}, fmt.Errorf("subscribe: watching %q failed: %w; rollback also failed: %w", obj, err, rollbackErr)
+			if len(result.Channels) > 0 {
+				rollbackErr := a.stopAllChannels(ctx, result.Channels)
+				if rollbackErr != nil {
+					return &common.SubscriptionResult{
+						Status: common.SubscriptionStatusFailedToRollback,
+						Result: result,
+					}, fmt.Errorf("subscribe: watching %q failed: %w; rollback also failed: %w", obj, err, rollbackErr)
+				}
 			}
 
 			return &common.SubscriptionResult{
@@ -239,18 +241,20 @@ func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
 	for _, obj := range sortedKeys(toAdd) {
 		resp, watchErr := a.watchObject(ctx, obj, baseID, watchReq)
 		if watchErr != nil {
-			rollbackErr := a.stopAllChannels(ctx, newChannels)
-			if rollbackErr != nil {
-				return &common.SubscriptionResult{
-					Status: common.SubscriptionStatusFailedToRollback,
-					Result: &CalendarSubscriptionResult{Channels: updatedChannels},
-				}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
-			}
+			if len(newChannels) > 0 {
+				rollbackErr := a.stopAllChannels(ctx, newChannels)
+				if rollbackErr != nil {
+					return &common.SubscriptionResult{
+						Status: common.SubscriptionStatusFailedToRollback,
+						Result: &CalendarSubscriptionResult{Channels: updatedChannels},
+					}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
+				}
 
-			// Rollback succeeded — prune the stopped channels from the result
-			// so it accurately reflects what is still active in Google Calendar.
-			for o := range newChannels {
-				delete(updatedChannels, o)
+				// Rollback succeeded — prune the stopped channels from the result
+				// so it accurately reflects what is still active in Google Calendar.
+				for o := range newChannels {
+					delete(updatedChannels, o)
+				}
 			}
 
 			return &common.SubscriptionResult{

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -236,25 +236,27 @@ func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
 		baseID = uuid.New().String()
 	}
 
-	newChannels := make(map[common.ObjectName]*WatchResponse)
+	// justAdded tracks objects successfully watched in this call so they can be
+	// rolled back if a later watch in the same loop fails.
+	var justAdded []common.ObjectName
 
 	for _, obj := range sortedKeys(toAdd) {
 		resp, watchErr := a.watchObject(ctx, obj, baseID, watchReq)
 		if watchErr != nil {
-			if len(newChannels) > 0 {
-				rollbackErr := a.stopAllChannels(ctx, newChannels)
-				if rollbackErr != nil {
-					return &common.SubscriptionResult{
-						Status: common.SubscriptionStatusFailedToRollback,
-						Result: &CalendarSubscriptionResult{Channels: updatedChannels},
-					}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
-				}
-
-				// Rollback succeeded — prune the stopped channels from the result
-				// so it accurately reflects what is still active in Google Calendar.
-				for o := range newChannels {
+			var rollbackErr error
+			for _, o := range justAdded {
+				if err := a.stopChannel(ctx, updatedChannels[o].ID, updatedChannels[o].ResourceID); err != nil {
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("stopping channel for %q: %w", o, err))
+				} else {
 					delete(updatedChannels, o)
 				}
+			}
+
+			if rollbackErr != nil {
+				return &common.SubscriptionResult{
+					Status: common.SubscriptionStatusFailedToRollback,
+					Result: &CalendarSubscriptionResult{Channels: updatedChannels},
+				}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
 			}
 
 			return &common.SubscriptionResult{
@@ -263,7 +265,7 @@ func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
 			}, fmt.Errorf("update: watching %q: %w", obj, watchErr)
 		}
 
-		newChannels[obj] = resp
+		justAdded = append(justAdded, obj)
 		updatedChannels[obj] = resp
 	}
 

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -20,12 +19,6 @@ import (
 // calendarMaxConcurrentWatches bounds the number of watch/stop calls issued in
 // parallel so we don't trip Google Calendar's per-user rate limits.
 const calendarMaxConcurrentWatches = 4
-
-// Compile-time interface conformance checks.
-var (
-	_ connectors.SubscribeConnector              = &Adapter{}
-	_ connectors.SubscriptionMaintainerConnector = &Adapter{}
-)
 
 // objectWatchPaths maps supported subscribe objects to their watch URL paths.
 //
@@ -226,36 +219,6 @@ func (a *Adapter) RunScheduledMaintenance(
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
 	return a.UpdateSubscription(ctx, params, previousResult)
-}
-
-// VerifyWebhookMessage is not yet implemented for Google Calendar.
-//
-// Verification (comparing the X-Goog-Channel-Token header against a stored token) is
-// being delivered in a separate PR. Until then this refuses verification rather than
-// asserting authenticity it never checked — callers must not treat unverified messages
-// as trusted.
-func (a *Adapter) VerifyWebhookMessage(
-	ctx context.Context,
-	request *common.WebhookRequest,
-	params *common.VerificationParams,
-) (bool, error) {
-	return false, common.ErrNotImplemented
-}
-
-// GetRecordsByIds is not yet implemented for Google Calendar.
-//
-// Calendar push notifications deliver an empty body — only headers are sent (X-Goog-Resource-State,
-// X-Goog-Resource-ID, etc.). There is no record payload to enrich from; fetching what actually
-// changed requires a follow-up API read (e.g. events.list). That strategy is being delivered in a
-// separate PR alongside verification.
-func (a *Adapter) GetRecordsByIds( //nolint:revive
-	ctx context.Context,
-	objectName string,
-	recordIds []string, //nolint:revive
-	fields []string,
-	associations []string,
-) ([]common.ReadResultRow, error) {
-	return nil, common.ErrNotImplemented
 }
 
 // watchResult pairs a created watch channel with the object it belongs to so the

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -238,7 +238,7 @@ func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
 
 	// justAdded tracks objects successfully watched in this call so they can be
 	// rolled back if a later watch in the same loop fails.
-	var justAdded []common.ObjectName
+	justAdded := make([]common.ObjectName, 0, len(toAdd))
 
 	for _, obj := range sortedKeys(toAdd) {
 		resp, watchErr := a.watchObject(ctx, obj, baseID, watchReq)

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -4,16 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/url"
 	"slices"
+	"sync"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/simultaneously"
 	"github.com/google/uuid"
 )
+
+// calendarMaxConcurrentWatches bounds the number of watch/stop calls issued in
+// parallel so we don't trip Google Calendar's per-user rate limits.
+const calendarMaxConcurrentWatches = 4
 
 // Compile-time interface conformance checks.
 var (
@@ -120,11 +126,6 @@ func (a *Adapter) EmptySubscriptionResult() *common.SubscriptionResult {
 //	"exists"     — a resource was created or updated
 //	"not_exists" — a resource was deleted
 //
-// If any watch call fails after some have succeeded, the successfully-created
-// channels are rolled back via stopChannel before returning. If rollback also
-// fails, returns SubscriptionStatusFailedToRollback so the caller knows orphaned
-// channels may exist in Google Calendar.
-//
 // ref: https://developers.google.com/workspace/calendar/api/v3/reference/events/watch
 // ref: https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/watch
 func (a *Adapter) Subscribe(
@@ -141,139 +142,62 @@ func (a *Adapter) Subscribe(
 		baseID = uuid.New().String()
 	}
 
-	result := &CalendarSubscriptionResult{
-		Channels: make(map[common.ObjectName]*WatchResponse),
-	}
-
-	// Sort for deterministic processing order so rollback behaviour is predictable.
-	objects := sortedKeys(params.SubscriptionEvents)
-
-	for _, obj := range objects {
-		resp, err := a.watchObject(ctx, obj, baseID, watchReq)
-		if err != nil {
-			if len(result.Channels) > 0 {
-				rollbackErr := a.stopAllChannels(ctx, result.Channels)
-				if rollbackErr != nil {
-					return &common.SubscriptionResult{
-						Status: common.SubscriptionStatusFailedToRollback,
-						Result: result,
-					}, fmt.Errorf("subscribe: watching %q failed: %w; rollback also failed: %w", obj, err, rollbackErr)
-				}
+	// watchObjects returns whatever channels were created even on failure, so we can
+	// roll them back here rather than mid-loop.
+	channels, err := a.watchObjects(ctx, sortedKeys(params.SubscriptionEvents), baseID, watchReq)
+	if err != nil {
+		if len(channels) > 0 {
+			if rollbackErr := a.stopAllChannels(ctx, channels); rollbackErr != nil {
+				return &common.SubscriptionResult{
+					Status: common.SubscriptionStatusFailedToRollback,
+					Result: &CalendarSubscriptionResult{Channels: channels},
+				}, fmt.Errorf("subscribe: %w; rollback also failed: %w", err, rollbackErr)
 			}
-
-			return &common.SubscriptionResult{
-				Status: common.SubscriptionStatusFailed,
-			}, fmt.Errorf("subscribe: watching %q: %w", obj, err)
 		}
 
-		result.Channels[obj] = resp
+		return &common.SubscriptionResult{
+			Status: common.SubscriptionStatusFailed,
+		}, fmt.Errorf("subscribe: %w", err)
 	}
 
 	return &common.SubscriptionResult{
-		Result:       result,
+		Result:       &CalendarSubscriptionResult{Channels: channels},
 		Status:       common.SubscriptionStatusSuccess,
 		ObjectEvents: params.SubscriptionEvents,
 	}, nil
 }
 
-// UpdateSubscription reconciles an existing subscription with the new desired state.
+// UpdateSubscription moves an existing subscription to the new desired object set.
 //
-// Objects present in prev but absent from params are stopped. Objects in params
-// but absent from prev are newly watched. Objects present in both are left untouched
-// (Google Calendar does not support mutating an existing channel).
-func (a *Adapter) UpdateSubscription( //nolint: cyclop,funlen
+// Google Calendar channels cannot be extended or mutated, so an "update" is really
+// a recreate: we create a fresh set of channels for the full desired object set and
+// then stop the previous channels. Recreating everything — not just the delta — keeps
+// all channels on the same expiration clock so they renew together.
+//
+// Creating the new channels happens first; if that fails nothing has changed and the
+// error is returned. Stopping the previous channels is best-effort: they expire on
+// their own, so a failure there is logged and tolerated (the caller may briefly receive
+// duplicate notifications until the old channels lapse).
+func (a *Adapter) UpdateSubscription(
 	ctx context.Context,
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
-	watchReq, err := validateWatchRequest(params)
+	result, err := a.Subscribe(ctx, params)
 	if err != nil {
-		return nil, err
+		return result, fmt.Errorf("update: creating new subscription: %w", err)
 	}
 
-	prevChannels := extractChannels(previousResult)
-
-	toAdd := make(map[common.ObjectName]common.ObjectEvents)
-	toRemove := make(map[common.ObjectName]*WatchResponse)
-
-	for obj, evt := range params.SubscriptionEvents {
-		if _, exists := prevChannels[obj]; !exists {
-			toAdd[obj] = evt
+	if previousResult != nil {
+		if err := a.DeleteSubscription(ctx, *previousResult); err != nil {
+			logging.Logger(ctx).Warn(
+				"update: failed to stop previous channels; they will expire automatically",
+				"error", err,
+			)
 		}
 	}
 
-	for obj, ch := range prevChannels {
-		if _, exists := params.SubscriptionEvents[obj]; !exists {
-			toRemove[obj] = ch
-		}
-	}
-
-	// Start from a copy of the previous channels; we'll mutate it below.
-	updatedChannels := make(map[common.ObjectName]*WatchResponse, len(prevChannels))
-	maps.Copy(updatedChannels, prevChannels)
-
-	// Stop removed channels.
-	var stopErr error
-
-	for obj, ch := range toRemove {
-		if err := a.stopChannel(ctx, ch.ID, ch.ResourceID); err != nil {
-			stopErr = errors.Join(stopErr, fmt.Errorf("update: stopping %q: %w", obj, err))
-		} else {
-			delete(updatedChannels, obj)
-		}
-	}
-
-	if stopErr != nil {
-		return &common.SubscriptionResult{
-			Status: common.SubscriptionStatusFailed,
-			Result: &CalendarSubscriptionResult{Channels: updatedChannels},
-		}, stopErr
-	}
-
-	// Watch newly added objects.
-	baseID := watchReq.ID
-	if baseID == "" {
-		baseID = uuid.New().String()
-	}
-
-	// justAdded tracks objects successfully watched in this call so they can be
-	// rolled back if a later watch in the same loop fails.
-	justAdded := make([]common.ObjectName, 0, len(toAdd))
-
-	for _, obj := range sortedKeys(toAdd) {
-		resp, watchErr := a.watchObject(ctx, obj, baseID, watchReq)
-		if watchErr != nil {
-			var rollbackErr error
-			for _, o := range justAdded {
-				if err := a.stopChannel(ctx, updatedChannels[o].ID, updatedChannels[o].ResourceID); err != nil {
-					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("stopping channel for %q: %w", o, err))
-				} else {
-					delete(updatedChannels, o)
-				}
-			}
-
-			if rollbackErr != nil {
-				return &common.SubscriptionResult{
-					Status: common.SubscriptionStatusFailedToRollback,
-					Result: &CalendarSubscriptionResult{Channels: updatedChannels},
-				}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
-			}
-
-			return &common.SubscriptionResult{
-				Status: common.SubscriptionStatusFailed,
-				Result: &CalendarSubscriptionResult{Channels: updatedChannels},
-			}, fmt.Errorf("update: watching %q: %w", obj, watchErr)
-		}
-
-		justAdded = append(justAdded, obj)
-		updatedChannels[obj] = resp
-	}
-
-	return &common.SubscriptionResult{
-		Result:       &CalendarSubscriptionResult{Channels: updatedChannels},
-		Status:       common.SubscriptionStatusSuccess,
-		ObjectEvents: params.SubscriptionEvents,
-	}, nil
+	return result, nil
 }
 
 // DeleteSubscription stops all active watch channels stored in result.
@@ -291,9 +215,9 @@ func (a *Adapter) DeleteSubscription(
 
 // RunScheduledMaintenance renews all watch channels.
 //
-// Google Calendar does not support extending an existing channel's lifetime.
-// Renewal requires stopping each channel and re-watching the same objects.
-// This is equivalent to DeleteSubscription followed by Subscribe with the same params.
+// Google Calendar does not support extending an existing channel's lifetime, so renewal
+// is the same recreate-then-stop flow as UpdateSubscription: create a fresh set of
+// channels for the same objects, then stop the previous ones.
 //
 // Callers should schedule maintenance before the earliest expiration across all channels.
 func (a *Adapter) RunScheduledMaintenance(
@@ -301,32 +225,29 @@ func (a *Adapter) RunScheduledMaintenance(
 	params common.SubscribeParams,
 	previousResult *common.SubscriptionResult,
 ) (*common.SubscriptionResult, error) {
-	if err := a.DeleteSubscription(ctx, *previousResult); err != nil {
-		return &common.SubscriptionResult{
-			Status: common.SubscriptionStatusFailed,
-		}, fmt.Errorf("maintenance: stopping old channels: %w", err)
-	}
-
-	return a.Subscribe(ctx, params)
+	return a.UpdateSubscription(ctx, params, previousResult)
 }
 
-// VerifyWebhookMessage always returns true for Google Calendar.
-// Push notifications are delivered via Google's infrastructure and authenticated
-// at the transport layer; no application-level signature verification is needed.
-// Callers should verify the X-Goog-Channel-Token header against their stored token
-// if they set one in WatchRequest.Token.
+// VerifyWebhookMessage is not yet implemented for Google Calendar.
+//
+// Verification (comparing the X-Goog-Channel-Token header against a stored token) is
+// being delivered in a separate PR. Until then this refuses verification rather than
+// asserting authenticity it never checked — callers must not treat unverified messages
+// as trusted.
 func (a *Adapter) VerifyWebhookMessage(
 	ctx context.Context,
 	request *common.WebhookRequest,
 	params *common.VerificationParams,
 ) (bool, error) {
-	return true, nil
+	return false, common.ErrNotImplemented
 }
 
-// GetRecordsByIds is not implemented for Google Calendar.
+// GetRecordsByIds is not yet implemented for Google Calendar.
+//
 // Calendar push notifications deliver an empty body — only headers are sent (X-Goog-Resource-State,
-// X-Goog-Resource-ID, etc.). There is no record payload to enrich from; callers must issue
-// a follow-up API read (e.g. events.list) to fetch what actually changed.
+// X-Goog-Resource-ID, etc.). There is no record payload to enrich from; fetching what actually
+// changed requires a follow-up API read (e.g. events.list). That strategy is being delivered in a
+// separate PR alongside verification.
 func (a *Adapter) GetRecordsByIds( //nolint:revive
 	ctx context.Context,
 	objectName string,
@@ -334,7 +255,58 @@ func (a *Adapter) GetRecordsByIds( //nolint:revive
 	fields []string,
 	associations []string,
 ) ([]common.ReadResultRow, error) {
-	return nil, common.ErrGetRecordNotSupportedForObject
+	return nil, common.ErrNotImplemented
+}
+
+// watchResult pairs a created watch channel with the object it belongs to so the
+// concurrent fan-in can rebuild the object→channel map.
+// watchObjects creates a watch channel for each object concurrently, bounded by
+// calendarMaxConcurrentWatches.
+//
+// Each job records its outcome under a mutex and returns nil regardless of failure, so
+// every watch call runs to completion rather than cancelling its siblings on the first
+// error. This mirrors the other subscribe connectors (outreach, salesloft, zoho) and
+// guarantees the returned map holds *every* channel that was created — even when err is
+// non-nil — so the caller has the full set to roll back. Per-object failures are joined
+// into the returned error.
+func (a *Adapter) watchObjects(
+	ctx context.Context,
+	objects []common.ObjectName,
+	baseID string,
+	req *WatchRequest,
+) (map[common.ObjectName]*WatchResponse, error) {
+	var (
+		mutex    sync.Mutex
+		watchErr error
+	)
+
+	channels := make(map[common.ObjectName]*WatchResponse, len(objects))
+	callbacks := make([]simultaneously.Job, 0, len(objects))
+
+	for _, obj := range objects {
+		callbacks = append(callbacks, func(ctx context.Context) error {
+			resp, err := a.watchObject(ctx, obj, baseID, req)
+
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			if err != nil {
+				watchErr = errors.Join(watchErr, fmt.Errorf("watching %q: %w", obj, err))
+
+				return nil
+			}
+
+			channels[obj] = resp
+
+			return nil
+		})
+	}
+
+	if err := simultaneously.DoCtx(ctx, calendarMaxConcurrentWatches, callbacks...); err != nil {
+		return channels, err
+	}
+
+	return channels, watchErr
 }
 
 // watchObject POSTs a watch request for a single object and returns the channel response.

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -1,0 +1,463 @@
+package calendar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/google/uuid"
+)
+
+// Compile-time interface conformance checks.
+var (
+	_ connectors.SubscribeConnector              = &Adapter{}
+	_ connectors.SubscriptionMaintainerConnector = &Adapter{}
+)
+
+// objectWatchPaths maps supported subscribe objects to their watch URL paths.
+//
+//nolint:gochecknoglobals
+var objectWatchPaths = map[common.ObjectName]string{
+	objectNameEvents:       "calendars/primary/events/watch",
+	objectNameCalendarList: "users/me/calendarList/watch",
+	objectNameSettings:     "users/me/settings/watch",
+	objectNameAcl:          "calendars/primary/acl/watch",
+}
+
+// WatchRequest is the caller-provided config for creating watch channels.
+// One WatchRequest is used for all subscribed objects; the adapter derives
+// per-object channel IDs by appending the object name to ID.
+// If ID is empty, the adapter generates a UUID base per Subscribe call.
+type WatchRequest struct {
+	// ID is the base channel identifier. The adapter appends "-{objectName}" per object.
+	// If empty, a UUID is generated automatically.
+	ID string `json:"id,omitempty"`
+
+	// Address is the HTTPS URL that receives push notifications.
+	Address string `json:"address"`
+
+	// Token is an arbitrary string delivered in the X-Goog-Channel-Token header.
+	// Optional; useful for verifying that a notification came from Google.
+	Token string `json:"token,omitempty"`
+
+	// Expiration is the requested channel lifetime in epoch milliseconds.
+	// 0 means use the provider's default (up to ~30 days).
+	Expiration int64 `json:"expiration,omitempty"`
+}
+
+// watchPayload is the request body sent to the Google Calendar watch endpoint.
+type watchPayload struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Address    string `json:"address"`
+	Token      string `json:"token,omitempty"`
+	Expiration int64  `json:"expiration,omitempty"`
+}
+
+// WatchResponse is the response from the Calendar watch endpoint.
+// Both ID and ResourceID are required to stop a channel later.
+type WatchResponse struct {
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	ResourceID  string `json:"resourceId"`
+	ResourceURI string `json:"resourceUri"`
+	Expiration  string `json:"expiration"` // epoch millis as string
+}
+
+// CalendarSubscriptionResult stores one WatchResponse per subscribed object.
+// Persisted as SubscriptionResult.Result.
+type CalendarSubscriptionResult struct {
+	Channels map[common.ObjectName]*WatchResponse `json:"channels"`
+}
+
+// stopPayload is the request body for the channels/stop endpoint.
+type stopPayload struct {
+	ID         string `json:"id"`
+	ResourceID string `json:"resourceId"`
+}
+
+// EmptySubscriptionParams returns a zero-value SubscribeParams with a typed WatchRequest.
+func (a *Adapter) EmptySubscriptionParams() *common.SubscribeParams {
+	return &common.SubscribeParams{
+		Request: &WatchRequest{},
+	}
+}
+
+// EmptySubscriptionResult returns a zero-value SubscriptionResult with a typed CalendarSubscriptionResult.
+func (a *Adapter) EmptySubscriptionResult() *common.SubscriptionResult {
+	return &common.SubscriptionResult{
+		Result: &CalendarSubscriptionResult{
+			Channels: make(map[common.ObjectName]*WatchResponse),
+		},
+	}
+}
+
+// Subscribe creates a watch channel for each requested object.
+//
+// Google Calendar requires a separate watch call per object — there is no
+// multi-resource batch watch. For each object in params.SubscriptionEvents,
+// this method POSTs to the object's watch endpoint and stores the resulting
+// WatchResponse (which contains the channel ID and resourceId needed to stop it).
+//
+// # Event type filtering
+//
+// The ObjectEvents.Events field (SubscriptionEventTypeCreate, SubscriptionEventTypeUpdate,
+// SubscriptionEventTypeDelete) is accepted for interface compliance but is NOT forwarded
+// to the Google Calendar API. The Watch API does not support filtering by event type —
+// every channel receives notifications for all changes (creates, updates, and deletes).
+//
+// Consumers must distinguish event types themselves using the X-Goog-Resource-State
+// header delivered with each push notification:
+//
+//	"sync"       — initial handshake when the channel is created; ignore it
+//	"exists"     — a resource was created or updated
+//	"not_exists" — a resource was deleted
+//
+// If any watch call fails after some have succeeded, the successfully-created
+// channels are rolled back via stopChannel before returning. If rollback also
+// fails, returns SubscriptionStatusFailedToRollback so the caller knows orphaned
+// channels may exist in Google Calendar.
+//
+// ref: https://developers.google.com/workspace/calendar/api/v3/reference/events/watch
+// ref: https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/watch
+func (a *Adapter) Subscribe(
+	ctx context.Context,
+	params common.SubscribeParams,
+) (*common.SubscriptionResult, error) {
+	watchReq, err := validateWatchRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	baseID := watchReq.ID
+	if baseID == "" {
+		baseID = uuid.New().String()
+	}
+
+	result := &CalendarSubscriptionResult{
+		Channels: make(map[common.ObjectName]*WatchResponse),
+	}
+
+	// Sort for deterministic processing order so rollback behaviour is predictable.
+	objects := sortedKeys(params.SubscriptionEvents)
+
+	for _, obj := range objects {
+		resp, err := a.watchObject(ctx, obj, baseID, watchReq)
+		if err != nil {
+			rollbackErr := a.stopAllChannels(ctx, result.Channels)
+			if rollbackErr != nil {
+				return &common.SubscriptionResult{
+					Status: common.SubscriptionStatusFailedToRollback,
+					Result: result,
+				}, fmt.Errorf("subscribe: watching %q failed: %w; rollback also failed: %w", obj, err, rollbackErr)
+			}
+
+			return &common.SubscriptionResult{
+				Status: common.SubscriptionStatusFailed,
+			}, fmt.Errorf("subscribe: watching %q: %w", obj, err)
+		}
+
+		result.Channels[obj] = resp
+	}
+
+	return &common.SubscriptionResult{
+		Result:       result,
+		Status:       common.SubscriptionStatusSuccess,
+		ObjectEvents: params.SubscriptionEvents,
+	}, nil
+}
+
+// UpdateSubscription reconciles an existing subscription with the new desired state.
+//
+// Objects present in prev but absent from params are stopped. Objects in params
+// but absent from prev are newly watched. Objects present in both are left untouched
+// (Google Calendar does not support mutating an existing channel).
+func (a *Adapter) UpdateSubscription(
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	watchReq, err := validateWatchRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	prevChannels := extractChannels(previousResult)
+
+	toAdd := make(map[common.ObjectName]common.ObjectEvents)
+	toRemove := make(map[common.ObjectName]*WatchResponse)
+
+	for obj, evt := range params.SubscriptionEvents {
+		if _, exists := prevChannels[obj]; !exists {
+			toAdd[obj] = evt
+		}
+	}
+
+	for obj, ch := range prevChannels {
+		if _, exists := params.SubscriptionEvents[obj]; !exists {
+			toRemove[obj] = ch
+		}
+	}
+
+	// Start from a copy of the previous channels; we'll mutate it below.
+	updatedChannels := make(map[common.ObjectName]*WatchResponse, len(prevChannels))
+	for obj, ch := range prevChannels {
+		updatedChannels[obj] = ch
+	}
+
+	// Stop removed channels.
+	var stopErr error
+
+	for obj, ch := range toRemove {
+		if err := a.stopChannel(ctx, ch.ID, ch.ResourceID); err != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("update: stopping %q: %w", obj, err))
+		} else {
+			delete(updatedChannels, obj)
+		}
+	}
+
+	if stopErr != nil {
+		return &common.SubscriptionResult{
+			Status: common.SubscriptionStatusFailed,
+			Result: &CalendarSubscriptionResult{Channels: updatedChannels},
+		}, stopErr
+	}
+
+	// Watch newly added objects.
+	baseID := watchReq.ID
+	if baseID == "" {
+		baseID = uuid.New().String()
+	}
+
+	newChannels := make(map[common.ObjectName]*WatchResponse)
+
+	for _, obj := range sortedKeys(toAdd) {
+		resp, watchErr := a.watchObject(ctx, obj, baseID, watchReq)
+		if watchErr != nil {
+			rollbackErr := a.stopAllChannels(ctx, newChannels)
+			if rollbackErr != nil {
+				return &common.SubscriptionResult{
+					Status: common.SubscriptionStatusFailedToRollback,
+					Result: &CalendarSubscriptionResult{Channels: updatedChannels},
+				}, fmt.Errorf("update: watching %q failed: %w; rollback also failed: %w", obj, watchErr, rollbackErr)
+			}
+
+			// Rollback succeeded — prune the stopped channels from the result
+			// so it accurately reflects what is still active in Google Calendar.
+			for o := range newChannels {
+				delete(updatedChannels, o)
+			}
+
+			return &common.SubscriptionResult{
+				Status: common.SubscriptionStatusFailed,
+				Result: &CalendarSubscriptionResult{Channels: updatedChannels},
+			}, fmt.Errorf("update: watching %q: %w", obj, watchErr)
+		}
+
+		newChannels[obj] = resp
+		updatedChannels[obj] = resp
+	}
+
+	return &common.SubscriptionResult{
+		Result:       &CalendarSubscriptionResult{Channels: updatedChannels},
+		Status:       common.SubscriptionStatusSuccess,
+		ObjectEvents: params.SubscriptionEvents,
+	}, nil
+}
+
+// DeleteSubscription stops all active watch channels stored in result.
+// Errors across individual channel stops are joined and returned together.
+//
+// ref: https://developers.google.com/workspace/calendar/api/v3/reference/channels/stop
+func (a *Adapter) DeleteSubscription(
+	ctx context.Context,
+	result common.SubscriptionResult,
+) error {
+	channels := extractChannels(&result)
+	return a.stopAllChannels(ctx, channels)
+}
+
+// RunScheduledMaintenance renews all watch channels.
+//
+// Google Calendar does not support extending an existing channel's lifetime.
+// Renewal requires stopping each channel and re-watching the same objects.
+// This is equivalent to DeleteSubscription followed by Subscribe with the same params.
+//
+// Callers should schedule maintenance before the earliest expiration across all channels.
+func (a *Adapter) RunScheduledMaintenance(
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	if err := a.DeleteSubscription(ctx, *previousResult); err != nil {
+		return &common.SubscriptionResult{
+			Status: common.SubscriptionStatusFailed,
+		}, fmt.Errorf("maintenance: stopping old channels: %w", err)
+	}
+
+	return a.Subscribe(ctx, params)
+}
+
+// VerifyWebhookMessage always returns true for Google Calendar.
+// Push notifications are delivered via Google's infrastructure and authenticated
+// at the transport layer; no application-level signature verification is needed.
+// Callers should verify the X-Goog-Channel-Token header against their stored token
+// if they set one in WatchRequest.Token.
+func (a *Adapter) VerifyWebhookMessage(
+	_ context.Context,
+	_ *common.WebhookRequest,
+	_ *common.VerificationParams,
+) (bool, error) {
+	return true, nil
+}
+
+// GetRecordsByIds is not implemented for Google Calendar.
+// Calendar push notifications deliver an empty body — only headers are sent (X-Goog-Resource-State,
+// X-Goog-Resource-ID, etc.). There is no record payload to enrich from; callers must issue
+// a follow-up API read (e.g. events.list) to fetch what actually changed.
+func (a *Adapter) GetRecordsByIds( //nolint:revive
+	_ context.Context,
+	_ string,
+	_ []string,
+	_ []string,
+	_ []string,
+) ([]common.ReadResultRow, error) {
+	return nil, common.ErrGetRecordNotSupportedForObject
+}
+
+// watchObject POSTs a watch request for a single object and returns the channel response.
+// The caller's ObjectEvents.Events (create/update/delete) are not included in the payload —
+// the Google Calendar Watch API has no event-type filter; all change types are always delivered.
+func (a *Adapter) watchObject(
+	ctx context.Context,
+	objectName common.ObjectName,
+	baseID string,
+	req *WatchRequest,
+) (*WatchResponse, error) {
+	watchPath, supported := objectWatchPaths[objectName]
+	if !supported {
+		return nil, fmt.Errorf("%w: %q", errUnsupportedSubscribeObject, objectName)
+	}
+
+	watchURL, err := url.JoinPath(a.ModuleInfo().BaseURL, apiVersion, watchPath)
+	if err != nil {
+		return nil, fmt.Errorf("watchObject: building URL for %q: %w", objectName, err)
+	}
+
+	payload := &watchPayload{
+		ID:         perObjectChannelID(baseID, objectName),
+		Type:       "web_hook",
+		Address:    req.Address,
+		Token:      req.Token,
+		Expiration: req.Expiration,
+	}
+
+	response, err := a.JSONHTTPClient().Post(ctx, watchURL, payload)
+	if err != nil {
+		return nil, fmt.Errorf("watchObject: POST for %q: %w", objectName, err)
+	}
+
+	result, err := common.UnmarshalJSON[WatchResponse](response)
+	if err != nil {
+		return nil, fmt.Errorf("watchObject: unmarshalling response for %q: %w", objectName, err)
+	}
+
+	return result, nil
+}
+
+// stopChannel calls the Calendar channels/stop endpoint to terminate a single watch channel.
+func (a *Adapter) stopChannel(ctx context.Context, id, resourceID string) error {
+	stopURL, err := urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, "channels/stop")
+	if err != nil {
+		return fmt.Errorf("stopChannel: building URL: %w", err)
+	}
+
+	response, err := a.JSONHTTPClient().Post(ctx, stopURL.String(), &stopPayload{
+		ID:         id,
+		ResourceID: resourceID,
+	})
+	if err != nil {
+		return fmt.Errorf("stopChannel: POST: %w", err)
+	}
+
+	// channels/stop returns 204 No Content on success with no body.
+	if response.Code != http.StatusNoContent && response.Code != http.StatusOK {
+		return fmt.Errorf("stopChannel: unexpected status %d", response.Code)
+	}
+
+	return nil
+}
+
+// stopAllChannels stops every channel in the map, joining errors across failures.
+func (a *Adapter) stopAllChannels(ctx context.Context, channels map[common.ObjectName]*WatchResponse) error {
+	var errs error
+
+	for obj, ch := range channels {
+		if ch == nil {
+			continue
+		}
+
+		if err := a.stopChannel(ctx, ch.ID, ch.ResourceID); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("stopping channel for %q: %w", obj, err))
+		}
+	}
+
+	return errs
+}
+
+// perObjectChannelID appends the object name to the base ID to produce a unique channel ID.
+// Google Calendar requires each channel to have a globally unique ID.
+func perObjectChannelID(baseID string, objectName common.ObjectName) string {
+	return baseID + "-" + string(objectName)
+}
+
+// extractChannels safely extracts the Channels map from a SubscriptionResult.
+// Returns an empty map if the result is nil or has no CalendarSubscriptionResult.
+func extractChannels(result *common.SubscriptionResult) map[common.ObjectName]*WatchResponse {
+	if result == nil || result.Result == nil {
+		return make(map[common.ObjectName]*WatchResponse)
+	}
+
+	sub, ok := result.Result.(*CalendarSubscriptionResult)
+	if !ok || sub == nil {
+		return make(map[common.ObjectName]*WatchResponse)
+	}
+
+	return sub.Channels
+}
+
+// validateWatchRequest type-asserts and validates the WatchRequest from params.
+func validateWatchRequest(params common.SubscribeParams) (*WatchRequest, error) {
+	if params.Request == nil {
+		return nil, fmt.Errorf("%w: request is nil", errMissingParams)
+	}
+
+	req, ok := params.Request.(*WatchRequest)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected '*WatchRequest', got '%T'", errInvalidRequestType, params.Request)
+	}
+
+	if req.Address == "" {
+		return nil, fmt.Errorf("%w: WatchRequest.Address is required", errMissingParams)
+	}
+
+	return req, nil
+}
+
+// sortedKeys returns the keys of m in ascending order so callers iterate deterministically.
+func sortedKeys(m map[common.ObjectName]common.ObjectEvents) []common.ObjectName {
+	keys := make([]common.ObjectName, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}

--- a/providers/google/internal/calendar/subscribe.go
+++ b/providers/google/internal/calendar/subscribe.go
@@ -310,9 +310,9 @@ func (a *Adapter) RunScheduledMaintenance(
 // Callers should verify the X-Goog-Channel-Token header against their stored token
 // if they set one in WatchRequest.Token.
 func (a *Adapter) VerifyWebhookMessage(
-	_ context.Context,
-	_ *common.WebhookRequest,
-	_ *common.VerificationParams,
+	ctx context.Context,
+	request *common.WebhookRequest,
+	params *common.VerificationParams,
 ) (bool, error) {
 	return true, nil
 }
@@ -322,11 +322,11 @@ func (a *Adapter) VerifyWebhookMessage(
 // X-Goog-Resource-ID, etc.). There is no record payload to enrich from; callers must issue
 // a follow-up API read (e.g. events.list) to fetch what actually changed.
 func (a *Adapter) GetRecordsByIds( //nolint:revive
-	_ context.Context,
-	_ string,
-	_ []string,
-	_ []string,
-	_ []string,
+	ctx context.Context,
+	objectName string,
+	recordIds []string, //nolint:revive
+	fields []string,
+	associations []string,
 ) ([]common.ReadResultRow, error) {
 	return nil, common.ErrGetRecordNotSupportedForObject
 }

--- a/test/google/calendar/subscribe/main.go
+++ b/test/google/calendar/subscribe/main.go
@@ -24,8 +24,8 @@ func main() {
 
 	conn := connTest.GetGoogleCalendarConnector(ctx)
 
-	// Subscribe to both supported objects.
-	subscribeResult, err := conn.Subscribe(ctx, common.SubscribeParams{
+	// Subscribe to two supported objects.
+	subscribeParams := common.SubscribeParams{
 		Request: &google.CalendarWatchRequest{
 			Address: webhookAddress,
 			Token:   "my-secret-verification-token",
@@ -38,11 +38,49 @@ func main() {
 				Events: []common.SubscriptionEventType{},
 			},
 		},
-	})
+	}
+
+	subscribeResult, err := conn.Subscribe(ctx, subscribeParams)
 	if err != nil {
 		utils.Fail("error subscribing to Google Calendar", "error", err)
 	}
 
 	slog.Info("Subscribe result", "status", subscribeResult.Status)
 	utils.DumpJSON(subscribeResult, os.Stdout)
+
+	// RunScheduledMaintenance renews the channels (recreate-then-stop). Feed it the
+	// latest result so it knows which previous channels to stop.
+	maintenanceResult, err := conn.RunScheduledMaintenance(ctx, subscribeParams, subscribeResult)
+	if err != nil {
+		utils.Fail("error running scheduled maintenance for Google Calendar", "error", err)
+	}
+
+	slog.Info("RunScheduledMaintenance result", "status", maintenanceResult.Status)
+	utils.DumpJSON(maintenanceResult, os.Stdout)
+
+	// UpdateSubscription to a different desired object set: drop calendarList and add
+	// settings, keeping events. This exercises both the add and the remove paths.
+	// Pass the latest result as the previous state so the old channels get stopped.
+	updateParams := common.SubscribeParams{
+		Request: &google.CalendarWatchRequest{
+			Address: webhookAddress,
+			Token:   "my-secret-verification-token",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"events": {
+				Events: []common.SubscriptionEventType{},
+			},
+			"settings": {
+				Events: []common.SubscriptionEventType{},
+			},
+		},
+	}
+
+	updateResult, err := conn.UpdateSubscription(ctx, updateParams, maintenanceResult)
+	if err != nil {
+		utils.Fail("error updating Google Calendar subscription", "error", err)
+	}
+
+	slog.Info("UpdateSubscription result", "status", updateResult.Status)
+	utils.DumpJSON(updateResult, os.Stdout)
 }

--- a/test/google/calendar/subscribe/main.go
+++ b/test/google/calendar/subscribe/main.go
@@ -32,18 +32,10 @@ func main() {
 		},
 		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 			"events": {
-				Events: []common.SubscriptionEventType{
-					common.SubscriptionEventTypeCreate,
-					common.SubscriptionEventTypeUpdate,
-					common.SubscriptionEventTypeDelete,
-				},
+				Events: []common.SubscriptionEventType{},
 			},
 			"calendarList": {
-				Events: []common.SubscriptionEventType{
-					common.SubscriptionEventTypeCreate,
-					common.SubscriptionEventTypeUpdate,
-					common.SubscriptionEventTypeDelete,
-				},
+				Events: []common.SubscriptionEventType{},
 			},
 		},
 	})

--- a/test/google/calendar/subscribe/main.go
+++ b/test/google/calendar/subscribe/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/google"
+	connTest "github.com/amp-labs/connectors/test/google"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+const webhookAddress = "https://play.svix.com/in/e_QwY3goanA4qKfh62do3rTkOPGOm/"
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetGoogleCalendarConnector(ctx)
+
+	// Subscribe to both supported objects.
+	subscribeResult, err := conn.Subscribe(ctx, common.SubscribeParams{
+		Request: &google.CalendarWatchRequest{
+			Address: webhookAddress,
+			Token:   "my-secret-verification-token",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"events": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeCreate,
+					common.SubscriptionEventTypeUpdate,
+					common.SubscriptionEventTypeDelete,
+				},
+			},
+			"calendarList": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeCreate,
+					common.SubscriptionEventTypeUpdate,
+					common.SubscriptionEventTypeDelete,
+				},
+			},
+		},
+	})
+	if err != nil {
+		utils.Fail("error subscribing to Google Calendar", "error", err)
+	}
+
+	slog.Info("Subscribe result", "status", subscribeResult.Status)
+	utils.DumpJSON(subscribeResult, os.Stdout)
+}


### PR DESCRIPTION
  Implements Subscribe, UpdateSubscription, DeleteSubscription, and RunScheduledMaintenance for the Google Calendar connector using the Calendar Watch API.

  Objects supported:
  - events — POST /calendars/primary/events/watch
  - calendarList — POST /users/me/calendarList/watch
  - settings — POST /users/me/settings/watch
  - acl — POST /calendars/primary/acl/watch 
 
Live Tests:
<img width="1458" height="883" alt="Screenshot 2026-05-12 at 16 54 47" src="https://github.com/user-attachments/assets/fc89b607-5ed1-438a-af55-05018a361557" />
<img width="1467" height="760" alt="Screenshot 2026-05-12 at 16 55 00" src="https://github.com/user-attachments/assets/cf8bc922-aea7-497d-b4cf-f9b8a436b388" />

 Google Calendar push notifications are delivered as HTTP POST requests to the address set in WatchRequest.Address. The body is always empty. All
  information arrives in headers:

  Header: X-Goog-Resource-State
    Values: sync
    Meaning: Initial handshake on channel creation — ignore it   
    Values: exists          
    Meaning: A resource was created or updated
    Values: not_exists
    Meaning: A resource was deleted

  Header: X-Goog-Channel-ID
    Values: e.g. <base-id>-events
    Meaning: The channel ID set during subscribe

  Header: X-Goog-Resource-ID
    Values: opaque string
    Meaning: Stable ID of the watched resource (needed to stop the channel)

  Header: X-Goog-Resource-URI
    Values: URL
    Meaning: The API endpoint of the changed resource

  Header: X-Goog-Channel-Token
    Values: string
    Meaning: The token set in WatchRequest.Token, echoed back verbatim — use this to verify the notification came from Google

  Header: X-Goog-Channel-Expiration
    Values: RFC 1123 date
    Meaning: When the channel expires