### PR TITLE
fix(granola): Fetch notes with transcript by default

### DIFF
--- a/providers/granola/notes.go
+++ b/providers/granola/notes.go
@@ -36,14 +36,15 @@ type NoteRecords map[string]NoteRecord
 // fetchNotes retrieves the full note payloads for all note IDs found in the
 // provided list response.
 func (c *Connector) fetchNotes(
-	ctx context.Context, collectionResp *common.JSONHTTPResponse, params common.ReadParams,
+	ctx context.Context, collectionResp *common.JSONHTTPResponse,
 ) (NoteRecords, error) {
 	collection, err := common.UnmarshalJSON[NotesCollection](collectionResp)
 	if err != nil {
 		return nil, err
 	}
 
-	includeTranscript := params.Fields.Has("transcript")
+	// Always include the transcript when fetching a full note
+	includeTranscript := true
 	notesChannel := make(chan NoteRecord, len(collection.Notes))
 	callbacks := make([]simultaneously.Job, 0, len(collection.Notes))
 

--- a/providers/granola/read.go
+++ b/providers/granola/read.go
@@ -79,7 +79,7 @@ func (c *Connector) parseReadResponse(ctx context.Context, params common.ReadPar
 	//   - https://docs.granola.ai/api-reference/list-notes
 	//   - https://docs.granola.ai/api-reference/get-note
 	if needsFullNotesFetch(params) {
-		notes, err := c.fetchNotes(ctx, resp, params)
+		notes, err := c.fetchNotes(ctx, resp)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/granola/read_test.go
+++ b/providers/granola/read_test.go
@@ -136,15 +136,25 @@ func TestRead(t *testing.T) {
 						Then: mockserver.Response(http.StatusOK, responseNotes),
 					},
 					{
-						If:   mockcond.Path("/v1/notes/not_1d3tmYTlCICgjy"),
+						If: mockcond.And{
+							mockcond.Path("/v1/notes/not_1d3tmYTlCICgjy"),
+							mockcond.QueryParam("include", "transcript"),
+						},
 						Then: mockserver.Response(http.StatusOK, noteFull["not_1d3tmYTlCICgjy"]),
 					},
 					{
-						If:   mockcond.Path("/v1/notes/not_4f7kQhLpMNBvxy"),
+
+						If: mockcond.And{
+							mockcond.Path("/v1/notes/not_4f7kQhLpMNBvxy"),
+							mockcond.QueryParam("include", "transcript"),
+						},
 						Then: mockserver.Response(http.StatusOK, noteFull["not_4f7kQhLpMNBvxy"]),
 					},
 					{
-						If:   mockcond.Path("/v1/notes/not_9b2xRwNsTLCfop"),
+						If: mockcond.And{
+							mockcond.Path("/v1/notes/not_9b2xRwNsTLCfop"),
+							mockcond.QueryParam("include", "transcript"),
+						},
 						Then: mockserver.Response(http.StatusOK, noteFull["not_9b2xRwNsTLCfop"]),
 					},
 				},


### PR DESCRIPTION
Always request `include=transcript` when calling Get Note while building the full note registry for notes.

## TESTS

<img width="1980" height="954" alt="Screenshot from 2026-05-21 01-13-20" src="https://github.com/user-attachments/assets/454bf884-265a-457f-8e22-2568dbeda845" />

<img width="1980" height="954" alt="Screenshot from 2026-05-21 01-13-26" src="https://github.com/user-attachments/assets/d42d17bf-3d5e-4865-93a5-64cad2ce2a2a" />

