### PR TITLE
[CON-3071] feat(gusto): enable read and write

### DIFF
--- a/providers/gusto.go
+++ b/providers/gusto.go
@@ -27,9 +27,9 @@ func init() { //nolint:funlen
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
@@ -72,9 +72,9 @@ func init() { //nolint:funlen
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1017" height="856" alt="image" src="https://github.com/user-attachments/assets/68a7d1b6-0315-46b0-aa48-2e810e0f21c0" />
<img width="967" height="859" alt="image" src="https://github.com/user-attachments/assets/55a07d70-880e-4031-ab4f-f4579c4e4829" />
<img width="968" height="838" alt="image" src="https://github.com/user-attachments/assets/fa545dd0-18dc-4c1a-a73f-f08c605e4ac3" />
<img width="920" height="629" alt="image" src="https://github.com/user-attachments/assets/24a8c346-f658-4fc5-9a0b-2aa9f1d5ea93" />
<img width="953" height="631" alt="image" src="https://github.com/user-attachments/assets/ff916f6a-49b9-456a-8c01-70488fdade60" />





- [x] Insert screenshot of Svix destination.
<img width="1590" height="1036" alt="image" src="https://github.com/user-attachments/assets/b0a2daf3-0f27-41d6-b1a9-cc939b21fd19" />
<img width="1590" height="1036" alt="image" src="https://github.com/user-attachments/assets/6866e104-ef26-4320-bf3b-771022db1364" />
<img width="1590" height="1047" alt="image" src="https://github.com/user-attachments/assets/c12b932e-55dd-4274-bd7f-51f1ec998e2e" />
<img width="1609" height="1040" alt="image" src="https://github.com/user-attachments/assets/0a3c925b-cf69-4c02-8d52-b41851761d20" />






- [x] Screenshot of operations on dashboard
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/4905ad61-402c-4446-b991-99caa1269b50" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/1d7814c1-82a4-4894-b949-987e024f6eec" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/892ab00b-4db8-437e-8576-07feab702168" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/80074194-f4a2-45a9-b646-3507cda64efe" />



# Write
- [x] Insert screenshot of dashboard.
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/678723a1-ea09-44d6-8d15-e70c3f49dc44" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/bcf7380c-458a-4ed7-982b-b0d1edad7d4d" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/f437c561-8295-4ee3-8e1d-d8123963f347" />
<img width="1545" height="1042" alt="image" src="https://github.com/user-attachments/assets/f1fdddb0-5f40-483c-a0f5-ef5c133ae526" />





- [x] Insert screenshot of HTTP call.
<img width="1433" height="1008" alt="image" src="https://github.com/user-attachments/assets/b0c531a4-2d36-4758-b310-891dec341459" />
<img width="1381" height="960" alt="image" src="https://github.com/user-attachments/assets/06752d55-dfbd-4893-a1b2-e9f44f390e4a" />
<img width="1452" height="825" alt="image" src="https://github.com/user-attachments/assets/44287acc-07f8-489e-8abd-952d6ccee7fa" />
<img width="1439" height="1064" alt="image" src="https://github.com/user-attachments/assets/71fbf333-651d-4d4b-a9f1-03ebfc9832c2" />





