### PR TITLE
[CON-3293] feat(hubspot): handle referencedObjectType in ListObjectMe…

### DIFF
--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -262,8 +262,12 @@ type fieldDescription struct {
 	FieldType string `json:"fieldType"`
 	// IsBuiltIn indicates whether the field is HubSpot-defined (built-in).
 	// If false or omitted, the field is custom.
-	IsBuiltIn            bool                      `json:"hubspotDefined"`
-	Options              []fieldEnumerationOption  `json:"options"`
+	IsBuiltIn bool                     `json:"hubspotDefined"`
+	Options   []fieldEnumerationOption `json:"options"`
+	// ReferencedObjectType, when set, marks the property as a foreign key to
+	// another HubSpot object (e.g. "OWNER", "COMPANY"). It overrides ValueType
+	// to ValueTypeReference in transformToFieldMetadata.
+	ReferencedObjectType string                    `json:"referencedObjectType"`
 	ModificationMetadata fieldModificationMetadata `json:"modificationMetadata"`
 }
 
@@ -314,6 +318,18 @@ func (f fieldDescription) transformToFieldMetadata() common.FieldMetadata {
 		valueType = common.ValueTypeOther
 	}
 
+	// Properties carrying a referencedObjectType are foreign keys to another
+	// HubSpot object (e.g. hubspot_owner_id → users, associatedcompanyid →
+	// companies). Surface that to consumers via ValueTypeReference + ReferenceTo
+	// so field-mapping UIs can render an object picker rather than a dropdown.
+	// Values are preserved so callers still get the available option list.
+	var referenceTo []string
+
+	if f.ReferencedObjectType != "" {
+		valueType = common.ValueTypeReference
+		referenceTo = []string{resolveReferencedObjectName(f.ReferencedObjectType)}
+	}
+
 	return common.FieldMetadata{
 		DisplayName:  f.Label,
 		ValueType:    valueType,
@@ -322,8 +338,9 @@ func (f fieldDescription) transformToFieldMetadata() common.FieldMetadata {
 		IsCustom:     new(!f.IsBuiltIn),
 		// IsRequired is not known from current struct,
 		// info is acquired by different API call and set by fetchRequiredFieldsBestEffort.
-		IsRequired: nil,
-		Values:     values,
+		IsRequired:  nil,
+		Values:      values,
+		ReferenceTo: referenceTo,
 	}
 }
 

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -99,14 +99,18 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 							},
 
 							// Float.
+							// associatedcompanyid is a number property carrying
+							// referencedObjectType="COMPANY", so it surfaces as
+							// a reference to companies rather than a raw float.
 							"associatedcompanyid": {
 								DisplayName:  "Primary Associated Company ID",
-								ValueType:    "float",
+								ValueType:    "reference",
 								ProviderType: "number.number",
 								ReadOnly:     new(false),
 								IsCustom:     new(false),
 								IsRequired:   new(false),
 								Values:       nil,
+								ReferenceTo:  []string{"companies"},
 							},
 							"hubspotscore": {
 								DisplayName:  "HubSpot Score",
@@ -504,6 +508,123 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 							"eventType":  {DisplayName: "eventType"},
 							"occurredAt": {DisplayName: "occurredAt"},
 							"id":         {DisplayName: "id"},
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// CON-3293: a property carrying referencedObjectType="OWNER"
+			// (HubSpot's name for users) must surface as a reference to
+			// users rather than a generic singleSelect, even though its
+			// underlying type/fieldType is enumeration/select.
+			Name:  "Property with referencedObjectType=OWNER becomes a reference to users",
+			Input: []string{"contacts"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.Path("/crm/v3/properties/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, `{
+						"results": [{
+							"name": "hubspot_owner_id",
+							"label": "Contact owner",
+							"type": "enumeration",
+							"fieldType": "select",
+							"referencedObjectType": "OWNER",
+							"options": [
+								{"label": "Sarah Chen", "value": "12345"},
+								{"label": "Tom Rodriguez", "value": "67890"}
+							],
+							"hubspotDefined": true,
+							"modificationMetadata": {"readOnlyValue": false}
+						}]
+					}`),
+				}, {
+					If:   mockcond.Path("/crm/pipelines/2026-03/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, "{}"),
+				}, {
+					If:   mockcond.Path("/crm-object-schemas/2026-03/schemas/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, "{}"),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"contacts": {
+						DisplayName: "contacts",
+						Fields: map[string]common.FieldMetadata{
+							"hubspot_owner_id": {
+								DisplayName:  "Contact owner",
+								ValueType:    "reference",
+								ProviderType: "enumeration.select",
+								ReadOnly:     new(false),
+								IsCustom:     new(false),
+								IsRequired:   new(false),
+								Values: []common.FieldValue{{
+									Value:        "12345",
+									DisplayValue: "Sarah Chen",
+								}, {
+									Value:        "67890",
+									DisplayValue: "Tom Rodriguez",
+								}},
+								ReferenceTo: []string{"users"},
+							},
+						},
+					},
+				},
+				Errors: nil,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// CON-3293: an unrecognized referencedObjectType (e.g. a HubSpot
+			// custom-object FQN like "p12345_my_object") falls through to a
+			// lowercased passthrough so downstream consumers still see a
+			// usable reference name instead of losing the field entirely.
+			Name:  "Property with custom referencedObjectType passes through lowercased",
+			Input: []string{"contacts"},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.Path("/crm/v3/properties/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, `{
+						"results": [{
+							"name": "custom_link_id",
+							"label": "Linked Custom Object",
+							"type": "number",
+							"fieldType": "number",
+							"referencedObjectType": "P12345_CUSTOM_OBJECT",
+							"options": [],
+							"hubspotDefined": false,
+							"modificationMetadata": {"readOnlyValue": false}
+						}]
+					}`),
+				}, {
+					If:   mockcond.Path("/crm/pipelines/2026-03/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, "{}"),
+				}, {
+					If:   mockcond.Path("/crm-object-schemas/2026-03/schemas/contacts"),
+					Then: mockserver.ResponseString(http.StatusOK, "{}"),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"contacts": {
+						DisplayName: "contacts",
+						Fields: map[string]common.FieldMetadata{
+							"custom_link_id": {
+								DisplayName:  "Linked Custom Object",
+								ValueType:    "reference",
+								ProviderType: "number.number",
+								ReadOnly:     new(false),
+								IsCustom:     new(true),
+								IsRequired:   new(false),
+								Values:       nil,
+								ReferenceTo:  []string{"p12345_custom_object"},
+							},
 						},
 					},
 				},

--- a/providers/hubspot/schema.go
+++ b/providers/hubspot/schema.go
@@ -1,5 +1,7 @@
 package hubspot
 
+import "strings"
+
 // KnownObjectTypes
 // https://developers.hubspot.com/docs/guides/api/crm/understanding-the-crm#object-type-ids
 var KnownObjectTypes = map[string]string{ // nolint:gochecknoglobals
@@ -25,4 +27,48 @@ var KnownObjectTypes = map[string]string{ // nolint:gochecknoglobals
 	"0-69":  "subscriptions",
 	"0-27":  "tasks",
 	"0-115": "users",
+}
+
+// referencedObjectTypeMap translates the values HubSpot returns in a property's
+// `referencedObjectType` (uppercase singular, e.g. "OWNER") into the object
+// names this connector exposes (matching KnownObjectTypes values).
+//
+// Used by ListObjectMetadata when populating common.FieldMetadata.ReferenceTo
+// for reference-typed fields.
+var referencedObjectTypeMap = map[string]string{ // nolint:gochecknoglobals
+	"APPOINTMENT":     "appointments",
+	"CALL":            "calls",
+	"COMMUNICATION":   "communications",
+	"COMPANY":         "companies",
+	"CONTACT":         "contacts",
+	"COURSE":          "courses",
+	"DEAL":            "deals",
+	"EMAIL":           "emails",
+	"LEAD":            "leads",
+	"LINE_ITEM":       "line_items",
+	"LISTING":         "listings",
+	"MARKETING_EVENT": "marketing_events",
+	"MEETING":         "meetings",
+	"NOTE":            "notes",
+	"OWNER":           "users",
+	"POSTAL_MAIL":     "postal_mail",
+	"PRODUCT":         "products",
+	"QUOTE":           "quotes",
+	"SERVICE":         "services",
+	"SUBSCRIPTION":    "subscriptions",
+	"TASK":            "tasks",
+	"TICKET":          "tickets",
+}
+
+// resolveReferencedObjectName maps a HubSpot referencedObjectType value to the
+// object name this connector uses. For known core CRM types it returns the
+// mapped name from referencedObjectTypeMap. For anything else (custom-object
+// FQNs like "p123_my_object", future types we don't know yet) it returns the
+// lowercased input so downstream consumers still get a usable reference name.
+func resolveReferencedObjectName(hsType string) string {
+	if name, ok := referencedObjectTypeMap[hsType]; ok {
+		return name
+	}
+
+	return strings.ToLower(hsType)
 }


### PR DESCRIPTION
## Summary

  HubSpot Properties with `referencedObjectType` now surface as references instead of plain singleSelect/float.

  Before / After

  For {type:"enumeration", fieldType:"select", referencedObjectType:"OWNER"}:

    "providerType": "enumeration.select"
  - "valueType":    "singleSelect"
  + "valueType":    "reference"
  + "referenceTo":  ["users"]

  22-entry mapping (OWNER→users, COMPANY→companies, etc.) mirrors schema.go's KnownObjectTypes. Unknown values fall through lowercased.

  Tests

  - OWNER enumeration → reference + ["users"]
  - COMPANY number → reference + ["companies"]
  - Custom FQN passthrough (lowercased)
  - No regression on non-reference fields
  - make lint clean

  Screenshots

<img width="1470" height="525" alt="image" src="https://github.com/user-attachments/assets/c33cb9c4-3303-4b9d-b320-3dc74433e064" />
