### PR TITLE
[ENG-3906] feat(hubspot): Read Engagements

### DIFF
--- a/providers/hubspot/internal/core/objects.go
+++ b/providers/hubspot/internal/core/objects.go
@@ -14,7 +14,7 @@ const (
 
 const ObjectMarketingForms = "forms"
 
-//nolint:gochecknoglobals
+//nolint:gochecknoglobals,lll
 var (
 
 	// CRMObjectsWithoutPropertiesAPISupport contains HubSpot CRM object names that
@@ -38,6 +38,7 @@ var (
 			Path:              "campaigns",
 			RecordTransformer: common.FlattenNestedFields("properties"),
 			Version:           APIVersion2026March,
+			PageSize:          DefaultPageSize,
 		},
 		// "marketing/emails" refers to HubSpot marketing emails, which are distinct
 		// from the CRM email activity resource.
@@ -55,12 +56,25 @@ var (
 			Path:              "emails",
 			RecordTransformer: nil, // None. Fields and Raw are the same.
 			Version:           APIVersion2026March,
+			PageSize:          DefaultPageSize,
 		},
 		// https://developers.hubspot.com/docs/api-reference/2026-09-beta/marketing/forms/get-forms
 		ObjectMarketingForms: {
 			Path:              "forms",
 			RecordTransformer: nil,
 			Version:           APIVersion2026Sep,
+			PageSize:          DefaultPageSize,
+		},
+	}
+
+	// MiscellaneousObjects are objects outside the CRM and Marketing APIs.
+	MiscellaneousObjects = datautils.Map[string, ObjectDescription]{
+		// https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/engagements/get-engagements-v1-engagements-paged
+		"engagements-legacy": {
+			Path:              "/engagements/v1/engagements/paged",
+			RecordTransformer: common.FlattenNestedFields("engagement"),
+			Version:           "", // version is already part of the path.
+			PageSize:          "250",
 		},
 	}
 )
@@ -72,4 +86,6 @@ type ObjectDescription struct {
 	RecordTransformer common.RecordTransformer
 	// Hubspot API Version.
 	Version string
+	// PageSize is maximum possible page limit for an object.
+	PageSize string
 }

--- a/providers/hubspot/internal/core/parse.go
+++ b/providers/hubspot/internal/core/parse.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
@@ -42,6 +43,10 @@ func GetRecords(node *ajson.Node) ([]*ajson.Node, error) {
 }
 
 func GetNextRecordsURLCRM(node *ajson.Node) (string, error) {
+	return offsetPagination(node)
+}
+
+func offsetPagination(node *ajson.Node) (string, error) {
 	hasMore, err := jsonquery.New(node).BoolWithDefault("hasMore", false)
 	if err != nil {
 		return "", err
@@ -58,6 +63,19 @@ func GetNextRecordsURLCRM(node *ajson.Node) (string, error) {
 	}
 
 	return strconv.FormatInt(offset, 10), nil
+}
+
+func NextPageTokenFromOffset(url *urlbuilder.URL) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		offset, err := offsetPagination(node)
+		if err != nil || offset == "" {
+			return "", err
+		}
+
+		url.WithQueryParam("offset", offset)
+
+		return url.String(), nil
+	}
 }
 
 // GetDataMarshaller returns a function that accepts a list of records and fields

--- a/providers/hubspot/internal/metadata/schemas.json
+++ b/providers/hubspot/internal/metadata/schemas.json
@@ -747,6 +747,113 @@
               "providerType": "string<date-time>"
             }
           }
+        },
+        "engagements-legacy": {
+          "displayName": "Engagements",
+          "description": "/engagements/v1/engagements/paged",
+          "responseKey": "results",
+          "fields": {
+            "id": {
+              "displayName": "id",
+              "valueType": "int",
+              "providerType": "int"
+            },
+            "portalId": {
+              "displayName": "portalId",
+              "valueType": "int",
+              "providerType": "int"
+            },
+            "active": {
+              "displayName": "active",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "createdAt": {
+              "displayName": "createdAt",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "lastUpdated": {
+              "displayName": "lastUpdated",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "createdBy": {
+              "displayName": "createdBy",
+              "valueType": "other",
+              "providerType": "int"
+            },
+            "modifiedBy": {
+              "displayName": "modifiedBy",
+              "valueType": "other",
+              "providerType": "int"
+            },
+            "ownerId": {
+              "displayName": "ownerId",
+              "valueType": "other",
+              "providerType": "int"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "timestamp": {
+              "displayName": "timestamp",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "source": {
+              "displayName": "source",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "allAccessibleTeamIds": {
+              "displayName": "allAccessibleTeamIds",
+              "valueType": "array",
+              "providerType": "array"
+            },
+            "bodyPreview": {
+              "displayName": "bodyPreview",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "queueMembershipIds": {
+              "displayName": "queueMembershipIds",
+              "valueType": "array",
+              "providerType": "array"
+            },
+            "bodyPreviewIsTruncated": {
+              "displayName": "bodyPreviewIsTruncated",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "bodyPreviewHtml": {
+              "displayName": "bodyPreviewHtmls",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "associations": {
+              "displayName": "associations",
+              "valueType": "object",
+              "providerType": "object"
+            },
+            "metadata": {
+              "displayName": "metadata",
+              "valueType": "object",
+              "providerType": "object"
+            },
+            "attachments": {
+              "displayName": "attachments",
+              "valueType": "other",
+              "providerTyper": "array"
+            },
+            "scheduledTasks": {
+              "displayName": "scheduledTasks",
+              "valueType": "array",
+              "providerTyper": "array"
+            }
+          }
         }
       }
     }

--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -117,6 +117,8 @@ func (c *Connector) getObjectMetadata(ctx context.Context, objectName string) (*
 		// Object is part of Hubspot Marketing API.
 		// There is no discovery endpoint. Using local file with schema definition.
 		return metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
+	case core.MiscellaneousObjects.Has(objectName):
+		return metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
 	default:
 		// Otherwise object belongs to Hubspot Objects API (sub-category of CRM namespace).
 		return c.getObjectMetadataFromPropertyAPI(ctx, objectName)

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -372,7 +372,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		},
 		{
 			Name:       "Successfully describe marketing campaigns and emails",
-			Input:      []string{"campaigns", "marketing/emails", "forms"},
+			Input:      []string{"campaigns", "marketing/emails", "forms", "engagements-legacy"},
 			Server:     mockserver.Dummy(),
 			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
@@ -433,6 +433,16 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 							},
 							"name": {
 								DisplayName:  "name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"engagements-legacy": {
+						DisplayName: "Engagements",
+						Fields: map[string]common.FieldMetadata{
+							"bodyPreviewHtml": {
+								DisplayName:  "bodyPreviewHtmls",
 								ValueType:    "string",
 								ProviderType: "string",
 							},

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -40,6 +40,8 @@ func (c *Connector) Read(ctx context.Context, params common.ReadParams) (*common
 	case core.MarketingObjects.Has(params.ObjectName):
 		// Object is part of Hubspot Marketing API.
 		return c.readMarketing(ctx, params, core.MarketingObjects[params.ObjectName])
+	case core.MiscellaneousObjects.Has(params.ObjectName):
+		return c.readMiscAPI(ctx, params, core.MiscellaneousObjects[params.ObjectName])
 	default:
 		// Otherwise object belongs to Hubspot Objects API (sub-category of CRM namespace).
 		return c.readCRMObjectsAPI(ctx, params)
@@ -177,7 +179,7 @@ func (c *Connector) buildMarketingReadURL(
 		return nil, err
 	}
 
-	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, core.DefaultPageSize))
+	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, object.PageSize))
 
 	if params.ObjectName == core.ObjectMarketingForms {
 		// This object does not have such query params. For consistency, it is reflected here.
@@ -208,4 +210,54 @@ func makeIncrementalFilterFunc(params common.ReadParams) common.RecordsFilterFun
 		"updatedAt", time.RFC3339,
 		core.GetNextRecordsURL,
 	)
+}
+
+func (c *Connector) readMiscAPI(ctx context.Context,
+	params common.ReadParams, object core.ObjectDescription,
+) (*common.ReadResult, error) {
+	url, err := c.buildMiscURL(params, &object)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResultFiltered(
+		params,
+		resp,
+		common.MakeRecordsFunc("results"),
+		readhelper.MakeTimeFilterFuncWithZoom(
+			readhelper.Unordered,
+			readhelper.NewTimeBoundary(),
+			[]string{"engagement"}, "lastUpdated", readhelper.TimestampFormatUnixMs,
+			core.NextPageTokenFromOffset(url),
+		),
+		readhelper.MakeMarshaledDataFuncWithId(
+			object.RecordTransformer,
+			readhelper.IdFieldQuery{Zoom: []string{"engagement"}, Field: "id"},
+		),
+		params.Fields,
+	)
+}
+
+func (c *Connector) buildMiscURL(
+	params common.ReadParams, object *core.ObjectDescription,
+) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	// First page
+	url, err := c.rootURL(object.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, object.PageSize))
+
+	return url, nil
 }

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -27,6 +28,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMarketingEmailFirst := testutils.DataFromFile(t, "read/marketing-emails/1-first-page.json")
 	responseMarketingEmailLast := testutils.DataFromFile(t, "read/marketing-emails/2-last-page.json")
 	responseMarketingForms := testutils.DataFromFile(t, "read/marketing-forms.json")
+	responseEngagements := testutils.DataFromFile(t, "read/engagements.json")
 
 	tests := []testroutines.Read{
 		{
@@ -482,6 +484,39 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 				},
 				NextPage: "https://api.hubapi.com/marketing/forms/2026-09-beta?limit=1&after=MQ%3D%3D",
+				Done:     false,
+			},
+		}, {
+			Name: "Read engagements",
+			Input: common.ReadParams{
+				ObjectName: "engagements-legacy",
+				Fields:     connectors.Fields("bodyPreview", "lastUpdated"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/engagements/v1/engagements/paged"),
+				Then:  mockserver.Response(http.StatusOK, responseEngagements),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"bodypreview": "Regarding meeting logged on Friday, December 22, 2023 10:11 AM",
+							"lastupdated": float64(1743307535349),
+						},
+						Raw: map[string]any{
+							"engagement":     mockutils.Any{},
+							"associations":   mockutils.Any{},
+							"attachments":    []any{},
+							"scheduledTasks": mockutils.Any{},
+							"metadata":       mockutils.Any{},
+						},
+						Id: "44699354671",
+					},
+				},
+				NextPage: testroutines.URLTestServer + "/engagements/v1/engagements/paged?limit=250&offset=44699354672",
 				Done:     false,
 			},
 		},

--- a/providers/hubspot/schema.go
+++ b/providers/hubspot/schema.go
@@ -2,6 +2,7 @@ package hubspot
 
 // KnownObjectTypes
 // https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
+// https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis#object-type-id-values
 var KnownObjectTypes = map[string]string{ // nolint:gochecknoglobals
 	"0-2":   "companies",
 	"0-1":   "contacts",

--- a/providers/hubspot/test/read/engagements.json
+++ b/providers/hubspot/test/read/engagements.json
@@ -1,0 +1,70 @@
+{
+  "results": [
+    {
+      "engagement": {
+        "id": 44699354671,
+        "portalId": 44623425,
+        "active": true,
+        "createdAt": 1703268683752,
+        "lastUpdated": 1743307535349,
+        "createdBy": 62365053,
+        "modifiedBy": 62365053,
+        "ownerId": 641085326,
+        "type": "TASK",
+        "timestamp": 1705512600000,
+        "source": "CRM_UI",
+        "allAccessibleTeamIds": [],
+        "bodyPreview": "Regarding meeting logged on Friday, December 22, 2023 10:11 AM",
+        "queueMembershipIds": [],
+        "bodyPreviewIsTruncated": false,
+        "bodyPreviewHtml": "<html>\n <head></head>\n <body>\n Regarding meeting logged on Friday, December 22, 2023 10:11 AM\n </body>\n</html>"
+      },
+      "associations": {
+        "contactIds": [
+          16352,
+          16301,
+          16351
+        ],
+        "companyIds": [
+          18497374840
+        ],
+        "dealIds": [],
+        "ownerIds": [],
+        "workflowIds": [],
+        "ticketIds": [],
+        "contentIds": [],
+        "quoteIds": [],
+        "marketingEventIds": [],
+        "partnerClientIds": [],
+        "orderIds": [],
+        "cartIds": []
+      },
+      "attachments": [],
+      "scheduledTasks": [
+        {
+          "engagementId": 44699354671,
+          "portalId": 44623425,
+          "engagementType": "TASK",
+          "taskType": "REMINDER",
+          "timestamp": 1705512600000,
+          "uuid": "TASK:c8b7782f-6010-4e70-87e7-9a6c62924bc5"
+        }
+      ],
+      "metadata": {
+        "body": "Regarding meeting logged on Friday, December 22, 2023 10:11 AM",
+        "status": "NOT_STARTED",
+        "forObjectType": "OWNER",
+        "subject": "Follow up with Clara",
+        "taskType": "TODO",
+        "reminders": [
+          1705512600000
+        ],
+        "priority": "NONE",
+        "isAllDay": false,
+        "calendarEventId": "6pij0cj469i3eb9g68p3eb9kc8pm2bb26goj8bb665h38dphc8q36d1pck"
+      }
+    }
+  ],
+  "hasMore": true,
+  "offset": 44699354672
+}

--- a/providers/hubspot/url.go
+++ b/providers/hubspot/url.go
@@ -35,7 +35,7 @@ import (
 // Used by GetPostAuthInfo.
 // https://developers.hubspot.com/docs/api-reference/latest/account/account-information/get-account-details
 func (c *Connector) getAccountDetailsURL() (*urlbuilder.URL, error) {
-	return urlbuilder.New(c.ProviderInfo().BaseURL, "account-info", core.APIVersion2026March, "details")
+	return c.rootURL("account-info", core.APIVersion2026March, "details")
 }
 
 // Returns the schema endpoint for an object definition.
@@ -45,7 +45,7 @@ func (c *Connector) getAccountDetailsURL() (*urlbuilder.URL, error) {
 //
 // https://developers.hubspot.com/docs/api-reference/latest/crm/objects/schemas/get-schema
 func (c *Connector) getCRMSchemaURL(objectName string) (*urlbuilder.URL, error) {
-	return urlbuilder.New(c.ProviderInfo().BaseURL, "crm-object-schemas", core.APIVersion2026March, "schemas", objectName)
+	return c.rootURL("crm-object-schemas", core.APIVersion2026March, "schemas", objectName)
 }
 
 // Returns the properties endpoint for an object.
@@ -120,14 +120,18 @@ func (c *Connector) getCRMSearchURL(objectName string) (*urlbuilder.URL, error) 
 // https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/update-campaign
 // https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/delete-campaign
 func (c *Connector) getMarketingURL(object *core.ObjectDescription) (*urlbuilder.URL, error) {
-	return urlbuilder.New(c.ProviderInfo().BaseURL, "marketing", object.Path, object.Version)
+	return c.rootURL("marketing", object.Path, object.Version)
 }
 
 func (c *Connector) crmURL(paths ...string) (*urlbuilder.URL, error) {
 	parts := append([]string{"crm"}, paths...)
 
 	// URL: "https://api.hubapi.com/crm"
-	return urlbuilder.New(c.ProviderInfo().BaseURL, parts...)
+	return c.rootURL(parts...)
+}
+
+func (c *Connector) rootURL(paths ...string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, paths...)
 }
 
 func (c *Connector) getURLFromRoot(relativePath string) string {

--- a/test/hubspot/metadata/read/engagements/main.go
+++ b/test/hubspot/metadata/read/engagements/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	metadata, err := conn.ListObjectMetadata(ctx, []string{
+		"engagements-legacy",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata", "error", err)
+	}
+
+	fmt.Println("Metadata...")
+	utils.DumpJSON(metadata, os.Stdout)
+}

--- a/test/hubspot/read/engagement/main.go
+++ b/test/hubspot/read/engagement/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/hubspot"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetHubspotConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "engagements-legacy",
+		Fields:     connectors.Fields("bodyPreview", "lastUpdated"),
+		PageSize:   1,
+		//Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
+	})
+	if err != nil {
+		utils.Fail("error reading from connector", "error", err)
+	}
+
+	fmt.Println("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/utils/mockutils/readResult.go
+++ b/test/utils/mockutils/readResult.go
@@ -7,6 +7,37 @@ import (
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
+// Any represents a wildcard value used in response comparisons.
+//
+// When a field value in the expected response is set to Any{},
+// the comparator only checks that the field exists in the actual response,
+// without validating its concrete value.
+//
+// Example:
+//
+//	expected := &common.ReadResult{
+//		Data: []common.ReadResultData{
+//			{
+//				Raw: map[string]any{
+//					"id":        Any{},
+//					"createdAt": Any{},
+//					"status":    "active",
+//				},
+//			},
+//		},
+//	}
+//
+// In this example:
+//   - "id" and "createdAt" must be present in the response
+//   - their values can be anything
+//   - "status" must equal "active"
+//
+// Private field is used to make the type non-empty and prevent
+// accidental structural equivalence with other empty structs.
+type Any struct {
+	_ any
+}
+
 var ReadResultComparator = readResultComparator{}
 
 type readResultComparator struct{}
@@ -25,9 +56,19 @@ func (readResultComparator) SubsetRaw(actual, expected *common.ReadResult) *test
 
 	for i := range expected.Data {
 		for field := range expected.Data[i].Raw {
-			got := actual.Data[i].Raw[field]
+			got, ok := actual.Data[i].Raw[field]
 			exp := expected.Data[i].Raw[field]
+
+			if _, anyValue := exp.(Any); anyValue {
+				if !ok {
+					result.AddDiff("Data[%d].Raw[%s] is missing", i, field)
+				}
+				// As long as any value is present we are good.
+				continue
+			}
+
 			result.Assert(fmt.Sprintf("Data[%d].Raw[%s]", i, field), exp, got)
+
 		}
 	}
 
@@ -48,8 +89,17 @@ func (readResultComparator) SubsetFields(actual, expected *common.ReadResult) *t
 
 	for i := range expected.Data {
 		for field := range expected.Data[i].Fields {
-			got := actual.Data[i].Fields[field]
+			got, ok := actual.Data[i].Fields[field]
 			exp := expected.Data[i].Fields[field]
+
+			if _, anyValue := exp.(Any); anyValue {
+				if !ok {
+					result.AddDiff("Data[%d].Raw[%s] is missing", i, field)
+				}
+				// As long as any value is present we are good.
+				continue
+			}
+
 			result.Assert(fmt.Sprintf("Data[%d].Fields[%s]", i, field), exp, got)
 		}
 	}


### PR DESCRIPTION
# Description

Engagements object exist as part of CRM. But the legacy endpoint is different, this PR adds support to it.

Note: we may support associations if this object will be popular or used at all.
<img width="295" height="551" alt="image" src="https://github.com/user-attachments/assets/93af6854-2f1d-4076-9f07-cd85e52f4a30" />


# Live Tests

### Metadata
<img width="372" height="409" alt="image" src="https://github.com/user-attachments/assets/d5c1368a-304f-4cc3-93e2-5e65e17f7bcc" />

### Read
<img width="747" height="685" alt="image" src="https://github.com/user-attachments/assets/0cca73a8-a2ac-4951-980b-8e9971fd2325" />
