### PR TITLE
[CON-3245] fix(gong): use api_base_url_for_customer field and full URL from OAuth token response

### DIFF
--- a/providers/gong.go
+++ b/providers/gong.go
@@ -12,7 +12,7 @@ func init() {
 		// US tenants get https://api.gong.io; EU/APAC tenants get a different URL.
 		// Without this, non-US tenants receive "access token has been revoked" errors
 		// because their token is valid only for their regional endpoint.
-		BaseURL: "https://{{.api_base_url}}",
+		BaseURL: "{{.api_base_url_for_customer}}",
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722327371/media/gong_1722327370.svg",
@@ -30,7 +30,7 @@ func init() {
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
 			TokenMetadataFields: TokenMetadataFields{
-				WorkspaceRefField: "api_base_url",
+				WorkspaceRefField: "api_base_url_for_customer",
 				ScopesField:       "scope",
 			},
 		},

--- a/providers/gong.go
+++ b/providers/gong.go
@@ -30,6 +30,7 @@ func init() {
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
 			TokenMetadataFields: TokenMetadataFields{
+				// See https://help.gong.io/docs/create-an-app-for-gong#exchange-the-code-for-an-access-token
 				WorkspaceRefField: "api_base_url_for_customer",
 				ScopesField:       "scope",
 			},

--- a/providers/gong.go
+++ b/providers/gong.go
@@ -9,7 +9,8 @@ func init() {
 		AuthType:    Oauth2,
 		// Gong API base URL is region-specific. The OAuth token response includes
 		// an `api_base_url` field pointing to the tenant's regional endpoint.
-		// US tenants get https://api.gong.io; EU/APAC tenants get a different URL.
+		// US tenants get a tenant-specific URL, with a fallback to https://api.gong.io if missing.
+		// EU/APAC tenants get a different URL, with no safe fallback.
 		// Without this, non-US tenants receive "access token has been revoked" errors
 		// because their token is valid only for their regional endpoint.
 		BaseURL: "{{.api_base_url_for_customer}}",

--- a/providers/gong/connector.go
+++ b/providers/gong/connector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/providers/gong/metadata"
 )
 
-const defaultAPIBaseURL = "api.gong.io"
+const defaultAPIBaseURL = "https://api.gong.io"
 
 const ApiVersion = "v2"
 
@@ -42,7 +42,7 @@ func NewConnector(opts ...Option) (conn *Connector, outErr error) {
 	// Read provider info with regional base URL substitution.
 	providerInfo, err := providers.ReadInfo(conn.Provider(), catalogreplacer.CustomCatalogVariable{
 		Plan: catalogreplacer.SubstitutionPlan{
-			From: "api_base_url",
+			From: "api_base_url_for_customer",
 			To:   apiBaseURL,
 		},
 	})

--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -17,7 +17,7 @@ type Option = func(params *parameters)
 
 type parameters struct {
 	paramsbuilder.Client
-	APIBaseURL string // Regional API base URL from OAuth token (e.g. "api.eu.gong.io")
+	APIBaseURL string // Regional API base URL from OAuth token (e.g. "https://us-12345.api.gong.io")
 }
 
 // WithWorkspace sets the regional API base URL for the Gong connector.

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -256,7 +256,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 func constructTestConnector(serverURL string) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(mockutils.NewClient()),
-		WithWorkspace("api.gong.io"), // any valid domain works; setBaseURL below overrides for tests
+		WithWorkspace("https://api.gong.io"), // full URL required; setBaseURL below overrides origin for tests
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

Corrects the Gong regional base URL implementation. The previous PR (#2998) used the wrong field name and wrong URL format.

**Fixes:**
- `WorkspaceRefField`: `api_base_url` → `api_base_url_for_customer` (correct field name from Gong OAuth token response)
- `BaseURL`: `https://{{.api_base_url}}` → `{{.api_base_url_for_customer}}` (Gong returns full URL including scheme, e.g. `https://us-49467.api.gong.io`)
- `defaultAPIBaseURL`: `api.gong.io` → `https://api.gong.io` (full URL to match template format)

## Why?

The Gong OAuth token response returns the tenant's regional base URL as `api_base_url_for_customer` — a full URL like `https://us-49467.api.gong.io`. Customers on non-default Gong regions were getting tokens rejected because API calls were routing to the wrong endpoint.

## How was this tested?

**E2E test via preview environment** (server PR https://github.com/amp-labs/server/pull/6251 pinned to commit `17efba30`):

1. Deployed amp.yaml with Gong proxy enabled to preview stack
2. Completed OAuth flow — confirmed `api_base_url_for_customer` captured in `providerMetadata` from token response
3. Made proxy call `GET /v2/users` → **200 with 12 real Gong users**
4. Connection metadata confirmed: `api_base_url_for_customer: https://api.gong.io`

US routing confirmed working. EU routing follows the same code path with a tenant-specific subdomain URL.