### PR TITLE
[CON-3292] feat(gong): fetch flows across all users (paginated) + association

### DIFF
--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -45,6 +45,7 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 			continue
 		}
 
+		// Attach user association to flows
 		for _, flow := range flows {
 			if _, seen := aggregated[flow.Id]; seen {
 				continue

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -43,7 +43,8 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 		flows, err := c.fetchFlowsForUser(ctx, userEmail, config)
 		if err != nil || len(flows) == 0 {
 			// Some users may not have engage license or may not be added to flows
-			// we ignore these errors and continue
+			// we log the error and continue
+			fmt.Printf("failed to fetch flows for user %s: %v\n", userEmail, err)
 			continue
 		}
 

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -3,6 +3,8 @@ package gong
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/gong/metadata"
@@ -10,6 +12,8 @@ import (
 
 // readFlows handles the special case for reading flows which requires flowOwnerEmail query param.
 // It fetches all users first, then iterates through their emails to fetch flows for each user.
+// Flows are aggregated across users and deduplicated by id, because shared/company flows may
+// appear in multiple users' result sets while personal flows are unique to their owner.
 // Some users may not have engage license or may not be added to flows, so we handle errors gracefully.
 // ref: https://gong.app.gong.io/settings/api/documentation#get-/v2/flows
 func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { // nolint:cyclop,lll
@@ -19,13 +23,14 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 	}
 
 	if len(users) == 0 {
-		return &common.ReadResult{
-			Rows:     0,
-			Data:     nil,
-			NextPage: "",
-			Done:     true,
-		}, nil
+		return emptyFlowsResult(), nil
 	}
+
+	includeUserAssoc := wantsUserAssociation(config.AssociatedObjects)
+
+	// Aggregate flows across all users, keyed by id to dedupe shared/company flows
+	// that surface in multiple users' result sets.
+	aggregated := make(map[string]common.ReadResultRow)
 
 	for _, user := range users {
 		userEmail, ok := user.Raw["emailAddress"].(string)
@@ -40,21 +45,78 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 			continue
 		}
 
-		// Return as soon as we find flows for a user
-		return &common.ReadResult{
-			Rows:     int64(len(flows)),
-			Data:     flows,
-			NextPage: "",
-			Done:     true,
-		}, nil
+		for _, flow := range flows {
+			if _, seen := aggregated[flow.Id]; seen {
+				continue
+			}
+
+			if includeUserAssoc {
+				attachUserToPersonalFlow(&flow, user)
+			}
+
+			aggregated[flow.Id] = flow
+		}
 	}
 
+	data := make([]common.ReadResultRow, 0, len(aggregated))
+	for _, flow := range aggregated {
+		data = append(data, flow)
+	}
+
+	// Stable order: map iteration is random in Go.
+	sort.Slice(data, func(i, j int) bool {
+		return data[i].Id < data[j].Id
+	})
+
+	return &common.ReadResult{
+		Rows:     int64(len(data)),
+		Data:     data,
+		NextPage: "",
+		Done:     true,
+	}, nil
+}
+
+func emptyFlowsResult() *common.ReadResult {
 	return &common.ReadResult{
 		Rows:     0,
 		Data:     nil,
 		NextPage: "",
 		Done:     true,
-	}, nil
+	}
+}
+
+// wantsUserAssociation reports whether the caller asked for user records to be
+// attached alongside each flow.
+func wantsUserAssociation(associatedObjects []string) bool {
+	for _, name := range associatedObjects {
+		switch strings.ToLower(name) {
+		case "user", "users":
+			return true
+		}
+	}
+
+	return false
+}
+
+// attachUserToPersonalFlow attaches the owning user as an association if the flow
+// has Personal visibility. Shared and Company flows are not user-specific.
+func attachUserToPersonalFlow(flow *common.ReadResultRow, user common.ReadResultRow) {
+	visibility, _ := flow.Raw["visibility"].(string)
+	if !strings.EqualFold(visibility, "Personal") {
+		return
+	}
+
+	if flow.Associations == nil {
+		flow.Associations = make(map[string][]common.Association)
+	}
+
+	flow.Associations[objectNameUsers] = append(
+		flow.Associations[objectNameUsers],
+		common.Association{
+			ObjectId: user.Id,
+			Raw:      user.Raw,
+		},
+	)
 }
 
 // fetchAllUsers retrieves all users from the /users endpoint.

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/providers/gong/metadata"
@@ -41,17 +42,29 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 		}
 
 		flows, err := c.fetchFlowsForUser(ctx, userEmail, config)
-		if err != nil || len(flows) == 0 {
-			// Some users may not have engage license or may not be added to flows
-			// we log the error and continue
-			fmt.Printf("failed to fetch flows for user %s: %v\n", userEmail, err)
+		if err != nil {
+			// A user without an engage license (or not added to any flow) errors
+			// here. We skip them so one user can't fail the whole sync, and log it
+			// so a genuine failure (5xx / rate-limit / network) is still visible.
+			logging.Logger(ctx).Warn("could not fetch flows for user, skipping",
+				"user", userEmail, "error", err.Error())
+
+			continue
+		}
+
+		if len(flows) == 0 {
 			continue
 		}
 
 		mergeUserFlows(aggregated, flows, user, includeUserAssoc)
 	}
 
+	if len(aggregated) == 0 {
+		return emptyFlowsResult(), nil
+	}
+
 	data := make([]common.ReadResultRow, 0, len(aggregated))
+
 	for _, flow := range aggregated {
 		data = append(data, flow)
 	}

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -16,7 +16,7 @@ import (
 // appear in multiple users' result sets while personal flows are unique to their owner.
 // Some users may not have engage license or may not be added to flows, so we handle errors gracefully.
 // ref: https://gong.app.gong.io/settings/api/documentation#get-/v2/flows
-func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { // nolint:cyclop,lll
+func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { // nolint:lll
 	users, err := c.fetchAllUsers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch users: %w", err)
@@ -28,8 +28,8 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 
 	includeUserAssoc := wantsUserAssociation(config.AssociatedObjects)
 
-	// Aggregate flows across all users, keyed by id to dedupe shared/company flows
-	// that surface in multiple users' result sets.
+	// Collect every user's flows into one map keyed by flow id.
+	// Company and shared flows show up for many users, so the map drops the repeats.
 	aggregated := make(map[string]common.ReadResultRow)
 
 	for _, user := range users {
@@ -45,18 +45,7 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 			continue
 		}
 
-		// Attach user association to flows
-		for _, flow := range flows {
-			if _, seen := aggregated[flow.Id]; seen {
-				continue
-			}
-
-			if includeUserAssoc {
-				attachUserToPersonalFlow(&flow, user)
-			}
-
-			aggregated[flow.Id] = flow
-		}
+		mergeUserFlows(aggregated, flows, user, includeUserAssoc)
 	}
 
 	data := make([]common.ReadResultRow, 0, len(aggregated))
@@ -86,6 +75,28 @@ func emptyFlowsResult() *common.ReadResult {
 	}
 }
 
+// mergeUserFlows adds a user's flows to the aggregate, skipping ids already
+// collected and attaching the owning user to personal flows when requested.
+func mergeUserFlows(
+	aggregated map[string]common.ReadResultRow,
+	flows []common.ReadResultRow,
+	owner common.ReadResultRow,
+	includeUserAssoc bool,
+) {
+	for _, flow := range flows {
+		_, seen := aggregated[flow.Id]
+		if seen {
+			continue
+		}
+
+		if includeUserAssoc {
+			attachUserToPersonalFlow(&flow, owner)
+		}
+
+		aggregated[flow.Id] = flow
+	}
+}
+
 // wantsUserAssociation reports whether the caller asked for user records to be
 // attached alongside each flow.
 func wantsUserAssociation(associatedObjects []string) bool {
@@ -99,8 +110,8 @@ func wantsUserAssociation(associatedObjects []string) bool {
 	return false
 }
 
-// attachUserToPersonalFlow attaches the owning user as an association if the flow
-// has Personal visibility. Shared and Company flows are not user-specific.
+// attachUserToPersonalFlow links a flow to the user who owns it, but only for
+// personal flows. Company and shared flows aren't tied to one person, so we skip them.
 func attachUserToPersonalFlow(flow *common.ReadResultRow, user common.ReadResultRow) {
 	visibility, _ := flow.Raw["visibility"].(string)
 	if !strings.EqualFold(visibility, "Personal") {

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/providers/gong/metadata"
 )
 
@@ -131,34 +133,19 @@ func attachUserToPersonalFlow(flow *common.ReadResultRow, user common.ReadResult
 	)
 }
 
-// fetchAllUsers retrieves all users from the /users endpoint.
+// fetchAllUsers retrieves every user from the /users endpoint, following
+// pagination so users beyond the first page are not missed.
 func (c *Connector) fetchAllUsers(ctx context.Context) ([]common.ReadResultRow, error) {
 	url, err := c.getReadURL(objectNameUsers)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := c.Client.Get(ctx, url.String())
-	if err != nil {
-		return nil, err
-	}
-
-	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, objectNameUsers)
-
-	result, err := common.ParseResult(res,
-		common.ExtractRecordsFromPath(responseFieldName),
-		getNextRecordsURL,
-		common.GetMarshaledData,
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Data, nil
+	return c.fetchAllPages(ctx, url, objectNameUsers, nil)
 }
 
-// fetchFlowsForUser fetches flows for a specific user email.
+// fetchFlowsForUser fetches every flow for a specific user email, following
+// pagination so a user with many flows does not lose the overflow.
 func (c *Connector) fetchFlowsForUser(ctx context.Context, userEmail string, config common.ReadParams,
 ) ([]common.ReadResultRow, error) {
 	url, err := c.getReadURL(objectNameFlows)
@@ -168,22 +155,46 @@ func (c *Connector) fetchFlowsForUser(ctx context.Context, userEmail string, con
 
 	url.WithQueryParam("flowOwnerEmail", userEmail)
 
-	res, err := c.Client.Get(ctx, url.String())
-	if err != nil {
-		return nil, err
+	return c.fetchAllPages(ctx, url, objectNameFlows, config.Fields)
+}
+
+// fetchAllPages issues GET requests against url, following Gong's records.cursor
+// until none is returned, and accumulates every page of rows.
+func (c *Connector) fetchAllPages(
+	ctx context.Context,
+	url *urlbuilder.URL,
+	objectName string,
+	fields datautils.Set[string],
+) ([]common.ReadResultRow, error) {
+	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, objectName)
+
+	var rows []common.ReadResultRow
+
+	for {
+		res, err := c.Client.Get(ctx, url.String())
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := common.ParseResult(res,
+			common.ExtractRecordsFromPath(responseFieldName),
+			getNextRecordsURL,
+			common.GetMarshaledData,
+			fields,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		rows = append(rows, result.Data...)
+
+		if result.NextPage == "" {
+			break
+		}
+
+		// Re-request with the next cursor; flowOwnerEmail (if set) is preserved on url.
+		url.WithQueryParam("cursor", result.NextPage.String())
 	}
 
-	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, objectNameFlows)
-
-	result, err := common.ParseResult(res,
-		common.ExtractRecordsFromPath(responseFieldName),
-		getNextRecordsURL,
-		common.GetMarshaledData,
-		config.Fields,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Data, nil
+	return rows, nil
 }

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -251,6 +251,166 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		},
 
 		{
+			Name: "Flows: no users returns empty result",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.Path("/v2/users"),
+					Then: mockserver.ResponseString(http.StatusOK, `{
+						"requestId": "noUsers",
+						"records": {"totalRecords": 0, "currentPageSize": 0, "currentPageNumber": 0},
+						"users": []
+					}`),
+				}},
+			}.Server(),
+			Expected:     &common.ReadResult{Done: true, Rows: 0, Data: nil},
+			ExpectedErrs: nil,
+		},
+		{
+			// Branch B behavior: aggregate flows across every user, dedupe shared
+			// flow (id 9000000000000099) which appears under both Alice and Bob.
+			Name: "Flows: aggregate across all users and dedupe by id",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name", "visibility"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "get-records-users.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000001",
+					Fields: map[string]any{
+						"name":       "Alice's Personal Outreach",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000001",
+						"visibility": "Personal",
+					},
+				}, {
+					Id: "9000000000000002",
+					Fields: map[string]any{
+						"name":       "Bob's Personal Outreach",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000002",
+						"visibility": "Personal",
+					},
+				}, {
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"name":       "Company-wide Sales Cadence",
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Flows: AssociatedObjects=users attaches each Personal flow's owner",
+			Input: common.ReadParams{
+				ObjectName:        "flows",
+				Fields:            connectors.Fields("id", "name", "visibility"),
+				AssociatedObjects: []string{"users"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "get-records-users.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000001",
+					Fields: map[string]any{
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"visibility": "Personal",
+					},
+					Associations: map[string][]common.Association{
+						"users": {{
+							ObjectId: "8000000000000001",
+							Raw: map[string]any{
+								"emailAddress": "alice@example.com",
+							},
+						}},
+					},
+				}, {
+					Id: "9000000000000002",
+					Fields: map[string]any{
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"visibility": "Personal",
+					},
+					Associations: map[string][]common.Association{
+						"users": {{
+							ObjectId: "8000000000000002",
+							Raw: map[string]any{
+								"emailAddress": "bob@example.com",
+							},
+						}},
+					},
+				}, {
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"visibility": "Company",
+					},
+					// Company flows: no user association.
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name:  "Successful read transcripts using POST",
 			Input: common.ReadParams{ObjectName: "transcripts", Fields: connectors.Fields("callid")},
 			Server: mockserver.Conditional{

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -358,6 +358,133 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "Flows: users with multiple pages, every page's users get their flows fetched",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name", "visibility"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					// users page 2 (cursor present) must be matched before the page 1 fallback
+					If: mockcond.And{
+						mockcond.Path("/v2/users"),
+						mockcond.QueryParam("cursor", "USERS_PAGE_2"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page2.json")),
+				}, {
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page1.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000001",
+					Fields: map[string]any{
+						"id":         "9000000000000001",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000001",
+						"visibility": "Personal",
+					},
+				}, {
+					// bob lives on users page 2 — proves we followed the users cursor
+					Id: "9000000000000002",
+					Fields: map[string]any{
+						"id":         "9000000000000002",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000002",
+						"visibility": "Personal",
+					},
+				}, {
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Flows: a single user's flows with multiple pages, all pages are fetched",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name", "visibility"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					// alice flows page 2 (cursor present) must be matched before the page 1 fallback
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+						mockcond.QueryParam("cursor", "FLOWS_PAGE_2"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice_page2.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice_page1.json")),
+				}, {
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_alice_only.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000001",
+					Fields: map[string]any{
+						"id":         "9000000000000001",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000001",
+						"visibility": "Personal",
+					},
+				}, {
+					// this flow is only on page 2 — proves we followed the flows cursor
+					Id: "9000000000000003",
+					Fields: map[string]any{
+						"id":         "9000000000000003",
+						"visibility": "Personal",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000003",
+						"visibility": "Personal",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name:  "Successful read transcripts using POST",
 			Input: common.ReadParams{ObjectName: "transcripts", Fields: connectors.Fields("callid")},
 			Server: mockserver.Conditional{

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -271,71 +271,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
-			// Branch B behavior: aggregate flows across every user, dedupe shared
-			// flow (id 9000000000000099) which appears under both Alice and Bob.
-			Name: "Flows: aggregate across all users and dedupe by id",
-			Input: common.ReadParams{
-				ObjectName: "flows",
-				Fields:     connectors.Fields("id", "name", "visibility"),
-			},
-			Server: mockserver.Switch{
-				Setup: mockserver.ContentJSON(),
-				Cases: []mockserver.Case{{
-					If:   mockcond.Path("/v2/users"),
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "get-records-users.json")),
-				}, {
-					If: mockcond.And{
-						mockcond.Path("/v2/flows"),
-						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
-					},
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
-				}, {
-					If: mockcond.And{
-						mockcond.Path("/v2/flows"),
-						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
-					},
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
-				}},
-			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
-			Expected: &common.ReadResult{
-				Rows: 3,
-				Data: []common.ReadResultRow{{
-					Id: "9000000000000001",
-					Fields: map[string]any{
-						"name":       "Alice's Personal Outreach",
-						"visibility": "Personal",
-					},
-					Raw: map[string]any{
-						"id":         "9000000000000001",
-						"visibility": "Personal",
-					},
-				}, {
-					Id: "9000000000000002",
-					Fields: map[string]any{
-						"name":       "Bob's Personal Outreach",
-						"visibility": "Personal",
-					},
-					Raw: map[string]any{
-						"id":         "9000000000000002",
-						"visibility": "Personal",
-					},
-				}, {
-					Id: "9000000000000099",
-					Fields: map[string]any{
-						"name":       "Company-wide Sales Cadence",
-						"visibility": "Company",
-					},
-					Raw: map[string]any{
-						"id":         "9000000000000099",
-						"visibility": "Company",
-					},
-				}},
-				Done: true,
-			},
-			ExpectedErrs: nil,
-		},
-		{
 			Name: "Flows: AssociatedObjects=users attaches each Personal flow's owner",
 			Input: common.ReadParams{
 				ObjectName:        "flows",
@@ -368,9 +303,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Id: "9000000000000001",
 					Fields: map[string]any{
 						"visibility": "Personal",
+						"id":         "9000000000000001",
 					},
 					Raw: map[string]any{
 						"visibility": "Personal",
+						"id":         "9000000000000001",
 					},
 					Associations: map[string][]common.Association{
 						"users": {{
@@ -384,24 +321,34 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Id: "9000000000000002",
 					Fields: map[string]any{
 						"visibility": "Personal",
+						"id":         "9000000000000002",
 					},
 					Raw: map[string]any{
 						"visibility": "Personal",
+						"id":         "9000000000000002",
 					},
 					Associations: map[string][]common.Association{
 						"users": {{
 							ObjectId: "8000000000000002",
 							Raw: map[string]any{
+								"id":           "8000000000000002",
 								"emailAddress": "bob@example.com",
+								"firstName":    "Bob",
+								"lastName":     "Brown",
+								"active":       true,
+								"title":        "Sales Engineer",
 							},
 						}},
 					},
 				}, {
 					Id: "9000000000000099",
 					Fields: map[string]any{
+						"id":         "9000000000000099",
 						"visibility": "Company",
 					},
+
 					Raw: map[string]any{
+						"id":         "9000000000000099",
 						"visibility": "Company",
 					},
 					// Company flows: no user association.

--- a/providers/gong/test/read_flows_alice.json
+++ b/providers/gong/test/read_flows_alice.json
@@ -1,0 +1,28 @@
+{
+  "requestId": "a1b2c3d4e5f6g7h8i9j0",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 2,
+    "currentPageNumber": 0
+  },
+  "flows": [
+    {
+      "id": "9000000000000001",
+      "name": "Alice's Personal Outreach",
+      "folderId": "7000000000000001",
+      "folderName": "My Folder",
+      "visibility": "Personal",
+      "creationDate": "2025-01-15T10:00:00Z",
+      "exclusive": false
+    },
+    {
+      "id": "9000000000000099",
+      "name": "Company-wide Sales Cadence",
+      "folderId": "7000000000000099",
+      "folderName": "Shared Folder",
+      "visibility": "Company",
+      "creationDate": "2025-01-10T08:30:00Z",
+      "exclusive": true
+    }
+  ]
+}

--- a/providers/gong/test/read_flows_alice_page1.json
+++ b/providers/gong/test/read_flows_alice_page1.json
@@ -1,0 +1,20 @@
+{
+  "requestId": "flows-alice-page-1",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 1,
+    "currentPageNumber": 0,
+    "cursor": "FLOWS_PAGE_2"
+  },
+  "flows": [
+    {
+      "id": "9000000000000001",
+      "name": "Alice's First Flow",
+      "folderId": "7000000000000001",
+      "folderName": "My Folder",
+      "visibility": "Personal",
+      "creationDate": "2025-01-15T10:00:00Z",
+      "exclusive": false
+    }
+  ]
+}

--- a/providers/gong/test/read_flows_alice_page2.json
+++ b/providers/gong/test/read_flows_alice_page2.json
@@ -1,0 +1,19 @@
+{
+  "requestId": "flows-alice-page-2",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 1,
+    "currentPageNumber": 1
+  },
+  "flows": [
+    {
+      "id": "9000000000000003",
+      "name": "Alice's Second Flow",
+      "folderId": "7000000000000003",
+      "folderName": "My Folder",
+      "visibility": "Personal",
+      "creationDate": "2025-01-17T12:00:00Z",
+      "exclusive": false
+    }
+  ]
+}

--- a/providers/gong/test/read_flows_bob.json
+++ b/providers/gong/test/read_flows_bob.json
@@ -1,0 +1,28 @@
+{
+  "requestId": "b1b2c3d4e5f6g7h8i9j0",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 2,
+    "currentPageNumber": 0
+  },
+  "flows": [
+    {
+      "id": "9000000000000002",
+      "name": "Bob's Personal Outreach",
+      "folderId": "7000000000000002",
+      "folderName": "My Folder",
+      "visibility": "Personal",
+      "creationDate": "2025-01-16T11:00:00Z",
+      "exclusive": false
+    },
+    {
+      "id": "9000000000000099",
+      "name": "Company-wide Sales Cadence",
+      "folderId": "7000000000000099",
+      "folderName": "Shared Folder",
+      "visibility": "Company",
+      "creationDate": "2025-01-10T08:30:00Z",
+      "exclusive": true
+    }
+  ]
+}

--- a/providers/gong/test/read_flows_empty.json
+++ b/providers/gong/test/read_flows_empty.json
@@ -1,0 +1,9 @@
+{
+  "requestId": "empty1234567890",
+  "records": {
+    "totalRecords": 0,
+    "currentPageSize": 0,
+    "currentPageNumber": 0
+  },
+  "flows": []
+}

--- a/providers/gong/test/read_users_alice_only.json
+++ b/providers/gong/test/read_users_alice_only.json
@@ -1,0 +1,18 @@
+{
+  "requestId": "users-alice-only",
+  "records": {
+    "totalRecords": 1,
+    "currentPageSize": 1,
+    "currentPageNumber": 0
+  },
+  "users": [
+    {
+      "id": "8000000000000001",
+      "emailAddress": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Anderson",
+      "active": true,
+      "title": "Account Executive"
+    }
+  ]
+}

--- a/providers/gong/test/read_users_page1.json
+++ b/providers/gong/test/read_users_page1.json
@@ -1,0 +1,19 @@
+{
+  "requestId": "users-page-1",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 1,
+    "currentPageNumber": 0,
+    "cursor": "USERS_PAGE_2"
+  },
+  "users": [
+    {
+      "id": "8000000000000001",
+      "emailAddress": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Anderson",
+      "active": true,
+      "title": "Account Executive"
+    }
+  ]
+}

--- a/providers/gong/test/read_users_page2.json
+++ b/providers/gong/test/read_users_page2.json
@@ -1,0 +1,18 @@
+{
+  "requestId": "users-page-2",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 1,
+    "currentPageNumber": 1
+  },
+  "users": [
+    {
+      "id": "8000000000000002",
+      "emailAddress": "bob@example.com",
+      "firstName": "Bob",
+      "lastName": "Brown",
+      "active": true,
+      "title": "Sales Engineer"
+    }
+  ]
+}

--- a/test/gong/read/flows/read.go
+++ b/test/gong/read/flows/read.go
@@ -23,14 +23,26 @@ func main() {
 
 	conn := connTest.GetGongConnector(ctx)
 
+	slog.Info("Reading flows aggregated across all users..")
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "flows",
-		Fields:     connectors.Fields("id", "name"),
+		Fields:     connectors.Fields("id", "name", "visibility"),
 	})
 	if err != nil {
 		utils.Fail("error reading from Gong", "error", err)
 	}
 
-	slog.Info("Reading flows..")
 	utils.DumpJSON(res, os.Stdout)
+
+	slog.Info("Reading flows with users association..")
+	resWithAssoc, err := conn.Read(ctx, common.ReadParams{
+		ObjectName:        "flows",
+		Fields:            connectors.Fields("id", "name", "visibility"),
+		AssociatedObjects: []string{"users"},
+	})
+	if err != nil {
+		utils.Fail("error reading from Gong with associations", "error", err)
+	}
+
+	utils.DumpJSON(resWithAssoc, os.Stdout)
 }


### PR DESCRIPTION
* When we read `flows`, now we loop through all user and get their flows. We also follow pagination for
users and flows/

* If `ReadParams.AssociatedObjects` has `users`, we attach the owner user to each
Personal flow in `ReadResultRow.Associations`. Company and shared flows are not
owned by one user, so we skip them.

### Testing
Added unit tests but could do live testing because the sandbox has no Personal flows and when creating new flows it is created as a Shared flows. 