### PR TITLE
chore: Add better prompt and doc URL for Netsuite workspace input

### DIFF
--- a/providers/netsuite.go
+++ b/providers/netsuite.go
@@ -92,7 +92,9 @@ func init() {
 			Input: []MetadataItemInput{
 				{
 					Name:        "workspace",
-					DisplayName: "Account ID",
+					DisplayName: "Netsuite URL Prefix",
+					Prompt: "If your Netsuite URL is https://1234567-sb.app.netsuite.com/, then the prefix is 1234567-sb.",
+					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},


### PR DESCRIPTION
We actually need the URL prefix, not Account ID, for sandbox accounts, the Account ID looks like 123456_SB1 but the prefix is 123456-sb1, we need the latter. 