### PR TITLE
[CON-3259, CON-3260] feat: add incremental read & pagination support in servicenow connector

### DIFF
--- a/providers/servicenow/handlers.go
+++ b/providers/servicenow/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/providers"
+	"github.com/spyzhov/ajson"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
@@ -190,8 +191,9 @@ func (c *Connector) parseWriteResponse(
 
 	result, err := body.GetKey("result")
 	if err != nil {
-		// No "result" field (e.g. an empty body). The write still succeeded.
-		return &common.WriteResult{Success: true}, nil //nolint: nilerr
+		// No "result" envelope. Some APIs (lead and other TMF/Open APIs) return the
+		// created record as a bare top-level object, so recover sys_id from the root.
+		return c.writeResultFromRecord(ctx, params, body) //nolint: nilerr
 	}
 
 	// Some scoped APIs (e.g. Contact, Consumer) return only the new record's sys_id
@@ -208,18 +210,29 @@ func (c *Connector) parseWriteResponse(
 
 	// Most APIs (Table API and the like) return the written record object:
 	// {"result": {...}}.
-	if !result.IsObject() {
+	return c.writeResultFromRecord(ctx, params, result)
+}
+
+// writeResultFromRecord builds a WriteResult from a record object node, capturing
+// its fields as Data and its sys_id as the RecordId. A node that isn't an object,
+// or that carries no sys_id, still yields a successful result.
+func (c *Connector) writeResultFromRecord(
+	ctx context.Context,
+	params common.WriteParams,
+	record *ajson.Node,
+) (*common.WriteResult, error) {
+	if !record.IsObject() {
 		return &common.WriteResult{Success: true}, nil
 	}
 
-	data, err := jsonquery.Convertor.ObjectToMap(result)
+	data, err := jsonquery.Convertor.ObjectToMap(record)
 	if err != nil {
 		logging.Logger(ctx).Error("failed to convert result object to map", "object", params.ObjectName, "err", err.Error())
 
 		return &common.WriteResult{Success: true}, nil
 	}
 
-	recordID, err := jsonquery.New(result).StringOptional("sys_id")
+	recordID, err := jsonquery.New(record).StringOptional("sys_id")
 	if err != nil || recordID == nil {
 		return &common.WriteResult{ //nolint: nilerr
 			Success: true,

--- a/providers/servicenow/handlers.go
+++ b/providers/servicenow/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/logging"
@@ -90,6 +91,26 @@ func (c *Connector) constructReadURL(params common.ReadParams) (string, error) {
 		return "", err
 	}
 
+	// Offset-paginated objects (e.g. the Knowledge and Change APIs) page via offset
+	// rather than the Link header, so seed the first page's window here. Some accept
+	// a page-size param (limitKey); others (Change) only take an offset.
+	if pg, ok := offsetPaginationOf(params.ObjectName); ok {
+		if pg.limitKey != "" {
+			url.WithQueryParam(pg.limitKey, strconv.Itoa(offsetPageSize))
+		}
+
+		url.WithQueryParam(pg.offsetKey, "0")
+	} else if pp, ok := pagePaginationOf(params.ObjectName); ok {
+		url.WithQueryParam(pp.perPageKey, strconv.Itoa(offsetPageSize))
+		url.WithQueryParam(pp.pageKey, "1")
+	}
+
+	// Incremental read: filter by sys_updated_on when Since/Until are set and the
+	// object's list endpoint accepts sysparm_query.
+	if query := incrementalQuery(params); query != "" {
+		url.WithQueryParam("sysparm_query", query)
+	}
+
 	return url.String(), nil
 }
 
@@ -108,9 +129,18 @@ func (c *Connector) parseReadResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
+	// Objects that paginate via limit/offset (e.g. the Knowledge API) advance the
+	// window from the request URL; everything else follows the Link header.
+	nextPage := getNextRecordsURL(response, c.ProviderInfo().BaseURL)
+	if _, ok := offsetPaginationOf(params.ObjectName); ok {
+		nextPage = offsetNextPage(params.ObjectName, request)
+	} else if _, ok := pagePaginationOf(params.ObjectName); ok {
+		nextPage = pageNextPage(params.ObjectName, request)
+	}
+
 	return common.ParseResult(response,
 		recordsFunc(params.ObjectName),
-		getNextRecordsURL(response, c.ProviderInfo().BaseURL),
+		nextPage,
 		common.GetMarshaledData,
 		params.Fields,
 	)

--- a/providers/servicenow/incremental.go
+++ b/providers/servicenow/incremental.go
@@ -1,0 +1,54 @@
+package servicenow
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// snDateTimeFormat is ServiceNow's encoded-query datetime layout.
+const snDateTimeFormat = "2006-01-02 15:04:05"
+
+// incrementalScopedObjects are non-Table-API objects whose list GET accepts a
+// sysparm_query on sys_updated_on, so they support Since/Until delta reads.
+var incrementalScopedObjects = []string{
+	"account",
+	"case",
+	"change",
+	"consumer",
+	"contact",
+	"lead",
+}
+
+// supportsIncrementalRead reports whether the object can be filtered by
+// sys_updated_on via sysparm_query. Every Table API object qualifies, as do a few
+// scoped APIs that accept sysparm_query. TMF/Open (bare-array) and SCIM responses
+// don't expose sysparm_query, so for those a read with Since simply returns the
+// full set.
+func supportsIncrementalRead(objectName string) bool {
+	if slices.Contains(incrementalScopedObjects, objectName) {
+		return true
+	}
+
+	return strings.HasPrefix(objectPaths[objectName], "now/table/")
+}
+
+// incrementalQuery builds the sys_updated_on sysparm_query fragment for the
+// [Since, Until] window, or returns "" when no incremental filter applies.
+//
+// Note: ServiceNow interprets the datetime in the integration user's timezone, so
+// that user's timezone should be UTC for the window to line up exactly.
+func incrementalQuery(params common.ReadParams) string {
+	if params.Since.IsZero() || !supportsIncrementalRead(params.ObjectName) {
+		return ""
+	}
+
+	updates := []string{"sys_updated_on>=" + params.Since.UTC().Format(snDateTimeFormat)}
+
+	if !params.Until.IsZero() {
+		updates = append(updates, "sys_updated_on<="+params.Until.UTC().Format(snDateTimeFormat))
+	}
+
+	return strings.Join(updates, "^")
+}

--- a/providers/servicenow/incremental.go
+++ b/providers/servicenow/incremental.go
@@ -12,7 +12,7 @@ const snDateTimeFormat = "2006-01-02 15:04:05"
 
 // incrementalScopedObjects are non-Table-API objects whose list GET accepts a
 // sysparm_query on sys_updated_on, so they support Since/Until delta reads.
-var incrementalScopedObjects = []string{
+var incrementalScopedObjects = []string{ //nolint: gochecknoglobals
 	"account",
 	"case",
 	"change",

--- a/providers/servicenow/parse.go
+++ b/providers/servicenow/parse.go
@@ -106,7 +106,7 @@ type offsetParams struct {
 // and at an offset past the end it returns a duplicate of the last record rather
 // than an empty page, so offset pagination can't terminate. Its default read
 // returns all records in a single page, so it's read without paging.
-var offsetPaginatedObjects = map[string]offsetParams{
+var offsetPaginatedObjects = map[string]offsetParams{ //nolint: gochecknoglobals
 	"articles": {limitKey: "limit", offsetKey: "offset"},
 }
 
@@ -165,7 +165,7 @@ type pageParams struct {
 
 // pagePaginatedObjects use 1-based page-number pagination (page + per-page) and
 // signal the end with a short or empty page.
-var pagePaginatedObjects = map[string]pageParams{
+var pagePaginatedObjects = map[string]pageParams{ //nolint: gochecknoglobals
 	"scorecards": {pageKey: "sysparm_page", perPageKey: "sysparm_per_page"},
 }
 

--- a/providers/servicenow/parse.go
+++ b/providers/servicenow/parse.go
@@ -1,10 +1,13 @@
 package servicenow
 
 import (
+	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/httpkit"
+	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
 )
 
@@ -81,5 +84,129 @@ func getNextRecordsURL(resp *common.JSONHTTPResponse, baseURL string) common.Nex
 		}
 
 		return next, nil
+	}
+}
+
+// offsetPageSize is the page size requested for offset-paginated objects.
+const offsetPageSize = 100
+
+// offsetParams names the query parameters an object paginates with. limitKey may
+// be empty for APIs that don't accept a page-size parameter (e.g. the Change API,
+// which only takes sysparm_offset and returns a server-controlled page size).
+type offsetParams struct {
+	limitKey  string // optional; when set, the first page requests offsetPageSize
+	offsetKey string
+}
+
+// offsetPaginatedObjects use offset-style pagination rather than the Link header,
+// requiring the client to advance the offset, and signal the end with an empty
+// page. The Knowledge API (limit/offset) qualifies.
+//
+// The Change API is intentionally excluded: it sends no Link header or total-count,
+// and at an offset past the end it returns a duplicate of the last record rather
+// than an empty page, so offset pagination can't terminate. Its default read
+// returns all records in a single page, so it's read without paging.
+var offsetPaginatedObjects = map[string]offsetParams{
+	"articles": {limitKey: "limit", offsetKey: "offset"},
+}
+
+func offsetPaginationOf(objectName string) (offsetParams, bool) {
+	p, ok := offsetPaginatedObjects[objectName]
+
+	return p, ok
+}
+
+// recordsNodes returns a page's record nodes for an object, respecting its
+// response shape (default "result", or the nested path in objectRecordsPath),
+// without the per-record map conversion that recordsFunc performs.
+func recordsNodes(objectName string, node *ajson.Node) ([]*ajson.Node, error) {
+	spec, ok := objectRecordsPath[objectName]
+	if !ok {
+		spec = recordsPath{jsonPath: "result"}
+	}
+
+	return jsonquery.New(node, spec.nested...).ArrayOptional(spec.jsonPath)
+}
+
+// offsetNextPage advances the offset by the number of records returned and stops
+// once a page comes back empty. Advancing by the actual count (rather than a fixed
+// limit) avoids gaps or overlaps for APIs that return a server-controlled page
+// size or an extra look-ahead record.
+func offsetNextPage(objectName string, request *http.Request) common.NextPageFunc {
+	params, _ := offsetPaginationOf(objectName)
+
+	return func(node *ajson.Node) (string, error) {
+		records, err := recordsNodes(objectName, node)
+		if err != nil {
+			return "", err
+		}
+
+		if len(records) == 0 {
+			return "", nil // empty page => end of records
+		}
+
+		query := request.URL.Query()
+		offset, _ := strconv.Atoi(query.Get(params.offsetKey))
+		query.Set(params.offsetKey, strconv.Itoa(offset+len(records)))
+
+		next := *request.URL
+		next.RawQuery = query.Encode()
+
+		return next.String(), nil
+	}
+}
+
+// pageParams names the page-number/per-page query parameters an object paginates
+// with (e.g. the Performance Analytics Scorecards API).
+type pageParams struct {
+	pageKey    string
+	perPageKey string
+}
+
+// pagePaginatedObjects use 1-based page-number pagination (page + per-page) and
+// signal the end with a short or empty page.
+var pagePaginatedObjects = map[string]pageParams{
+	"scorecards": {pageKey: "sysparm_page", perPageKey: "sysparm_per_page"},
+}
+
+func pagePaginationOf(objectName string) (pageParams, bool) {
+	p, ok := pagePaginatedObjects[objectName]
+
+	return p, ok
+}
+
+// pageNextPage advances the page number by one until a page returns fewer records
+// than the requested per-page size, which marks the end.
+func pageNextPage(objectName string, request *http.Request) common.NextPageFunc {
+	params, _ := pagePaginationOf(objectName)
+
+	return func(node *ajson.Node) (string, error) {
+		records, err := recordsNodes(objectName, node)
+		if err != nil {
+			return "", err
+		}
+
+		query := request.URL.Query()
+
+		perPage, err := strconv.Atoi(query.Get(params.perPageKey))
+		if err != nil || perPage <= 0 {
+			perPage = offsetPageSize
+		}
+
+		if len(records) < perPage {
+			return "", nil // short page => end of records
+		}
+
+		page, err := strconv.Atoi(query.Get(params.pageKey))
+		if err != nil || page <= 0 {
+			page = 1
+		}
+
+		query.Set(params.pageKey, strconv.Itoa(page+1))
+
+		next := *request.URL
+		next.RawQuery = query.Encode()
+
+		return next.String(), nil
 	}
 }

--- a/providers/servicenow/search.go
+++ b/providers/servicenow/search.go
@@ -3,7 +3,6 @@ package servicenow
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -18,12 +17,6 @@ import (
 // with AND. Only equality is supported in common.SearchFilter today, which maps
 // cleanly onto the `field=value` form.
 func (c *Connector) Search(ctx context.Context, params *common.SearchParams) (*common.SearchResult, error) {
-	// Search filters a list response, so it is only available for objects whose
-	// collection can be listed.
-	if !slices.Contains(readSupportedObjects, params.ObjectName) {
-		return nil, fmt.Errorf("%w: %s does not support search", common.ErrOperationNotSupportedForObject, params.ObjectName)
-	}
-
 	url, err := c.constructSearchURL(params)
 	if err != nil {
 		return nil, err

--- a/test/servicenow/write/main.go
+++ b/test/servicenow/write/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
 	ServiceNow "github.com/amp-labs/connectors/providers/servicenow"
 	"github.com/amp-labs/connectors/test/servicenow"
 )
@@ -32,7 +33,7 @@ func run() error {
 		return err
 	}
 
-	err = testUpdateCase(ctx, conn)
+	err = testCreateCase(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -52,6 +53,8 @@ func testCreateLead(ctx context.Context, conn *ServiceNow.Connector) error {
 			"short_description": "Interested in premium plan",
 			"state":             "1",
 			"company":           "Withampersand",
+			"first_name":        "Mohammed",
+			"last_name":         "Salah",
 		},
 	}
 
@@ -74,9 +77,25 @@ func testCreateLead(ctx context.Context, conn *ServiceNow.Connector) error {
 }
 
 func testUpdateLead(ctx context.Context, conn *ServiceNow.Connector) error {
+	// Fetch a real lead id from the instance rather than hardcoding one, so the
+	// update targets an existing record.
+	read, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "lead",
+		Fields:     datautils.NewStringSet("sys_id"),
+	})
+	if err != nil {
+		return fmt.Errorf("reading a lead to update: %w", err)
+	}
+
+	if len(read.Data) == 0 {
+		return fmt.Errorf("no lead found to update")
+	}
+
+	recordID, _ := read.Data[0].Fields["sys_id"].(string)
+
 	params := common.WriteParams{
 		ObjectName: "lead",
-		RecordId:   "6a2f6fbb83f02210290fed70deaad320",
+		RecordId:   recordID,
 		RecordData: map[string]any{
 			"company": "Ampersand",
 		},
@@ -99,12 +118,12 @@ func testUpdateLead(ctx context.Context, conn *ServiceNow.Connector) error {
 	return nil
 }
 
-func testUpdateCase(ctx context.Context, conn *ServiceNow.Connector) error {
+func testCreateCase(ctx context.Context, conn *ServiceNow.Connector) error {
 	params := common.WriteParams{
 		ObjectName: "case",
-		RecordId:   "280ffff1c0a8000b0083f5395b44bc97",
 		RecordData: map[string]any{
-			"priority": "2",
+			"short_description": "Customer reported a billing discrepancy",
+			"priority":          "2",
 		},
 	}
 
@@ -133,7 +152,6 @@ func testCreateContact(ctx context.Context, conn *ServiceNow.Connector) error {
 			"agent_status": "On break",
 			"city":         "Liverpool",
 			"company":      "Withampersand",
-			"country":      "UK",
 			"email":        "ywnwa@lfc.com",
 			"first_name":   "Mohammed",
 			"last_name":    "Salah",


### PR DESCRIPTION
- Adds incremental read support
- Adds pagination to some uniquely behaving objects

<img width="2450" height="148" alt="Screenshot 2026-06-01 at 22 46 03" src="https://github.com/user-attachments/assets/d6a54ed0-d6ae-4e9e-be94-3ba43f7f06e5" />


Metadata Live Tests:
<img width="2272" height="1352" alt="Screenshot 2026-06-01 at 22 46 27" src="https://github.com/user-attachments/assets/ddfbfc56-25b2-4b23-83df-64c42a4a7339" />

Read Live Tests:
<img width="2270" height="1349" alt="Screenshot 2026-06-01 at 22 46 49" src="https://github.com/user-attachments/assets/bec17464-b678-46e0-aeca-4472c22bed95" />

Search live Tests:
<img width="2271" height="487" alt="Screenshot 2026-06-01 at 22 47 10" src="https://github.com/user-attachments/assets/813c110d-4b86-4b0f-9395-3dbcee16399a" />

Write Live Tests:
<img width="2274" height="1303" alt="Screenshot 2026-06-01 at 22 47 30" src="https://github.com/user-attachments/assets/175aa2a7-5f08-4571-b5a4-ddb972bbfd8a" />
