### PR TITLE
[CON-3225] feat(goTo): enable read and write

### DIFF
--- a/providers/goTo.go
+++ b/providers/goTo.go
@@ -45,9 +45,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		PostAuthInfoNeeded: true,
 		Metadata: &ProviderMetadata{
@@ -67,9 +67,9 @@ func init() {
 				BaseURL:     "https://api.getgo.com",
 				DisplayName: "GoTo",
 				Support: Support{
-					Read:      false,
+					Read:      true,
 					Subscribe: false,
-					Write:     false,
+					Write:     true,
 				},
 			},
 			ModuleGoToConnect: {


### PR DESCRIPTION
# Installation
Mailmonkey using OAuth
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination
- [ ]  Read supports incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read and Write
- [x] Insert screenshot of metadata fields from read object installation.
<img width="925" height="841" alt="image" src="https://github.com/user-attachments/assets/44461254-c3da-4fa4-92d1-ce9792475f67" />
<img width="933" height="849" alt="image" src="https://github.com/user-attachments/assets/8c4614d9-3e1f-4deb-b2f1-6f379e03992b" />
<img width="959" height="858" alt="image" src="https://github.com/user-attachments/assets/80c22fa6-de54-4617-bef4-bf4000971a00" />
<img width="950" height="625" alt="image" src="https://github.com/user-attachments/assets/88683ef3-8928-40b9-a871-d6f89a844a31" />




- [x] Insert screenshot of Svix destination.
<img width="1608" height="1039" alt="image" src="https://github.com/user-attachments/assets/a4ad8978-5e25-4f5c-a346-9590357ef48a" />
<img width="1608" height="1039" alt="image" src="https://github.com/user-attachments/assets/e9146f16-9272-4934-9a4d-eacd20b7956b" />
<img width="1608" height="1039" alt="image" src="https://github.com/user-attachments/assets/0cf3cf23-5f20-4e92-9e03-a338a9ce4d33" />




- [x] Screenshot of operations on dashboard
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/cce05e8d-a810-444c-973b-d83c74b0116d" />
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/81ba44e4-6ea4-4b78-ab2e-7948b56714a9" />
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/7e28ed9d-0c54-4263-829d-a455a9fa7950" />



# Write
- [x] Insert screenshot of dashboard.
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/087645d6-58bb-4252-a857-f4839f75a4ba" />
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/0a5df4d6-86b9-469c-8243-40c55b1ca8c0" />
<img width="1548" height="1041" alt="image" src="https://github.com/user-attachments/assets/6c3ca9f8-083d-4875-a3b8-adb8ac1cbfc9" />






- [x] Insert screenshot of HTTP call.

<img width="1453" height="693" alt="image" src="https://github.com/user-attachments/assets/a88061ac-9f53-4152-9087-0a65956598fc" />
<img width="1408" height="562" alt="image" src="https://github.com/user-attachments/assets/6e653d06-fb3b-4ec9-accd-7eb40cfde740" />
<img width="1458" height="608" alt="image" src="https://github.com/user-attachments/assets/35694423-7022-4cc6-8c1a-26ec05e787bb" />





