### PR TITLE
feat(salesforce): per-object alternate timestamp column

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -208,9 +208,6 @@ type ReadParams struct {
 
 	// PageSize specifies the # of records to request when making a read request.
 	PageSize int // optional
-
-	// UseAlternateTimestamp specifies if the alternate timestamp should be used for pagination.
-	UseAlternateTimestamp bool // optional
 }
 
 func (p ReadParams) IsFirstPage() bool {

--- a/common/types.go
+++ b/common/types.go
@@ -208,6 +208,9 @@ type ReadParams struct {
 
 	// PageSize specifies the # of records to request when making a read request.
 	PageSize int // optional
+
+	// UseAlternateTimestamp specifies if the alternate timestamp should be used for pagination.
+	UseAlternateTimestamp bool // optional
 }
 
 func (p ReadParams) IsFirstPage() bool {

--- a/connector/new.go
+++ b/connector/new.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -314,7 +315,7 @@ func newSalesforceConnector(params common.ConnectorParams) (*salesforce.Connecto
 	}
 
 	if field, ok := params.Metadata["timestampColumn"]; ok && field != "" {
-		opts = append(opts, salesforce.WithTimestampColumn(field))
+		opts = append(opts, salesforce.WithTimestampColumn(field, extractAlternateTimestampUsingObjects(params.Metadata)))
 	}
 
 	return salesforce.NewConnector(opts...)
@@ -336,10 +337,42 @@ func newSalesforceJWTConnector(params common.ConnectorParams) (*salesforce.Conne
 	}
 
 	if field, ok := params.Metadata["timestampColumn"]; ok && field != "" {
-		opts = append(opts, salesforce.WithTimestampColumn(field))
+		opts = append(opts, salesforce.WithTimestampColumn(field, extractAlternateTimestampUsingObjects(params.Metadata)))
 	}
 
 	return salesforce.NewConnector(opts...)
+}
+
+// alternateTimestampMetadataSuffix is the suffix on per-object metadata keys
+// that opt that object into the alternate timestamp column. For example, a
+// metadata entry "Account_timestampColumnCreateTime" opts Account into
+// salesforce.WithTimestampColumn's overridden column for incremental reads.
+// Object names are matched case-insensitively because getTimestampColumn
+// lowercases the lookup.
+const alternateTimestampMetadataSuffix = "_timestampColumnCreateTime"
+
+// extractAlternateTimestampUsingObjects walks the connector metadata for
+// "<ObjectName>_timestampColumnCreateTime" entries and returns the set of
+// objects (keyed lowercase, matching the runtime lookup) that opt into the
+// alternate timestamp column. Returns an empty map (never nil) so callers can
+// rely on lookups without nil-checking.
+func extractAlternateTimestampUsingObjects(metadata map[string]string) map[common.ObjectName]bool {
+	objects := make(map[common.ObjectName]bool)
+
+	for key := range metadata {
+		if !strings.HasSuffix(key, alternateTimestampMetadataSuffix) {
+			continue
+		}
+
+		object := strings.TrimSuffix(key, alternateTimestampMetadataSuffix)
+		if object == "" {
+			continue
+		}
+
+		objects[common.ObjectName(strings.ToLower(object))] = true
+	}
+
+	return objects
 }
 
 func newHubspotConnector(params common.ConnectorParams) (*hubspot.Connector, error) {

--- a/connector/new_test.go
+++ b/connector/new_test.go
@@ -1,0 +1,365 @@
+package connector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+)
+
+// Test_extractAlternateTimestampUsingObjects covers the helper that parses
+// per-object opt-in metadata keys ("<ObjectName>_timestampColumnCreateTime")
+// into the set passed to salesforce.WithTimestampColumn. The runtime lookup
+// in salesforce.Connector.getTimestampColumn lowercases the object name, so
+// the map keys must also be lowercase.
+func Test_extractAlternateTimestampUsingObjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     map[common.ObjectName]bool
+	}{
+		{
+			name:     "nil metadata yields empty set",
+			metadata: nil,
+			want:     map[common.ObjectName]bool{},
+		},
+		{
+			name:     "empty metadata yields empty set",
+			metadata: map[string]string{},
+			want:     map[common.ObjectName]bool{},
+		},
+		{
+			name: "timestampColumn alone (no per-object keys) yields empty set",
+			metadata: map[string]string{
+				"timestampColumn": "MyTimestamp__c",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "single opt-in stored lowercase",
+			metadata: map[string]string{
+				"Account_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+			},
+		},
+		{
+			name: "multiple opt-ins all stored lowercase",
+			metadata: map[string]string{
+				"Account_timestampColumnCreateTime": "true",
+				"Contact_timestampColumnCreateTime": "true",
+				"Lead_timestampColumnCreateTime":    "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+				"contact": true,
+				"lead":    true,
+			},
+		},
+		{
+			name: "custom object with double underscore is preserved",
+			metadata: map[string]string{
+				"MyCustom__c_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"mycustom__c": true,
+			},
+		},
+		{
+			name: "object name with single underscore is preserved",
+			metadata: map[string]string{
+				"My_Object_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"my_object": true,
+			},
+		},
+		{
+			name: "uppercase object name folded to lowercase",
+			metadata: map[string]string{
+				"ACCOUNT_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+			},
+		},
+		{
+			name: "unrelated keys are ignored",
+			metadata: map[string]string{
+				"timestampColumn":                   "MyTimestamp__c",
+				"businessUnitId":                    "abc-123",
+				"isDemo":                            "true",
+				"Account_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+			},
+		},
+		{
+			name: "suffix not at end of key is ignored",
+			metadata: map[string]string{
+				"Account_timestampColumnCreateTime_extra": "true",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "bare suffix with empty prefix is ignored",
+			metadata: map[string]string{
+				"_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "value is irrelevant — only key presence matters",
+			metadata: map[string]string{
+				"Account_timestampColumnCreateTime": "",
+				"Contact_timestampColumnCreateTime": "false",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+				"contact": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractAlternateTimestampUsingObjects(tt.metadata)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractAlternateTimestampUsingObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_newSalesforceConnector_alternateTimestampUsingObjects asserts directly
+// on the salesforce.Connector's alternateTimestampUsingObjects set after
+// newSalesforceConnector runs. This is the structural counterpart to
+// Test_newSalesforceConnector_timestampColumn, which only checks behavior
+// via GetTimestampColumn.
+func Test_newSalesforceConnector_alternateTimestampUsingObjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     map[common.ObjectName]bool
+	}{
+		{
+			name:     "no metadata yields empty set",
+			metadata: nil,
+			want:     map[common.ObjectName]bool{},
+		},
+		{
+			name: "metadata without timestampColumn: per-object keys are NOT consumed",
+			metadata: map[string]string{
+				"Account_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "empty timestampColumn: per-object keys are NOT consumed",
+			metadata: map[string]string{
+				"timestampColumn":                   "",
+				"Account_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "timestampColumn alone: empty set",
+			metadata: map[string]string{
+				"timestampColumn": "MyTimestamp__c",
+			},
+			want: map[common.ObjectName]bool{},
+		},
+		{
+			name: "multiple opt-ins are stored lowercase",
+			metadata: map[string]string{
+				"timestampColumn":                   "MyTimestamp__c",
+				"Account_timestampColumnCreateTime": "true",
+				"Contact_timestampColumnCreateTime": "true",
+				"Lead_timestampColumnCreateTime":    "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+				"contact": true,
+				"lead":    true,
+			},
+		},
+		{
+			name: "custom object with double underscore preserved",
+			metadata: map[string]string{
+				"timestampColumn":                       "MyTimestamp__c",
+				"MyCustom__c_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"mycustom__c": true,
+			},
+		},
+		{
+			name: "unrelated keys are ignored",
+			metadata: map[string]string{
+				"timestampColumn":                   "MyTimestamp__c",
+				"businessUnitId":                    "abc-123",
+				"isDemo":                            "true",
+				"Account_timestampColumnCreateTime": "true",
+			},
+			want: map[common.ObjectName]bool{
+				"account": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn, err := newSalesforceConnector(common.ConnectorParams{
+				AuthenticatedClient: mockutils.NewClient(),
+				Workspace:           "test-workspace",
+				Module:              providers.ModuleSalesforceCRM,
+				Metadata:            tt.metadata,
+			})
+			if err != nil {
+				t.Fatalf("newSalesforceConnector() returned unexpected error: %v", err)
+			}
+
+			got := conn.AlternateTimestampUsingObjects()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("connector.alternateTimestampUsingObjects = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_newSalesforceConnector_timestampColumn exercises newSalesforceConnector
+// end-to-end and asserts that the per-object opt-in metadata actually lands
+// in the Connector's alternateTimestampUsingObjects set, via the exported
+// GetTimestampColumn behavioral accessor.
+//
+// For each case: objects listed in optedIn must return the configured
+// alternate column; objects listed in notOptedIn must return the default
+// (SystemModstamp). When no override column is supplied, every object falls
+// back to the default regardless of metadata.
+func Test_newSalesforceConnector_timestampColumn(t *testing.T) {
+	t.Parallel()
+
+	const (
+		altColumn     = "MyTimestamp__c"
+		defaultColumn = "SystemModstamp"
+	)
+
+	tests := []struct {
+		name       string
+		metadata   map[string]string
+		optedIn    map[common.ObjectName]string // object → expected column
+		notOptedIn []common.ObjectName          // objects that must fall back to default
+	}{
+		{
+			name:       "no metadata: everything uses default",
+			metadata:   nil,
+			notOptedIn: []common.ObjectName{"Account", "Contact"},
+		},
+		{
+			name: "metadata without timestampColumn: everything uses default",
+			metadata: map[string]string{
+				"businessUnitId":                    "abc-123",
+				"Account_timestampColumnCreateTime": "true",
+			},
+			notOptedIn: []common.ObjectName{"Account", "Contact"},
+		},
+		{
+			name: "empty timestampColumn is ignored even when opt-ins present",
+			metadata: map[string]string{
+				"timestampColumn":                   "",
+				"Account_timestampColumnCreateTime": "true",
+			},
+			notOptedIn: []common.ObjectName{"Account", "Contact"},
+		},
+		{
+			name: "timestampColumn set without opt-ins: still default everywhere",
+			metadata: map[string]string{
+				"timestampColumn": altColumn,
+			},
+			notOptedIn: []common.ObjectName{"Account", "Contact"},
+		},
+		{
+			name: "opted-in objects get alternate, others get default",
+			metadata: map[string]string{
+				"timestampColumn":                   altColumn,
+				"Account_timestampColumnCreateTime": "true",
+				"Contact_timestampColumnCreateTime": "true",
+			},
+			optedIn: map[common.ObjectName]string{
+				"Account": altColumn,
+				"Contact": altColumn,
+			},
+			notOptedIn: []common.ObjectName{"Lead", "Opportunity"},
+		},
+		{
+			name: "object lookup is case-insensitive against metadata key casing",
+			metadata: map[string]string{
+				"timestampColumn":                   altColumn,
+				"Account_timestampColumnCreateTime": "true",
+			},
+			optedIn: map[common.ObjectName]string{
+				"Account": altColumn, // exact
+				"account": altColumn, // lowercase
+				"ACCOUNT": altColumn, // uppercase
+			},
+		},
+		{
+			name: "custom object with double underscore opts in",
+			metadata: map[string]string{
+				"timestampColumn":                       altColumn,
+				"MyCustom__c_timestampColumnCreateTime": "true",
+			},
+			optedIn: map[common.ObjectName]string{
+				"MyCustom__c": altColumn,
+			},
+			notOptedIn: []common.ObjectName{"Account"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn, err := newSalesforceConnector(common.ConnectorParams{
+				AuthenticatedClient: mockutils.NewClient(),
+				Workspace:           "test-workspace",
+				Module:              providers.ModuleSalesforceCRM,
+				Metadata:            tt.metadata,
+			})
+			if err != nil {
+				t.Fatalf("newSalesforceConnector() returned unexpected error: %v", err)
+			}
+
+			if conn == nil {
+				t.Fatal("newSalesforceConnector() returned nil connector")
+			}
+
+			for obj, wantCol := range tt.optedIn {
+				if got := conn.GetTimestampColumn(obj); got != wantCol {
+					t.Errorf("GetTimestampColumn(%q) = %q, want %q (opted-in object)", obj, got, wantCol)
+				}
+			}
+
+			for _, obj := range tt.notOptedIn {
+				if got := conn.GetTimestampColumn(obj); got != defaultColumn {
+					t.Errorf("GetTimestampColumn(%q) = %q, want %q (object not opted in)", obj, got, defaultColumn)
+				}
+			}
+		})
+	}
+}

--- a/providers/gong/params.go
+++ b/providers/gong/params.go
@@ -17,6 +17,7 @@ type Option = func(params *parameters)
 
 type parameters struct {
 	paramsbuilder.Client
+
 	APIBaseURL string // Regional API base URL from OAuth token (e.g. "https://us-12345.api.gong.io")
 }
 

--- a/providers/livestorm/errors.go
+++ b/providers/livestorm/errors.go
@@ -2,7 +2,5 @@ package livestorm
 
 import "errors"
 
-var (
-	// ErrSessionIDRequired is returned when reading session_chat_messages without a session id in ReadParams.Filter.
-	ErrSessionIDRequired = errors.New("read session_chat_messages requires a non-empty ReadParams.Filter (session id)")
-)
+// ErrSessionIDRequired is returned when reading session_chat_messages without a session id in ReadParams.Filter.
+var ErrSessionIDRequired = errors.New("read session_chat_messages requires a non-empty ReadParams.Filter (session id)")

--- a/providers/salesforce/bulk-read.go
+++ b/providers/salesforce/bulk-read.go
@@ -21,7 +21,7 @@ func (c *Connector) BulkRead(ctx context.Context, params common.ReadParams) (*Ge
 		return nil, err
 	}
 
-	soql := makeSOQL(params, c.getTimestampColumn())
+	soql := makeSOQL(params, c.getTimestampColumn(params))
 	// Note: if params.Deleted is set to true query will return only removed items.
 
 	query := soql.String()

--- a/providers/salesforce/bulk-read.go
+++ b/providers/salesforce/bulk-read.go
@@ -21,7 +21,7 @@ func (c *Connector) BulkRead(ctx context.Context, params common.ReadParams) (*Ge
 		return nil, err
 	}
 
-	soql := makeSOQL(params, c.getTimestampColumn(params))
+	soql := makeSOQL(params, c.GetTimestampColumn(common.ObjectName(params.ObjectName)))
 	// Note: if params.Deleted is set to true query will return only removed items.
 
 	query := soql.String()

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -1,6 +1,9 @@
 package salesforce
 
 import (
+	"maps"
+	"strings"
+
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -47,7 +50,8 @@ type Connector struct {
 	// timestampColumn overrides the default "SystemModstamp" field used in
 	// incremental read queries (Since/Until WHERE clauses). When empty,
 	// "SystemModstamp" is used.
-	timestampColumn string
+	timestampColumn                string
+	alternateTimestampUsingObjects map[common.ObjectName]bool
 }
 
 // NewConnector returns a new Salesforce connector.
@@ -70,6 +74,7 @@ func NewConnector(opts ...Option) (*Connector, error) {
 	}
 
 	conn.timestampColumn = params.timestampColumn
+	conn.alternateTimestampUsingObjects = params.alternateTimestampUsingObjects
 
 	connectorParams, err := newParams(opts)
 	if err != nil {
@@ -151,6 +156,31 @@ func (c *Connector) SetBaseURL(newURL string) {
 	c.HTTPClient().Base = newURL
 }
 
+// GetTimestampColumn returns the field name used in incremental-read WHERE
+// clauses (Since/Until) for the given object. The configured alternate column
+// applies only to objects that opted in via WithTimestampColumn's second
+// argument; all other objects fall back to defaultTimestampColumn. Object
+// names are matched case-insensitively.
+func (c *Connector) GetTimestampColumn(objectName common.ObjectName) string {
+	if c.timestampColumn != "" {
+		if _, ok := c.alternateTimestampUsingObjects[common.ObjectName(strings.ToLower(string(objectName)))]; ok {
+			return c.timestampColumn
+		}
+	}
+
+	return defaultTimestampColumn
+}
+
+// AlternateTimestampUsingObjects returns a copy of the set of objects that
+// opted into the alternate timestamp column configured via WithTimestampColumn.
+// A copy is returned so callers cannot mutate connector state.
+func (c *Connector) AlternateTimestampUsingObjects() map[common.ObjectName]bool {
+	out := make(map[common.ObjectName]bool, len(c.alternateTimestampUsingObjects))
+	maps.Copy(out, c.alternateTimestampUsingObjects)
+
+	return out
+}
+
 func (c *Connector) getRestApiURL(paths ...string) (*urlbuilder.URL, error) {
 	parts := append([]string{
 		crmcore.RestAPISuffix, // scope URLs to API version
@@ -179,17 +209,6 @@ func (c *Connector) getURIPartSobjectsDescribe(objectName string) (*urlbuilder.U
 }
 
 const defaultTimestampColumn = "SystemModstamp"
-
-// getTimestampColumn returns the field name used for incremental read queries.
-func (c *Connector) getTimestampColumn(params common.ReadParams) string {
-	if params.UseAlternateTimestamp {
-		if c.timestampColumn != "" {
-			return c.timestampColumn
-		}
-	}
-
-	return defaultTimestampColumn
-}
 
 func (c *Connector) isPardotModule() bool {
 	return c.pardotAdapter != nil

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -181,9 +181,11 @@ func (c *Connector) getURIPartSobjectsDescribe(objectName string) (*urlbuilder.U
 const defaultTimestampColumn = "SystemModstamp"
 
 // getTimestampColumn returns the field name used for incremental read queries.
-func (c *Connector) getTimestampColumn() string {
-	if c.timestampColumn != "" {
-		return c.timestampColumn
+func (c *Connector) getTimestampColumn(params common.ReadParams) string {
+	if params.UseAlternateTimestamp {
+		if c.timestampColumn != "" {
+			return c.timestampColumn
+		}
 	}
 
 	return defaultTimestampColumn

--- a/providers/salesforce/params.go
+++ b/providers/salesforce/params.go
@@ -27,7 +27,8 @@ type parameters struct {
 	// different provider name (e.g. salesforceJWT), which shares the underlying
 	// Salesforce APIs but differs only in its authentication scheme. Defaults
 	// to providers.Salesforce when unset.
-	provider providers.Provider
+	provider                       providers.Provider
+	alternateTimestampUsingObjects map[common.ObjectName]bool
 }
 
 func newParams(opts []Option) (*common.ConnectorParams, error) { // nolint:unused
@@ -100,9 +101,10 @@ func WithMetadata(metadata map[string]string) Option {
 // WithTimestampColumn overrides the default "SystemModstamp" field used for
 // incremental read queries. When set, the given field name is used in the
 // Since/Until WHERE clauses instead of SystemModstamp.
-func WithTimestampColumn(field string) Option {
+func WithTimestampColumn(field string, alternateTimestampUsingObjects map[common.ObjectName]bool) Option {
 	return func(params *parameters) {
 		params.timestampColumn = field
+		params.alternateTimestampUsingObjects = alternateTimestampUsingObjects
 	}
 }
 

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -59,7 +59,7 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	url.WithQueryParam("q", makeSOQL(config, c.getTimestampColumn()).String())
+	url.WithQueryParam("q", makeSOQL(config, c.getTimestampColumn(config)).String())
 
 	return url, nil
 }

--- a/providers/salesforce/read.go
+++ b/providers/salesforce/read.go
@@ -59,7 +59,7 @@ func (c *Connector) buildReadURL(config common.ReadParams) (*urlbuilder.URL, err
 		return nil, err
 	}
 
-	url.WithQueryParam("q", makeSOQL(config, c.getTimestampColumn(config)).String())
+	url.WithQueryParam("q", makeSOQL(config, c.GetTimestampColumn(common.ObjectName(config.ObjectName))).String())
 
 	return url, nil
 }

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -537,12 +537,14 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	}
 }
 
-func constructTestConnectorWithTimestampColumn(serverURL, field string) (*Connector, error) {
+func constructTestConnectorWithTimestampColumn(
+	serverURL, field string, alternateObjects map[common.ObjectName]bool,
+) (*Connector, error) {
 	connector, err := NewConnector(
 		WithAuthenticatedClient(mockutils.NewClient()),
 		WithWorkspace("test-workspace"),
 		WithModule(providers.ModuleSalesforceCRM),
-		WithTimestampColumn(field),
+		WithTimestampColumn(field, alternateObjects),
 	)
 	if err != nil {
 		return nil, err

--- a/providers/salesforce/record-count.go
+++ b/providers/salesforce/record-count.go
@@ -29,7 +29,7 @@ func (c *Connector) GetRecordCount(
 	soql := (&crmcore.SOQLBuilder{}).SelectCount().From(params.ObjectName)
 
 	// Add WHERE clauses based on timestamps
-	timestampColumn := c.getTimestampColumn(common.ReadParams{})
+	timestampColumn := c.GetTimestampColumn(common.ObjectName(params.ObjectName))
 
 	if params.SinceTimestamp != nil && !params.SinceTimestamp.IsZero() {
 		soql.Where(timestampColumn + " > " + datautils.Time.FormatRFC3339inUTC(*params.SinceTimestamp))

--- a/providers/salesforce/record-count.go
+++ b/providers/salesforce/record-count.go
@@ -29,7 +29,7 @@ func (c *Connector) GetRecordCount(
 	soql := (&crmcore.SOQLBuilder{}).SelectCount().From(params.ObjectName)
 
 	// Add WHERE clauses based on timestamps
-	timestampColumn := c.getTimestampColumn()
+	timestampColumn := c.getTimestampColumn(common.ReadParams{})
 
 	if params.SinceTimestamp != nil && !params.SinceTimestamp.IsZero() {
 		soql.Where(timestampColumn + " > " + datautils.Time.FormatRFC3339inUTC(*params.SinceTimestamp))

--- a/providers/salesforce/record.go
+++ b/providers/salesforce/record.go
@@ -69,7 +69,7 @@ func (c *Connector) buildReadByIdentifierURL(config recordsByIDsParams) (*urlbui
 		return nil, err
 	}
 
-	query := makeSOQL(config.ReadParams, c.getTimestampColumn()).
+	query := makeSOQL(config.ReadParams, c.getTimestampColumn(config.ReadParams)).
 		WithIDs(config.RecordIdentifiers.List()).
 		String()
 

--- a/providers/salesforce/record.go
+++ b/providers/salesforce/record.go
@@ -69,7 +69,7 @@ func (c *Connector) buildReadByIdentifierURL(config recordsByIDsParams) (*urlbui
 		return nil, err
 	}
 
-	query := makeSOQL(config.ReadParams, c.getTimestampColumn(config.ReadParams)).
+	query := makeSOQL(config.ReadParams, c.GetTimestampColumn(common.ObjectName(config.ObjectName))).
 		WithIDs(config.RecordIdentifiers.List()).
 		String()
 


### PR DESCRIPTION
## Summary

- `WithTimestampColumn` now takes a per-object opt-in set; objects in the set use the configured column for `Since`/`Until` WHERE clauses, everything else falls back to `SystemModstamp`.
- The dispatcher (`newSalesforceConnector` and `newSalesforceJWTConnector`) parses `<ObjectName>_timestampColumnCreateTime` metadata keys into that set. Object names are folded to lowercase to match the case-insensitive runtime lookup, and the parser uses `HasSuffix`/`TrimSuffix` so custom-object names with double underscores (e.g. `MyCustom__c`) resolve correctly.
- Exports `Connector.GetTimestampColumn(objectName)` and adds `Connector.AlternateTimestampUsingObjects()` (returns a defensive copy) so callers and tests can introspect the per-object configuration.
- The earlier `UseAlternateTimestamp` field added to `common.ReadParams` is dropped — the new design lives entirely inside the salesforce connector.

## Test plan

- [x] `go test ./connector/...` — new `Test_extractAlternateTimestampUsingObjects`, `Test_newSalesforceConnector_alternateTimestampUsingObjects` (asserts directly on the connector struct), and `Test_newSalesforceConnector_timestampColumn` (behavioral via `GetTimestampColumn`) pass
- [x] `go test ./providers/salesforce/...` passes
- [x] `go build ./...` clean
- [ ] Smoke-test in a workspace with `timestampColumn` + per-object metadata to confirm SOQL `Since`/`Until` clauses use the configured column only for opted-in objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)