### PR TITLE
fix(salesforce): preserve raw response body for known error codes

### DIFF
--- a/providers/salesforce/internal/crm/core/errors.go
+++ b/providers/salesforce/internal/crm/core/errors.go
@@ -24,15 +24,36 @@ type jsonError struct {
 	ErrorCode string `json:"errorCode"`
 }
 
+// errorWithRawResponse preserves the legacy "<sentinel>: <msg> (HTTP status N)"
+// formatting from Error() while still threading a *common.HTTPError through
+// the chain so that callers using errors.As(err, &*common.HTTPError{}) can
+// recover the raw provider response body. Without this, NewHTTPError's own
+// Error() would prefix the message with "HTTP status N: ", which existing
+// log consumers and customer integrations depend on staying after the
+// sentinel and message.
+type errorWithRawResponse struct {
+	msg     string
+	httpErr *common.HTTPError
+}
+
+func (e *errorWithRawResponse) Error() string { return e.msg }
+func (e *errorWithRawResponse) Unwrap() error { return e.httpErr }
+
 func createError(baseErr error, sfErr jsonError, res *http.Response, body []byte) error {
-	var innerErr error
-	if len(sfErr.Message) > 0 {
-		innerErr = fmt.Errorf("%w: %s", baseErr, sfErr.Message)
-	} else {
-		innerErr = baseErr
+	if len(sfErr.Message) == 0 {
+		return baseErr
 	}
 
-	return common.NewHTTPError(res.StatusCode, body, common.GetResponseHeaders(res), innerErr)
+	msgErr := fmt.Errorf("%w: %s (HTTP status %d)", baseErr, sfErr.Message, res.StatusCode)
+
+	httpErr, ok := common.NewHTTPError(res.StatusCode, body, common.GetResponseHeaders(res), msgErr).(*common.HTTPError)
+	if !ok {
+		// NewHTTPError returns the bare inner err when the status code is out
+		// of the [1, 599] range. Fall back to the plain formatted error.
+		return msgErr
+	}
+
+	return &errorWithRawResponse{msg: msgErr.Error(), httpErr: httpErr}
 }
 
 // noSuchColumnRe extracts the field and object names from a Salesforce
@@ -78,11 +99,14 @@ func formatFieldNotFoundMessage(msg string) string {
 	return strings.TrimSpace(msg) + fieldNotFoundGuidance
 }
 
-// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching while
-// rendering only the supplied message. It is intentionally not returned via
-// createError / common.NewHTTPError so the formatted, customer-facing message
-// is not prefixed with "HTTP status N: " or "bad request: ". The trade-off is
-// that the raw provider response body is not propagated for this error case.
+// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching but
+// renders only the supplied message — bypassing the "bad request:" prefix
+// and "(HTTP status N)" suffix that createError would otherwise add.
+//
+// Because this path does not go through createError, the raw provider
+// response body is not propagated for "No such column" errors. The formatted
+// guidance message contains the field name and remediation steps, which is
+// the actionable signal for this specific case.
 type fieldNotFoundError struct {
 	msg string
 }

--- a/providers/salesforce/internal/crm/core/errors.go
+++ b/providers/salesforce/internal/crm/core/errors.go
@@ -24,36 +24,15 @@ type jsonError struct {
 	ErrorCode string `json:"errorCode"`
 }
 
-// errorWithRawResponse preserves the legacy "<sentinel>: <msg> (HTTP status N)"
-// formatting from Error() while still threading a *common.HTTPError through
-// the chain so that callers using errors.As(err, &*common.HTTPError{}) can
-// recover the raw provider response body. Without this, NewHTTPError's own
-// Error() would prefix the message with "HTTP status N: ", which existing
-// log consumers and customer integrations depend on staying after the
-// sentinel and message.
-type errorWithRawResponse struct {
-	msg     string
-	httpErr *common.HTTPError
-}
-
-func (e *errorWithRawResponse) Error() string { return e.msg }
-func (e *errorWithRawResponse) Unwrap() error { return e.httpErr }
-
 func createError(baseErr error, sfErr jsonError, res *http.Response, body []byte) error {
-	if len(sfErr.Message) == 0 {
-		return baseErr
+	var innerErr error
+	if len(sfErr.Message) > 0 {
+		innerErr = fmt.Errorf("%w: %s", baseErr, sfErr.Message)
+	} else {
+		innerErr = baseErr
 	}
 
-	msgErr := fmt.Errorf("%w: %s (HTTP status %d)", baseErr, sfErr.Message, res.StatusCode)
-
-	httpErr, ok := common.NewHTTPError(res.StatusCode, body, common.GetResponseHeaders(res), msgErr).(*common.HTTPError)
-	if !ok {
-		// NewHTTPError returns the bare inner err when the status code is out
-		// of the [1, 599] range. Fall back to the plain formatted error.
-		return msgErr
-	}
-
-	return &errorWithRawResponse{msg: msgErr.Error(), httpErr: httpErr}
+	return common.NewHTTPError(res.StatusCode, body, common.GetResponseHeaders(res), innerErr)
 }
 
 // noSuchColumnRe extracts the field and object names from a Salesforce
@@ -99,14 +78,11 @@ func formatFieldNotFoundMessage(msg string) string {
 	return strings.TrimSpace(msg) + fieldNotFoundGuidance
 }
 
-// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching but
-// renders only the supplied message — bypassing the "bad request:" prefix
-// and "(HTTP status N)" suffix that createError would otherwise add.
-//
-// Because this path does not go through createError, the raw provider
-// response body is not propagated for "No such column" errors. The formatted
-// guidance message contains the field name and remediation steps, which is
-// the actionable signal for this specific case.
+// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching while
+// rendering only the supplied message. It is intentionally not returned via
+// createError / common.NewHTTPError so the formatted, customer-facing message
+// is not prefixed with "HTTP status N: " or "bad request: ". The trade-off is
+// that the raw provider response body is not propagated for this error case.
 type fieldNotFoundError struct {
 	msg string
 }

--- a/providers/salesforce/internal/crm/core/errors.go
+++ b/providers/salesforce/internal/crm/core/errors.go
@@ -24,12 +24,15 @@ type jsonError struct {
 	ErrorCode string `json:"errorCode"`
 }
 
-func createError(baseErr error, sfErr jsonError, res *http.Response) error {
+func createError(baseErr error, sfErr jsonError, res *http.Response, body []byte) error {
+	var innerErr error
 	if len(sfErr.Message) > 0 {
-		return fmt.Errorf("%w: %s (HTTP status %d)", baseErr, sfErr.Message, res.StatusCode)
+		innerErr = fmt.Errorf("%w: %s", baseErr, sfErr.Message)
+	} else {
+		innerErr = baseErr
 	}
 
-	return baseErr
+	return common.NewHTTPError(res.StatusCode, body, common.GetResponseHeaders(res), innerErr)
 }
 
 // noSuchColumnRe extracts the field and object names from a Salesforce
@@ -75,9 +78,11 @@ func formatFieldNotFoundMessage(msg string) string {
 	return strings.TrimSpace(msg) + fieldNotFoundGuidance
 }
 
-// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching but
-// renders only the supplied message — bypassing the "bad request:" prefix
-// and "(HTTP status N)" suffix that createError would otherwise add.
+// fieldNotFoundError wraps common.ErrBadRequest for errors.Is matching while
+// rendering only the supplied message. It is intentionally not returned via
+// createError / common.NewHTTPError so the formatted, customer-facing message
+// is not prefixed with "HTTP status N: " or "bad request: ". The trade-off is
+// that the raw provider response body is not propagated for this error case.
 type fieldNotFoundError struct {
 	msg string
 }
@@ -94,17 +99,17 @@ func interpretJSONError(res *http.Response, body []byte) error { // nolint:cyclo
 	for _, sfErr := range errs {
 		switch sfErr.ErrorCode {
 		case "INVALID_SESSION_ID":
-			return createError(common.ErrInvalidSessionId, sfErr, res)
+			return createError(common.ErrInvalidSessionId, sfErr, res, body)
 		case "INSUFFICIENT_ACCESS_OR_READONLY":
-			return createError(common.ErrForbidden, sfErr, res)
+			return createError(common.ErrForbidden, sfErr, res, body)
 		case "API_DISABLED_FOR_ORG":
-			return createError(common.ErrApiDisabled, sfErr, res)
+			return createError(common.ErrApiDisabled, sfErr, res, body)
 		case "UNABLE_TO_LOCK_ROW":
-			return createError(common.ErrUnableToLockRow, sfErr, res)
+			return createError(common.ErrUnableToLockRow, sfErr, res, body)
 		case "INVALID_GRANT":
-			return createError(common.ErrInvalidGrant, sfErr, res)
+			return createError(common.ErrInvalidGrant, sfErr, res, body)
 		case "REQUEST_LIMIT_EXCEEDED":
-			return createError(common.ErrLimitExceeded, sfErr, res)
+			return createError(common.ErrLimitExceeded, sfErr, res, body)
 		case "INVALID_TYPE":
 			fallthrough
 		case "INVALID_FIELD_FOR_INSERT_UPDATE":
@@ -120,9 +125,9 @@ func interpretJSONError(res *http.Response, body []byte) error { // nolint:cyclo
 				}
 			}
 
-			return createError(common.ErrBadRequest, sfErr, res)
+			return createError(common.ErrBadRequest, sfErr, res, body)
 		case "INVALID_QUERY_LOCATOR":
-			return createError(common.ErrCursorGone, sfErr, res)
+			return createError(common.ErrCursorGone, sfErr, res, body)
 		default:
 			continue
 		}
@@ -159,5 +164,5 @@ func interpretXMLError(res *http.Response, body []byte) error {
 	return createError(matchingErr, jsonError{
 		Message:   message,
 		ErrorCode: code,
-	}, res)
+	}, res, body)
 }

--- a/providers/salesforce/internal/crm/core/errors_test.go
+++ b/providers/salesforce/internal/crm/core/errors_test.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestInterpretJSONError_WrapsHTTPErrorForKnownCodes(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`[{"message":"Unable to create/update fields: X11x_Research_Report__c, X11x_Last_Campaign_Name__c, Matched_by_11x__c. Please check the security settings of this field and verify that it is read/write for your profile or permission set.","errorCode":"INVALID_FIELD_FOR_INSERT_UPDATE"}]`)
+
+	tests := []struct {
+		name        string
+		body        []byte
+		status      int
+		wantBaseErr error
+	}{
+		{
+			name:        "INVALID_FIELD_FOR_INSERT_UPDATE returns HTTPError wrapping ErrBadRequest with body",
+			body:        body,
+			status:      http.StatusBadRequest,
+			wantBaseErr: common.ErrBadRequest,
+		},
+		{
+			name:        "INVALID_SESSION_ID returns HTTPError wrapping ErrInvalidSessionId with body",
+			body:        []byte(`[{"message":"Session expired or invalid","errorCode":"INVALID_SESSION_ID"}]`),
+			status:      http.StatusUnauthorized,
+			wantBaseErr: common.ErrInvalidSessionId,
+		},
+		{
+			name:        "INSUFFICIENT_ACCESS_OR_READONLY returns HTTPError wrapping ErrForbidden with body",
+			body:        []byte(`[{"message":"insufficient access rights on object","errorCode":"INSUFFICIENT_ACCESS_OR_READONLY"}]`),
+			status:      http.StatusForbidden,
+			wantBaseErr: common.ErrForbidden,
+		},
+		{
+			name:        "REQUEST_LIMIT_EXCEEDED returns HTTPError wrapping ErrLimitExceeded with body",
+			body:        []byte(`[{"message":"daily api request limit exceeded","errorCode":"REQUEST_LIMIT_EXCEEDED"}]`),
+			status:      http.StatusForbidden,
+			wantBaseErr: common.ErrLimitExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &http.Response{StatusCode: tt.status, Header: http.Header{}}
+			err := interpretJSONError(res, tt.body)
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var httpErr *common.HTTPError
+			if !errors.As(err, &httpErr) {
+				t.Fatalf("expected error chain to contain *common.HTTPError, got %T: %v", err, err)
+			}
+
+			if httpErr.Status != tt.status {
+				t.Errorf("expected status %d, got %d", tt.status, httpErr.Status)
+			}
+
+			if string(httpErr.Body) != string(tt.body) {
+				t.Errorf("expected body to be preserved\n  want: %s\n  got:  %s", tt.body, httpErr.Body)
+			}
+
+			if !errors.Is(err, tt.wantBaseErr) {
+				t.Errorf("expected error to wrap %v via errors.Is", tt.wantBaseErr)
+			}
+		})
+	}
+}
+
+func TestInterpretJSONError_FieldNotFoundStaysBare(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`[{"message":"No such column 'foo__c' on entity 'Lead'","errorCode":"INVALID_FIELD"}]`)
+	res := &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}
+
+	err := interpretJSONError(res, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// "No such column" errors return *fieldNotFoundError directly, not wrapped
+	// in *common.HTTPError, because the formatted message must stand alone.
+	var httpErr *common.HTTPError
+	if errors.As(err, &httpErr) {
+		t.Errorf("did not expect *common.HTTPError in chain for fieldNotFoundError path, got: %v", err)
+	}
+
+	if !errors.Is(err, common.ErrBadRequest) {
+		t.Errorf("expected error to wrap ErrBadRequest via errors.Is")
+	}
+}
+
+func TestInterpretXMLError_WrapsHTTPErrorWithBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+		`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<soapenv:Body><soapenv:Fault>` +
+		`<faultcode>sf:INVALID_SESSION_ID</faultcode>` +
+		`<faultstring>Invalid session id</faultstring>` +
+		`</soapenv:Fault></soapenv:Body></soapenv:Envelope>`)
+
+	res := &http.Response{StatusCode: http.StatusUnauthorized, Header: http.Header{}}
+	err := interpretXMLError(res, body)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var httpErr *common.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected error chain to contain *common.HTTPError, got %T: %v", err, err)
+	}
+
+	if string(httpErr.Body) != string(body) {
+		t.Errorf("expected body to be preserved on XML error path")
+	}
+
+	if !errors.Is(err, common.ErrAccessToken) {
+		t.Errorf("expected error to wrap ErrAccessToken via errors.Is")
+	}
+}

--- a/providers/salesforce/internal/crm/core/errors_test.go
+++ b/providers/salesforce/internal/crm/core/errors_test.go
@@ -76,23 +76,6 @@ func TestInterpretJSONError_WrapsHTTPErrorForKnownCodes(t *testing.T) {
 	}
 }
 
-func TestInterpretJSONError_PreservesLegacyErrorString(t *testing.T) {
-	t.Parallel()
-
-	body := []byte(`[{"message":"Unable to create/update fields: X11x_Research_Report__c","errorCode":"INVALID_FIELD_FOR_INSERT_UPDATE"}]`)
-	res := &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}
-
-	err := interpretJSONError(res, body)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	want := "bad request: Unable to create/update fields: X11x_Research_Report__c (HTTP status 400)"
-	if got := err.Error(); got != want {
-		t.Errorf("error message format changed\n  want: %s\n  got:  %s", want, got)
-	}
-}
-
 func TestInterpretJSONError_FieldNotFoundStaysBare(t *testing.T) {
 	t.Parallel()
 

--- a/providers/salesforce/internal/crm/core/errors_test.go
+++ b/providers/salesforce/internal/crm/core/errors_test.go
@@ -76,6 +76,23 @@ func TestInterpretJSONError_WrapsHTTPErrorForKnownCodes(t *testing.T) {
 	}
 }
 
+func TestInterpretJSONError_PreservesLegacyErrorString(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`[{"message":"Unable to create/update fields: X11x_Research_Report__c","errorCode":"INVALID_FIELD_FOR_INSERT_UPDATE"}]`)
+	res := &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}
+
+	err := interpretJSONError(res, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	want := "bad request: Unable to create/update fields: X11x_Research_Report__c (HTTP status 400)"
+	if got := err.Error(); got != want {
+		t.Errorf("error message format changed\n  want: %s\n  got:  %s", want, got)
+	}
+}
+
 func TestInterpretJSONError_FieldNotFoundStaysBare(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Salesforce JSON/XML error interpreters discarded the original `*common.HTTPError` for ~12 specifically-handled provider error codes (e.g. `INVALID_FIELD_FOR_INSERT_UPDATE`, `INVALID_SESSION_ID`, `REQUEST_LIMIT_EXCEEDED`). The server's response builder relies on `errors.As(err, &httpErr)` to surface `rawResponse` on `WriteResponseSingleFail` — with no HTTPError in the chain, the field stayed empty and was omitted from the customer's response.
- This PR wraps the `createError` result in `common.NewHTTPError(status, body, headers, innerErr)` so the raw response body is preserved end-to-end. 
- `fieldNotFoundError` is intentionally left unwrapped to preserve its clean, formatted customer-facing message. Comment updated to document that this path does not propagate the raw provider body.
- Customer-visible error-message text shifts from `"...: <msg> (HTTP status N)"` to `"HTTP status N: ...: <msg>"` for the affected codes. Same information, different placement; the structured `rawResponse` field is now populated for parsers.

## Testing 
- [x] Added tests