### PR TITLE
fix(contexts): Resolve intermittent unit test issue

### DIFF
--- a/common/contexts/contexts_test.go
+++ b/common/contexts/contexts_test.go
@@ -39,7 +39,8 @@ func TestIsContextAlive(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
 		defer cancel()
 
-		time.Sleep(10 * time.Millisecond)
+		// wait for context to expire
+		<-ctx.Done()
 		assert.False(t, IsContextAlive(ctx))
 	})
 

--- a/providers/netsuite.go
+++ b/providers/netsuite.go
@@ -91,11 +91,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},

--- a/providers/netsuiteM2M.go
+++ b/providers/netsuiteM2M.go
@@ -103,11 +103,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},


### PR DESCRIPTION
# Problem

The test used `time.Sleep()` to wait for a `context.WithTimeout` to expire, then checked if the context was done. This is flaky because Go closes the `Done()` channel **asynchronously** after the timer fires.
`Sleep()` may return before `Done()` is actually closed. This is noticable because we are using small time units `time.Millisecond`.

# Fix

Replace `time.Sleep()` with `<-ctx.Done()` to block until the `Done()` channel is actually closed