### PR TITLE
[CON-3245] fix(gong): use regional base URL from OAuth token response

### DIFF
--- a/providers/gong.go
+++ b/providers/gong.go
@@ -7,7 +7,12 @@ func init() {
 	SetInfo(Gong, ProviderInfo{
 		DisplayName: "Gong",
 		AuthType:    Oauth2,
-		BaseURL:     "https://api.gong.io",
+		// Gong API base URL is region-specific. The OAuth token response includes
+		// an `api_base_url` field pointing to the tenant's regional endpoint.
+		// US tenants get https://api.gong.io; EU/APAC tenants get a different URL.
+		// Without this, non-US tenants receive "access token has been revoked" errors
+		// because their token is valid only for their regional endpoint.
+		BaseURL: "https://{{.api_base_url}}",
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327371/media/gong_1722327370.svg",
@@ -25,7 +30,8 @@ func init() {
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
 			TokenMetadataFields: TokenMetadataFields{
-				ScopesField: "scope",
+				WorkspaceRefField: "api_base_url",
+				ScopesField:       "scope",
 			},
 		},
 		Support: Support{

--- a/providers/gong/connector.go
+++ b/providers/gong/connector.go
@@ -4,10 +4,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/gong/metadata"
 )
+
+const defaultAPIBaseURL = "api.gong.io"
 
 const ApiVersion = "v2"
 
@@ -30,8 +33,19 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 		},
 	}
 
-	// Read provider info
-	providerInfo, err := providers.ReadInfo(conn.Provider())
+	// Determine regional API base URL; default to api.gong.io for US tenants.
+	apiBaseURL := params.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = defaultAPIBaseURL
+	}
+
+	// Read provider info with regional base URL substitution.
+	providerInfo, err := providers.ReadInfo(conn.Provider(), catalogreplacer.CustomCatalogVariable{
+		Plan: catalogreplacer.SubstitutionPlan{
+			From: "api_base_url",
+			To:   apiBaseURL,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -17,6 +17,16 @@ type Option = func(params *parameters)
 
 type parameters struct {
 	paramsbuilder.Client
+	APIBaseURL string // Regional API base URL from OAuth token (e.g. "api.eu.gong.io")
+}
+
+// WithWorkspace sets the regional API base URL for the Gong connector.
+// This is extracted from the OAuth token response field "api_base_url".
+// US tenants may omit this (defaults to api.gong.io).
+func WithWorkspace(apiBaseURL string) Option {
+	return func(params *parameters) {
+		params.APIBaseURL = apiBaseURL
+	}
 }
 
 func newParams(opts []Option) (*common.ConnectorParams, error) { // nolint:unused

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -256,6 +256,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(mockutils.NewClient()),
+		WithWorkspace("api.gong.io"), // any valid domain works; setBaseURL below overrides for tests
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Changes the Gong connector to use the tenant-specific `api_base_url` returned in the OAuth token response, rather than hardcoding `https://api.gong.io`.

## Why

Gong is a multi-region provider (US, EU, APAC). The OAuth token response includes an `api_base_url` field pointing to the correct regional API endpoint for the tenant. Previously this field was ignored and all API calls went to `https://api.gong.io` (US), causing non-US tenants to receive 'access token has been revoked' errors because their token was being used against the wrong regional endpoint.

This follows the same pattern used for Zoho's `api_domain` field.

## Changes

- `BaseURL`: `https://api.gong.io` → `https://{{.api_base_url}}`
- Added `WorkspaceRefField: "api_base_url"` to `TokenMetadataFields` so the field is captured and stored on the connection at auth time

## Notes

Existing connections have empty `providerMetadata` (the field was never captured before this fix). Affected customers will need to re-authorize once after this is deployed to populate `api_base_url` on their connection. US-region customers are unaffected — Gong returns `https://api.gong.io` as the `api_base_url` for US tenants.

## Test Results

No automated tests added — this is a provider config change. Manually verified the field name against Gong's OAuth documentation and confirmed the pattern matches the existing Zoho implementation.