### PR TITLE
fix(goto): wrap single object into array for array-body endpoints

### DIFF
--- a/providers/goto/internal/gotocore/write.go
+++ b/providers/goto/internal/gotocore/write.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
 )
@@ -40,7 +40,7 @@ func (a *Adapter) buildWriteRequest(ctx context.Context, params common.WritePara
 		}
 	}
 
-	jsonData, err := marshalWriteBody(params.RecordData)
+	jsonData, err := marshalWriteBody(params.ObjectName, params.RecordData)
 	if err != nil {
 		return nil, err
 	}
@@ -48,26 +48,26 @@ func (a *Adapter) buildWriteRequest(ctx context.Context, params common.WritePara
 	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
-// marshalWriteBody serializes the write payload. Most GoTo endpoints accept a
-// JSON object, but a few (e.g. webhooks, userSubscriptions) accept an array of
-// objects — for those we pass the slice through without coercing it to a map.
-func marshalWriteBody(recordData any) ([]byte, error) {
-	v := reflect.ValueOf(recordData)
-	if v.IsValid() && (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) {
-		jsonData, err := json.Marshal(recordData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal record data: %w", err)
-		}
+// arrayBodyObjects are the GoTo objects whose write endpoints expect the request
+// body to be a JSON array of records rather than a single object.
+var arrayBodyObjects = datautils.NewSet("webhooks", "userSubscriptions") //nolint:gochecknoglobals
 
-		return jsonData, nil
-	}
-
+// marshalWriteBody serializes the write payload. RecordData always arrives as a
+// single record object; most GoTo endpoints accept that object as-is, but a few
+// (webhooks, userSubscriptions) require a JSON array, so for those we wrap the
+// record in a one-element array before marshaling.
+func marshalWriteBody(objectName string, recordData any) ([]byte, error) {
 	asMap, err := common.RecordDataToMap(recordData)
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(asMap)
+	var payload any = asMap
+	if arrayBodyObjects.Has(objectName) {
+		payload = []map[string]any{asMap}
+	}
+
+	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal record data: %w", err)
 	}

--- a/providers/goto/test/create-webhook.json
+++ b/providers/goto/test/create-webhook.json
@@ -1,0 +1,15 @@
+{
+  "_embedded": {
+    "webhooks": [
+      {
+        "callbackUrl": "https://example.com/hook",
+        "createTime": "2026-05-29T11:08:44.508Z",
+        "eventName": "registrant.joined",
+        "eventVersion": "1.0.0",
+        "product": "g2w",
+        "state": "INACTIVE",
+        "webhookKey": "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2"
+      }
+    ]
+  }
+}

--- a/providers/goto/write_test.go
+++ b/providers/goto/write_test.go
@@ -18,6 +18,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createGroupsResponse := testutils.DataFromFile(t, "create-groups.json")
 	createTeamsResponse := testutils.DataFromFile(t, "create-teams.json")
 	createTemplatesResponse := testutils.DataFromFile(t, "create-templates.json")
+	createWebhookResponse := testutils.DataFromFile(t, "create-webhook.json")
 
 	tests := []testroutines.Write{
 		{
@@ -142,6 +143,40 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				Success:  true,
 				RecordId: "kdhoasdofaso",
 				Data:     map[string]any{},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// webhooks is an array-body endpoint: we accept a single record
+			// object and must wrap it into a one-element array in the request.
+			Name: "Create webhook wraps single object into array body",
+			Input: common.WriteParams{
+				ObjectName: "webhooks",
+				RecordData: map[string]any{
+					"callbackUrl":  "https://example.com/hook",
+					"eventName":    "registrant.joined",
+					"eventVersion": "1.0.0",
+					"product":      "g2w",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/G2W/rest/v2/webhooks"),
+					// the single record object must be wrapped in a one-element array
+					mockcond.Body(`[{"callbackUrl":"https://example.com/hook","eventName":"registrant.joined","eventVersion":"1.0.0","product":"g2w"}]`), //nolint:lll
+				},
+				Then: mockserver.Response(http.StatusOK, createWebhookResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2",
+				Data: map[string]any{
+					"webhookKey":  "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2",
+					"callbackUrl": "https://example.com/hook",
+				},
 			},
 			ExpectedErrs: nil,
 		},

--- a/test/goto/write/main.go
+++ b/test/goto/write/main.go
@@ -72,13 +72,12 @@ func testCreateWebhooks(ctx context.Context) error {
 	conn := connTest.GetGoToConnector(ctx, providers.ModuleGoTo)
 	res, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: "webhooks",
-		RecordData: []map[string]any{
-			{
-				"callbackUrl":  "https://webhook.site/4930c4f8-c82c-4183-9fb0-bce3b7450cd1",
-				"eventName":    "registrant.joined",
-				"eventVersion": "1.0.0",
-				"product":      "g2w",
-			},
+		RecordData: map[string]any{
+
+			"callbackUrl":  "https://webhook.site/a7abb896-0b6a-453e-944d-233c13664021",
+			"eventName":    "registrant.joined",
+			"eventVersion": "1.0.0",
+			"product":      "g2w",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
For objects whose endpoints expect an array (webhooks, userSubscriptions), we now accept a single object and wrap it into an array of objects during payload building.

### Test Results

```
   ~/Desktop/Ampersand/connectors    fix/gusto-write *12 !2  go run ./test/goto/write                                                                                          ✔  system   04:53:38 PM  
time=2026-05-29T16:53:41.929+05:45 level=DEBUG msg="loading credentials file" path=./go-to-creds.json
Created meeting..
{
  "Data": {
    "conferenceCallInfo": "string",
    "joinURL": "https://meet.goto.com/930111957",
    "maxParticipants": 26,
    "meetingid": 930111957,
    "uniqueMeetingId": 930111957
  },
  "Errors": [],
  "RecordId": "930111957",
  "Success": true
}
time=2026-05-29T16:53:43.714+05:45 level=DEBUG msg="loading credentials file" path=./go-to-creds.json
Created webhook..
{
  "Data": {
    "callbackUrl": "https://webhook.site/a7abb896-0b6a-453e-944d-233c13664021",
    "createTime": "2026-05-29T11:08:44.508Z",
    "eventName": "registrant.joined",
    "eventVersion": "1.0.0",
    "product": "g2w",
    "state": "INACTIVE",
    "webhookKey": "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2"
  },
  "Errors": [],
  "RecordId": "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2",
  "Success": true
}
time=2026-05-29T16:53:44.708+05:45 level=DEBUG msg="loading credentials file" path=./go-to-creds.json
Created attribute..
{
  "Data": {},
  "Errors": [],
  "RecordId": "1lwdoecpunbw9",
  "Success": true
}
Tests completed successfully
```