### PR TITLE
[ENG-3949] feat(hubspot): Marketing object renaming

### DIFF
--- a/providers/hubspot/internal/core/objects.go
+++ b/providers/hubspot/internal/core/objects.go
@@ -13,14 +13,16 @@ const (
 )
 
 const (
-	ObjectMarketingForms  = "forms"
-	ObjectMarketingEvents = "marketing-events"
-	ObjectMeetingLinks    = "meeting-links"
-	ObjectCustomChannels  = "custom-channels"
-	ObjectChannelAccounts = "channel-accounts"
-	ObjectChannels        = "channels"
-	ObjectInboxes         = "inboxes"
-	ObjectThreads         = "threads"
+	ObjectMarketingCampaigns = "marketing-campaigns"
+	ObjectMarketingEmails    = "marketing-emails"
+	ObjectMarketingForms     = "marketing-forms"
+	ObjectMarketingEvents    = "marketing-events"
+	ObjectMeetingLinks       = "meeting-links"
+	ObjectCustomChannels     = "custom-channels"
+	ObjectChannelAccounts    = "channel-accounts"
+	ObjectChannels           = "channels"
+	ObjectInboxes            = "inboxes"
+	ObjectThreads            = "threads"
 )
 
 //nolint:gochecknoglobals,lll
@@ -44,7 +46,7 @@ var (
 	// The Marketing API is separate from the CRM API and is not related to the Objects API.
 	MarketingObjects = datautils.Map[string, ObjectDescription]{
 		// https://developers.hubspot.com/docs/api-reference/latest/marketing/campaigns/get-campaigns
-		"campaigns": {
+		ObjectMarketingCampaigns: {
 			Path:              "campaigns",
 			RecordTransformer: common.FlattenNestedFields("properties"),
 			Version:           APIVersion2026March,
@@ -62,7 +64,7 @@ var (
 		// https://developers.hubspot.com/docs/api-reference/latest/marketing/marketing-emails/get-emails
 		// CRM emails:
 		// https://developers.hubspot.com/docs/api-reference/latest/crm/activities/emails/guide
-		"marketing/emails": {
+		ObjectMarketingEmails: {
 			Path:              "emails",
 			RecordTransformer: nil, // None. Fields and Raw are the same.
 			Version:           APIVersion2026March,

--- a/providers/hubspot/internal/metadata/schemas.json
+++ b/providers/hubspot/internal/metadata/schemas.json
@@ -59,9 +59,9 @@
             }
           }
         },
-        "campaigns": {
-          "displayName": "Campaigns",
-          "description": "Object does not belong to CRM: /marketing/campaigns",
+        "marketing-campaigns": {
+          "displayName": "Marketing Campaigns",
+          "description": "Object is not part of CRM but marketing: /marketing/campaigns",
           "responseKey": "results",
           "fields": {
             "hs_name": {
@@ -158,7 +158,7 @@
             }
           }
         },
-        "marketing/emails": {
+        "marketing-emails": {
           "displayName": "Marketing Emails",
           "description": "/marketing/emails/2026-03",
           "responseKey": "results",
@@ -680,7 +680,7 @@
             }
           }
         },
-        "forms": {
+        "marketing-forms": {
           "displayName": "Marketing Forms",
           "description": "/marketing/forms/2026-09-beta",
           "responseKey": "results",

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -373,15 +373,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		{
 			Name: "Successfully describe various objects",
 			Input: []string{
-				"campaigns", "marketing/emails", "forms",
+				"marketing-campaigns", "marketing-emails", "marketing-forms",
 				"marketing-events", "meeting-links",
 			},
 			Server:     mockserver.Dummy(),
 			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
-					"campaigns": {
-						DisplayName: "Campaigns",
+					"marketing-campaigns": {
+						DisplayName: "Marketing Campaigns",
 						Fields: map[string]common.FieldMetadata{
 							"hs_campaign_status": {
 								DisplayName:  "Campaign Status",
@@ -411,7 +411,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 							},
 						},
 					},
-					"marketing/emails": {
+					"marketing-emails": {
 						DisplayName: "Marketing Emails",
 						Fields: map[string]common.FieldMetadata{
 							"campaignName": {
@@ -426,7 +426,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 							},
 						},
 					},
-					"forms": {
+					"marketing-forms": {
 						DisplayName: "Marketing Forms",
 						Fields: map[string]common.FieldMetadata{
 							"archivedAt": {

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -253,7 +253,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name: "Read marketing campaigns first page",
 			Input: common.ReadParams{
-				ObjectName: "campaigns",
+				ObjectName: "marketing-campaigns",
 				Fields:     connectors.Fields("hs_name", "hs_notes", "hs_budget_items_sum_amount"),
 			},
 			Server: mockserver.Conditional{
@@ -307,7 +307,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name: "Read marketing campaigns with connector side filtering",
 			Input: common.ReadParams{
-				ObjectName: "campaigns",
+				ObjectName: "marketing-campaigns",
 				Fields:     connectors.Fields("hs_name"),
 				// The first item will be returned, last filtered out.
 				// Due to the sort order there will be no next page.
@@ -378,7 +378,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name: "Read marketing emails first page",
 			Input: common.ReadParams{
-				ObjectName: "marketing/emails",
+				ObjectName: "marketing-emails",
 				Fields:     connectors.Fields("subject"),
 			},
 			Server: mockserver.Conditional{
@@ -421,7 +421,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		{
 			Name: "Read marketing emails last page",
 			Input: common.ReadParams{
-				ObjectName: "marketing/emails",
+				ObjectName: "marketing-emails",
 				Fields:     connectors.Fields("subject"),
 				NextPage:   testroutines.URLTestServer + "/marketing/emails/2026-03?limit=3&sort=-updatedAt&after=Mw%3D%3D",
 			},
@@ -456,10 +456,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage: "",
 				Done:     true,
 			},
-		}, {
+		},
+		{
 			Name: "Read marketing forms",
 			Input: common.ReadParams{
-				ObjectName: "forms",
+				ObjectName: "marketing-forms",
 				Fields:     connectors.Fields("name", "updatedAt"),
 			},
 			Server: mockserver.Conditional{
@@ -486,7 +487,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage: "https://api.hubapi.com/marketing/forms/2026-09-beta?limit=1&after=MQ%3D%3D",
 				Done:     false,
 			},
-		}, {
+		},
+		{
 			Name: "Read marketing events",
 			Input: common.ReadParams{
 				ObjectName: "marketing-events",
@@ -518,7 +520,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				NextPage: "https://api.hubapi.com/marketing/marketing-events/2026-03?after=NTU1NDQyMTk2ODQw",
 				Done:     false,
 			},
-		}, {
+		},
+		{
 			Name: "Read meeting-links",
 			Input: common.ReadParams{
 				ObjectName: "meeting-links",

--- a/providers/hubspot/search_test.go
+++ b/providers/hubspot/search_test.go
@@ -392,7 +392,7 @@ func TestReadUsingSearchAPI(t *testing.T) {
 		{
 			Name: "Read marketing campaigns via Search",
 			Input: SearchParams{
-				ObjectName: "campaigns",
+				ObjectName: "marketing-campaigns",
 				Fields:     connectors.Fields("hs_budget_items_sum_amount", "hs_name", "hs_notes"),
 				Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
 			},

--- a/test/hubspot/metadata/read/marketing-campaigns/main.go
+++ b/test/hubspot/metadata/read/marketing-campaigns/main.go
@@ -19,7 +19,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		"campaigns",
+		"marketing-campaigns",
 	})
 	if err != nil {
 		utils.Fail("error listing metadata", "error", err)

--- a/test/hubspot/metadata/read/marketing-emails/main.go
+++ b/test/hubspot/metadata/read/marketing-emails/main.go
@@ -19,7 +19,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		"marketing/emails",
+		"marketing-emails",
 	})
 	if err != nil {
 		utils.Fail("error listing metadata", "error", err)

--- a/test/hubspot/metadata/read/marketing-forms/main.go
+++ b/test/hubspot/metadata/read/marketing-forms/main.go
@@ -19,7 +19,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	metadata, err := conn.ListObjectMetadata(ctx, []string{
-		"forms",
+		"marketing-forms",
 	})
 	if err != nil {
 		utils.Fail("error listing metadata", "error", err)

--- a/test/hubspot/read-via-search/marketing-campaigns/main.go
+++ b/test/hubspot/read-via-search/marketing-campaigns/main.go
@@ -22,7 +22,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	res, err := conn.ReadUsingSearchAPI(ctx, hubspot.SearchParams{
-		ObjectName: "campaigns",
+		ObjectName: "marketing-campaigns",
 		Fields:     connectors.Fields("hs_name", "hs_notes", "hs_budget_items_sum_amount"),
 		Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
 	})

--- a/test/hubspot/read/marketing-campaigns/main.go
+++ b/test/hubspot/read/marketing-campaigns/main.go
@@ -21,7 +21,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: "campaigns",
+		ObjectName: "marketing-campaigns",
 		Fields:     connectors.Fields("hs_name", "hs_notes", "hs_budget_items_sum_amount"),
 		// Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
 	})

--- a/test/hubspot/read/marketing-emails/main.go
+++ b/test/hubspot/read/marketing-emails/main.go
@@ -21,7 +21,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: "marketing/emails",
+		ObjectName: "marketing-emails",
 		Fields:     connectors.Fields("subject", "type", "updatedAt"),
 		// Since:      time.Date(2026, 5, 7, 22, 0, 0, 0, time.UTC),
 	})

--- a/test/hubspot/read/marketing-forms/main.go
+++ b/test/hubspot/read/marketing-forms/main.go
@@ -21,7 +21,7 @@ func main() {
 	conn := connTest.GetHubspotConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
-		ObjectName: "forms",
+		ObjectName: "marketing-forms",
 		Fields:     connectors.Fields("name", "updatedAt"),
 		// Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
 	})


### PR DESCRIPTION
# Description

Renamed objects. Final version of the names are as follows:
* marketing-campaigns
* marketing-emails
* marketing-forms


# Live Tests

## ListObjectMetadata
<img width="1565" height="1374" alt="Peek 2026-05-21 17-31" src="https://github.com/user-attachments/assets/d27295b6-6250-4e32-9383-6578a41385f5" />

### Read
<img width="1565" height="1374" alt="Peek 2026-05-21 17-36" src="https://github.com/user-attachments/assets/83155209-d584-4303-a6dd-a4e58201d4c9" />
