### PR TITLE
fix(monday): mark write support enabled

### DIFF
--- a/providers/monday.go
+++ b/providers/monday.go
@@ -35,7 +35,7 @@ func init() {
 			Proxy:     true,
 			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 	})
 }


### PR DESCRIPTION
## Summary

Marks Monday as supporting Write Actions in the provider catalog metadata.

## Why

`providers/monday` already registers write support for Monday objects, and runtime validation in amp-labs/connectors#3003 confirmed that creating a Monday board through the Write Actions API succeeds end-to-end. The generated/live catalog currently reports `support.write: false`, which causes docs drift and under-reports the capability.

## Scope

This is intentionally narrow:

- changes only `providers/monday.go`
- does not change AWS or any other provider
- runtime evidence covers Monday `boards` create only

Fixes #3003.

## Validation

- Reviewed connector source: `providers/monday/utils.go` registers `components.WriteSupport` for Monday objects.
- Runtime evidence is documented in #3003: `POST /objects/boards` returned HTTP 200 and created a real Monday board, which was cleaned up after the test.
- Local Go tests not run: `go` is not installed in this local environment.
