### PR TITLE
fix: classify Google rate-limit responses as retryable (Gmail/Calendar/Contacts)

### DIFF
--- a/providers/google/internal/calendar/adapter.go
+++ b/providers/google/internal/calendar/adapter.go
@@ -35,7 +35,7 @@ func constructor(base *components.Connector) (*Adapter, error) {
 	}
 
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		JSON: interpreter.DirectFaultyResponder{Callback: adapter.interpretJSONError},
 		HTML: interpreter.DirectFaultyResponder{Callback: adapter.interpretHTMLError},
 	}.Handle
 

--- a/providers/google/internal/calendar/errors.go
+++ b/providers/google/internal/calendar/errors.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
 )
 
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
@@ -18,6 +19,10 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 		},
 	}...,
 )
+
+// jsonResponder mirrors what was previously passed inline to ErrorHandler.JSON; it is
+// now reused as the non-rate-limit fallback in interpretJSONError.
+var jsonResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
 
 // ErrorDetails
 // nolint:tagliatelle
@@ -49,6 +54,14 @@ func (d ErrorDetails) CombineErr(base error) error {
 	}
 
 	return fmt.Errorf("%w: %v", base, message)
+}
+
+// interpretJSONError routes Calendar JSON error bodies through the shared Google
+// rate-limit detector. Calendar returns 403 with reason RATE_LIMIT_EXCEEDED for
+// per-user quota violations; without this hook the response maps to ErrForbidden
+// (unrecoverable) instead of ErrLimitExceeded (retryable).
+func (a *Adapter) interpretJSONError(res *http.Response, body []byte) error {
+	return core.InterpretJSONError(res, body, jsonResponder.HandleErrorResponse)
 }
 
 // Typical HTML google error message has Title with paragraph describing the problem.

--- a/providers/google/internal/contacts/adapter.go
+++ b/providers/google/internal/contacts/adapter.go
@@ -35,7 +35,7 @@ func constructor(base *components.Connector) (*Adapter, error) {
 	}
 
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
+		JSON: interpreter.DirectFaultyResponder{Callback: adapter.interpretJSONError},
 		HTML: interpreter.DirectFaultyResponder{Callback: adapter.interpretHTMLError},
 	}.Handle
 

--- a/providers/google/internal/contacts/errors.go
+++ b/providers/google/internal/contacts/errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
 )
 
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
@@ -24,6 +25,11 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
 	http.StatusConflict: errors.Join(common.ErrConflict, common.ErrBadRequest),
 }
+
+// jsonResponder mirrors what was previously passed inline to ErrorHandler.JSON; it is
+// now reused as the non-rate-limit fallback in interpretJSONError. The statusCodeMapping
+// remains in effect for non-rate-limit responses (e.g. 409 → ErrConflict).
+var jsonResponder = interpreter.NewFaultyResponder(errorFormats, statusCodeMapping) //nolint:gochecknoglobals
 
 // ErrorDetails
 // nolint:tagliatelle
@@ -55,6 +61,14 @@ func (d ErrorDetails) CombineErr(base error) error {
 	}
 
 	return fmt.Errorf("%w: %v", base, message)
+}
+
+// interpretJSONError routes Contacts JSON error bodies through the shared Google
+// rate-limit detector. People API returns 403 with reason RATE_LIMIT_EXCEEDED for
+// per-user quota violations; without this hook the response maps to ErrForbidden
+// (unrecoverable) instead of ErrLimitExceeded (retryable).
+func (a *Adapter) interpretJSONError(res *http.Response, body []byte) error {
+	return core.InterpretJSONError(res, body, jsonResponder.HandleErrorResponse)
 }
 
 // Typical HTML google error message has Title with paragraph describing the problem.

--- a/providers/google/internal/core/errors.go
+++ b/providers/google/internal/core/errors.go
@@ -1,0 +1,103 @@
+// Package core hosts cross-module helpers shared by the Google connector's
+// Gmail, Calendar, and Contacts adapters.
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// rateLimitReasons enumerates the reason strings Google uses to mark a response as
+// rate-limited or quota-exhausted. Google emits these in two places within the error
+// body and uses two different conventions — UPPER_SNAKE in details[].reason
+// (google.rpc.ErrorInfo) and camelCase in errors[].reason (legacy) — so we accept both.
+//
+// References:
+//   - https://developers.google.com/workspace/gmail/api/v1/reference/quota
+//   - https://cloud.google.com/apis/design/errors#error_info
+var rateLimitReasons = map[string]struct{}{ //nolint:gochecknoglobals
+	// details[].reason (UPPER_SNAKE)
+	"RATE_LIMIT_EXCEEDED":      {},
+	"USER_RATE_LIMIT_EXCEEDED": {},
+	"QUOTA_EXCEEDED":           {},
+	// errors[].reason (camelCase)
+	"rateLimitExceeded":     {},
+	"userRateLimitExceeded": {},
+	"quotaExceeded":         {},
+	"dailyLimitExceeded":    {},
+}
+
+type googleErrorBody struct {
+	Error struct {
+		Message string `json:"message"`
+		Errors  []struct {
+			Reason string `json:"reason"`
+		} `json:"errors"`
+		Details []struct {
+			Reason string `json:"reason"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+// IsRateLimitError reports whether (statusCode, body) represents a Google rate-limit
+// or quota response. Google historically returns 403 with a rate-limit reason in the
+// body for per-user quota violations on Workspace APIs (Gmail in particular); some
+// newer endpoints return 429. Either surface is treated as rate-limited.
+func IsRateLimitError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusForbidden && statusCode != http.StatusTooManyRequests {
+		return false
+	}
+
+	if len(body) == 0 {
+		return false
+	}
+
+	var parsed googleErrorBody
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+
+	for _, e := range parsed.Error.Errors {
+		if _, ok := rateLimitReasons[e.Reason]; ok {
+			return true
+		}
+	}
+
+	for _, d := range parsed.Error.Details {
+		if _, ok := rateLimitReasons[d.Reason]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// InterpretJSONError applies Google rate-limit detection on top of the per-adapter
+// JSON error parsing. If the response is a rate-limit / quota error it returns a
+// common.ErrLimitExceeded so the read workflow's retryable branch engages instead of
+// the unrecoverable ErrForbidden branch. Otherwise it delegates to fallback, which
+// preserves the adapter's existing rich error-message extraction.
+func InterpretJSONError(
+	res *http.Response,
+	body []byte,
+	fallback func(res *http.Response, body []byte) error,
+) error {
+	if !IsRateLimitError(res.StatusCode, body) {
+		return fallback(res, body)
+	}
+
+	var parsed googleErrorBody
+
+	_ = json.Unmarshal(body, &parsed)
+
+	message := parsed.Error.Message
+	if message == "" {
+		message = "rate limit exceeded"
+	}
+
+	return fmt.Errorf("%w: %s", common.ErrLimitExceeded, message)
+}

--- a/providers/google/internal/mail/adapter.go
+++ b/providers/google/internal/mail/adapter.go
@@ -35,7 +35,7 @@ func constructor(base *components.Connector) (*Adapter, error) {
 	adapter.SchemaProvider = schema.NewOpenAPISchemaProvider(adapter.ProviderContext.Module(), Schemas)
 
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		JSON: &interpreter.DirectFaultyResponder{Callback: adapter.interpretJSONError},
 		HTML: &interpreter.DirectFaultyResponder{Callback: adapter.interpretHTMLError},
 	}.Handle
 

--- a/providers/google/internal/mail/errors.go
+++ b/providers/google/internal/mail/errors.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
 )
 
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
@@ -18,6 +19,10 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 		},
 	}...,
 )
+
+// jsonResponder mirrors what was previously passed inline to ErrorHandler.JSON; it is
+// now reused as the non-rate-limit fallback in interpretJSONError.
+var jsonResponder = interpreter.NewFaultyResponder(errorFormats, nil) //nolint:gochecknoglobals
 
 type ErrorResponse struct {
 	Error ErrorDetails `json:"error"`
@@ -45,6 +50,14 @@ func (e ErrorResponse) CombineErr(base error) error {
 	}
 
 	return fmt.Errorf("%w: %v", base, strings.Join(messages, ","))
+}
+
+// interpretJSONError routes Gmail JSON error bodies through the shared Google
+// rate-limit detector. Gmail returns 403 with reason RATE_LIMIT_EXCEEDED for
+// per-user quota violations; without this hook the response maps to ErrForbidden
+// (unrecoverable) instead of ErrLimitExceeded (retryable).
+func (a *Adapter) interpretJSONError(res *http.Response, body []byte) error {
+	return core.InterpretJSONError(res, body, jsonResponder.HandleErrorResponse)
 }
 
 func (a *Adapter) interpretHTMLError(res *http.Response, body []byte) error {


### PR DESCRIPTION
## Summary
- Adds `providers/google/internal/core.InterpretJSONError` that detects Google's seven rate-limit/quota reason strings (UPPER_SNAKE in `details[].reason`, camelCase in `errors[].reason`) on both 403 and 429 responses, returning `common.ErrLimitExceeded` (retryable) instead of letting the default status mapper fall through to `ErrForbidden` (unrecoverable).
- Wires the helper into Gmail (mail), Calendar, and Contacts adapters via `DirectFaultyResponder`, matching the existing HTML override pattern. Contacts' 409 → `ErrConflict` mapping is preserved through the fallback path.

## Context
Discovered while triaging an issue. The underlying HTTP response was still classified as `ErrForbidden` by the connector and killed the read activity before the limiter's backoff could matter. This change closes that gap at the connector layer.