### PR TITLE
fix(hubspot): Fetch only unique contacts

### DIFF
--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -675,7 +675,7 @@ func (c *Connector) lookupMarketingCampaignContacts(ctx context.Context, // noli
 	}
 
 	campaignLookup := make(map[ContactID]contactRelationship)
-	contactIDs := make([]string, 0)
+	contactIDs := make(datautils.Set[string])
 
 	for relationship := range responseChannel {
 		for _, contactID := range relationship.ContactIDs {
@@ -683,14 +683,14 @@ func (c *Connector) lookupMarketingCampaignContacts(ctx context.Context, // noli
 				ContactType: relationship.ContactType,
 				CampaignID:  relationship.CampaignID,
 			}
-			contactIDs = append(contactIDs, string(contactID))
+			contactIDs.AddOne(string(contactID))
 		}
 	}
 
 	// Fetch contacts.
 	contactBatchResult := batch.Read[crmObjectSchema[ContactID]](ctx, c.batchAdapter, batch.ReadParams{
 		ObjectName:  core.ObjectContacts,
-		Identifiers: contactIDs,
+		Identifiers: contactIDs.List(),
 	})
 
 	if len(contactBatchResult.Errors) != 0 {

--- a/providers/netsuite.go
+++ b/providers/netsuite.go
@@ -91,11 +91,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},

--- a/providers/netsuiteM2M.go
+++ b/providers/netsuiteM2M.go
@@ -103,11 +103,11 @@ func init() {
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{
 				{
-					Name:        "workspace",
-					DisplayName: "Netsuite URL Prefix",
-					Prompt: "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
+					Name:         "workspace",
+					DisplayName:  "Netsuite URL Prefix",
+					Prompt:       "If your Netsuite URL is `https://1234567-sb.app.netsuite.com`, then the prefix is `1234567-sb`.",
 					DefaultValue: "1234567-sb",
-					DocsURL: "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
+					DocsURL:      "https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1498251763.html",
 					ModuleDependencies: &ModuleDependencies{
 						ModuleNetsuiteRESTAPI: ModuleDependency{},
 						ModuleNetsuiteSuiteQL: ModuleDependency{},


### PR DESCRIPTION
# Description

After acquring the list of contacts associated with each campaign we should ensure that no identifiers are duplicated to avoid batch reading the same contacts over and over again.

# Live Tests

Marketing campaigns with contacts associations:

<img width="901" height="1019" alt="image" src="https://github.com/user-attachments/assets/57b1c4ba-398e-4343-a076-0c6fbd35a929" />
