### PR TITLE
fix(tests): Remove reference http.DefaultClient

### DIFF
--- a/common/http_test.go
+++ b/common/http_test.go
@@ -618,9 +618,7 @@ func TestHTTPClient_Get_Success(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -646,9 +644,7 @@ func TestHTTPClient_Get_WithBaseURL(t *testing.T) {
 	client := &HTTPClient{
 		Base: server.URL,
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -670,9 +666,7 @@ func TestHTTPClient_Get_ErrorResponse(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -694,9 +688,7 @@ func TestHTTPClient_Get_CustomErrorHandler(t *testing.T) {
 	customErr := errors.New("custom error")
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ErrorHandler: func(rsp *http.Response, body []byte) error {
 			return customErr
@@ -728,9 +720,7 @@ func TestHTTPClient_Post_Success(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -759,9 +749,7 @@ func TestHTTPClient_Post_URLEncoded(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -795,9 +783,7 @@ func TestHTTPClient_Patch_Success(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -830,9 +816,7 @@ func TestHTTPClient_Put_Success(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -855,9 +839,7 @@ func TestHTTPClient_Delete_Success(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -880,9 +862,7 @@ func TestHTTPClient_CustomResponseHandler(t *testing.T) {
 	responseHandlerCalled := false
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ResponseHandler: func(rsp *http.Response) (*http.Response, error) {
 			responseHandlerCalled = true
@@ -912,9 +892,7 @@ func TestHTTPClient_CustomShouldHandleError(t *testing.T) {
 	shouldHandleErrorCalled := false
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ShouldHandleError: func(response *http.Response) bool {
 			shouldHandleErrorCalled = true
@@ -1452,9 +1430,7 @@ func TestHTTPClient_MethodsWithContext(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -1489,9 +1465,7 @@ func TestHTTPClient_WithEmptyResponseHandler(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ResponseHandler: nil, // Explicitly nil
 	}
@@ -1514,9 +1488,7 @@ func TestHTTPClient_WithEmptyErrorHandler(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ErrorHandler: nil, // Explicitly nil, should use default error handler
 	}
@@ -1538,9 +1510,7 @@ func TestHTTPClient_WithEmptyShouldHandleError(t *testing.T) {
 
 	client := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 		ShouldHandleError: nil, // Should use default 2xx check
 	}

--- a/common/interpreter/error_test.go
+++ b/common/interpreter/error_test.go
@@ -122,7 +122,7 @@ func TestErrorHandler(t *testing.T) { //nolint:funlen
 				t.Fatalf("test server failed to create request (%v)", err)
 			}
 
-			res, err := http.DefaultClient.Do(req)
+			res, err := tt.server.Client().Do(req)
 			if err != nil {
 				t.Fatalf("test server failed to respond (%v)", err)
 			}

--- a/common/json_test.go
+++ b/common/json_test.go
@@ -159,9 +159,7 @@ func TestJSONHTTPClient_Get_Success(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -209,9 +207,7 @@ func TestJSONHTTPClient_Get_ErrorResponse(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -238,9 +234,7 @@ func TestJSONHTTPClient_Get_ErrorPostProcessor(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -282,9 +276,7 @@ func TestJSONHTTPClient_Post_Success(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -357,9 +349,7 @@ func TestJSONHTTPClient_Put_Success(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -405,9 +395,7 @@ func TestJSONHTTPClient_Patch_Success(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -444,9 +432,7 @@ func TestJSONHTTPClient_Delete_Success(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 
@@ -481,9 +467,7 @@ func TestJSONHTTPClient_Delete_WithResponseBody(t *testing.T) {
 
 	httpClient := &HTTPClient{
 		Client: &mockAuthClient{
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return http.DefaultClient.Do(req)
-			},
+			doFunc: server.Client().Do,
 		},
 	}
 

--- a/memstore/connector_test.go
+++ b/memstore/connector_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1000,13 +1000,16 @@ func TestNewConnector_WithOptions(t *testing.T) {
 		"persons": testPersonSchema,
 	}
 
+	client := mockutils.NewClient()
+	defer client.CloseIdleConnections()
+
 	// Test WithClient option
-	conn, err := NewConnector(WithSchemas(schemas), WithClient(http.DefaultClient))
+	conn, err := NewConnector(WithSchemas(schemas), WithClient(client))
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
 	// Test WithAuthenticatedClient option
-	conn2, err := NewConnector(WithSchemas(schemas), WithAuthenticatedClient(http.DefaultClient))
+	conn2, err := NewConnector(WithSchemas(schemas), WithAuthenticatedClient(client))
 	require.NoError(t, err)
 	require.NotNil(t, conn2)
 }

--- a/providers/aircall/delete_test.go
+++ b/providers/aircall/delete_test.go
@@ -135,7 +135,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/aircall/metadata_test.go
+++ b/providers/aircall/metadata_test.go
@@ -1,7 +1,7 @@
 package aircall
 
 import (
-	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -84,17 +84,17 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			Module:              common.ModuleRoot,
-			AuthenticatedClient: &http.Client{},
+			AuthenticatedClient: server.Client(),
 			Workspace:           "test-workspace",
 		},
 	)
@@ -103,7 +103,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	}
 
 	// Override the base URL to point to the test server
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/aircall/read_test.go
+++ b/providers/aircall/read_test.go
@@ -461,7 +461,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/aircall/write_test.go
+++ b/providers/aircall/write_test.go
@@ -441,7 +441,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/breakcold/delete_test.go
+++ b/providers/breakcold/delete_test.go
@@ -72,7 +72,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/breakcold/metadata_test.go
+++ b/providers/breakcold/metadata_test.go
@@ -2,6 +2,7 @@ package breakcold
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -84,22 +85,22 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
-		AuthenticatedClient: http.DefaultClient,
+		AuthenticatedClient: server.Client(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	// for testing we want to redirect calls to our mock server
-	connector.SetBaseURL(serverURL)
+	connector.SetBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/breakcold/read_test.go
+++ b/providers/breakcold/read_test.go
@@ -101,7 +101,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/breakcold/write_test.go
+++ b/providers/breakcold/write_test.go
@@ -177,7 +177,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/campaignmonitor/delete_test.go
+++ b/providers/campaignmonitor/delete_test.go
@@ -72,7 +72,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/campaignmonitor/metadata_test.go
+++ b/providers/campaignmonitor/metadata_test.go
@@ -2,6 +2,7 @@ package campaignmonitor
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -64,22 +65,21 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
-		AuthenticatedClient: http.DefaultClient,
+		AuthenticatedClient: server.Client(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// for testing we want to redirect calls to our mock server
-	connector.SetBaseURL(serverURL)
+	connector.SetUnitTestMockServerBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/campaignmonitor/read_test.go
+++ b/providers/campaignmonitor/read_test.go
@@ -75,7 +75,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/campaignmonitor/write_test.go
+++ b/providers/campaignmonitor/write_test.go
@@ -48,7 +48,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/cloudtalk/delete_test.go
+++ b/providers/cloudtalk/delete_test.go
@@ -58,7 +58,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/cloudtalk/metadata_test.go
+++ b/providers/cloudtalk/metadata_test.go
@@ -1,7 +1,7 @@
 package cloudtalk
 
 import (
-	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -49,17 +49,17 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			Module:              common.ModuleRoot,
-			AuthenticatedClient: &http.Client{},
+			AuthenticatedClient: server.Client(),
 			Workspace:           "test-workspace",
 		},
 	)
@@ -68,7 +68,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 	}
 
 	// Override the base URL to point to the test server
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/cloudtalk/read_test.go
+++ b/providers/cloudtalk/read_test.go
@@ -222,7 +222,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/cloudtalk/write_test.go
+++ b/providers/cloudtalk/write_test.go
@@ -185,7 +185,7 @@ func TestWrite(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/dynamicsbusiness/delete_test.go
+++ b/providers/dynamicsbusiness/delete_test.go
@@ -49,7 +49,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/dynamicsbusiness/metadata_test.go
+++ b/providers/dynamicsbusiness/metadata_test.go
@@ -2,6 +2,7 @@ package dynamicsbusiness
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -73,15 +74,15 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
-		AuthenticatedClient: http.DefaultClient,
+		AuthenticatedClient: server.Client(),
 		Workspace:           "test-workspace",
 		Metadata: map[string]string{
 			"companyId":       "test-company-id",
@@ -92,7 +93,7 @@ func constructTestConnector(serverURL string) (*Connector, error) {
 		return nil, err
 	}
 
-	connector.SetBaseURL(serverURL)
+	connector.SetUnitTestMockServerBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/dynamicsbusiness/read_test.go
+++ b/providers/dynamicsbusiness/read_test.go
@@ -212,7 +212,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/dynamicsbusiness/write_test.go
+++ b/providers/dynamicsbusiness/write_test.go
@@ -105,7 +105,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/fourfour/metadata_test.go
+++ b/providers/fourfour/metadata_test.go
@@ -2,6 +2,7 @@ package fourfour
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -99,22 +100,21 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
-		AuthenticatedClient: http.DefaultClient,
+		AuthenticatedClient: server.Client(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// for testing we want to redirect calls to our mock server
-	connector.SetBaseURL(serverURL)
+	connector.SetUnitTestMockServerBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/fourfour/read_test.go
+++ b/providers/fourfour/read_test.go
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/getresponse/custom_test.go
+++ b/providers/getresponse/custom_test.go
@@ -102,7 +102,7 @@ func TestPrepareContactWriteRecordData(t *testing.T) {
 		jobTitleValue := "Senior Marketing Manager"
 
 		in := map[string]any{
-			"email":                              contactEmail,
+			"email":                               contactEmail,
 			CustomFieldKey(jobTitleCustomFieldID): jobTitleValue,
 		}
 		out := prepareContactWriteRecordData(in)

--- a/providers/getresponse/metadata_list.go
+++ b/providers/getresponse/metadata_list.go
@@ -2,6 +2,7 @@ package getresponse
 
 import (
 	"context"
+	"slices"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -48,11 +49,5 @@ func (c *Connector) listObjectMetadata(
 }
 
 func objectNamesIncludeCustomFields(objectNames []string) bool {
-	for _, objectName := range objectNames {
-		if objectsWithCustomFields.Has(objectName) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(objectNames, objectsWithCustomFields.Has)
 }

--- a/providers/getresponse/metadata_test.go
+++ b/providers/getresponse/metadata_test.go
@@ -55,9 +55,9 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			},
 		},
 		{
-			Name:  "Describe contacts merges custom field definitions",
-			Input: []string{"contacts"},
-			Server: testServerCustomFieldsListJSON(`[{"customFieldId":"fld1","name":"Tier","fieldType":"text","valueType":"single_select","values":["gold","silver"]}]`),
+			Name:       "Describe contacts merges custom field definitions",
+			Input:      []string{"contacts"},
+			Server:     testServerCustomFieldsListJSON(`[{"customFieldId":"fld1","name":"Tier","fieldType":"text","valueType":"single_select","values":["gold","silver"]}]`),
 			Comparator: testroutines.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{

--- a/providers/getresponse/read_test.go
+++ b/providers/getresponse/read_test.go
@@ -207,10 +207,10 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							"cf_f1": "gold",
 						},
 						Raw: map[string]any{
-							"contactId":       "pV3r",
-							"name":            "John Doe",
-							"email":           "john.doe@example.com",
-							"createdOn":       "2024-01-15T10:00:00+0000",
+							"contactId": "pV3r",
+							"name":      "John Doe",
+							"email":     "john.doe@example.com",
+							"createdOn": "2024-01-15T10:00:00+0000",
 							"customFieldValues": []any{
 								map[string]any{
 									"customFieldId": "f1",

--- a/providers/gusto/metadata_test.go
+++ b/providers/gusto/metadata_test.go
@@ -1,7 +1,7 @@
 package gusto
 
 import (
-	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -122,24 +122,24 @@ func TestListObjectMetadata(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			Module:              common.ModuleRoot,
-			AuthenticatedClient: &http.Client{},
+			AuthenticatedClient: server.Client(),
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/justcall/delete_test.go
+++ b/providers/justcall/delete_test.go
@@ -99,7 +99,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/justcall/metadata_test.go
+++ b/providers/justcall/metadata_test.go
@@ -57,7 +57,7 @@ func TestListObjectMetadata(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/justcall/read_test.go
+++ b/providers/justcall/read_test.go
@@ -2,6 +2,7 @@ package justcall
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -416,24 +417,24 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			Module:              common.ModuleRoot,
-			AuthenticatedClient: &http.Client{},
+			AuthenticatedClient: server.Client(),
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/justcall/write_test.go
+++ b/providers/justcall/write_test.go
@@ -220,7 +220,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/linkedin/delete_test.go
+++ b/providers/linkedin/delete_test.go
@@ -67,7 +67,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestAdsConnector(tt.Server.URL)
+				return constructTestAdsConnector(tt.Server)
 			})
 		})
 	}
@@ -101,7 +101,7 @@ func TestPlatformDelete(t *testing.T) { // nolint:funlen,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestPlatformConnector(tt.Server.URL)
+				return constructTestPlatformConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/linkedin/metadata_test.go
+++ b/providers/linkedin/metadata_test.go
@@ -115,7 +115,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestAdsConnector(tt.Server.URL)
+				return constructTestAdsConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/linkedin/read_test.go
+++ b/providers/linkedin/read_test.go
@@ -197,7 +197,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestAdsConnector(tt.Server.URL)
+				return constructTestAdsConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/linkedin/write_test.go
+++ b/providers/linkedin/write_test.go
@@ -3,6 +3,7 @@ package linkedin
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -79,7 +80,7 @@ func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestAdsConnector(tt.Server.URL)
+				return constructTestAdsConnector(tt.Server)
 			})
 		})
 	}
@@ -150,24 +151,27 @@ func TestPlatformWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestPlatformConnector(tt.Server.URL)
+				return constructTestPlatformConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestPlatformConnector(serverURL string) (*Connector, error) {
-	return constructTestConnector(serverURL, providers.ModuleLinkedInPlatform, nil)
+func constructTestPlatformConnector(server *httptest.Server) (*Connector, error) {
+	return constructTestConnector(server, providers.ModuleLinkedInPlatform, nil)
 }
 
-func constructTestAdsConnector(serverURL string) (*Connector, error) {
-	return constructTestConnector(serverURL, providers.ModuleLinkedInAds, map[string]string{"adAccountId": "514674276"})
+func constructTestAdsConnector(server *httptest.Server) (*Connector, error) {
+	return constructTestConnector(server, providers.ModuleLinkedInAds, map[string]string{"adAccountId": "514674276"})
 }
 
-func constructTestConnector(serverURL string, moduleID common.ModuleID, metadata map[string]string) (*Connector, error) { //nolint:lll
+func constructTestConnector(server *httptest.Server,
+	moduleID common.ModuleID,
+	metadata map[string]string,
+) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
 		Module:              moduleID,
-		AuthenticatedClient: http.DefaultClient,
+		AuthenticatedClient: server.Client(),
 		Metadata:            metadata,
 	})
 	if err != nil {
@@ -175,7 +179,7 @@ func constructTestConnector(serverURL string, moduleID common.ModuleID, metadata
 	}
 
 	// for testing we want to redirect calls to our mock server
-	connector.setUnitTestBaseURL(mockutils.ReplaceURLOrigin(connector.ModuleInfo().BaseURL, serverURL))
+	connector.setUnitTestBaseURL(mockutils.ReplaceURLOrigin(connector.ModuleInfo().BaseURL, server.URL))
 
 	return connector, nil
 }

--- a/providers/okta/delete_test.go
+++ b/providers/okta/delete_test.go
@@ -99,7 +99,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.DeleteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/okta/metadata_test.go
+++ b/providers/okta/metadata_test.go
@@ -1,7 +1,7 @@
 package okta
 
 import (
-	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -294,24 +294,24 @@ func TestListObjectMetadata(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(
 		common.ConnectorParams{
 			Module:              common.ModuleRoot,
-			AuthenticatedClient: &http.Client{},
+			AuthenticatedClient: server.Client(),
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/okta/read_test.go
+++ b/providers/okta/read_test.go
@@ -349,7 +349,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/okta/write_test.go
+++ b/providers/okta/write_test.go
@@ -153,7 +153,7 @@ func TestWrite(t *testing.T) {
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}


### PR DESCRIPTION
# Description

Tests should not use `http.DefaultClient` because its internal transport behaves like a singleton. In the past, closing the client could cause intermittent errors in other tests that relied on it.

## Changes

This change ensures that a new client instance is created for each test via `mockutils.NewClient()` (however, only one such case).

For most other cases, we reuse the client provided by `httptest.Server`. Since the mock server is created per unit test, and each test initializes a new connector instance, there is no risk in reusing a non-singleton client. When the test completes, the server is closed, and the associated client is cleaned up through the resulting teardown chain and connector instance is discarded.

# Note

The other files may still use `http.DefaultClient` and those are not changed. The change is about tests that run in parallel which can cause side effects via the singelton client transport instance.