### PR TITLE
[CON-3211] feat(acculynx): add write connector

### DIFF
--- a/providers/acculynx/batchRecordReader.go
+++ b/providers/acculynx/batchRecordReader.go
@@ -1,0 +1,130 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/simultaneously"
+)
+
+// AccuLynx has no batch read endpoint; GetRecordsByIds fans out per id
+// (capped by maxConcurrentChildFetch) and preserves input order.
+
+var errBatchReadEmptyResponse = errors.New("acculynx: empty response body for record fetch")
+
+//nolint:gochecknoglobals
+var batchReadableObjects = datautils.NewStringSet(objectContacts, objectJobs)
+
+//nolint:revive
+func (c *Connector) GetRecordsByIds(
+	ctx context.Context,
+	objectName string,
+	recordIds []string,
+	fields []string,
+	_ []string, // associations: AccuLynx single-record endpoints have no association support
+) ([]common.ReadResultRow, error) {
+	objectName = strings.ToLower(objectName)
+
+	if !batchReadableObjects.Has(objectName) {
+		return nil, fmt.Errorf("%w: %s (only contacts and jobs supported)",
+			common.ErrGetRecordNotSupportedForObject, objectName)
+	}
+
+	if len(recordIds) == 0 {
+		return []common.ReadResultRow{}, nil
+	}
+
+	fieldSet := datautils.NewSetFromList(fields)
+
+	rows := make([]common.ReadResultRow, len(recordIds))
+	jobs := make([]simultaneously.Job, len(recordIds))
+
+	for i, recordID := range recordIds {
+		idx, id := i, recordID
+
+		jobs[idx] = func(ctx context.Context) error {
+			row, err := c.fetchSingleRecord(ctx, objectName, id, fieldSet)
+			if err != nil {
+				return fmt.Errorf("fetch %s/%s: %w", objectName, id, err)
+			}
+
+			rows[idx] = row
+
+			return nil
+		}
+	}
+
+	if err := simultaneously.DoCtx(ctx, maxConcurrentChildFetch, jobs...); err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+func (c *Connector) fetchSingleRecord(
+	ctx context.Context,
+	objectName, recordID string,
+	fieldSet datautils.StringSet,
+) (common.ReadResultRow, error) {
+	u, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectName, recordID)
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, u.String())
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	raw, err := common.UnmarshalJSON[map[string]any](resp)
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	if raw == nil {
+		return common.ReadResultRow{}, errBatchReadEmptyResponse
+	}
+
+	rawCopy := *raw
+
+	return common.ReadResultRow{
+		Id:     recordID,
+		Fields: pickFields(rawCopy, fieldSet),
+		Raw:    rawCopy,
+	}, nil
+}
+
+// pickFields filters raw to entries in fieldSet. Empty fieldSet returns a
+// shallow clone of raw. Matches case-insensitively because AccuLynx uses
+// camelCase keys but the framework lower-cases requested field names.
+func pickFields(raw map[string]any, fieldSet datautils.StringSet) map[string]any {
+	if len(fieldSet) == 0 {
+		out := make(map[string]any, len(raw))
+		maps.Copy(out, raw)
+
+		return out
+	}
+
+	out := make(map[string]any, len(fieldSet))
+
+	for k, v := range raw {
+		if fieldSet.Has(k) {
+			out[k] = v
+
+			continue
+		}
+
+		lower := strings.ToLower(k)
+		if fieldSet.Has(lower) {
+			out[lower] = v
+		}
+	}
+
+	return out
+}

--- a/providers/acculynx/batchRecordReader_test.go
+++ b/providers/acculynx/batchRecordReader_test.go
@@ -1,0 +1,143 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"gotest.tools/v3/assert"
+)
+
+func TestGetRecordsByIds_RejectsUnsupportedObject(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	_, err = conn.GetRecordsByIds(context.Background(), "leads",
+		[]string{"id-1"}, []string{"id"}, nil)
+
+	assert.Assert(t, errors.Is(err, common.ErrGetRecordNotSupportedForObject))
+}
+
+func TestGetRecordsByIds_LowercasesObjectName(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	// "CONTACTS" should be normalized to "contacts" and accepted (empty ids → empty slice, no error).
+	rows, err := conn.GetRecordsByIds(context.Background(), "CONTACTS", nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 0)
+}
+
+func TestGetRecordsByIds_EmptyIdsReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectContacts, nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 0)
+}
+
+func TestGetRecordsByIds_FetchesEachIdInOrder(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Switch{
+		Setup: mockserver.ContentJSON(),
+		Cases: []mockserver.Case{
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/job-1"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK,
+					`{"id":"job-1","jobName":"First","modifiedDate":"2026-05-01T00:00:00Z"}`),
+			},
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/job-2"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK,
+					`{"id":"job-2","jobName":"Second","modifiedDate":"2026-05-02T00:00:00Z"}`),
+			},
+		},
+		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-1", "job-2"}, []string{"id", "jobName"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 2)
+
+	assert.Equal(t, rows[0].Id, "job-1")
+	assert.Equal(t, rows[0].Fields["id"], "job-1")
+	assert.Equal(t, rows[0].Fields["jobName"], "First")
+
+	assert.Equal(t, rows[1].Id, "job-2")
+	assert.Equal(t, rows[1].Fields["id"], "job-2")
+	assert.Equal(t, rows[1].Fields["jobName"], "Second")
+}
+
+func TestGetRecordsByIds_RawPreservedUntouched(t *testing.T) {
+	t.Parallel()
+
+	body := `{"id":"contact-1","firstName":"Diane","lastName":"Tiblin",` +
+		`"_link":"https://api.acculynx.com/api/v2/contacts/contact-1"}`
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/v2/contacts/contact-1"),
+		},
+		Then: mockserver.ResponseString(http.StatusOK, body),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectContacts,
+		[]string{"contact-1"}, []string{"id"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+
+	// Fields was filtered to just "id" — but Raw must keep every key the API returned.
+	assert.Equal(t, rows[0].Raw["firstName"], "Diane")
+	assert.Equal(t, rows[0].Raw["lastName"], "Tiblin")
+	assert.Equal(t, rows[0].Raw["_link"], "https://api.acculynx.com/api/v2/contacts/contact-1")
+}
+
+func TestGetRecordsByIds_FailingFetchPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/v2/jobs/missing-job"),
+		},
+		Then: mockserver.ResponseString(http.StatusNotFound, `{"detail":"NotFound"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	_, err = conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"missing-job"}, []string{"id"}, nil)
+
+	assert.Assert(t, err != nil, "404 from upstream should surface as an error")
+}

--- a/providers/acculynx/connector.go
+++ b/providers/acculynx/connector.go
@@ -8,9 +8,11 @@ package acculynx
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/acculynx/metadata"
 )
@@ -22,6 +24,8 @@ type Connector struct {
 
 	components.SchemaProvider
 	components.Reader
+	components.Writer
+	components.Deleter
 }
 
 // NewConnector creates a new AccuLynx connector.
@@ -44,6 +48,28 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/acculynx/connector.go
+++ b/providers/acculynx/connector.go
@@ -6,6 +6,7 @@
 package acculynx
 
 import (
+	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/deleter"
@@ -15,6 +16,12 @@ import (
 	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/acculynx/metadata"
+)
+
+var (
+	_ connectors.BatchRecordReaderConnector = &Connector{}
+	_ connectors.WebhookVerifierConnector   = &Connector{}
+	_ connectors.SubscribeConnector         = &Connector{}
 )
 
 // Connector is the AccuLynx connector.

--- a/providers/acculynx/custom.go
+++ b/providers/acculynx/custom.go
@@ -1,0 +1,342 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/internal/simultaneously"
+	"github.com/spyzhov/ajson"
+)
+
+// AccuLynx returns entityType as "Job"/"Contact" (capitalized) but the docs
+// show it lowercased — lowercase at the boundary so case drift doesn't break
+// the registry lookup.
+
+// AccuLynx custom-field model:
+//   - Definitions are global, fetched from /company-settings/custom-fields and
+//     bucketed by entityType ("contact" | "job"). The endpoint already filters
+//     to active definitions only.
+//   - Values are per-record, fetched from /{contacts|jobs}/{id}/custom-fields.
+//     Unlike the inline pattern in other providers (Copper, Sellsy, etc.),
+//     AccuLynx requires one extra call per parent record on every read.
+//
+// References:
+//   - Definitions: https://apidocs.acculynx.com/reference/getcompanysettingscustomfields
+//   - Contact values: https://apidocs.acculynx.com/reference/getcontactcustomfields
+//   - Job values: https://apidocs.acculynx.com/reference/getjobcustomfields
+
+const (
+	customFieldDefinitionsPath = "company-settings/custom-fields"
+
+	entityTypeContact = "contact"
+	entityTypeJob     = "job"
+)
+
+//nolint:gochecknoglobals
+var customFieldEntityByObject = map[string]string{
+	objectContacts: entityTypeContact,
+	objectJobs:     entityTypeJob,
+}
+
+// usesCustomFields reports whether AccuLynx exposes custom fields directly on
+// the records of the given object. Only top-level contacts and jobs do — the
+// "contacts/custom-fields" / "jobs/custom-fields" nested objects are handled
+// via the separate nested-object pipeline.
+func usesCustomFields(objectName string) bool {
+	_, ok := customFieldEntityByObject[objectName]
+
+	return ok
+}
+
+// customFieldDefinition mirrors the customFieldDefinitionFull schema.
+type customFieldDefinition struct {
+	ID         string                 `json:"id"`
+	Label      string                 `json:"label"`
+	EntityType string                 `json:"entityType"`
+	FieldType  string                 `json:"fieldType"`
+	Options    []customFieldOptionDef `json:"options"`
+}
+
+type customFieldOptionDef struct {
+	ID    string `json:"id"`
+	Value string `json:"value"`
+}
+
+// fieldName derives the slug used to expose the custom field at the top level
+// of a record. Lower-cased label with spaces replaced by underscores; no
+// prefix. Built-in AccuLynx fields are camelCase, so collisions are avoided
+// by case alone. (Same shape as Copper's slug, sans the "custom_field_" prefix.)
+func (d customFieldDefinition) fieldName() string {
+	return slugFromLabel(d.Label)
+}
+
+// valueType maps AccuLynx field types to the connector value-type taxonomy.
+// AccuLynx's customFieldType enum is Text|Number|Date|Boolean. Definitions
+// with a non-empty options list are treated as singleSelect — the framework
+// caller can read possible values from FieldMetadata.Values.
+//
+// Note: AccuLynx exposes no API signal to distinguish single-select from
+// multi-select definitions (unlike Copper's "MultiSelect" type or Sellsy's
+// "checkbox"). All options-bearing fields surface as singleSelect; downstream
+// code that cares about cardinality should look at the returned values array
+// at read time.
+func (d customFieldDefinition) valueType() common.ValueType {
+	if len(d.Options) > 0 {
+		return common.ValueTypeSingleSelect
+	}
+
+	switch d.FieldType {
+	case "Text":
+		return common.ValueTypeString
+	case "Number":
+		return common.ValueTypeFloat
+	case "Date":
+		return common.ValueTypeDate
+	case "Boolean":
+		return common.ValueTypeBoolean
+	default:
+		return common.ValueTypeOther
+	}
+}
+
+func (d customFieldDefinition) getValues() []common.FieldValue {
+	if len(d.Options) == 0 {
+		return nil
+	}
+
+	values := make([]common.FieldValue, 0, len(d.Options))
+	for _, opt := range d.Options {
+		values = append(values, common.FieldValue{
+			Value:        opt.ID,
+			DisplayValue: opt.Value,
+		})
+	}
+
+	return values
+}
+
+func slugFromLabel(label string) string {
+	slug := strings.ToLower(strings.TrimSpace(label))
+
+	return strings.ReplaceAll(slug, " ", "_")
+}
+
+// customFieldValue mirrors the per-record customField schema. The label
+// travels with the value so the read transformer can build slugs without a
+// definitions cross-lookup. AccuLynx returns "values" as a plain string array
+// (e.g. ["42"] or ["Phone","Email"]), accompanied by "formattedValues" with
+// the same shape — we ignore the latter.
+type customFieldValue struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	FieldType string   `json:"fieldType"`
+	Values    []string `json:"values"`
+}
+
+// customFieldDefinitionsResponse mirrors the customFieldDefinitionsCollection
+// schema (an `items` array on top of baseCollection).
+type customFieldDefinitionsResponse struct {
+	Items []customFieldDefinition `json:"items"`
+}
+
+// customFieldsResponse mirrors the customFieldsCollection schema.
+type customFieldsResponse struct {
+	Items []customFieldValue `json:"items"`
+}
+
+// fetchCustomFieldDefinitions retrieves all active custom-field definitions
+// across both contact and job entity types in one paginated sweep, and
+// returns them bucketed by entityType — matching the salesloft pattern.
+func (c *Connector) fetchCustomFieldDefinitions(
+	ctx context.Context,
+) (datautils.NamedLists[customFieldDefinition], error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), customFieldDefinitionsPath)
+	if err != nil {
+		return nil, errors.Join(common.ErrResolvingCustomFields, err)
+	}
+
+	url.WithQueryParam(pageSizeParam, defaultPageSize)
+	url.WithQueryParam(recordStartParam, "0")
+
+	registry := make(datautils.NamedLists[customFieldDefinition])
+
+	for {
+		resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+		if err != nil {
+			return nil, errors.Join(common.ErrResolvingCustomFields, err)
+		}
+
+		page, err := common.UnmarshalJSON[customFieldDefinitionsResponse](resp)
+		if err != nil {
+			return nil, errors.Join(common.ErrResolvingCustomFields, err)
+		}
+
+		if page == nil {
+			break
+		}
+
+		for _, def := range page.Items {
+			registry.Add(strings.ToLower(def.EntityType), def)
+		}
+
+		if len(page.Items) < maxPageSize {
+			break
+		}
+
+		current, _ := url.GetFirstQueryParam(recordStartParam)
+		currentInt, _ := strconv.Atoi(current)
+		url.WithQueryParam(recordStartParam, strconv.Itoa(currentInt+len(page.Items)))
+	}
+
+	return registry, nil
+}
+
+// fetchCustomFieldValuesForRecords fans out one GET per parent ID concurrently,
+// honouring the per-key rate limit via maxConcurrentChildFetch. Returns a
+// map keyed by parent ID with the slice of values that record carries.
+func (c *Connector) fetchCustomFieldValuesForRecords(
+	ctx context.Context,
+	parentObject string,
+	parentIDs []string,
+) (map[string][]customFieldValue, error) {
+	if len(parentIDs) == 0 {
+		return map[string][]customFieldValue{}, nil
+	}
+
+	results := make([][]customFieldValue, len(parentIDs))
+	jobs := make([]simultaneously.Job, len(parentIDs))
+
+	for i, parentID := range parentIDs {
+		idx, id := i, parentID
+
+		jobs[idx] = func(ctx context.Context) error {
+			values, err := c.fetchCustomFieldValuesForRecord(ctx, parentObject, id)
+			if err != nil {
+				return fmt.Errorf("fetch custom field values for %s %s: %w", parentObject, id, err)
+			}
+
+			results[idx] = values
+
+			return nil
+		}
+	}
+
+	if err := simultaneously.DoCtx(ctx, maxConcurrentChildFetch, jobs...); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string][]customFieldValue, len(parentIDs))
+	for i, id := range parentIDs {
+		out[id] = results[i]
+	}
+
+	return out, nil
+}
+
+func (c *Connector) fetchCustomFieldValuesForRecord(
+	ctx context.Context,
+	parentObject string,
+	parentID string,
+) ([]customFieldValue, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), parentObject, parentID, "custom-fields")
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam(pageSizeParam, defaultPageSize)
+	url.WithQueryParam(recordStartParam, "0")
+
+	var collected []customFieldValue
+
+	for {
+		resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+		if err != nil {
+			return nil, err
+		}
+
+		page, err := common.UnmarshalJSON[customFieldsResponse](resp)
+		if err != nil {
+			return nil, err
+		}
+
+		if page == nil {
+			break
+		}
+
+		collected = append(collected, page.Items...)
+
+		if len(page.Items) < maxPageSize {
+			break
+		}
+
+		current, _ := url.GetFirstQueryParam(recordStartParam)
+		currentInt, _ := strconv.Atoi(current)
+		url.WithQueryParam(recordStartParam, strconv.Itoa(currentInt+len(page.Items)))
+	}
+
+	return collected, nil
+}
+
+// attachReadCustomFields returns a RecordTransformer that flattens the
+// pre-fetched custom-field values into the record map. The slug is derived
+// from the value's own label, which the AccuLynx response carries on each
+// record so the transformer doesn't need a definitions cross-lookup. Single-
+// element value arrays are unwrapped to scalars; multi-element arrays
+// preserved. Raw is never modified — this only mutates the marshalled Fields
+// map.
+func attachReadCustomFields(valuesByParentID map[string][]customFieldValue) common.RecordTransformer {
+	return func(node *ajson.Node) (map[string]any, error) {
+		object, err := jsonquery.Convertor.ObjectToMap(node)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(valuesByParentID) == 0 {
+			return object, nil
+		}
+
+		parentID, err := jsonquery.New(node).StrWithDefault("id", "")
+		if err != nil {
+			return nil, err
+		}
+
+		for _, value := range valuesByParentID[parentID] {
+			object[slugFromLabel(value.Label)] = unwrapValueItems(value.Values)
+		}
+
+		return object, nil
+	}
+}
+
+// unwrapValueItems converts the AccuLynx values array into the most natural
+// shape: a scalar string for single-element arrays, a slice of strings for
+// multi-element arrays, and nil for empty arrays.
+func unwrapValueItems(items []string) any {
+	switch len(items) {
+	case 0:
+		return nil
+	case 1:
+		return items[0]
+	default:
+		return items
+	}
+}
+
+// extractParentIDsFromBody pulls the records array out of the response and
+// returns just the "id" field of each record. Used to plan the value fan-out
+// before invoking the framework's record-iteration pipeline.
+func (c *Connector) extractParentIDsFromBody(objectName string, body *ajson.Node) ([]string, error) {
+	records, err := c.recordsFunc(objectName)(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractIDs(records), nil
+}

--- a/providers/acculynx/delete.go
+++ b/providers/acculynx/delete.go
@@ -43,10 +43,10 @@ func (c *Connector) buildDeleteURL(params common.DeleteParams) (*urlbuilder.URL,
 
 	switch params.ObjectName {
 	case deletableJobsARRepresentative:
-		return urlbuilder.New(baseURL, apiVersionPrefix,
+		return urlbuilder.New(baseURL, c.modulePath(),
 			"jobs", params.RecordId, "representatives", "ar-owner")
 	case deletableJobsSalesRepresentative:
-		return urlbuilder.New(baseURL, apiVersionPrefix,
+		return urlbuilder.New(baseURL, c.modulePath(),
 			"jobs", params.RecordId, "representatives", "sales-owner")
 	default:
 		return nil, common.ErrOperationNotSupportedForObject

--- a/providers/acculynx/delete.go
+++ b/providers/acculynx/delete.go
@@ -1,0 +1,69 @@
+package acculynx
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// AccuLynx delete API references:
+//   - Delete AR Owner from job:     https://apidocs.acculynx.com/reference/deleteAROwnerFromJob
+//   - Delete Sales Owner from job:  https://apidocs.acculynx.com/reference/deleteSalesOwnerFromJob
+//
+// AccuLynx exposes no DELETE for top-level /contacts or /jobs. The only DELETE
+// endpoints in the V2 API remove a representative slot from an existing job;
+// RecordId here is the jobId, ObjectName selects which representative slot
+// (ar-owner or sales-owner) to clear.
+
+const (
+	deletableJobsARRepresentative    = "jobs/representatives/ar-owner"
+	deletableJobsSalesRepresentative = "jobs/representatives/sales-owner"
+)
+
+func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	url, err := c.buildDeleteURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodDelete, url.String(), nil)
+}
+
+// buildDeleteURL maps a deletable ObjectName + RecordId (= jobId) to its
+// fully-qualified AccuLynx URL. Returns ErrOperationNotSupportedForObject for
+// any object outside the small set AccuLynx allows deletes on.
+func (c *Connector) buildDeleteURL(params common.DeleteParams) (*urlbuilder.URL, error) {
+	baseURL := c.ProviderInfo().BaseURL
+
+	switch params.ObjectName {
+	case deletableJobsARRepresentative:
+		return urlbuilder.New(baseURL, apiVersionPrefix,
+			"jobs", params.RecordId, "representatives", "ar-owner")
+	case deletableJobsSalesRepresentative:
+		return urlbuilder.New(baseURL, apiVersionPrefix,
+			"jobs", params.RecordId, "representatives", "sales-owner")
+	default:
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+}
+
+func (c *Connector) parseDeleteResponse(
+	_ context.Context,
+	_ common.DeleteParams,
+	_ *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	if response.Code != http.StatusOK &&
+		response.Code != http.StatusNoContent &&
+		response.Code != http.StatusAccepted {
+		return nil, common.ErrRequestFailed
+	}
+
+	return &common.DeleteResult{Success: true}, nil
+}

--- a/providers/acculynx/delete_test.go
+++ b/providers/acculynx/delete_test.go
@@ -1,0 +1,83 @@
+package acculynx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	tests := []testroutines.Delete{
+		{
+			Name:         "Delete param object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Delete param record id must be included",
+			Input:        common.DeleteParams{ObjectName: "jobs/representatives/ar-owner"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name: "Unsupported object returns ErrOperationNotSupportedForObject",
+			Input: common.DeleteParams{
+				ObjectName: "jobs",
+				RecordId:   "9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75",
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Successful AR-owner deletion",
+			Input: common.DeleteParams{
+				ObjectName: "jobs/representatives/ar-owner",
+				RecordId:   "9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/api/v2/jobs/9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75/representatives/ar-owner"),
+					mockcond.MethodDELETE(),
+				},
+				Then: mockserver.Response(http.StatusOK),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Successful sales-owner deletion (204 No Content)",
+			Input: common.DeleteParams{
+				ObjectName: "jobs/representatives/sales-owner",
+				RecordId:   "9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/api/v2/jobs/9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75/representatives/sales-owner"),
+					mockcond.MethodDELETE(),
+				},
+				Then: mockserver.Response(http.StatusNoContent),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.DeleteConnector, error) {
+				return constructTestReadConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/acculynx/metadata.go
+++ b/providers/acculynx/metadata.go
@@ -1,0 +1,60 @@
+package acculynx
+
+import (
+	"context"
+	"slices"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx/metadata"
+)
+
+// ListObjectMetadata shadows the embedded SchemaProvider's method so we can
+// enrich the static schema for "contacts" and "jobs" with custom-field
+// metadata sourced live from /company-settings/custom-fields. Other objects
+// pass through unchanged.
+//
+// Strict on definitions-fetch failure (matches copper, sellsy, salesloft):
+// the whole call aborts so callers don't silently miss custom fields.
+func (c *Connector) ListObjectMetadata(
+	ctx context.Context, objectNames []string,
+) (*common.ListObjectMetadataResult, error) {
+	result, err := metadata.Schemas.Select(c.ProviderContext.Module(), objectNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if !slices.ContainsFunc(objectNames, usesCustomFields) {
+		return result, nil
+	}
+
+	defs, err := c.fetchCustomFieldDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range objectNames {
+		entity, ok := customFieldEntityByObject[name]
+		if !ok {
+			continue
+		}
+
+		objectMetadata := result.GetObjectMetadata(name)
+		if objectMetadata == nil {
+			continue
+		}
+
+		for _, def := range defs[entity] {
+			objectMetadata.AddFieldMetadata(def.fieldName(), common.FieldMetadata{
+				DisplayName:  def.Label,
+				ValueType:    def.valueType(),
+				ProviderType: def.FieldType,
+				Values:       def.getValues(),
+				IsCustom:     new(true),
+			})
+		}
+
+		result.Result[name] = *objectMetadata
+	}
+
+	return result, nil
+}

--- a/providers/acculynx/metadata_test.go
+++ b/providers/acculynx/metadata_test.go
@@ -1,11 +1,14 @@
 package acculynx
 
 import (
+	_ "embed"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
@@ -34,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		{
 			Name:   "Successfully describe top-level jobs object",
 			Input:  []string{"jobs"},
-			Server: mockserver.Dummy(),
+			Server: customFieldDefinitionsServer(customFieldDefinitionsEmptyResponse),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"jobs": {
@@ -52,7 +55,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		{
 			Name:   "Successfully describe top-level contacts object",
 			Input:  []string{"contacts"},
-			Server: mockserver.Dummy(),
+			Server: customFieldDefinitionsServer(customFieldDefinitionsEmptyResponse),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -84,9 +87,76 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 			Comparator: testroutines.ComparatorSubsetMetadata,
 		},
 		{
+			Name:  "Contacts metadata enriched with custom field definitions",
+			Input: []string{"contacts"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsFixture),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"contacts": {
+						DisplayName: "Contacts",
+						FieldsMap: map[string]string{
+							// Built-in fields (subset of the static schema).
+							"id":        "id",
+							"firstName": "firstName",
+							// customer_preference and preferred_contact_method
+							// are custom fields, slugs derived from their
+							// labels — display names map back to the labels.
+							"customer_preference":      "Customer Preference",
+							"preferred_contact_method": "Preferred Contact Method",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "Jobs metadata enriched with custom field definitions",
+			Input: []string{"jobs"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsFixture),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"jobs": {
+						DisplayName: "Jobs",
+						FieldsMap: map[string]string{
+							"id": "id",
+							// estimated_squares is a custom field on jobs —
+							// proves entityType bucketing works (this
+							// definition has entityType=job in the fixture).
+							"estimated_squares": "Estimated Squares",
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:   "Successfully describe multiple objects at once",
 			Input:  []string{"jobs", "users", "calendars"},
-			Server: mockserver.Dummy(),
+			Server: customFieldDefinitionsServer(customFieldDefinitionsEmptyResponse),
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"jobs": {
@@ -139,4 +209,25 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	connector.SetUnitTestBaseURL(serverURL)
 
 	return connector, nil
+}
+
+// customFieldDefinitionsServer returns a mock server that responds to the
+// /company-settings/custom-fields endpoint with the given fixture, and 500s
+// on anything else. ListObjectMetadata is strict on definitions-fetch
+// failure, so every test that targets contacts/jobs needs this mock — even
+// tests that don't otherwise care about custom fields.
+func customFieldDefinitionsServer(fixture []byte) *httptest.Server {
+	return mockserver.Switch{
+		Setup: mockserver.ContentJSON(),
+		Cases: []mockserver.Case{
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/company-settings/custom-fields"),
+				},
+				Then: mockserver.Response(http.StatusOK, fixture),
+			},
+		},
+		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+	}.Server()
 }

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -177,14 +177,62 @@ func (c *Connector) parseReadResponse(
 		return nil, err
 	}
 
+	var transformer common.RecordTransformer
+
+	if usesCustomFields(params.ObjectName) {
+		transformer, err = c.buildCustomFieldsTransformer(ctx, params, resp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return common.ParseResultFiltered(
 		params,
 		resp,
 		c.recordsFunc(params.ObjectName),
 		c.makeFilterFunc(params, reqURL),
-		common.MakeMarshaledDataFunc(nil),
+		common.MakeMarshaledDataFunc(transformer),
 		params.Fields,
 	)
+}
+
+// buildCustomFieldsTransformer fetches custom-field definitions and per-record
+// values, returning a transformer that flattens those values onto the
+// marshalled record. Caller must guarantee usesCustomFields(params.ObjectName)
+// is true. When there is nothing to attach (empty body or no definitions for
+// this entity), the returned transformer carries an empty map and short-
+// circuits per record without touching the value-fan-out path.
+func (c *Connector) buildCustomFieldsTransformer(
+	ctx context.Context,
+	params common.ReadParams,
+	resp *common.JSONHTTPResponse,
+) (common.RecordTransformer, error) {
+	body, hasBody := resp.Body()
+	if !hasBody {
+		return attachReadCustomFields(nil), nil
+	}
+
+	defs, err := c.fetchCustomFieldDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entity, hasEntity := customFieldEntityByObject[params.ObjectName]
+	if !hasEntity || len(defs[entity]) == 0 {
+		return attachReadCustomFields(nil), nil
+	}
+
+	parentIDs, err := c.extractParentIDsFromBody(params.ObjectName, body)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := c.fetchCustomFieldValuesForRecords(ctx, params.ObjectName, parentIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return attachReadCustomFields(values), nil
 }
 
 // recordsFunc resolves the records-array key from the schema's responseKey.

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -37,6 +37,21 @@ var calendarsListResponse []byte
 //go:embed test/read/units-of-measure.json
 var unitsOfMeasureResponse []byte
 
+//go:embed test/read/custom-fields/definitions.json
+var customFieldDefinitionsFixture []byte
+
+//go:embed test/read/custom-fields/definitions-empty.json
+var customFieldDefinitionsEmptyResponse []byte
+
+//go:embed test/read/custom-fields/contacts-list.json
+var customFieldsContactsListResponse []byte
+
+//go:embed test/read/custom-fields/contact-001-values.json
+var customFieldsContact001ValuesResponse []byte
+
+//go:embed test/read/custom-fields/contact-002-values.json
+var customFieldsContact002ValuesResponse []byte
+
 //go:embed test/read/jobs-list-single.json
 var jobsListSingleResponse []byte
 
@@ -164,12 +179,109 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						},
 						Then: mockserver.Response(http.StatusOK, jobsListResponse),
 					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsEmptyResponse),
+					},
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
 			Comparator: testroutines.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
+				Done: true,
+			},
+		},
+		{
+			Name: "Read contacts flattens custom field values onto each row",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields: connectors.Fields(
+					"id", "firstName", "customer_preference", "preferred_contact_method",
+				),
+				PageSize: 100,
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/contacts"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldsContactsListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsFixture),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/contacts/ctc_001/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldsContact001ValuesResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/contacts/ctc_002/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldsContact002ValuesResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":        "ctc_001",
+							"firstname": "Carol",
+							// customer_preference is a custom field — single-value
+							// arrays are unwrapped to scalars. Slug derives from
+							// the definition label lowercased, spaces→underscores.
+							"customer_preference": "White Roof",
+							// preferred_contact_method is a custom field with
+							// multiple values — preserved as a slice.
+							"preferred_contact_method": []string{"Phone", "Email"},
+						},
+						// Raw must remain the untouched API response: custom
+						// field values must NOT bleed into Raw, and
+						// provider-returned fields like _link must NOT be
+						// stripped (paranoia check).
+						Raw: map[string]any{
+							"id":           "ctc_001",
+							"_link":        "https://api.acculynx.com/api/v2/contacts/ctc_001",
+							"firstName":    "Carol",
+							"lastName":     "Customer",
+							"modifiedDate": "2026-04-10T12:00:00Z",
+						},
+					},
+					{
+						// ctc_002 has no custom-field values — built-in fields
+						// only.
+						Fields: map[string]any{
+							"id":        "ctc_002",
+							"firstname": "Dave",
+						},
+						Raw: map[string]any{
+							"id":           "ctc_002",
+							"_link":        "https://api.acculynx.com/api/v2/contacts/ctc_002",
+							"firstName":    "Dave",
+							"lastName":     "Donor",
+							"modifiedDate": "2026-04-11T12:00:00Z",
+						},
+					},
+				},
 				Done: true,
 			},
 		},

--- a/providers/acculynx/subscribe.go
+++ b/providers/acculynx/subscribe.go
@@ -1,0 +1,389 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/go-playground/validator"
+)
+
+// AccuLynx exposes a single subscription per installation. UpdateSubscription
+// replaces the topic list in-place; consumerUrl is immutable after creation.
+// Only contact_added/changed and job_created/updated are first-class; every
+// other topic is reachable via ObjectEvents.PassThroughEvents.
+//
+// Reference: https://apidocs.acculynx.com/reference/postsubscription
+
+const (
+	webhooksVersionPrefix = "/webhooks/v2"
+	subscriptionsPath     = "subscriptions"
+)
+
+var (
+	errMissingSubscribeParams      = errors.New("acculynx: missing subscribe params")
+	errInvalidSubscribeRequestType = errors.New("acculynx: invalid subscribe request type")
+	errInvalidSubscriptionResult   = errors.New("acculynx: invalid subscription result type")
+	errNoTopicsResolved            = errors.New("acculynx: no AccuLynx topics resolved from requested events")
+	errUnsupportedSubscribeObject  = errors.New("acculynx: object does not support subscriptions")
+	errUnsupportedSubscribeEvent   = errors.New("acculynx: event type not supported by AccuLynx for this object")
+	errUnknownPassThroughTopic     = errors.New("acculynx: passThrough event is not a recognized AccuLynx topic")
+	errEmptySubscriptionID         = errors.New("acculynx: empty subscriptionId in create response")
+)
+
+// SubscriptionRequest is the provider-specific input the framework passes via
+// common.SubscribeParams.Request.
+type SubscriptionRequest struct {
+	// ConsumerURL is the HTTPS endpoint AccuLynx will POST events to. Immutable
+	// after subscription creation.
+	ConsumerURL string `json:"consumerUrl" validate:"required,url"`
+	// TechContact is the email AccuLynx contacts about subscription status.
+	TechContact string `json:"techContact" validate:"required,email"`
+}
+
+// SubscriptionResult is the persistent connector state stored between Subscribe
+// calls. The framework keeps this verbatim and passes it back on UpdateSubscription
+// / DeleteSubscription so we can identify the existing AccuLynx subscription.
+type SubscriptionResult struct {
+	SubscriptionID string   `json:"subscriptionId"`
+	ConsumerURL    string   `json:"consumerUrl"`
+	TechContact    string   `json:"techContact"`
+	TopicNames     []string `json:"topicNames"`
+	Status         string   `json:"status"`
+}
+
+// subscriptionCreateRequest mirrors the POST /webhooks/v2/subscriptions body.
+type subscriptionCreateRequest struct {
+	ConsumerURL     string   `json:"consumerUrl"`
+	TechContact     string   `json:"techContact"`
+	TopicNames      []string `json:"topicNames"`
+	IntegrationType string   `json:"integrationType,omitempty"`
+}
+
+// subscriptionUpdateRequest mirrors the PUT /webhooks/v2/subscriptions/{id} body.
+// Only technicalContact and topicNames are mutable on AccuLynx.
+type subscriptionUpdateRequest struct {
+	TechnicalContact string   `json:"technicalContact,omitempty"`
+	TopicNames       []string `json:"topicNames"`
+}
+
+// subscriptionCreateResponse mirrors the POST response.
+type subscriptionCreateResponse struct {
+	SubscriptionID string `json:"subscriptionId"`
+}
+
+// objectEventTopics maps (object, framework event) to AccuLynx topic name.
+// AccuLynx has no delete topics; non-standard topics go via PassThroughEvents.
+//
+//nolint:gochecknoglobals
+var objectEventTopics = map[common.ObjectName]map[common.SubscriptionEventType][]string{
+	objectContacts: {
+		common.SubscriptionEventTypeCreate: {"contact_added"},
+		common.SubscriptionEventTypeUpdate: {"contact_changed"},
+	},
+	objectJobs: {
+		common.SubscriptionEventTypeCreate: {"job_created"},
+		common.SubscriptionEventTypeUpdate: {"job_updated"},
+	},
+}
+
+// validAcculynxTopics is the complete set of topicNames AccuLynx accepts on
+// POST /webhooks/v2/subscriptions, verified live via GET /webhooks/v2/topics.
+//
+//nolint:gochecknoglobals
+var validAcculynxTopics = datautils.NewStringSet(
+	"contact_added",
+	"contact_changed",
+	"contact.custom-field.status_changed",
+	"contact.custom-field.value_changed",
+	"job_created",
+	"job_updated",
+	"job.accounting.integration-status.current_changed",
+	"job.appointments.initial_created",
+	"job.appointments.initial_updated",
+	"job.category_changed",
+	"job.contacts.primary_changed",
+	"job.custom-field.status_changed",
+	"job.custom-field.value_changed",
+	"job.financials.approved-value_changed",
+	"job.invoice_updated",
+	"job.invoice_voided",
+	"job.milestone.current_changed",
+	"job.milestone.status.current_changed",
+	"job.representatives.company_assigned",
+	"job.representatives.company_changed",
+	"job.trade-type_changed",
+	"job.work-type_changed",
+)
+
+func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
+	return &common.SubscribeParams{
+		Request: &SubscriptionRequest{},
+	}
+}
+
+func (c *Connector) EmptySubscriptionResult() *common.SubscriptionResult {
+	return &common.SubscriptionResult{
+		Result: &SubscriptionResult{},
+	}
+}
+
+// Subscribe creates a single AccuLynx subscription containing every topic
+// resolved from the requested SubscriptionEvents.
+func (c *Connector) Subscribe(
+	ctx context.Context, params common.SubscribeParams,
+) (*common.SubscriptionResult, error) {
+	req, err := validateSubscribeRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	topics, err := resolveTopics(params.SubscriptionEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := subscriptionCreateRequest{
+		ConsumerURL:     req.ConsumerURL,
+		TechContact:     req.TechContact,
+		TopicNames:      topics,
+		IntegrationType: "Api",
+	}
+
+	created, err := c.createSubscription(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.SubscriptionResult{
+		Status:       common.SubscriptionStatusSuccess,
+		ObjectEvents: params.SubscriptionEvents,
+		Result: &SubscriptionResult{
+			SubscriptionID: created.SubscriptionID,
+			ConsumerURL:    req.ConsumerURL,
+			TechContact:    req.TechContact,
+			TopicNames:     topics,
+			Status:         "enabled",
+		},
+	}, nil
+}
+
+// UpdateSubscription replaces the topic list on the existing subscription.
+// Returns an error if the caller asks to change consumerUrl (immutable on AccuLynx).
+func (c *Connector) UpdateSubscription(
+	ctx context.Context, params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	req, err := validateSubscribeRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	prev, err := extractSubscriptionResult(previousResult)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.ConsumerURL != prev.ConsumerURL {
+		return nil, fmt.Errorf("%w: consumerUrl is immutable on AccuLynx (%s -> %s)",
+			errInvalidSubscribeRequestType, prev.ConsumerURL, req.ConsumerURL)
+	}
+
+	topics, err := resolveTopics(params.SubscriptionEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := subscriptionUpdateRequest{
+		TechnicalContact: req.TechContact,
+		TopicNames:       topics,
+	}
+
+	if err := c.updateSubscription(ctx, prev.SubscriptionID, payload); err != nil {
+		return nil, err
+	}
+
+	return &common.SubscriptionResult{
+		Status:       common.SubscriptionStatusSuccess,
+		ObjectEvents: params.SubscriptionEvents,
+		Result: &SubscriptionResult{
+			SubscriptionID: prev.SubscriptionID,
+			ConsumerURL:    prev.ConsumerURL,
+			TechContact:    req.TechContact,
+			TopicNames:     topics,
+			Status:         prev.Status,
+		},
+	}, nil
+}
+
+// DeleteSubscription removes the subscription identified by previousResult.
+func (c *Connector) DeleteSubscription(
+	ctx context.Context, previousResult common.SubscriptionResult,
+) error {
+	prev, err := extractSubscriptionResult(&previousResult)
+	if err != nil {
+		return err
+	}
+
+	return c.deleteSubscription(ctx, prev.SubscriptionID)
+}
+
+func (c *Connector) createSubscription(
+	ctx context.Context, payload subscriptionCreateRequest,
+) (*subscriptionCreateResponse, error) {
+	u, err := c.subscriptionsURL()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Post(ctx, u.String(), payload)
+	if err != nil {
+		return nil, fmt.Errorf("create subscription: %w", err)
+	}
+
+	parsed, err := common.UnmarshalJSON[subscriptionCreateResponse](resp)
+	if err != nil {
+		return nil, fmt.Errorf("parse create subscription response: %w", err)
+	}
+
+	if parsed == nil || parsed.SubscriptionID == "" {
+		return nil, errEmptySubscriptionID
+	}
+
+	return parsed, nil
+}
+
+// updateSubscription sends the PUT. AccuLynx returns 200 with an empty body,
+// so there is no parsed result to return.
+func (c *Connector) updateSubscription(
+	ctx context.Context, subscriptionID string, payload subscriptionUpdateRequest,
+) error {
+	u, err := c.subscriptionByIDURL(subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.JSONHTTPClient().Put(ctx, u.String(), payload)
+	if err != nil {
+		return fmt.Errorf("update subscription %s: %w", subscriptionID, err)
+	}
+
+	return nil
+}
+
+func (c *Connector) deleteSubscription(ctx context.Context, subscriptionID string) error {
+	u, err := c.subscriptionByIDURL(subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.JSONHTTPClient().Delete(ctx, u.String())
+	if err != nil {
+		return fmt.Errorf("delete subscription %s: %w", subscriptionID, err)
+	}
+
+	return nil
+}
+
+func (c *Connector) subscriptionsURL() (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, webhooksVersionPrefix, subscriptionsPath)
+}
+
+func (c *Connector) subscriptionByIDURL(subscriptionID string) (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ProviderInfo().BaseURL, webhooksVersionPrefix, subscriptionsPath, subscriptionID)
+}
+
+func validateSubscribeRequest(params common.SubscribeParams) (*SubscriptionRequest, error) {
+	if params.Request == nil {
+		return nil, fmt.Errorf("%w: Request is nil", errMissingSubscribeParams)
+	}
+
+	req, ok := params.Request.(*SubscriptionRequest)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected *SubscriptionRequest, got %T",
+			errInvalidSubscribeRequestType, params.Request)
+	}
+
+	if err := validator.New().Struct(req); err != nil {
+		return nil, fmt.Errorf("%w: %w", errInvalidSubscribeRequestType, err)
+	}
+
+	return req, nil
+}
+
+func extractSubscriptionResult(result *common.SubscriptionResult) (*SubscriptionResult, error) {
+	if result == nil || result.Result == nil {
+		return nil, fmt.Errorf("%w: previousResult.Result is nil", errInvalidSubscriptionResult)
+	}
+
+	prev, ok := result.Result.(*SubscriptionResult)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected *SubscriptionResult, got %T",
+			errInvalidSubscriptionResult, result.Result)
+	}
+
+	if prev.SubscriptionID == "" {
+		return nil, fmt.Errorf("%w: missing SubscriptionID", errInvalidSubscriptionResult)
+	}
+
+	return prev, nil
+}
+
+// resolveTopics returns the deduplicated, sorted AccuLynx topic-name slice
+// for the given events. Objects must be in objectEventTopics; pass-through
+// events must be in validAcculynxTopics.
+func resolveTopics(events map[common.ObjectName]common.ObjectEvents) ([]string, error) {
+	seen := datautils.NewSet[string]()
+
+	for obj, objEvents := range events {
+		if err := appendObjectTopics(obj, objEvents, seen); err != nil {
+			return nil, err
+		}
+	}
+
+	if seen.IsEmpty() {
+		return nil, errNoTopicsResolved
+	}
+
+	topics := seen.List()
+	slices.Sort(topics)
+
+	return topics, nil
+}
+
+func appendObjectTopics(
+	obj common.ObjectName,
+	objEvents common.ObjectEvents,
+	seen datautils.Set[string],
+) error {
+	objMap, supported := objectEventTopics[obj]
+	if !supported && len(objEvents.PassThroughEvents) == 0 {
+		return fmt.Errorf("%w: %s", errUnsupportedSubscribeObject, obj)
+	}
+
+	for _, evt := range objEvents.Events {
+		topics, ok := objMap[evt]
+		if !ok {
+			return fmt.Errorf("%w: object=%s event=%s",
+				errUnsupportedSubscribeEvent, obj, evt)
+		}
+
+		for _, t := range topics {
+			seen.AddOne(t)
+		}
+	}
+
+	for _, raw := range objEvents.PassThroughEvents {
+		if !validAcculynxTopics.Has(raw) {
+			return fmt.Errorf("%w: %s", errUnknownPassThroughTopic, raw)
+		}
+
+		seen.AddOne(raw)
+	}
+
+	return nil
+}

--- a/providers/acculynx/subscribe_test.go
+++ b/providers/acculynx/subscribe_test.go
@@ -1,0 +1,471 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"gotest.tools/v3/assert"
+)
+
+func TestResolveTopics_StandardEvents(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectContacts: {Events: []common.SubscriptionEventType{
+			common.SubscriptionEventTypeCreate,
+			common.SubscriptionEventTypeUpdate,
+		}},
+		objectJobs: {Events: []common.SubscriptionEventType{
+			common.SubscriptionEventTypeCreate,
+		}},
+	}
+
+	got, err := resolveTopics(events)
+	assert.NilError(t, err)
+
+	expected := []string{"contact_added", "contact_changed", "job_created"}
+	assert.DeepEqual(t, got, expected)
+}
+
+func TestResolveTopics_MergesPassThroughEvents(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectJobs: {
+			Events: []common.SubscriptionEventType{common.SubscriptionEventTypeUpdate},
+			PassThroughEvents: []string{
+				"job.milestone.current_changed",
+				"job.financials.approved-value_changed",
+			},
+		},
+	}
+
+	got, err := resolveTopics(events)
+	assert.NilError(t, err)
+	assert.Assert(t, slices.Contains(got, "job_updated"))
+	assert.Assert(t, slices.Contains(got, "job.milestone.current_changed"))
+	assert.Assert(t, slices.Contains(got, "job.financials.approved-value_changed"))
+}
+
+func TestResolveTopics_DeduplicatesAcrossSources(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectJobs: {
+			Events:            []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
+			PassThroughEvents: []string{"job_created", "job_updated"},
+		},
+	}
+
+	got, err := resolveTopics(events)
+	assert.NilError(t, err)
+
+	count := 0
+	for _, t := range got {
+		if t == "job_created" {
+			count++
+		}
+	}
+
+	assert.Equal(t, count, 1, "job_created should appear exactly once")
+}
+
+func TestResolveTopics_RejectsUnsupportedObject(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		"leads": {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+	}
+
+	_, err := resolveTopics(events)
+	assert.Assert(t, errors.Is(err, errUnsupportedSubscribeObject))
+}
+
+func TestResolveTopics_RejectsDeleteEvent(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectContacts: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeDelete}},
+	}
+
+	_, err := resolveTopics(events)
+	assert.Assert(t, errors.Is(err, errUnsupportedSubscribeEvent))
+}
+
+func TestResolveTopics_RejectsUnknownPassThroughTopic(t *testing.T) {
+	t.Parallel()
+
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectJobs: {
+			Events:            []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
+			PassThroughEvents: []string{"job.invented_event"},
+		},
+	}
+
+	_, err := resolveTopics(events)
+	assert.Assert(t, errors.Is(err, errUnknownPassThroughTopic))
+}
+
+func TestResolveTopics_NoEventsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTopics(map[common.ObjectName]common.ObjectEvents{
+		objectContacts: {},
+	})
+	assert.Assert(t, errors.Is(err, errNoTopicsResolved))
+}
+
+func TestValidateSubscribeRequest_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil request", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := validateSubscribeRequest(common.SubscribeParams{})
+		assert.Assert(t, errors.Is(err, errMissingSubscribeParams))
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := validateSubscribeRequest(common.SubscribeParams{Request: "not a struct"})
+		assert.Assert(t, errors.Is(err, errInvalidSubscribeRequestType))
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := validateSubscribeRequest(common.SubscribeParams{Request: &SubscriptionRequest{}})
+		assert.Assert(t, errors.Is(err, errInvalidSubscribeRequestType))
+	})
+
+	t.Run("invalid email", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := validateSubscribeRequest(common.SubscribeParams{Request: &SubscriptionRequest{
+			ConsumerURL: "https://example.com/wh",
+			TechContact: "not-an-email",
+		}})
+		assert.Assert(t, errors.Is(err, errInvalidSubscribeRequestType))
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := validateSubscribeRequest(common.SubscribeParams{Request: &SubscriptionRequest{
+			ConsumerURL: "https://example.com/wh",
+			TechContact: "ops@example.com",
+		}})
+		assert.NilError(t, err)
+	})
+}
+
+func TestEmptyFactories(t *testing.T) {
+	t.Parallel()
+
+	c := &Connector{}
+
+	params := c.EmptySubscriptionParams()
+	assert.Assert(t, params != nil)
+	_, ok := params.Request.(*SubscriptionRequest)
+	assert.Assert(t, ok, "Request should be *SubscriptionRequest")
+
+	res := c.EmptySubscriptionResult()
+	assert.Assert(t, res != nil)
+	_, ok = res.Result.(*SubscriptionResult)
+	assert.Assert(t, ok, "Result should be *SubscriptionResult")
+}
+
+func TestVerifyWebhookMessage_PlaceholderAcceptsAll(t *testing.T) {
+	t.Parallel()
+
+	c := &Connector{}
+
+	ok, err := c.VerifyWebhookMessage(context.Background(), nil, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, ok, "placeholder should return true until verification mechanism is known")
+}
+
+func TestSubscribe_PostsToCreateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/webhooks/v2/subscriptions"),
+		},
+		Then: mockserver.ResponseString(http.StatusCreated,
+			`{"subscriptionId":"sub-abc-123"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	res, err := conn.Subscribe(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, res.Status, common.SubscriptionStatusSuccess)
+
+	stored, ok := res.Result.(*SubscriptionResult)
+	assert.Assert(t, ok)
+	assert.Equal(t, stored.SubscriptionID, "sub-abc-123")
+	assert.DeepEqual(t, stored.TopicNames, []string{"job_created"})
+}
+
+func TestUpdateSubscription_PutsToSubscriptionByIdEndpoint(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodPUT(),
+			mockcond.Path("/webhooks/v2/subscriptions/sub-abc-123"),
+		},
+		Then: mockserver.Response(http.StatusNoContent),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	prev := &common.SubscriptionResult{
+		Result: &SubscriptionResult{
+			SubscriptionID: "sub-abc-123",
+			ConsumerURL:    "https://listener.example.com/wh",
+			TechContact:    "ops@example.com",
+			TopicNames:     []string{"job_created"},
+			Status:         "enabled",
+		},
+	}
+
+	res, err := conn.UpdateSubscription(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{
+				common.SubscriptionEventTypeCreate,
+				common.SubscriptionEventTypeUpdate,
+			}},
+		},
+	}, prev)
+
+	assert.NilError(t, err)
+	assert.Equal(t, res.Status, common.SubscriptionStatusSuccess)
+
+	stored, ok := res.Result.(*SubscriptionResult)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, stored.TopicNames, []string{"job_created", "job_updated"})
+}
+
+func TestUpdateSubscription_RejectsConsumerUrlChange(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	prev := &common.SubscriptionResult{
+		Result: &SubscriptionResult{
+			SubscriptionID: "sub-abc",
+			ConsumerURL:    "https://original.example.com/wh",
+		},
+	}
+
+	_, err = conn.UpdateSubscription(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://different.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	}, prev)
+
+	assert.Assert(t, errors.Is(err, errInvalidSubscribeRequestType))
+}
+
+func TestDeleteSubscription_DeletesById(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodDELETE(),
+			mockcond.Path("/webhooks/v2/subscriptions/sub-abc-123"),
+		},
+		Then: mockserver.Response(http.StatusNoContent),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	err = conn.DeleteSubscription(context.Background(), common.SubscriptionResult{
+		Result: &SubscriptionResult{SubscriptionID: "sub-abc-123"},
+	})
+
+	assert.NilError(t, err)
+}
+
+func TestDeleteSubscription_MissingIdReturnsError(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	err = conn.DeleteSubscription(context.Background(), common.SubscriptionResult{
+		Result: &SubscriptionResult{},
+	})
+
+	assert.Assert(t, errors.Is(err, errInvalidSubscriptionResult))
+}
+
+// Subscribe must reject a 200 response that omits subscriptionId — without this
+// check we would persist a SubscriptionResult with no way to update/delete it later.
+func TestSubscribe_RejectsEmptySubscriptionID(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/webhooks/v2/subscriptions"),
+		},
+		Then: mockserver.ResponseString(http.StatusOK, `{}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	_, err = conn.Subscribe(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	})
+
+	assert.Assert(t, errors.Is(err, errEmptySubscriptionID))
+}
+
+func TestSubscribe_PropagatesHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/webhooks/v2/subscriptions"),
+		},
+		Then: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"upstream"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	_, err = conn.Subscribe(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	})
+
+	assert.Assert(t, err != nil, "5xx from AccuLynx should surface as an error")
+}
+
+// UpdateSubscription must refuse to operate without a usable previousResult —
+// otherwise it would try to PUT to /subscriptions/ (empty id) and corrupt state.
+func TestUpdateSubscription_RejectsMissingPreviousResult(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestReadConnector("http://unused")
+	assert.NilError(t, err)
+
+	_, err = conn.UpdateSubscription(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	}, nil)
+
+	assert.Assert(t, errors.Is(err, errInvalidSubscriptionResult))
+}
+
+func TestUpdateSubscription_PropagatesHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodPUT(),
+			mockcond.Path("/webhooks/v2/subscriptions/sub-abc-123"),
+		},
+		Then: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"upstream"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	prev := &common.SubscriptionResult{
+		Result: &SubscriptionResult{
+			SubscriptionID: "sub-abc-123",
+			ConsumerURL:    "https://listener.example.com/wh",
+		},
+	}
+
+	_, err = conn.UpdateSubscription(context.Background(), common.SubscribeParams{
+		Request: &SubscriptionRequest{
+			ConsumerURL: "https://listener.example.com/wh",
+			TechContact: "ops@example.com",
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			objectJobs: {Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate}},
+		},
+	}, prev)
+
+	assert.Assert(t, err != nil, "5xx from AccuLynx should surface as an error")
+}
+
+func TestDeleteSubscription_PropagatesHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodDELETE(),
+			mockcond.Path("/webhooks/v2/subscriptions/sub-abc-123"),
+		},
+		Then: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"upstream"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	err = conn.DeleteSubscription(context.Background(), common.SubscriptionResult{
+		Result: &SubscriptionResult{SubscriptionID: "sub-abc-123"},
+	})
+
+	assert.Assert(t, err != nil, "5xx from AccuLynx should surface as an error")
+}

--- a/providers/acculynx/subscriptionEvent.go
+++ b/providers/acculynx/subscriptionEvent.go
@@ -1,0 +1,271 @@
+package acculynx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// SubscriptionEvent is the parsed AccuLynx webhook payload. The documented
+// payload shape is stale: real deliveries use lowercase "event", nest the
+// record under event.<object>.id, and omit companyId entirely.
+//
+// Sample delivery (contact_added):
+//
+//	{
+//	  "topicName":      "contact_added",
+//	  "eventDateTime":  "2026-05-26T14:23:55.4999782Z",
+//	  "eventId":        "38e4c045-2a6c-43f2-8309-ac8b5fc3fc2b",
+//	  "subscriptionId": "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8",
+//	  "event": {
+//	    "contact": {
+//	      "id":   "eadaaa11-1276-4166-bb93-db02f46b39a2",
+//	      "date": "2026-05-26T14:23:55.2976156Z",
+//	      "_link": "https://api.acculynx.com/api/v2/contacts/eadaaa11-..."
+//	    }
+//	  }
+//	}
+type SubscriptionEvent map[string]any
+
+var (
+	_ common.SubscriptionEvent       = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent = SubscriptionEvent{}
+)
+
+const (
+	eventFieldTopicName      = "topicName"
+	eventFieldEventDateTime  = "eventDateTime"
+	eventFieldEvent          = "event"
+	eventFieldSubscriptionID = "subscriptionId"
+
+	objectWrapperJob     = "job"
+	objectWrapperContact = "contact"
+
+	innerFieldID = "id"
+)
+
+var (
+	errMissingTopicName      = errors.New("acculynx event: missing topicName")
+	errUnsupportedTopicName  = errors.New("acculynx event: topicName does not map to a supported object")
+	errMissingInnerEvent     = errors.New("acculynx event: missing inner event payload")
+	errMissingObjectWrapper  = errors.New("acculynx event: missing object wrapper inside event")
+	errMissingSubscriptionID = errors.New("acculynx event: missing subscriptionId")
+	errMissingRecordID       = errors.New("acculynx event: missing record id for topic")
+	errUnparsableEventTime   = errors.New("acculynx event: unparsable eventDateTime")
+	// errParentRecordIDUnavailable is returned for topics whose payload omits
+	// the parent contact/job id entirely (only the changed sub-object is sent).
+	errParentRecordIDUnavailable = errors.New(
+		"acculynx event: parent record id is not available in payload for this topic")
+)
+
+//nolint:gochecknoglobals
+var topicsWithoutParentRecordID = datautils.NewStringSet(
+	"contact.custom-field.status_changed",
+	"job.custom-field.status_changed",
+)
+
+// PreLoadData is a no-op for AccuLynx — webhook payloads are self-contained.
+func (e SubscriptionEvent) PreLoadData(_ *common.SubscriptionEventPreLoadData) error {
+	return nil
+}
+
+// RawMap returns a defensive clone so callers don't mutate the original.
+func (e SubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(e), nil
+}
+
+// RawEventName returns AccuLynx's topicName verbatim (e.g. "job_created").
+func (e SubscriptionEvent) RawEventName() (string, error) {
+	topic, ok := e[eventFieldTopicName].(string)
+	if !ok || topic == "" {
+		return "", errMissingTopicName
+	}
+
+	return topic, nil
+}
+
+// EventType maps the topic suffix to Create / Update / Other. AccuLynx has
+// no delete topics.
+func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
+	topic, err := e.RawEventName()
+	if err != nil {
+		return common.SubscriptionEventTypeOther, err
+	}
+
+	switch {
+	case strings.HasSuffix(topic, "_added"), strings.HasSuffix(topic, "_created"):
+		return common.SubscriptionEventTypeCreate, nil
+	case strings.HasSuffix(topic, "_changed"),
+		strings.HasSuffix(topic, "_updated"),
+		strings.HasSuffix(topic, "_voided"):
+		return common.SubscriptionEventTypeUpdate, nil
+	default:
+		return common.SubscriptionEventTypeOther, nil
+	}
+}
+
+// ObjectName derives the target object from the topic prefix
+// (contact* → contacts, job* → jobs).
+func (e SubscriptionEvent) ObjectName() (string, error) {
+	topic, err := e.RawEventName()
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case strings.HasPrefix(topic, "contact"):
+		return objectContacts, nil
+	case strings.HasPrefix(topic, "job"):
+		return objectJobs, nil
+	default:
+		return "", fmt.Errorf("%w: %s", errUnsupportedTopicName, topic)
+	}
+}
+
+// Workspace returns the top-level subscriptionId. AccuLynx enforces one
+// subscription per installation, making it a 1:1 proxy for the installation.
+func (e SubscriptionEvent) Workspace() (string, error) {
+	subID, ok := e[eventFieldSubscriptionID].(string)
+	if !ok || subID == "" {
+		return "", errMissingSubscriptionID
+	}
+
+	return subID, nil
+}
+
+// RecordId returns the affected contact/job id from event.<object>.id.
+// Returns errParentRecordIDUnavailable for topics where AccuLynx omits the
+// parent id (see topicsWithoutParentRecordID).
+func (e SubscriptionEvent) RecordId() (string, error) {
+	topic, err := e.RawEventName()
+	if err != nil {
+		return "", err
+	}
+
+	if topicsWithoutParentRecordID.Has(topic) {
+		return "", fmt.Errorf("%w (%s)", errParentRecordIDUnavailable, topic)
+	}
+
+	wrapper, err := e.objectWrapper()
+	if err != nil {
+		return "", err
+	}
+
+	id, ok := wrapper[innerFieldID].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("%w (%s)", errMissingRecordID, topic)
+	}
+
+	return id, nil
+}
+
+// EventTimeStampNano parses AccuLynx's RFC3339Nano eventDateTime and returns
+// nanoseconds since epoch.
+func (e SubscriptionEvent) EventTimeStampNano() (int64, error) {
+	raw, ok := e[eventFieldEventDateTime].(string)
+	if !ok || raw == "" {
+		return 0, fmt.Errorf("%w: %v", errUnparsableEventTime, e[eventFieldEventDateTime])
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", errUnparsableEventTime, err)
+	}
+
+	return t.UnixNano(), nil
+}
+
+// topicToUpdatedFields maps each specific-change topic to its wire-format
+// field name under event.<object>. Generic and create topics resolve to an
+// empty slice in UpdatedFields.
+//
+//nolint:gochecknoglobals
+var topicToUpdatedFields = map[string][]string{
+	"job.milestone.current_changed":                     {"milestone"},
+	"job.milestone.status.current_changed":              {"milestone"},
+	"job.financials.approved-value_changed":             {"financials"},
+	"job.category_changed":                              {"jobCategory"},
+	"job.work-type_changed":                             {"workType"},
+	"job.trade-type_changed":                            {"tradeTypes"},
+	"job.contacts.primary_changed":                      {"contacts"},
+	"job.representatives.company_assigned":              {"companyRepresentative"},
+	"job.representatives.company_changed":               {"companyRepresentative"},
+	"job.appointments.initial_created":                  {"initialAppointment"},
+	"job.appointments.initial_updated":                  {"initialAppointment"},
+	"job.invoice_updated":                               {"invoice"},
+	"job.invoice_voided":                                {"invoice"},
+	"job.custom-field.value_changed":                    {"customField"},
+	"job.custom-field.status_changed":                   {"customField"},
+	"contact.custom-field.value_changed":                {"customField"},
+	"contact.custom-field.status_changed":               {"customField"},
+	"job.accounting.integration-status.current_changed": {"accounting"},
+}
+
+// UpdatedFields returns the field name(s) the topic implies. Empty slice for
+// generic update/create topics.
+func (e SubscriptionEvent) UpdatedFields() ([]string, error) {
+	topic, err := e.RawEventName()
+	if err != nil {
+		return nil, err
+	}
+
+	if fields, ok := topicToUpdatedFields[topic]; ok {
+		return fields, nil
+	}
+
+	return []string{}, nil
+}
+
+func (e SubscriptionEvent) innerEvent() (map[string]any, error) {
+	inner, ok := e[eventFieldEvent].(map[string]any)
+	if !ok {
+		return nil, errMissingInnerEvent
+	}
+
+	return inner, nil
+}
+
+func (e SubscriptionEvent) objectWrapper() (map[string]any, error) {
+	objName, err := e.ObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	inner, err := e.innerEvent()
+	if err != nil {
+		return nil, err
+	}
+
+	var key string
+
+	switch objName {
+	case objectContacts:
+		key = objectWrapperContact
+	case objectJobs:
+		key = objectWrapperJob
+	}
+
+	wrapper, ok := inner[key].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected event.%s", errMissingObjectWrapper, key)
+	}
+
+	return wrapper, nil
+}
+
+// VerifyWebhookMessage always returns true. AccuLynx's docs reference a
+// webhook secret, but the live API does not return one on subscription create
+// and deliveries carry no signing header (verified empirically).
+func (c *Connector) VerifyWebhookMessage(
+	_ context.Context,
+	_ *common.WebhookRequest,
+	_ *common.VerificationParams,
+) (bool, error) {
+	return true, nil
+}

--- a/providers/acculynx/subscriptionEvent_test.go
+++ b/providers/acculynx/subscriptionEvent_test.go
@@ -1,0 +1,449 @@
+package acculynx
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"gotest.tools/v3/assert"
+)
+
+func TestSubscriptionEvent_ObjectName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		topic    string
+		expected string
+		wantErr  error
+	}{
+		{"contact_added", objectContacts, nil},
+		{"contact_changed", objectContacts, nil},
+		{"contact.custom-field.value_changed", objectContacts, nil},
+		{"contact.custom-field.status_changed", objectContacts, nil},
+		{"job_created", objectJobs, nil},
+		{"job_updated", objectJobs, nil},
+		{"job.milestone.current_changed", objectJobs, nil},
+		{"job.financials.approved-value_changed", objectJobs, nil},
+		{"unsupported_topic", "", errUnsupportedTopicName},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.topic, func(t *testing.T) {
+			t.Parallel()
+
+			evt := SubscriptionEvent{eventFieldTopicName: tc.topic}
+
+			got, err := evt.ObjectName()
+			if tc.wantErr != nil {
+				assert.Assert(t, errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
+
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, got, tc.expected)
+		})
+	}
+}
+
+func TestSubscriptionEvent_EventType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		topic    string
+		expected common.SubscriptionEventType
+	}{
+		{"contact_added", common.SubscriptionEventTypeCreate},
+		{"job_created", common.SubscriptionEventTypeCreate},
+		{"job.appointments.initial_created", common.SubscriptionEventTypeCreate},
+		{"contact_changed", common.SubscriptionEventTypeUpdate},
+		{"job_updated", common.SubscriptionEventTypeUpdate},
+		{"job.milestone.current_changed", common.SubscriptionEventTypeUpdate},
+		{"job.invoice_voided", common.SubscriptionEventTypeUpdate},
+		{"job.something_weird", common.SubscriptionEventTypeOther},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.topic, func(t *testing.T) {
+			t.Parallel()
+
+			evt := SubscriptionEvent{eventFieldTopicName: tc.topic}
+
+			got, err := evt.EventType()
+
+			assert.NilError(t, err)
+			assert.Equal(t, got, tc.expected)
+		})
+	}
+}
+
+func TestSubscriptionEvent_Workspace_ReturnsSubscriptionId(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		eventFieldTopicName:      "job_created",
+		eventFieldSubscriptionID: "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8",
+		eventFieldEvent: map[string]any{
+			objectWrapperJob: map[string]any{
+				innerFieldID: "185548c3-3de4-4dca-b79d-e8cf38c0f776",
+			},
+		},
+	}
+
+	got, err := evt.Workspace()
+	assert.NilError(t, err)
+	assert.Equal(t, got, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
+}
+
+func TestSubscriptionEvent_Workspace_MissingSubscriptionIdReturnsError(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{eventFieldTopicName: "job_created"}
+
+	_, err := evt.Workspace()
+	assert.Assert(t, errors.Is(err, errMissingSubscriptionID))
+}
+
+func TestSubscriptionEvent_RecordId_RoutesByObjectType(t *testing.T) {
+	t.Parallel()
+
+	jobEvt := SubscriptionEvent{
+		eventFieldTopicName: "job.milestone.current_changed",
+		eventFieldEvent: map[string]any{
+			objectWrapperJob: map[string]any{
+				innerFieldID: "job-123",
+			},
+		},
+	}
+
+	jobID, err := jobEvt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, jobID, "job-123")
+
+	contactEvt := SubscriptionEvent{
+		eventFieldTopicName: "contact_changed",
+		eventFieldEvent: map[string]any{
+			objectWrapperContact: map[string]any{
+				innerFieldID: "contact-456",
+			},
+		},
+	}
+
+	contactID, err := contactEvt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, contactID, "contact-456")
+}
+
+func TestSubscriptionEvent_RecordId_MissingObjectWrapperReturnsError(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		eventFieldTopicName: "job_created",
+		eventFieldEvent:     map[string]any{},
+	}
+
+	_, err := evt.RecordId()
+	assert.Assert(t, errors.Is(err, errMissingObjectWrapper))
+}
+
+func TestSubscriptionEvent_RecordId_MissingIdReturnsError(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		eventFieldTopicName: "job_created",
+		eventFieldEvent: map[string]any{
+			objectWrapperJob: map[string]any{},
+		},
+	}
+
+	_, err := evt.RecordId()
+	assert.Assert(t, errors.Is(err, errMissingRecordID))
+}
+
+func TestSubscriptionEvent_EventTimeStampNano_ParsesRFC3339Nano(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		eventFieldEventDateTime: "2023-07-11T22:38:57.1993216Z",
+	}
+
+	got, err := evt.EventTimeStampNano()
+	assert.NilError(t, err)
+
+	expected := time.Date(2023, 7, 11, 22, 38, 57, 199321600, time.UTC).UnixNano()
+	assert.Equal(t, got, expected)
+}
+
+func TestSubscriptionEvent_EventTimeStampNano_RejectsBogus(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{eventFieldEventDateTime: "not a timestamp"}
+
+	_, err := evt.EventTimeStampNano()
+	assert.Assert(t, errors.Is(err, errUnparsableEventTime))
+}
+
+func TestSubscriptionEvent_RawEventName_ReturnsVerbatim(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{eventFieldTopicName: "job.milestone.current_changed"}
+
+	got, err := evt.RawEventName()
+	assert.NilError(t, err)
+	assert.Equal(t, got, "job.milestone.current_changed")
+}
+
+func TestSubscriptionEvent_RawEventName_MissingReturnsError(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{}
+
+	_, err := evt.RawEventName()
+	assert.Assert(t, errors.Is(err, errMissingTopicName))
+}
+
+func TestSubscriptionEvent_RawMap_ReturnsCloneNotAlias(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		eventFieldTopicName: "job_created",
+		eventFieldEvent: map[string]any{
+			objectWrapperJob: map[string]any{innerFieldID: "job-1"},
+		},
+	}
+
+	clone, err := evt.RawMap()
+	assert.NilError(t, err)
+
+	// Mutating the clone should not affect the original.
+	clone[eventFieldTopicName] = "tampered"
+	got, _ := evt.RawEventName()
+	assert.Equal(t, got, "job_created", "original should be unchanged")
+}
+
+func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		topic    string
+		expected []string
+	}{
+		// Specific-change topics — each maps to a single field name verified
+		// against live AccuLynx test-event payloads.
+		{"job.milestone.current_changed", []string{"milestone"}},
+		{"job.milestone.status.current_changed", []string{"milestone"}},
+		{"job.financials.approved-value_changed", []string{"financials"}},
+		{"job.category_changed", []string{"jobCategory"}},
+		{"job.work-type_changed", []string{"workType"}},
+		{"job.trade-type_changed", []string{"tradeTypes"}},
+		{"job.contacts.primary_changed", []string{"contacts"}},
+		{"job.representatives.company_assigned", []string{"companyRepresentative"}},
+		{"job.representatives.company_changed", []string{"companyRepresentative"}},
+		{"job.appointments.initial_created", []string{"initialAppointment"}},
+		{"job.appointments.initial_updated", []string{"initialAppointment"}},
+		{"job.invoice_updated", []string{"invoice"}},
+		{"job.invoice_voided", []string{"invoice"}},
+		{"job.custom-field.value_changed", []string{"customField"}},
+		{"job.custom-field.status_changed", []string{"customField"}},
+		{"contact.custom-field.value_changed", []string{"customField"}},
+		{"contact.custom-field.status_changed", []string{"customField"}},
+		{"job.accounting.integration-status.current_changed", []string{"accounting"}},
+		// Generic update topics — field is unknown, empty slice expected.
+		{"job_updated", []string{}},
+		{"contact_changed", []string{}},
+		// Create topics — not field-specific, empty slice expected.
+		{"job_created", []string{}},
+		{"contact_added", []string{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.topic, func(t *testing.T) {
+			t.Parallel()
+
+			evt := SubscriptionEvent{eventFieldTopicName: tc.topic}
+
+			got, err := evt.UpdatedFields()
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tc.expected)
+		})
+	}
+}
+
+func TestSubscriptionEvent_UpdatedFields_MissingTopicReturnsError(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{}
+
+	_, err := evt.UpdatedFields()
+	assert.Assert(t, errors.Is(err, errMissingTopicName))
+}
+
+// Real production payload captured live for contact_added — round-trips through
+// every accessor to lock in the verified wire format.
+func TestSubscriptionEvent_RealPayload_ContactAdded(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		"topicName":      "contact_added",
+		"eventDateTime":  "2026-05-26T14:23:55.4999782Z",
+		"eventId":        "38e4c045-2a6c-43f2-8309-ac8b5fc3fc2b",
+		"subscriptionId": "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8",
+		"event": map[string]any{
+			"contact": map[string]any{
+				"id":    "eadaaa11-1276-4166-bb93-db02f46b39a2",
+				"date":  "2026-05-26T14:23:55.2976156Z",
+				"_link": "https://api.acculynx.com/api/v2/contacts/eadaaa11-1276-4166-bb93-db02f46b39a2",
+			},
+		},
+	}
+
+	obj, err := evt.ObjectName()
+	assert.NilError(t, err)
+	assert.Equal(t, obj, objectContacts)
+
+	evtType, err := evt.EventType()
+	assert.NilError(t, err)
+	assert.Equal(t, evtType, common.SubscriptionEventTypeCreate)
+
+	ws, err := evt.Workspace()
+	assert.NilError(t, err)
+	assert.Equal(t, ws, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
+
+	rid, err := evt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, rid, "eadaaa11-1276-4166-bb93-db02f46b39a2")
+
+	raw, err := evt.RawEventName()
+	assert.NilError(t, err)
+	assert.Equal(t, raw, "contact_added")
+
+	ts, err := evt.EventTimeStampNano()
+	assert.NilError(t, err)
+	assert.Assert(t, ts > 0)
+
+	fields, err := evt.UpdatedFields()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, fields, []string{})
+}
+
+// Real production payload captured live for job.milestone.current_changed.
+func TestSubscriptionEvent_RealPayload_JobMilestoneChanged(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		"topicName":      "job.milestone.current_changed",
+		"eventDateTime":  "2026-05-26T13:28:42.400449Z",
+		"eventId":        "8ee2d58a-3062-462e-b1c2-57a9dd24921d",
+		"subscriptionId": "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8",
+		"event": map[string]any{
+			"job": map[string]any{
+				"id": "0fb0dfde-6cff-4590-a864-9823e10e58c0",
+				"milestone": map[string]any{
+					"id":        "5c60878e-8fb1-42a9-883d-9b734e800e7e",
+					"name":      "MilestoneName439637d0-d451-4a7a-a845-fdc6b3ed408e",
+					"isCurrent": true,
+				},
+				"_link": "https://api.acculynx.com/api/v2/jobs/0fb0dfde-6cff-4590-a864-9823e10e58c0",
+			},
+		},
+	}
+
+	obj, err := evt.ObjectName()
+	assert.NilError(t, err)
+	assert.Equal(t, obj, objectJobs)
+
+	evtType, err := evt.EventType()
+	assert.NilError(t, err)
+	assert.Equal(t, evtType, common.SubscriptionEventTypeUpdate)
+
+	ws, err := evt.Workspace()
+	assert.NilError(t, err)
+	assert.Equal(t, ws, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
+
+	rid, err := evt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, rid, "0fb0dfde-6cff-4590-a864-9823e10e58c0")
+
+	fields, err := evt.UpdatedFields()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, fields, []string{"milestone"})
+}
+
+// Real production payload captured live for job.invoice_updated — verifies the
+// invoice (singular) field path our mapping returns.
+func TestSubscriptionEvent_RealPayload_JobInvoiceUpdated(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		"topicName":      "job.invoice_updated",
+		"eventDateTime":  "2026-05-27T06:59:49.8688855Z",
+		"eventId":        "6f8adfd1-263a-466e-9031-bb005610e2ff",
+		"subscriptionId": "404d797c-af65-4ca3-a38e-a490ca222ad2",
+		"event": map[string]any{
+			"job": map[string]any{
+				"id": "9e22b9e5-787f-4052-9f47-1aad34f6f515",
+				"invoice": map[string]any{
+					"id":              "39e2c252-eb64-433b-a0c8-02258241df93",
+					"costTotal":       float64(23132),
+					"priceTotal":      float64(15358),
+					"amountCollected": float64(27235),
+				},
+				"_link": "https://api.acculynx.com/api/v2/jobs/9e22b9e5-787f-4052-9f47-1aad34f6f515",
+			},
+		},
+	}
+
+	rid, err := evt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, rid, "9e22b9e5-787f-4052-9f47-1aad34f6f515")
+
+	fields, err := evt.UpdatedFields()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, fields, []string{"invoice"})
+}
+
+// Verifies the special-case handling for *.custom-field.status_changed payloads:
+// AccuLynx omits the parent contact/job id entirely (only the changed
+// custom field's own id is delivered), so RecordId must return
+// errParentRecordIDUnavailable rather than a misleading id.
+func TestSubscriptionEvent_RecordId_CustomFieldStatusChanged_NoParentID(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"contact.custom-field.status_changed",
+		"job.custom-field.status_changed",
+	}
+
+	for _, topic := range cases {
+		t.Run(topic, func(t *testing.T) {
+			t.Parallel()
+
+			// Real wire shape: no contact/job wrapper — only customField.
+			evt := SubscriptionEvent{
+				eventFieldTopicName:      topic,
+				eventFieldSubscriptionID: "sub-xyz",
+				eventFieldEvent: map[string]any{
+					"customField": map[string]any{
+						"id":     "cf-id",
+						"label":  "Some Label",
+						"status": "Unknown",
+					},
+				},
+			}
+
+			// Other accessors still work.
+			obj, err := evt.ObjectName()
+			assert.NilError(t, err)
+			assert.Assert(t, obj == objectContacts || obj == objectJobs)
+
+			ws, err := evt.Workspace()
+			assert.NilError(t, err)
+			assert.Equal(t, ws, "sub-xyz")
+
+			// But RecordId fails with the dedicated sentinel so consumers can skip enrichment.
+			_, err = evt.RecordId()
+			assert.Assert(t, errors.Is(err, errParentRecordIDUnavailable))
+		})
+	}
+}

--- a/providers/acculynx/test/read/custom-fields/contact-001-values.json
+++ b/providers/acculynx/test/read/custom-fields/contact-001-values.json
@@ -1,0 +1,25 @@
+{
+  "totalRecords": 2,
+  "recordStartIndex": 0,
+  "pageSize": 100,
+  "items": [
+    {
+      "id": "cf-c1-text",
+      "_link": "https://api.acculynx.com/api/v2/contacts/ctc_001/custom-fields/cf-c1-text",
+      "label": "Customer Preference",
+      "fieldType": "Text",
+      "values": ["White Roof"],
+      "formattedValues": ["White Roof"],
+      "modifiedDate": "2026-04-10T12:00:00Z"
+    },
+    {
+      "id": "cf-c1-options",
+      "_link": "https://api.acculynx.com/api/v2/contacts/ctc_001/custom-fields/cf-c1-options",
+      "label": "Preferred Contact Method",
+      "fieldType": "Text",
+      "values": ["Phone", "Email"],
+      "formattedValues": ["Phone", "Email"],
+      "modifiedDate": "2026-04-10T12:00:00Z"
+    }
+  ]
+}

--- a/providers/acculynx/test/read/custom-fields/contact-002-values.json
+++ b/providers/acculynx/test/read/custom-fields/contact-002-values.json
@@ -1,0 +1,6 @@
+{
+  "totalRecords": 0,
+  "recordStartIndex": 0,
+  "pageSize": 100,
+  "items": []
+}

--- a/providers/acculynx/test/read/custom-fields/contacts-list.json
+++ b/providers/acculynx/test/read/custom-fields/contacts-list.json
@@ -1,0 +1,22 @@
+{
+  "totalRecords": 2,
+  "recordStartIndex": 0,
+  "pageSize": 100,
+  "pageNumber": 1,
+  "items": [
+    {
+      "id": "ctc_001",
+      "_link": "https://api.acculynx.com/api/v2/contacts/ctc_001",
+      "firstName": "Carol",
+      "lastName": "Customer",
+      "modifiedDate": "2026-04-10T12:00:00Z"
+    },
+    {
+      "id": "ctc_002",
+      "_link": "https://api.acculynx.com/api/v2/contacts/ctc_002",
+      "firstName": "Dave",
+      "lastName": "Donor",
+      "modifiedDate": "2026-04-11T12:00:00Z"
+    }
+  ]
+}

--- a/providers/acculynx/test/read/custom-fields/definitions-empty.json
+++ b/providers/acculynx/test/read/custom-fields/definitions-empty.json
@@ -1,0 +1,6 @@
+{
+  "totalRecords": 0,
+  "recordStartIndex": 0,
+  "pageSize": 100,
+  "items": []
+}

--- a/providers/acculynx/test/read/custom-fields/definitions.json
+++ b/providers/acculynx/test/read/custom-fields/definitions.json
@@ -1,0 +1,43 @@
+{
+  "totalRecords": 3,
+  "recordStartIndex": 0,
+  "pageSize": 100,
+  "items": [
+    {
+      "id": "def-contact-text",
+      "_link": "https://api.acculynx.com/api/v2/company-settings/custom-fields/def-contact-text",
+      "label": "Customer Preference",
+      "entityType": "Contact",
+      "fieldType": "Text",
+      "isActive": true,
+      "options": [],
+      "modifiedDate": "2026-04-01T10:00:00Z",
+      "createdDate": "2026-01-01T10:00:00Z"
+    },
+    {
+      "id": "def-contact-options",
+      "_link": "https://api.acculynx.com/api/v2/company-settings/custom-fields/def-contact-options",
+      "label": "Preferred Contact Method",
+      "entityType": "Contact",
+      "fieldType": "Text",
+      "isActive": true,
+      "options": [
+        { "id": "opt-1", "value": "Phone", "isActive": true, "sortOrder": 1 },
+        { "id": "opt-2", "value": "Email", "isActive": true, "sortOrder": 2 }
+      ],
+      "modifiedDate": "2026-04-02T10:00:00Z",
+      "createdDate": "2026-01-02T10:00:00Z"
+    },
+    {
+      "id": "def-job-number",
+      "_link": "https://api.acculynx.com/api/v2/company-settings/custom-fields/def-job-number",
+      "label": "Estimated Squares",
+      "entityType": "Job",
+      "fieldType": "Number",
+      "isActive": true,
+      "options": [],
+      "modifiedDate": "2026-04-03T10:00:00Z",
+      "createdDate": "2026-01-03T10:00:00Z"
+    }
+  ]
+}

--- a/providers/acculynx/test/write/contact-create.json
+++ b/providers/acculynx/test/write/contact-create.json
@@ -1,0 +1,4 @@
+{
+  "id": "ctc_001",
+  "_link": "https://api.acculynx.com/api/v2/contacts/ctc_001"
+}

--- a/providers/acculynx/test/write/job-create.json
+++ b/providers/acculynx/test/write/job-create.json
@@ -1,0 +1,4 @@
+{
+  "id": "job_001",
+  "_link": "https://api.acculynx.com/api/v2/jobs/job_001"
+}

--- a/providers/acculynx/write.go
+++ b/providers/acculynx/write.go
@@ -1,0 +1,308 @@
+package acculynx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+// AccuLynx write API references (all JSON; file-upload endpoints are excluded
+// — see metadata/README.md for the multipart exclusion rationale):
+//
+//   Create contact:                https://apidocs.acculynx.com/reference/postcontact
+//   Create job:                    https://apidocs.acculynx.com/reference/postjobs
+//   Update contact CF value:       https://apidocs.acculynx.com/reference/putcontactcustomfields
+//   Update job CF value:           https://apidocs.acculynx.com/reference/putjobcustomfield
+//   Set job AR/Sales/Company rep:  https://apidocs.acculynx.com/reference/postjobsarrepresentative
+//   Update initial appointment:    https://apidocs.acculynx.com/reference/putinitialappointmentforjob
+//   Set job insurance company:     https://apidocs.acculynx.com/reference/putjobsinsurance
+//   Add contact phone number:      https://apidocs.acculynx.com/reference/postcontactphonenumber
+//   Add contact log:               https://apidocs.acculynx.com/reference/postcontactlog
+//   Create external job reference: https://apidocs.acculynx.com/reference/postjobsexternalreferences
+//   Send job message:              https://apidocs.acculynx.com/reference/postjobmessage
+//   Reply to job message:          https://apidocs.acculynx.com/reference/postjobmessagereply
+//   Add payment (expense/paid/received):
+//     https://apidocs.acculynx.com/reference/postjobsadditionalexpense
+//     https://apidocs.acculynx.com/reference/postjobspaymentpaid
+//     https://apidocs.acculynx.com/reference/postjobspaymentreceived
+
+// Path-template parent-id keys carried in RecordData for nested writes.
+const (
+	parentIDKeyJobID     = "jobId"
+	parentIDKeyContactID = "contactId"
+	parentIDKeyMessageID = "messageId"
+)
+
+var errMissingParentID = errors.New("acculynx: missing parent id in record data")
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	if err := validateWriteParams(params); err != nil {
+		return nil, err
+	}
+
+	record, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	url, method, err := c.buildWriteURL(params, record)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("marshal record data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+// validateWriteParams rejects unsupported objects and operations early.
+// AccuLynx exposes no top-level updates and no general deletes.
+//
+//nolint:cyclop
+func validateWriteParams(params common.WriteParams) error {
+	switch params.ObjectName {
+	case objectContacts, objectJobs:
+		if params.IsUpdate() {
+			return common.ErrOperationNotSupportedForObject
+		}
+
+		return nil
+	case "contacts/custom-fields", "jobs/custom-fields":
+		if params.IsCreate() {
+			return common.ErrOperationNotSupportedForObject
+		}
+
+		return nil
+	case
+		// Job-singleton PUTs (set a slot on a job).
+		"jobs/initial-appointment",
+		"jobs/insurance/insurance-company",
+		// Job-rep POSTs (assign someone to a slot).
+		"jobs/representatives/ar-owner",
+		"jobs/representatives/sales-owner",
+		"jobs/representatives/company",
+		// Contact sub-resource POSTs.
+		"contacts/phone-numbers",
+		"contacts/logs",
+		// Job sub-resource POSTs.
+		"jobs/external-references",
+		"jobs/messages",
+		"jobs/messages/replies",
+		"jobs/payments/expense",
+		"jobs/payments/paid",
+		"jobs/payments/received":
+		if params.IsUpdate() {
+			return common.ErrOperationNotSupportedForObject
+		}
+
+		return nil
+	default:
+		return common.ErrOperationNotSupportedForObject
+	}
+}
+
+//nolint:cyclop,funlen
+func (c *Connector) buildWriteURL(
+	params common.WriteParams, record map[string]any,
+) (*urlbuilder.URL, string, error) {
+	baseURL := c.ProviderInfo().BaseURL
+
+	switch params.ObjectName {
+	// Top-level POSTs.
+	case objectContacts:
+		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "contacts")
+
+		return u, http.MethodPost, err
+
+	case objectJobs:
+		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "jobs")
+
+		return u, http.MethodPost, err
+
+	case "jobs/external-references":
+		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "jobs", "external-references")
+
+		return u, http.MethodPost, err
+
+	// Contact-nested PUTs/POSTs.
+	case "contacts/custom-fields":
+		u, err := c.buildContactNestedURL(record, "custom-fields", params.RecordId)
+
+		return u, http.MethodPut, err
+
+	case "contacts/phone-numbers":
+		u, err := c.buildContactNestedURL(record, "phone-numbers")
+
+		return u, http.MethodPost, err
+
+	case "contacts/logs":
+		u, err := c.buildContactNestedURL(record, "logs")
+
+		return u, http.MethodPost, err
+
+	// Job-nested PUTs.
+	case "jobs/custom-fields":
+		u, err := c.buildJobNestedURL(record, "custom-fields", params.RecordId)
+
+		return u, http.MethodPut, err
+
+	case "jobs/initial-appointment":
+		u, err := c.buildJobNestedURL(record, "initial-appointment")
+
+		return u, http.MethodPut, err
+
+	case "jobs/insurance/insurance-company":
+		u, err := c.buildJobNestedURL(record, "insurance", "insurance-company")
+
+		return u, http.MethodPut, err
+
+	// Job-nested POSTs (representatives + messages + payments).
+	case "jobs/representatives/ar-owner":
+		u, err := c.buildJobNestedURL(record, "representatives", "ar-owner")
+
+		return u, http.MethodPost, err
+
+	case "jobs/representatives/sales-owner":
+		u, err := c.buildJobNestedURL(record, "representatives", "sales-owner")
+
+		return u, http.MethodPost, err
+
+	case "jobs/representatives/company":
+		u, err := c.buildJobNestedURL(record, "representatives", "company")
+
+		return u, http.MethodPost, err
+
+	case "jobs/messages":
+		u, err := c.buildJobNestedURL(record, "messages")
+
+		return u, http.MethodPost, err
+
+	case "jobs/messages/replies":
+		messageID, ok := stringFromRecord(record, parentIDKeyMessageID)
+		if !ok {
+			return nil, "", fmt.Errorf("%w: %s", errMissingParentID, parentIDKeyMessageID)
+		}
+
+		u, err := c.buildJobNestedURL(record, "messages", messageID, "replies")
+
+		return u, http.MethodPost, err
+
+	case "jobs/payments/expense":
+		u, err := c.buildJobNestedURL(record, "payments", "expense")
+
+		return u, http.MethodPost, err
+
+	case "jobs/payments/paid":
+		u, err := c.buildJobNestedURL(record, "payments", "paid")
+
+		return u, http.MethodPost, err
+
+	case "jobs/payments/received":
+		u, err := c.buildJobNestedURL(record, "payments", "received")
+
+		return u, http.MethodPost, err
+
+	default:
+		return nil, "", common.ErrOperationNotSupportedForObject
+	}
+}
+
+// stringFromRecord pulls a parent-id from RecordData and removes it from the
+// map so it is not echoed back into the request body.
+func stringFromRecord(record map[string]any, key string) (string, bool) {
+	raw, ok := record[key]
+	if !ok {
+		return "", false
+	}
+
+	str, ok := raw.(string)
+	if !ok || str == "" {
+		return "", false
+	}
+
+	delete(record, key)
+
+	return str, true
+}
+
+// buildJobNestedURL extracts jobId from the record and builds a URL of the form
+// /api/v2/jobs/{jobId}/<segments...>. Returns errMissingParentID if jobId is
+// missing or empty in the record.
+func (c *Connector) buildJobNestedURL(record map[string]any, segments ...string) (*urlbuilder.URL, error) {
+	jobID, ok := stringFromRecord(record, parentIDKeyJobID)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errMissingParentID, parentIDKeyJobID)
+	}
+
+	path := append([]string{apiVersionPrefix, "jobs", jobID}, segments...)
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, path...)
+}
+
+// buildContactNestedURL extracts contactId from the record and builds a URL of
+// the form /api/v2/contacts/{contactId}/<segments...>.
+func (c *Connector) buildContactNestedURL(record map[string]any, segments ...string) (*urlbuilder.URL, error) {
+	contactID, ok := stringFromRecord(record, parentIDKeyContactID)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errMissingParentID, parentIDKeyContactID)
+	}
+
+	path := append([]string{apiVersionPrefix, "contacts", contactID}, segments...)
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, path...)
+}
+
+func (c *Connector) parseWriteResponse(
+	_ context.Context,
+	params common.WriteParams,
+	_ *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		// 204 No Content (PUT custom-fields). Echo the caller's RecordId so
+		// downstream code can correlate the update.
+		return &common.WriteResult{
+			Success:  true,
+			RecordId: params.RecordId,
+		}, nil
+	}
+
+	recordID, err := jsonquery.New(body).StrWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     data,
+	}, nil
+}

--- a/providers/acculynx/write.go
+++ b/providers/acculynx/write.go
@@ -11,6 +11,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/acculynx/metadata"
 )
 
 // AccuLynx write API references (all JSON; file-upload endpoints are excluded
@@ -132,17 +133,17 @@ func (c *Connector) buildWriteURL(
 	switch params.ObjectName {
 	// Top-level POSTs.
 	case objectContacts:
-		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "contacts")
+		u, err := urlbuilder.New(baseURL, c.modulePath(), "contacts")
 
 		return u, http.MethodPost, err
 
 	case objectJobs:
-		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "jobs")
+		u, err := urlbuilder.New(baseURL, c.modulePath(), "jobs")
 
 		return u, http.MethodPost, err
 
 	case "jobs/external-references":
-		u, err := urlbuilder.New(baseURL, apiVersionPrefix, "jobs", "external-references")
+		u, err := urlbuilder.New(baseURL, c.modulePath(), "jobs", "external-references")
 
 		return u, http.MethodPost, err
 
@@ -256,9 +257,16 @@ func (c *Connector) buildJobNestedURL(record map[string]any, segments ...string)
 		return nil, fmt.Errorf("%w: %s", errMissingParentID, parentIDKeyJobID)
 	}
 
-	path := append([]string{apiVersionPrefix, "jobs", jobID}, segments...)
+	path := append([]string{c.modulePath(), "jobs", jobID}, segments...)
 
 	return urlbuilder.New(c.ProviderInfo().BaseURL, path...)
+}
+
+// modulePath returns the module's URL prefix (e.g. "/api/v2") from schemas.json
+// root.path. Used by URL builders here that compose paths with dynamic record
+// IDs and therefore can't go through metadata.Schemas.LookupURLPath(objectName).
+func (c *Connector) modulePath() string {
+	return metadata.Schemas.LookupModuleURLPath(c.ProviderContext.Module())
 }
 
 // buildContactNestedURL extracts contactId from the record and builds a URL of
@@ -269,7 +277,7 @@ func (c *Connector) buildContactNestedURL(record map[string]any, segments ...str
 		return nil, fmt.Errorf("%w: %s", errMissingParentID, parentIDKeyContactID)
 	}
 
-	path := append([]string{apiVersionPrefix, "contacts", contactID}, segments...)
+	path := append([]string{c.modulePath(), "contacts", contactID}, segments...)
 
 	return urlbuilder.New(c.ProviderInfo().BaseURL, path...)
 }

--- a/providers/acculynx/write_test.go
+++ b/providers/acculynx/write_test.go
@@ -1,0 +1,508 @@
+package acculynx
+
+import (
+	_ "embed"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+//go:embed test/write/contact-create.json
+var contactCreateResponse []byte
+
+//go:embed test/write/job-create.json
+var jobCreateResponse []byte
+
+func TestWrite(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Object must be supported",
+			Input: common.WriteParams{
+				ObjectName: "users",
+				RecordData: map[string]any{"name": "test"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Update on contacts is not supported",
+			Input: common.WriteParams{
+				ObjectName: "contacts",
+				RecordId:   "ctc_001",
+				RecordData: map[string]any{"firstName": "Carol"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Create on jobs/custom-fields is not supported",
+			Input: common.WriteParams{
+				ObjectName: "jobs/custom-fields",
+				RecordData: map[string]any{"jobId": "job_001"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Create contact succeeds and returns recordId",
+			Input: common.WriteParams{
+				ObjectName: "contacts",
+				RecordData: map[string]any{
+					"firstName":      "Carol",
+					"lastName":       "Customer",
+					"contactTypeIds": []string{"52ba94c5-3ecf-4e7f-90cd-a91de12a72f5"},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/contacts"),
+						},
+						Then: mockserver.Response(http.StatusCreated, contactCreateResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "ctc_001",
+				Data: map[string]any{
+					"id": "ctc_001",
+					// Raw response field (_link) must round-trip through Data,
+					// proving the connector doesn't strip provider-returned fields.
+					"_link": "https://api.acculynx.com/api/v2/contacts/ctc_001",
+				},
+			},
+		},
+		{
+			Name: "Create job succeeds and returns recordId",
+			Input: common.WriteParams{
+				ObjectName: "jobs",
+				RecordData: map[string]any{
+					"contact": map[string]any{"id": "ctc_001"},
+					"notes":   "New roof",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs"),
+						},
+						Then: mockserver.Response(http.StatusCreated, jobCreateResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "job_001",
+				Data: map[string]any{
+					"id":    "job_001",
+					"_link": "https://api.acculynx.com/api/v2/jobs/job_001",
+				},
+			},
+		},
+		{
+			Name: "Update jobs/custom-fields succeeds with 204 and echoes recordId",
+			Input: common.WriteParams{
+				ObjectName: "jobs/custom-fields",
+				RecordId:   "cf_001",
+				RecordData: map[string]any{
+					"jobId":     "job_001",
+					"fieldType": "Text",
+					"values":    []string{"Updated value"},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPUT(),
+							mockcond.Path("/api/v2/jobs/job_001/custom-fields/cf_001"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "cf_001",
+			},
+		},
+		{
+			Name: "Update jobs/initial-appointment routes to PUT and uses jobId from record",
+			Input: common.WriteParams{
+				ObjectName: "jobs/initial-appointment",
+				RecordData: map[string]any{
+					"jobId":     "job_001",
+					"startDate": "2026-06-22T18:47:10Z",
+					"endDate":   "2026-06-22T19:47:10Z",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPUT(),
+							mockcond.Path("/api/v2/jobs/job_001/initial-appointment"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "Update jobs/insurance/insurance-company routes to PUT",
+			Input: common.WriteParams{
+				ObjectName: "jobs/insurance/insurance-company",
+				RecordData: map[string]any{
+					"jobId":              "job_001",
+					"insuranceCompanyId": "ins_001",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPUT(),
+							mockcond.Path("/api/v2/jobs/job_001/insurance/insurance-company"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/representatives/ar-owner routes correctly",
+			Input: common.WriteParams{
+				ObjectName: "jobs/representatives/ar-owner",
+				RecordData: map[string]any{
+					"jobId": "job_001",
+					"id":    "user_001",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/representatives/ar-owner"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/representatives/sales-owner routes correctly",
+			Input: common.WriteParams{
+				ObjectName: "jobs/representatives/sales-owner",
+				RecordData: map[string]any{
+					"jobId": "job_001",
+					"id":    "user_002",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/representatives/sales-owner"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/representatives/company routes correctly",
+			Input: common.WriteParams{
+				ObjectName: "jobs/representatives/company",
+				RecordData: map[string]any{
+					"jobId": "job_001",
+					"id":    "user_003",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/representatives/company"),
+						},
+						Then: mockserver.Response(http.StatusNoContent, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST contacts/phone-numbers fans out under the parent contact",
+			Input: common.WriteParams{
+				ObjectName: "contacts/phone-numbers",
+				RecordData: map[string]any{
+					"contactId": "ctc_001",
+					"number":    "5551234567",
+					"type":      "Mobile",
+					"primary":   true,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/contacts/ctc_001/phone-numbers"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST contacts/logs fans out under the parent contact",
+			Input: common.WriteParams{
+				ObjectName: "contacts/logs",
+				RecordData: map[string]any{
+					"contactId": "ctc_001",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/contacts/ctc_001/logs"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/external-references routes to top-level path (no parent in URL)",
+			Input: common.WriteParams{
+				ObjectName: "jobs/external-references",
+				RecordData: map[string]any{
+					"jobId":  "job_001",
+					"source": "test-source",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/external-references"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/messages fans out under parent job",
+			Input: common.WriteParams{
+				ObjectName: "jobs/messages",
+				RecordData: map[string]any{
+					"jobId":   "job_001",
+					"message": "Hello world",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/messages"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/messages/replies uses two-level fan-out (jobId + messageId)",
+			Input: common.WriteParams{
+				ObjectName: "jobs/messages/replies",
+				RecordData: map[string]any{
+					"jobId":     "job_001",
+					"messageId": "msg_001",
+					"message":   "Reply text",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/messages/msg_001/replies"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/payments/expense fans out under parent job",
+			Input: common.WriteParams{
+				ObjectName: "jobs/payments/expense",
+				RecordData: map[string]any{
+					"jobId":  "job_001",
+					"amount": 100,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/payments/expense"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/payments/paid fans out under parent job",
+			Input: common.WriteParams{
+				ObjectName: "jobs/payments/paid",
+				RecordData: map[string]any{
+					"jobId":  "job_001",
+					"amount": 200,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/payments/paid"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+		{
+			Name: "POST jobs/payments/received fans out under parent job",
+			Input: common.WriteParams{
+				ObjectName: "jobs/payments/received",
+				RecordData: map[string]any{
+					"jobId":  "job_001",
+					"amount": 300,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/api/v2/jobs/job_001/payments/received"),
+						},
+						Then: mockserver.Response(http.StatusCreated, nil),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected:   &common.WriteResult{Success: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestWriteConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestWriteConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		Module:              common.ModuleRoot,
+		AuthenticatedClient: &http.Client{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetUnitTestBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/test/acculynx/custom-fields/main.go
+++ b/test/acculynx/custom-fields/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	testAccuLynx "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// Exercises the read-side custom-fields resolver end-to-end. The connector:
+//   1. Fetches definitions from /company-settings/custom-fields
+//   2. For each parent record, fetches values from /{contacts|jobs}/{id}/custom-fields
+//   3. Joins definitions + values, surfacing fields by their human-readable
+//      label slug (e.g. "Customer Preference" → customer_preference) alongside
+//      built-in fields, while leaving Raw untouched.
+//
+// Requires a custom field with a populated value to actually demonstrate the
+// flatten — create one via AccuLynx UI (Settings → Custom Fields) and set a
+// value on at least one record before running.
+
+// Built-in field names per object — anything else surfaced in Fields is a
+// resolved custom field. The connector lowercases field names in the Fields
+// map (matching ReadParams.Fields normalization), so these are lowercase too.
+//
+//nolint:gochecknoglobals
+var (
+	builtinContactFields = map[string]bool{
+		"id": true, "firstname": true, "lastname": true, "salutation": true,
+		"crossreference": true, "companyname": true, "mailingaddress": true,
+		"billingaddress": true, "phonenumbers": true, "emailaddresses": true,
+		"_link": true,
+	}
+
+	builtinJobFields = map[string]bool{
+		"id": true, "jobname": true, "jobnumber": true, "priority": true,
+		"contacts": true, "locationaddress": true, "geolocation": true,
+		"tradetypes": true, "jobcategory": true, "worktype": true,
+		"leadsource": true, "leaddeadreason": true, "currentmilestone": true,
+		"milestonedate": true, "createddate": true, "modifieddate": true,
+		"initialappointment": true, "_link": true,
+	}
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testAccuLynx.GetAccuLynxConnector(ctx)
+
+	slog.Info("=== Test 1: ListObjectMetadata for contacts (includes custom field definitions) ===")
+	contactMeta := runMetadata(ctx, conn, "contacts")
+
+	slog.Info("=== Test 2: ListObjectMetadata for jobs (includes custom field definitions) ===")
+	jobMeta := runMetadata(ctx, conn, "jobs")
+
+	slog.Info("=== Test 3: Read contacts — verify resolver attaches values per record ===")
+	runReadAndFindCustomFields(ctx, conn, "contacts", contactMeta, builtinContactFields)
+
+	slog.Info("=== Test 4: Read jobs — verify resolver attaches values per record ===")
+	runReadAndFindCustomFields(ctx, conn, "jobs", jobMeta, builtinJobFields)
+
+	slog.Info("All custom-fields tests completed.")
+}
+
+func runMetadata(
+	ctx context.Context, conn *acculynx.Connector, objectName string,
+) *common.ListObjectMetadataResult {
+	res, err := conn.ListObjectMetadata(ctx, []string{objectName})
+	if err != nil {
+		slog.Error("ListObjectMetadata failed", "object", objectName, "error", err)
+
+		return nil
+	}
+
+	objMeta, ok := res.Result[objectName]
+	if !ok {
+		slog.Warn("Metadata result missing object", "object", objectName)
+		utils.DumpJSON(res, os.Stdout)
+
+		return res
+	}
+
+	slog.Info("Metadata fetched",
+		"object", objectName,
+		"displayName", objMeta.DisplayName,
+		"totalFields", len(objMeta.Fields))
+
+	utils.DumpJSON(res, os.Stdout)
+
+	return res
+}
+
+func runReadAndFindCustomFields(
+	ctx context.Context, conn *acculynx.Connector,
+	objectName string, meta *common.ListObjectMetadataResult, builtin map[string]bool,
+) {
+	// Build the Fields set from the metadata: this asks the connector for
+	// every field the object exposes, including custom-field slugs surfaced
+	// by ListObjectMetadata. Without this, ParseResultFiltered would drop
+	// resolved CF values from the output.
+	fieldNames := []string{"id"}
+	if obj, ok := meta.Result[objectName]; ok {
+		for name := range obj.FieldsMap {
+			fieldNames = append(fieldNames, name)
+		}
+	}
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields(fieldNames...),
+	})
+	if err != nil {
+		slog.Error("Read failed", "object", objectName, "error", err)
+
+		return
+	}
+
+	slog.Info("Read result", "object", objectName, "rows", res.Rows)
+
+	if len(res.Data) == 0 {
+		slog.Warn("Empty result — no records to inspect for custom fields", "object", objectName)
+
+		return
+	}
+
+	// Scan every record on the page for fields not in the built-in set. Only
+	// records that have a CF value set will surface anything — most won't.
+	hits := 0
+
+	for _, row := range res.Data {
+		extras := make(map[string]any)
+
+		for fieldName, value := range row.Fields {
+			// Skip built-ins and skip CF slugs that came back nil (the framework
+			// fills any requested field with nil on records that don't have it).
+			if builtin[fieldName] || value == nil {
+				continue
+			}
+
+			extras[fieldName] = value
+		}
+
+		if len(extras) == 0 {
+			continue
+		}
+
+		hits++
+
+		slog.Info("Custom fields resolved and attached to record",
+			"object", objectName, "recordId", row.Id, "customFields", extras)
+		utils.DumpJSON(row, os.Stdout)
+	}
+
+	if hits == 0 {
+		slog.Info("No custom field values found on any record in this page",
+			"object", objectName, "scanned", len(res.Data))
+	}
+}

--- a/test/acculynx/delete/main.go
+++ b/test/acculynx/delete/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	testAccuLynx "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// AccuLynx supports the following DELETE operations via the connector:
+//   - DELETE /jobs/{jobId}/representatives/ar-owner     (Remove AR Owner)
+//   - DELETE /jobs/{jobId}/representatives/sales-owner  (Remove Sales Owner)
+//
+// AccuLynx exposes no DELETE for top-level /contacts or /jobs — record
+// deletion is not part of its V2 API.
+
+// existingJobID is used as the RecordId for both delete operations. Pulled
+// from the sandbox; replace if testing against a different AccuLynx account.
+const existingJobID = "9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75"
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testAccuLynx.GetAccuLynxConnector(ctx)
+
+	slog.Info("=== Test 1: DELETE Job AR Owner ===")
+
+	if err := testDeleteARRepresentative(ctx, conn, existingJobID); err != nil {
+		slog.Error("Delete AR owner failed", "error", err)
+	} else {
+		slog.Info("✅ AR owner removed", "jobId", existingJobID)
+	}
+
+	slog.Info("=== Test 2: DELETE Job Sales Owner ===")
+
+	if err := testDeleteSalesRepresentative(ctx, conn, existingJobID); err != nil {
+		slog.Error("Delete sales owner failed", "error", err)
+	} else {
+		slog.Info("✅ Sales owner removed", "jobId", existingJobID)
+	}
+
+	slog.Info("All delete tests completed.")
+}
+
+func testDeleteARRepresentative(ctx context.Context, conn *acculynx.Connector, jobID string) error {
+	params := common.DeleteParams{
+		ObjectName: "jobs/representatives/ar-owner",
+		RecordId:   jobID,
+	}
+
+	slog.Info("Deleting AR owner", "jobId", jobID)
+
+	res, err := conn.Delete(ctx, params)
+	if err != nil {
+		return fmt.Errorf("delete AR owner: %w", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	return nil
+}
+
+func testDeleteSalesRepresentative(ctx context.Context, conn *acculynx.Connector, jobID string) error {
+	params := common.DeleteParams{
+		ObjectName: "jobs/representatives/sales-owner",
+		RecordId:   jobID,
+	}
+
+	slog.Info("Deleting sales owner", "jobId", jobID)
+
+	res, err := conn.Delete(ctx, params)
+	if err != nil {
+		return fmt.Errorf("delete sales owner: %w", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	return nil
+}

--- a/test/acculynx/subscribe/subscribe.go
+++ b/test/acculynx/subscribe/subscribe.go
@@ -1,0 +1,144 @@
+// Live scaffold: runs Subscribe → UpdateSubscription → DeleteSubscription.
+// AccuLynx allows one Enabled subscription per installation, so re-running
+// fails until any leftover is deleted.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	connTest "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+const (
+	consumerURL = "https://play.svix.com/in/e_t8O2GEkKHw4RL4bgd5a4it8Di5F/"
+	techContact = "me@ejazkarim.com"
+
+	// skipDelete keeps the subscription alive after Update so real events can
+	// be triggered against it. Requires manual cleanup via curl.
+	skipDelete = false
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetAccuLynxConnector(ctx)
+
+	subscribeParams := common.SubscribeParams{
+		Request: &acculynx.SubscriptionRequest{
+			ConsumerURL: consumerURL,
+			TechContact: techContact,
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"jobs": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeCreate,
+				},
+			},
+			"contacts": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeUpdate,
+				},
+			},
+		},
+	}
+
+	subscribeResult, err := conn.Subscribe(ctx, subscribeParams)
+	if err != nil {
+		logging.Logger(ctx).Error("Error subscribing",
+			"error", err, "subscribeResult", prettyPrint(subscribeResult))
+
+		return
+	}
+
+	fmt.Println("Subscribe results:", prettyPrint(subscribeResult))
+	fmt.Println("================================================")
+
+	updateParams := common.SubscribeParams{
+		Request: &acculynx.SubscriptionRequest{
+			ConsumerURL: consumerURL,
+			TechContact: techContact,
+		},
+		SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+			"jobs": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeCreate,
+					common.SubscriptionEventTypeUpdate,
+				},
+				PassThroughEvents: []string{
+					"job.milestone.current_changed",
+				},
+			},
+			"contacts": {
+				Events: []common.SubscriptionEventType{
+					common.SubscriptionEventTypeCreate,
+					common.SubscriptionEventTypeUpdate,
+				},
+			},
+		},
+	}
+
+	updateResult, err := conn.UpdateSubscription(ctx, updateParams, subscribeResult)
+	if err != nil {
+		logging.Logger(ctx).Error("Error updating subscription",
+			"error", err, "subscribeResult", prettyPrint(subscribeResult))
+
+		return
+	}
+
+	fmt.Println("Update results:", prettyPrint(updateResult))
+	fmt.Println("================================================")
+
+	if skipDelete {
+		printKeepAliveInstructions(updateResult)
+
+		return
+	}
+
+	if err := conn.DeleteSubscription(ctx, *updateResult); err != nil {
+		logging.Logger(ctx).Error("Error deleting subscription", "error", err)
+
+		return
+	}
+
+	fmt.Println("Delete subscription successful")
+}
+
+func printKeepAliveInstructions(result *common.SubscriptionResult) {
+	stored, ok := result.Result.(*acculynx.SubscriptionResult)
+	if !ok {
+		fmt.Println("subscription left alive but couldn't recover ID for cleanup instructions")
+
+		return
+	}
+
+	fmt.Println("Subscription left alive at:")
+	fmt.Println("  id:          ", stored.SubscriptionID)
+	fmt.Println("  consumerUrl: ", stored.ConsumerURL)
+	fmt.Println()
+	fmt.Println("Trigger an event from the AccuLynx UI (create/edit a job or contact) and")
+	fmt.Println("watch the consumerUrl for the delivered webhook.")
+	fmt.Println()
+	fmt.Println("When done, clean up manually:")
+	fmt.Printf("  curl -X DELETE -H 'Authorization: Bearer $TOKEN' \\\n"+
+		"    https://api.acculynx.com/webhooks/v2/subscriptions/%s\n", stored.SubscriptionID)
+}
+
+func prettyPrint(v any) string {
+	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	return string(jsonBytes)
+}

--- a/test/acculynx/write/main.go
+++ b/test/acculynx/write/main.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	testAccuLynx "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+// AccuLynx supported write operations (every JSON write endpoint AccuLynx
+// exposes; file-upload endpoints — documents/measurements/photos-videos —
+// require multipart and are intentionally excluded):
+//
+//   POST  /contacts                                   (Create contact)
+//   POST  /jobs                                       (Create job)
+//   PUT   /contacts/{id}/custom-fields/{fieldId}      (Update contact CF value)
+//   PUT   /jobs/{id}/custom-fields/{fieldId}          (Update job CF value)
+//   PUT   /jobs/{id}/initial-appointment              (Set appointment slot)
+//   PUT   /jobs/{id}/insurance/insurance-company      (Set insurance carrier)
+//   POST  /jobs/{id}/representatives/ar-owner         (Assign AR owner)
+//   POST  /jobs/{id}/representatives/sales-owner      (Assign sales owner)
+//   POST  /jobs/{id}/representatives/company          (Assign company rep)
+//   POST  /contacts/{id}/phone-numbers                (Add phone number)
+//   POST  /contacts/{id}/logs                         (Add log entry)
+//   POST  /jobs/external-references                   (Cross-system mapping)
+//   POST  /jobs/{id}/messages                         (Send message)
+//   POST  /jobs/{id}/messages/{messageId}/replies     (Reply to message)
+//   POST  /jobs/{id}/payments/expense                 (Add expense)
+//   POST  /jobs/{id}/payments/paid                    (Mark paid)
+//   POST  /jobs/{id}/payments/received                (Mark received)
+
+// Constants pulled from the AccuLynx sandbox; replace if testing against a
+// different account.
+const (
+	existingJobID           = "9ecc68c2-9beb-4b8f-a4b5-6f4e52a41d75"
+	customerContactTypeID   = "52ba94c5-3ecf-4e7f-90cd-a91de12a72f5" // "Customer" type
+	existingContactIDForJob = "f5d6d7fe-fd00-ef11-9149-3cecef1c5971" // contact linked to existingJobID
+	existingUserID          = "0c9b5100-bf4d-41d3-87c8-3729269baeef" // integrations user
+)
+
+func main() { //nolint:funlen,cyclop
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testAccuLynx.GetAccuLynxConnector(ctx)
+
+	slog.Info("=== Test 1: Create Contact (POST /contacts) ===")
+	contactID, err := testCreateContact(ctx, conn)
+	logResult("Create contact", contactID, err)
+
+	slog.Info("=== Test 2: Create Job (POST /jobs) ===")
+	contactIDForJob := contactID
+	if contactIDForJob == "" {
+		// Falls back to a known sandbox contact when Test 1 didn't return one.
+		contactIDForJob = existingContactIDForJob
+	}
+	jobID, err := testCreateJob(ctx, conn, contactIDForJob)
+	logResult("Create job", jobID, err)
+
+	// Placeholder fieldId — sandbox has no custom fields, so these will 404.
+	slog.Info("=== Test 3: PUT Contact Custom Field ===")
+	if contactID != "" {
+		runWrite(ctx, conn, "contacts/custom-fields", "00000000-0000-0000-0000-000000000001", map[string]any{
+			"contactId": contactID,
+			"fieldType": "Text",
+			"values":    []string{"ampersand-write-test"},
+		})
+	}
+
+	slog.Info("=== Test 4: PUT Job Custom Field ===")
+	runWrite(ctx, conn, "jobs/custom-fields", "00000000-0000-0000-0000-000000000001", map[string]any{
+		"jobId":     existingJobID,
+		"fieldType": "Text",
+		"values":    []string{"ampersand-write-test"},
+	})
+
+	slog.Info("=== Test 5: PUT Initial Appointment ===")
+	runWrite(ctx, conn, "jobs/initial-appointment", "", map[string]any{
+		"jobId":     existingJobID,
+		"startDate": "2026-06-22T18:47:10Z",
+		"endDate":   "2026-06-22T19:47:10Z",
+		"notes":     "Updated via Ampersand live write test",
+	})
+
+	slog.Info("=== Test 6: PUT Insurance Company (passes name instead of ID) ===")
+	runWrite(ctx, conn, "jobs/insurance/insurance-company", "", map[string]any{
+		"jobId":                existingJobID,
+		"insuranceCompanyName": "Ampersand Test Insurance",
+	})
+
+	slog.Info("=== Test 7: POST AR Owner ===")
+	runWrite(ctx, conn, "jobs/representatives/ar-owner", "", map[string]any{
+		"jobId": existingJobID,
+		"id":    existingUserID,
+	})
+
+	slog.Info("=== Test 8: POST Sales Owner ===")
+	runWrite(ctx, conn, "jobs/representatives/sales-owner", "", map[string]any{
+		"jobId": existingJobID,
+		"id":    existingUserID,
+	})
+
+	slog.Info("=== Test 9: POST Company Representative ===")
+	runWrite(ctx, conn, "jobs/representatives/company", "", map[string]any{
+		"jobId": existingJobID,
+		"id":    existingUserID,
+	})
+
+	if contactID != "" {
+		slog.Info("=== Test 10: POST Contact Phone Number ===")
+		runWrite(ctx, conn, "contacts/phone-numbers", "", map[string]any{
+			"contactId": contactID,
+			"number":    fmt.Sprintf("555%07d", gofakeit.Number(1000000, 9999999)),
+			"type":      "Mobile",
+			"primary":   false,
+		})
+
+		slog.Info("=== Test 11: POST Contact Log ===")
+		runWrite(ctx, conn, "contacts/logs", "", map[string]any{
+			"contactId": contactID,
+			"logDate":   time.Now().UTC().Format(time.RFC3339),
+			"type":      "PhoneCall",
+			"note":      "Ampersand live write test log entry",
+		})
+	}
+
+	slog.Info("=== Test 12: POST Job External Reference ===")
+	runWrite(ctx, conn, "jobs/external-references", "", map[string]any{
+		"jobId":     existingJobID,
+		"source":    "ampersand-test",
+		"projectId": fmt.Sprintf("amp-test-%d", time.Now().Unix()),
+	})
+
+	slog.Info("=== Test 13: POST Job Message ===")
+	runWrite(ctx, conn, "jobs/messages", "", map[string]any{
+		"jobId":   existingJobID,
+		"message": fmt.Sprintf("Ampersand live write test message %s", time.Now().Format(time.RFC3339)),
+	})
+
+	slog.Info("=== Test 14: POST Message Reply (will 404 unless messageId exists) ===")
+	runWrite(ctx, conn, "jobs/messages/replies", "", map[string]any{
+		"jobId":     existingJobID,
+		"messageId": "00000000-0000-0000-0000-000000000001",
+		"message":   "Ampersand test reply",
+	})
+
+	slog.Info("=== Test 15: POST Payment Expense ===")
+	runWrite(ctx, conn, "jobs/payments/expense", "", map[string]any{
+		"jobId":  existingJobID,
+		"to":     "Ampersand Test Vendor",
+		"amount": 100,
+		"notes":  "Live write test - expense",
+	})
+
+	slog.Info("=== Test 16: POST Payment Paid ===")
+	runWrite(ctx, conn, "jobs/payments/paid", "", map[string]any{
+		"jobId":       existingJobID,
+		"to":          "Ampersand Test Vendor",
+		"amount":      200,
+		"paymentDate": "2026-05-19T00:00:00Z",
+		"isPaid":      true,
+	})
+
+	slog.Info("=== Test 17: POST Payment Received ===")
+	runWrite(ctx, conn, "jobs/payments/received", "", map[string]any{
+		"jobId":       existingJobID,
+		"from":        "Ampersand Test Client",
+		"amount":      300,
+		"paymentDate": "2026-05-19T00:00:00Z",
+	})
+
+	slog.Info("All write tests completed.")
+}
+
+// runWrite invokes Write with the given params and logs the outcome. Errors are
+// recorded as warnings (not fatal) so subsequent tests still run — useful when
+// a sandbox is missing referenced IDs (insurance companies, account types,
+// pre-existing messages, etc.) but the connector code path itself is what we
+// want to verify.
+func runWrite(
+	ctx context.Context, conn *acculynx.Connector,
+	objectName, recordID string, recordData map[string]any,
+) {
+	params := common.WriteParams{
+		ObjectName: objectName,
+		RecordId:   recordID,
+		RecordData: recordData,
+	}
+
+	slog.Info("Write", "object", objectName, "recordId", recordID, "data", recordData)
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		slog.Warn("Write returned an error (may be expected if sandbox is missing referenced IDs)",
+			"object", objectName, "error", err)
+
+		return
+	}
+
+	slog.Info("✅ Write succeeded", "object", objectName, "recordId", res.RecordId, "success", res.Success)
+	utils.DumpJSON(res, os.Stdout)
+}
+
+func logResult(action, recordID string, err error) {
+	if err != nil {
+		slog.Error(action+" failed", "error", err)
+
+		return
+	}
+
+	slog.Info("✅ "+action+" succeeded", "recordId", recordID)
+}
+
+func testCreateContact(ctx context.Context, conn *acculynx.Connector) (string, error) {
+	recordData := map[string]any{
+		"contactTypeIds": []string{customerContactTypeID},
+		"firstName":      gofakeit.FirstName(),
+		"lastName":       gofakeit.LastName(),
+		"mailingAddress": map[string]any{
+			"street1": gofakeit.StreetName(),
+			"city":    gofakeit.City(),
+			"zipCode": gofakeit.Zip(),
+			"state":   map[string]any{"id": 46}, // Virginia (sandbox-known)
+			"country": map[string]any{"id": 1},  // United States
+		},
+	}
+
+	slog.Info("Creating contact", "data", recordData)
+
+	params := common.WriteParams{
+		ObjectName: "contacts",
+		RecordData: recordData,
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("create contact: %w", err)
+	}
+
+	slog.Info("Contact create result", "recordId", res.RecordId, "success", res.Success)
+	utils.DumpJSON(res, os.Stdout)
+
+	return res.RecordId, nil
+}
+
+func testCreateJob(ctx context.Context, conn *acculynx.Connector, contactID string) (string, error) {
+	recordData := map[string]any{
+		"contact": map[string]any{"id": contactID},
+		"notes":   fmt.Sprintf("Ampersand Test Job %s", time.Now().Format("2006-01-02T15:04:05Z")),
+		"locationAddress": map[string]any{
+			"street1": gofakeit.StreetName(),
+			"city":    gofakeit.City(),
+			"zipCode": gofakeit.Zip(),
+			"state":   "VA",
+			"country": "US",
+		},
+	}
+
+	slog.Info("Creating job", "data", recordData)
+
+	params := common.WriteParams{
+		ObjectName: "jobs",
+		RecordData: recordData,
+	}
+
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("create job: %w", err)
+	}
+
+	slog.Info("Job create result", "recordId", res.RecordId, "success", res.Success)
+	utils.DumpJSON(res, os.Stdout)
+
+	return res.RecordId, nil
+}


### PR DESCRIPTION
 # Description

  - [x] Connector uses `internal/components`
  - [x] Metadata uses V2 metadata format
  - [x] Read supports pagination and incremental sync
  - [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
  - [x] Write payloads should accept what `ReadResults.Fields` is returning.
  - [ ] Provider errors are mapped if non-standard
  - [x] Custom fields, if not human readable names, are resolved to readable names.
  - [x] Unit tests cover write & delete logic (placed in `/providers/acculynx`)
  - [x] live tests (placed in `/test/acculynx/write` and `/test/acculynx/delete`)
  - [x] Appropriate object names are used. Objects need to be resources, not actions.

  # Tests

  ## Unit Test

### Write

<img width="1217" height="641" alt="image" src="https://github.com/user-attachments/assets/91137758-b098-4deb-ab79-ee0d1cb6c655" />

### Delete

<img width="1217" height="516" alt="image" src="https://github.com/user-attachments/assets/bab784ae-9980-45f0-9d0b-8e4b0ed89974" />

  ## Live Test — Write

<img width="1477" height="882" alt="image" src="https://github.com/user-attachments/assets/0c1054e2-2f6d-4643-bc93-88cec99d62a7" />
<img width="1477" height="882" alt="image" src="https://github.com/user-attachments/assets/332044fe-e0cb-48f1-ab5a-4e9646df122e" />
<img width="1477" height="882" alt="image" src="https://github.com/user-attachments/assets/7427c0ea-ca8f-46c3-b605-722383f1580c" />

  ## Live Test — Delete

<img width="1080" height="272" alt="image" src="https://github.com/user-attachments/assets/7715fd2f-fdd3-44ff-b9ec-2217bc7df9c9" />