### PR TITLE
fix(gong): expose content/interaction/collaboration on calls

### DIFF
--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -94,21 +94,58 @@ func buildReadBody(config common.ReadParams) map[string]any {
 	}
 
 	if config.ObjectName == objectNameCalls {
-		body["contentSelector"] = callContentSelector()
+		body["contentSelector"] = callContentSelector(config.Fields)
 	}
 
 	return body
 }
 
-// callContentSelector returns the contentSelector used for POST /v2/calls/extensive, which
-// adds parties + media to the response.
+// callContentSelector returns the contentSelector used for POST /v2/calls/extensive.
+// parties and media are always requested. content, interaction, and collaboration are
+// requested only when the corresponding root field is in `fields`.
+//
+// Field selections arrive here already collapsed to root names by the server's
+// ExtractFieldForConnector, so we can't be more granular than per-section; when a
+// section is requested, every sub-flag in it is set to true.
 // https://app.gong.io/settings/api/documentation#post-/v2/calls/extensive
-func callContentSelector() map[string]any {
+func callContentSelector(fields datautils.StringSet) map[string]any {
+	exposed := map[string]any{
+		"parties": true,
+		"media":   true,
+	}
+
+	if fields.Has("content") {
+		exposed["content"] = map[string]any{
+			"structure":          true,
+			"topics":             true,
+			"trackers":           true,
+			"trackerOccurrences": true,
+			"pointsOfInterest":   true,
+			"brief":              true,
+			"outline":            true,
+			"highlights":         true,
+			"callOutcome":        true,
+			"keyPoints":          true,
+		}
+	}
+
+	if fields.Has("interaction") {
+		exposed["interaction"] = map[string]any{
+			"speakers":               true,
+			"video":                  true,
+			"personInteractionStats": true,
+			"questions":              true,
+		}
+	}
+
+	if fields.Has("collaboration") {
+		exposed["collaboration"] = map[string]any{
+			"publicComments": true,
+		}
+	}
+
 	return map[string]any{
-		"context": "Extended",
-		"exposedFields": map[string]any{
-			"parties": true,
-			"media":   true,
-		},
+		"context":       "Extended",
+		"exposedFields": exposed,
 	}
 }

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -114,6 +114,42 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "Requesting the content field opts only that section into exposedFields",
+			Input: common.ReadParams{
+				ObjectName: "calls",
+				Fields:     connectors.Fields("id", "content"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.Body(`{
+					"filter":{},
+					"contentSelector":{
+						"context":"Extended",
+						"exposedFields":{
+							"parties":true,
+							"media":true,
+							"content":{
+								"structure":true,
+								"topics":true,
+								"trackers":true,
+								"trackerOccurrences":true,
+								"pointsOfInterest":true,
+								"brief":true,
+								"outline":true,
+								"highlights":true,
+								"callOutcome":true,
+								"keyPoints":true
+							}
+						}
+					}
+				}`),
+				Then: mockserver.Response(http.StatusOK, fakeServerResp),
+			}.Server(),
+			Comparator:   testroutines.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
 			Name:  "Successful read with 2 entries without cursor/next page",
 			Input: common.ReadParams{ObjectName: "calls", Fields: connectors.Fields("id")},
 			Server: mockserver.Conditional{

--- a/providers/gong/record.go
+++ b/providers/gong/record.go
@@ -40,7 +40,7 @@ func (c *Connector) GetRecordsByIds( //nolint:revive,funlen
 	case objectNameCalls:
 		// getReadURL already appends /extensive for calls.
 		filterKey = "callIds"
-		contentSelector = callContentSelector()
+		contentSelector = callContentSelector(datautils.NewSetFromList(fields))
 		transformer = extractMetaDataFields
 	case objectNameUsers:
 		filterKey = "userIds"

--- a/providers/gong/record_test.go
+++ b/providers/gong/record_test.go
@@ -75,6 +75,82 @@ func TestGetRecordsByIds(t *testing.T) {
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "Calls by IDs opts into content/interaction/collaboration when those fields are requested",
+			Input: GetRecordsByIdsInput{
+				ObjectName: "calls",
+				Ids:        []string{"52947912500572621", "137982752092261989"},
+				Fields:     []string{"id", "content", "interaction", "collaboration"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/calls/extensive"),
+					mockcond.Body(`{
+						"filter":{"callIds":["52947912500572621","137982752092261989"]},
+						"contentSelector":{
+							"context":"Extended",
+							"exposedFields":{
+								"parties":true,
+								"media":true,
+								"content":{
+									"structure":true,
+									"topics":true,
+									"trackers":true,
+									"trackerOccurrences":true,
+									"pointsOfInterest":true,
+									"brief":true,
+									"outline":true,
+									"highlights":true,
+									"callOutcome":true,
+									"keyPoints":true
+								},
+								"interaction":{
+									"speakers":true,
+									"video":true,
+									"personInteractionStats":true,
+									"questions":true
+								},
+								"collaboration":{
+									"publicComments":true
+								}
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, callsResp),
+			}.Server(),
+			Expected: []common.ReadResultRow{
+				{
+					Id:     "52947912500572621",
+					Fields: map[string]any{"id": "52947912500572621"},
+					Raw: map[string]any{
+						"metaData": map[string]any{
+							"id":             "52947912500572621",
+							"url":            "https://us-49467.app.gong.io/call?id=52947912500572621",
+							"workspaceId":    "1007648505208900737",
+							"clientUniqueId": "ce93bb26-de69-41e3-8a7f-43ea3714b9e8",
+							"customData":     "R1201",
+						},
+					},
+				},
+				{
+					Id:     "137982752092261989",
+					Fields: map[string]any{"id": "137982752092261989"},
+					Raw: map[string]any{
+						"metaData": map[string]any{
+							"id":             "137982752092261989",
+							"url":            "https://us-49467.app.gong.io/call?id=137982752092261989",
+							"workspaceId":    "1007648505208900737",
+							"clientUniqueId": "f77501df-0c70-4c38-b565-a3a09fee14fb",
+							"customData":     "R1201",
+						},
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "Users by IDs POST to /v2/users/extensive with userIds filter and no contentSelector",
 			Input: GetRecordsByIdsInput{
 				ObjectName: "users",


### PR DESCRIPTION
## Summary

Customer report (databook) flagged that Gong's `/v2/calls/extensive` was returning only `metaData`, `context`, and `parties` — the `content`, `interaction`, and `collaboration` sections were missing despite being requested in their `amp.yaml`.

Gong's API only returns those three sections when the request body's `contentSelector.exposedFields` opts into them. Our Gong connector hardcoded that opt-in to just `parties` and `media`, so the other sections were never returned regardless of what the customer listed under `requiredFields`.

This change makes `callContentSelector` inspect `ReadParams.Fields` and turn on each section's sub-flags when the corresponding root field name is requested. `parties` and `media` remain unconditional (status quo).

Field selections arrive at the connector already collapsed to root names (server's `ExtractFieldForConnector`), so granularity is per-section rather than per-sub-field — when a section is requested, every sub-flag in it is set to `true`. Customers who don't request these sections see no change in behavior.

## Test plan

- [x] Existing unit tests for Gong calls/users read still pass (no body changes when only `id` is requested)
- [x] New unit test in `record_test.go`: `GetRecordsByIds` with `Fields = [id, content, interaction, collaboration]` sends the full `exposedFields` body
- [x] New unit test in `read_test.go`: list read with `Fields = [id, content]` sends only `content` under `exposedFields` (partial opt-in)
- [x] `go vet ./providers/gong/...` clean
- [ ] Verify with databook on staging once merged

## Notes

`collaboration.scorecards` (which the customer asked for) is **not** exposed by `/v2/calls/extensive` even after this fix — Gong's `CallCollaboration` schema only exposes `publicComments`. Scorecards would need a separate object/endpoint and should be tracked separately.

## Background on the commits on main

`3460db5e` and `2663ea7e` on `main` are an accidental direct-push of this fix followed by its revert (my mistake, not part of this change). Net effect on `main` is zero. This PR re-introduces the fix through the correct review path.