### PR TITLE
[CON-2236] feat: add zoominfo proxy connector

### DIFF
--- a/providers/zoominfo.go
+++ b/providers/zoominfo.go
@@ -1,0 +1,44 @@
+package providers
+
+const ZoomInfo Provider = "zoominfo"
+
+func init() {
+	// ZoomInfo configuration
+	SetInfo(ZoomInfo, ProviderInfo{
+		DisplayName: "ZoomInfo",
+		AuthType:    Oauth2,
+		BaseURL:     "https://api.zoominfo.com",
+		Oauth2Opts: &Oauth2Opts{
+			AuthURL:                   "https://api.zoominfo.com/gtm/oauth/v1/authorize",
+			TokenURL:                  "https://api.zoominfo.com/gtm/oauth/v1/token",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: false,
+			GrantType:                 AuthorizationCodePKCE,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758621074/media/zoominfo.com_1758621078.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758621183/media/zoominfo.com_1758621188.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758621074/media/zoominfo.com_1758621078.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1758621167/media/zoominfo.com_1758621172.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
<img width="1466" height="798" alt="Screenshot 2026-05-20 at 16 43 37" src="https://github.com/user-attachments/assets/5480ae27-6938-4aec-a42e-e6a824d75da3" />


## POST
<img width="1462" height="768" alt="Screenshot 2026-05-20 at 16 45 17" src="https://github.com/user-attachments/assets/f3528ce0-1243-414e-8f6d-1e44bb9ead43" />
<Please add the same information for all other methods available - PUT, PATCH, DELETE, etc>

## PATCH && DELETE
Few objects support this, and they are in Enteprise API.


## Invalid requests
Wrong verb applied
<img width="1466" height="673" alt="Screenshot 2026-05-20 at 17 23 25" src="https://github.com/user-attachments/assets/fbb6a88c-0f2c-41d0-a30c-420ab1b63a0c" />

invalid path.
<img width="1468" height="807" alt="Screenshot 2026-05-20 at 17 23 17" src="https://github.com/user-attachments/assets/b343ade6-ef28-47f5-b78a-1ca1df35ed01" />



