### PR TITLE
[CON-3266] feat(meta whatsaapp): write functionality

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -94,6 +94,7 @@ import (
 	"github.com/amp-labs/connectors/providers/livestorm"
 	"github.com/amp-labs/connectors/providers/loxo"
 	"github.com/amp-labs/connectors/providers/marketo"
+	"github.com/amp-labs/connectors/providers/meta"
 	"github.com/amp-labs/connectors/providers/microsoft"
 	"github.com/amp-labs/connectors/providers/mixmax"
 	"github.com/amp-labs/connectors/providers/monday"
@@ -244,6 +245,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Livestorm:                  wrapper(newLivestormConnector),
 	providers.Loxo:                       wrapper(newLoxoConnector),
 	providers.Marketo:                    wrapper(newMarketoConnector),
+	providers.Meta:                       wrapper(newMetaConnector),
 	providers.Microsoft:                  wrapper(newMicrosoftConnector),
 	providers.MicrosoftClientCredentials: wrapper(newMicrosoftClientCredentialsConnector),
 	providers.Mixmax:                     wrapper(newMixmaxConnector),
@@ -468,6 +470,12 @@ func newMarketoConnector(
 		marketo.WithWorkspace(params.Workspace),
 		marketo.WithAuthenticatedClient(params.AuthenticatedClient),
 	)
+}
+
+func newMetaConnector(
+	params common.ConnectorParams,
+) (*meta.Connector, error) {
+	return meta.NewConnector(params)
 }
 
 func newMicrosoftConnector(

--- a/providers/meta.go
+++ b/providers/meta.go
@@ -1,18 +1,23 @@
 package providers
 
+import "github.com/amp-labs/connectors/common"
+
 const (
 	Meta Provider = "meta"
+
+	// ModuleMetaWhatsApp is the module used for sending WhatsApp messages via the Cloud API.
+	ModuleMetaWhatsApp common.ModuleID = "whatsapp"
 )
 
-func init() {
+func init() { //nolint:funlen
 	SetInfo(Meta, ProviderInfo{
 		DisplayName: "Meta",
 		AuthType:    Oauth2,
 		BaseURL:     "https://graph.facebook.com",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://www.facebook.com/v23.0/dialog/oauth",
-			TokenURL:                  "https://graph.facebook.com/v23.0/oauth/access_token",
+			AuthURL:                   "https://www.facebook.com/v25.0/dialog/oauth",
+			TokenURL:                  "https://graph.facebook.com/v25.0/oauth/access_token",
 			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 		},
@@ -36,6 +41,44 @@ func init() {
 			Regular: &MediaTypeRegular{
 				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098801/media/meta.com_1753098801.png",
 				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1753098858/media/meta.com_1753098858.svg",
+			},
+		},
+		DefaultModule: ModuleMetaWhatsApp,
+		Modules: &Modules{
+			ModuleMetaWhatsApp: {
+				BaseURL:     "https://graph.facebook.com",
+				DisplayName: "WhatsApp Business Platform",
+				Support: Support{
+					Proxy:     false,
+					Read:      false,
+					Subscribe: false,
+					Write:     false,
+				},
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "whatsappAccountId",
+					DisplayName: "WhatsApp Business Account ID",
+					DocsURL:     "https://developers.facebook.com/docs/whatsapp/business-management-api/get-started",
+					Prompt: "The WhatsApp Business Account ID (WABA ID), found in Meta Business Manager " +
+						"under Business Settings, WhatsApp Accounts.",
+					ModuleDependencies: &ModuleDependencies{
+						ModuleMetaWhatsApp: ModuleDependency{},
+					},
+				},
+				{
+					Name:        "whatsappPhoneNumberId",
+					DisplayName: "Phone Number ID",
+					DocsURL:     "https://developers.facebook.com/docs/whatsapp/cloud-api/reference/phone-numbers",
+					Prompt: "The Phone Number ID, found in Meta Business Manager " +
+						"under WhatsApp Manager, Phone numbers. " +
+						"This is the numeric ID, not the actual phone number.",
+					ModuleDependencies: &ModuleDependencies{
+						ModuleMetaWhatsApp: ModuleDependency{},
+					},
+				},
 			},
 		},
 	})

--- a/providers/meta/connector.go
+++ b/providers/meta/connector.go
@@ -1,0 +1,51 @@
+package meta
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/meta/internal/whatsapp"
+)
+
+type Connector struct {
+	*components.Connector
+	common.RequireAuthenticatedClient
+
+	WhatsApp *whatsapp.Adapter
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	connector, err := components.Initialize(providers.Meta, params,
+		func(base *components.Connector) (*Connector, error) {
+			return &Connector{Connector: base}, nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	switch connector.Module() { //nolint:exhaustive
+	case providers.ModuleMetaWhatsApp:
+		adapter, err := whatsapp.NewAdapter(params)
+		if err != nil {
+			return nil, err
+		}
+
+		connector.WhatsApp = adapter
+	default:
+		return nil, common.ErrUnsupportedModule
+	}
+
+	return connector, nil
+}
+
+func (c *Connector) Write(ctx context.Context, params connectors.WriteParams) (*connectors.WriteResult, error) {
+	if c.WhatsApp != nil {
+		return c.WhatsApp.Write(ctx, params)
+	}
+
+	return nil, common.ErrNotImplemented
+}

--- a/providers/meta/internal/whatsapp/adapter.go
+++ b/providers/meta/internal/whatsapp/adapter.go
@@ -1,0 +1,61 @@
+package whatsapp
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/writer"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const (
+	metadataKeyWhatsAppAccountID = "whatsappAccountId"
+	metadataKeyPhoneNumberID     = "whatsappPhoneNumberId"
+)
+
+type Adapter struct {
+	*components.Connector
+	common.RequireMetadata
+	components.Writer
+
+	whatsappAccountId string
+	phoneNumberId     string
+}
+
+func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
+	adapter, err := components.Initialize(providers.Meta, params, constructor)
+	if err != nil {
+		return nil, err
+	}
+
+	adapter.whatsappAccountId = params.Metadata[metadataKeyWhatsAppAccountID]
+	adapter.phoneNumberId = params.Metadata[metadataKeyPhoneNumberID]
+
+	return adapter, nil
+}
+
+func constructor(base *components.Connector) (*Adapter, error) {
+	adapter := &Adapter{
+		Connector: base,
+		RequireMetadata: common.RequireMetadata{
+			ExpectedMetadataKeys: []string{
+				metadataKeyWhatsAppAccountID,
+				metadataKeyPhoneNumberID,
+			},
+		},
+	}
+
+	registry := components.NewEmptyEndpointRegistry()
+	adapter.Writer = writer.NewHTTPWriter(
+		adapter.HTTPClient().Client,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  adapter.buildWriteRequest,
+			ParseResponse: adapter.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return adapter, nil
+}

--- a/providers/meta/internal/whatsapp/test/message-create.json
+++ b/providers/meta/internal/whatsapp/test/message-create.json
@@ -1,0 +1,14 @@
+{
+    "messaging_product": "whatsapp",
+    "contacts": [
+        {
+            "input": "+16505551234",
+            "wa_id": "16505551234"
+        }
+    ],
+    "messages": [
+        {
+            "id": "wamid.HBgLMTY0NjcwNDM1OTUVAgARGBI4MjZGRDA0OUE2OTQ3RkEyMzcA"
+        }
+    ]
+}

--- a/providers/meta/internal/whatsapp/test/message-template-create.json
+++ b/providers/meta/internal/whatsapp/test/message-template-create.json
@@ -1,0 +1,5 @@
+{
+    "id": "2450146205448663",
+    "status": "PENDING",
+    "category": "MARKETING"
+}

--- a/providers/meta/internal/whatsapp/test/phone-number-create.json
+++ b/providers/meta/internal/whatsapp/test/phone-number-create.json
@@ -1,0 +1,8 @@
+{
+    "successful_creation": {
+        "summary": "Phone number successfully created",
+        "value": {
+            "id": "1906385232743451"
+        }
+    }
+}

--- a/providers/meta/internal/whatsapp/write.go
+++ b/providers/meta/internal/whatsapp/write.go
@@ -69,9 +69,7 @@ func (a *Adapter) buildWriteRequest(ctx context.Context, params common.WritePara
 	return req, nil
 }
 
-// buildWriteURL routes to one of:
-//   - POST /v25.0/{phone-number-id}/messages
-//   - POST /v25.0/{whatsapp-account-id}/message_templates
+// buildWriteURL routes phone-number-scoped and WABA-scoped objects under /v25.0/{id}/...
 func (a *Adapter) buildWriteURL(params common.WriteParams) (*urlbuilder.URL, error) {
 	baseURL := a.ModuleInfo().BaseURL
 
@@ -138,6 +136,18 @@ func extractWriteRecordID(objectName string, body *ajson.Node) (string, error) {
 		return jsonquery.New(arr[0]).StrWithDefault("id", "")
 
 	case "message_templates":
+		return jsonquery.New(body).StrWithDefault("id", "")
+
+	case "phone_numbers":
+		id, err := jsonquery.New(body, "successful_creation", "value").StrWithDefault("id", "")
+		if err != nil {
+			return "", err
+		}
+
+		if id != "" {
+			return id, nil
+		}
+
 		return jsonquery.New(body).StrWithDefault("id", "")
 
 	default:

--- a/providers/meta/internal/whatsapp/write.go
+++ b/providers/meta/internal/whatsapp/write.go
@@ -1,0 +1,146 @@
+package whatsapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+const apiVersion = "v25.0"
+
+//nolint:gochecknoglobals
+var (
+	phoneNumberScopedWrite = datautils.NewStringSet(
+		"block_users",
+		"business_compliance_info",
+		"deregister",
+		"messages",
+		"register",
+		"request_code",
+		"settings",
+		"verify_code",
+		"whatsapp_business_profile",
+		"whatsapp_commerce_settings",
+	)
+	wabaScopedWrite = datautils.NewStringSet(
+		"generate_payment_configuration_oauth_link",
+		"message_templates",
+		"payment_configurations",
+		"phone_numbers",
+	)
+
+	ErrMissingWhatsAppAccountID = errors.New("whatsapp: whatsappAccountId metadata is required for this object")
+	ErrMissingPhoneNumberID     = errors.New("whatsapp: whatsappPhoneNumberId metadata is required for this object")
+)
+
+func (a *Adapter) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	url, err := a.buildWriteURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	recordData, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(recordData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal record data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// buildWriteURL routes to one of:
+//   - POST /v25.0/{phone-number-id}/messages
+//   - POST /v25.0/{whatsapp-account-id}/message_templates
+func (a *Adapter) buildWriteURL(params common.WriteParams) (*urlbuilder.URL, error) {
+	baseURL := a.ModuleInfo().BaseURL
+
+	switch {
+	case phoneNumberScopedWrite.Has(params.ObjectName):
+		if a.phoneNumberId == "" {
+			return nil, ErrMissingPhoneNumberID
+		}
+
+		return urlbuilder.New(baseURL, apiVersion, a.phoneNumberId, params.ObjectName)
+
+	case wabaScopedWrite.Has(params.ObjectName):
+		if a.whatsappAccountId == "" {
+			return nil, ErrMissingWhatsAppAccountID
+		}
+
+		return urlbuilder.New(baseURL, apiVersion, a.whatsappAccountId, params.ObjectName)
+
+	default:
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+}
+
+func (a *Adapter) parseWriteResponse(ctx context.Context, params common.WriteParams,
+	request *http.Request, response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		return &common.WriteResult{
+			Success: true,
+		}, nil
+	}
+
+	recordID, err := extractWriteRecordID(params.ObjectName, body)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response body: %w", err)
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Errors:   nil,
+		Data:     data,
+	}, nil
+}
+
+func extractWriteRecordID(objectName string, body *ajson.Node) (string, error) {
+	switch objectName {
+	case "messages":
+		arr, err := jsonquery.New(body).ArrayOptional("messages")
+		if err != nil {
+			return "", err
+		}
+
+		if len(arr) == 0 {
+			return "", nil
+		}
+
+		return jsonquery.New(arr[0]).StrWithDefault("id", "")
+
+	case "message_templates":
+		return jsonquery.New(body).StrWithDefault("id", "")
+
+	default:
+		return "", nil
+	}
+}

--- a/providers/meta/internal/whatsapp/write_test.go
+++ b/providers/meta/internal/whatsapp/write_test.go
@@ -1,0 +1,148 @@
+package whatsapp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+const (
+	testPhoneNumberID     = "123456789012345"
+	testWhatsAppAccountID = "987654321098765"
+)
+
+func TestWrite(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	messageCreateResponse := testutils.DataFromFile(t, "message-create.json")
+	messageTemplateCreateResponse := testutils.DataFromFile(t, "message-template-create.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Object must be supported",
+			Input: common.WriteParams{
+				ObjectName: "contacts",
+				RecordData: map[string]any{"name": "test"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Create text message uses phone number scoped URL",
+			Input: common.WriteParams{
+				ObjectName: "messages",
+				RecordData: map[string]any{
+					"messaging_product": "whatsapp",
+					"recipient_type":    "individual",
+					"to":                "+16505551234",
+					"type":              "text",
+					"text": map[string]any{
+						"preview_url": true,
+						"body": "As requested, here's the link to our latest product: " +
+							"https://www.meta.com/quest/quest-3/",
+					},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/v25.0/" + testPhoneNumberID + "/messages"),
+						},
+						Then: mockserver.Response(http.StatusOK, messageCreateResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "wamid.HBgLMTY0NjcwNDM1OTUVAgARGBI4MjZGRDA0OUE2OTQ3RkEyMzcA",
+				Data: map[string]any{
+					"messaging_product": "whatsapp",
+					"contacts": []any{
+						map[string]any{
+							"input": "+16505551234",
+							"wa_id": "16505551234",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Create message template uses WABA scoped URL",
+			Input: common.WriteParams{
+				ObjectName: "message_templates",
+				RecordData: map[string]any{
+					"name": "seasonal_promotion",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/v25.0/" + testWhatsAppAccountID + "/message_templates"),
+						},
+						Then: mockserver.Response(http.StatusOK, messageTemplateCreateResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "2450146205448663",
+				Data: map[string]any{
+					"id":       "2450146205448663",
+					"status":   "PENDING",
+					"category": "MARKETING",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestAdapter(tt.Server)
+			})
+		})
+	}
+}
+
+func constructTestAdapter(server *httptest.Server) (*Adapter, error) {
+	adapter, err := NewAdapter(common.ConnectorParams{
+		Module:              providers.ModuleMetaWhatsApp,
+		AuthenticatedClient: server.Client(),
+		Metadata: map[string]string{
+			"whatsappPhoneNumberId": testPhoneNumberID,
+			"whatsappAccountId":     testWhatsAppAccountID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	adapter.SetUnitTestBaseURL(server.URL)
+
+	return adapter, nil
+}

--- a/providers/meta/internal/whatsapp/write_test.go
+++ b/providers/meta/internal/whatsapp/write_test.go
@@ -24,6 +24,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 
 	messageCreateResponse := testutils.DataFromFile(t, "message-create.json")
 	messageTemplateCreateResponse := testutils.DataFromFile(t, "message-template-create.json")
+	phoneNumberCreateResponse := testutils.DataFromFile(t, "phone-number-create.json")
 
 	tests := []testroutines.Write{
 		{
@@ -113,6 +114,43 @@ func TestWrite(t *testing.T) { //nolint:funlen
 					"id":       "2450146205448663",
 					"status":   "PENDING",
 					"category": "MARKETING",
+				},
+			},
+		},
+		{
+			Name: "Create phone number uses WABA scoped URL",
+			Input: common.WriteParams{
+				ObjectName: "phone_numbers",
+				RecordData: map[string]any{
+					"cc":            "1",
+					"phone_number":  "14195551518",
+					"verified_name": "Lucky Shrub",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodPOST(),
+							mockcond.Path("/v25.0/" + testWhatsAppAccountID + "/phone_numbers"),
+						},
+						Then: mockserver.Response(http.StatusOK, phoneNumberCreateResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "1906385232743451",
+				Data: map[string]any{
+					"successful_creation": map[string]any{
+						"summary": "Phone number successfully created",
+						"value": map[string]any{
+							"id": "1906385232743451",
+						},
+					},
 				},
 			},
 		},

--- a/test/meta/connector.go
+++ b/test/meta/connector.go
@@ -1,0 +1,70 @@
+package meta
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	metaconn "github.com/amp-labs/connectors/providers/meta"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+var ( //nolint:gochecknoglobals
+	fieldWhatsAppAccountID = credscanning.Field{
+		Name:      "whatsappAccountId",
+		PathJSON:  "metadata.whatsappAccountId",
+		SuffixENV: "WHATSAPP_ACCOUNT_ID",
+	}
+	fieldWhatsAppPhoneNumberID = credscanning.Field{
+		Name:      "whatsappPhoneNumberId",
+		PathJSON:  "metadata.whatsappPhoneNumberId",
+		SuffixENV: "WHATSAPP_PHONE_NUMBER_ID",
+	}
+)
+
+func GetWhatsAppConnector(ctx context.Context) *metaconn.Connector {
+	filePath := credscanning.LoadPath(providers.Meta)
+	reader := utils.MustCreateProvCredJSON(filePath, true, fieldWhatsAppAccountID, fieldWhatsAppPhoneNumberID)
+
+	client, err := common.NewOAuthHTTPClient(ctx,
+		common.WithOAuthClient(http.DefaultClient),
+		common.WithOAuthConfig(getConfig(reader)),
+		common.WithOAuthToken(reader.GetOauthToken()),
+	)
+	if err != nil {
+		utils.Fail(err.Error())
+	}
+
+	conn, err := metaconn.NewConnector(common.ConnectorParams{
+		Module:              providers.ModuleMetaWhatsApp,
+		AuthenticatedClient: client,
+		Metadata: map[string]string{
+			"whatsappAccountId":     reader.Get(fieldWhatsAppAccountID),
+			"whatsappPhoneNumberId": reader.Get(fieldWhatsAppPhoneNumberID),
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating meta whatsapp connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://www.facebook.com/v25.0/dialog/oauth",
+			TokenURL:  "https://graph.facebook.com/v25.0/oauth/access_token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{
+			"whatsapp_business_messaging",
+			"whatsapp_business_management",
+		},
+	}
+}

--- a/test/meta/connector.go
+++ b/test/meta/connector.go
@@ -23,11 +23,28 @@ var ( //nolint:gochecknoglobals
 		PathJSON:  "metadata.whatsappPhoneNumberId",
 		SuffixENV: "WHATSAPP_PHONE_NUMBER_ID",
 	}
+	// Optional: E.164 recipient for template message send integration test only.
+	fieldWhatsAppTo = credscanning.Field{
+		Name:      "whatsappTo",
+		PathJSON:  "metadata.whatsappTo",
+		SuffixENV: "WHATSAPP_TO",
+	}
 )
 
-func GetWhatsAppConnector(ctx context.Context) *metaconn.Connector {
+func loadWhatsAppCredentials() *credscanning.ProviderCredentials {
 	filePath := credscanning.LoadPath(providers.Meta)
-	reader := utils.MustCreateProvCredJSON(filePath, true, fieldWhatsAppAccountID, fieldWhatsAppPhoneNumberID)
+
+	return utils.MustCreateProvCredJSON(filePath, true,
+		fieldWhatsAppAccountID, fieldWhatsAppPhoneNumberID, fieldWhatsAppTo)
+}
+
+// GetWhatsAppTo returns the optional message recipient from meta-creds.json (metadata.whatsappTo) or META_WHATSAPP_TO.
+func GetWhatsAppTo() string {
+	return loadWhatsAppCredentials().Get(fieldWhatsAppTo)
+}
+
+func GetWhatsAppConnector(ctx context.Context) *metaconn.Connector {
+	reader := loadWhatsAppCredentials()
 
 	client, err := common.NewOAuthHTTPClient(ctx,
 		common.WithOAuthClient(http.DefaultClient),

--- a/test/meta/whatsapp/write/main.go
+++ b/test/meta/whatsapp/write/main.go
@@ -64,13 +64,18 @@ func runMessageTemplateCreate(ctx context.Context, conn connectors.WriteConnecto
 }
 
 func runTextMessageCreate(ctx context.Context, conn connectors.WriteConnector) {
+	to := os.Getenv("WHATSAPP_TO")
+	if to == "" {
+		slog.Info("Skipping text message create (set WHATSAPP_TO to run)")
+		return
+	}
 
 	createRes, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: "messages",
 		RecordData: textMessagePayload{
 			MessagingProduct: "whatsapp",
 			RecipientType:    "individual",
-			To:               "+16505551234",
+			To:               to,
 			Type:             "text",
 			Text: map[string]any{
 				"preview_url": true,

--- a/test/meta/whatsapp/write/main.go
+++ b/test/meta/whatsapp/write/main.go
@@ -35,8 +35,8 @@ func main() {
 
 	utils.SetupLogging()
 	conn := connTest.GetWhatsAppConnector(ctx)
-	// slog.Info("Running message template create")
-	// runMessageTemplateCreate(ctx, conn)
+	slog.Info("Running message template create")
+	runMessageTemplateCreate(ctx, conn)
 	slog.Info("Running template message send")
 	runTextMessageCreate(ctx, conn, connTest.GetWhatsAppTo())
 }

--- a/test/meta/whatsapp/write/main.go
+++ b/test/meta/whatsapp/write/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/meta"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type messageTemplatePayload struct {
+	Name       string           `json:"name"`
+	Language   string           `json:"language"`
+	Category   string           `json:"category"`
+	Components []map[string]any `json:"components"`
+}
+
+type textMessagePayload struct {
+	MessagingProduct string         `json:"messaging_product"`
+	RecipientType    string         `json:"recipient_type"`
+	To               string         `json:"to"`
+	Type             string         `json:"type"`
+	Text             map[string]any `json:"text"`
+}
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+	conn := connTest.GetWhatsAppConnector(ctx)
+	slog.Info("Running message template create")
+	runMessageTemplateCreate(ctx, conn)
+	slog.Info("Running text message create")
+	runTextMessageCreate(ctx, conn)
+}
+
+func runMessageTemplateCreate(ctx context.Context, conn connectors.WriteConnector) {
+	templateName := "seasonal_promotion_" + strings.ToLower(gofakeit.LetterN(8))
+
+	createRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "message_templates",
+		RecordData: messageTemplatePayload{
+			Name:       templateName,
+			Language:   "en_US",
+			Category:   "MARKETING",
+			Components: seasonalPromotionComponents(),
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating message template", "error", err)
+	}
+	if !createRes.Success {
+		utils.Fail("failed to create message template", "response", createRes)
+	}
+	utils.DumpJSON(createRes, os.Stdout)
+}
+
+func runTextMessageCreate(ctx context.Context, conn connectors.WriteConnector) {
+
+	createRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "messages",
+		RecordData: textMessagePayload{
+			MessagingProduct: "whatsapp",
+			RecipientType:    "individual",
+			To:               "+16505551234",
+			Type:             "text",
+			Text: map[string]any{
+				"preview_url": true,
+				"body": "As requested, here's the link to our latest product: " +
+					"https://www.meta.com/quest/quest-3/",
+			},
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating text message", "error", err)
+	}
+	if !createRes.Success {
+		utils.Fail("failed to create text message", "response", createRes)
+	}
+	utils.DumpJSON(createRes, os.Stdout)
+}
+
+func seasonalPromotionComponents() []map[string]any {
+	return []map[string]any{
+		{
+			"type":   "HEADER",
+			"format": "TEXT",
+			"text":   "Our {{1}} is on!",
+			"example": map[string]any{
+				"header_text": []string{"Summer Sale"},
+			},
+		},
+		{
+			"type": "BODY",
+			"text": "Shop now through {{1}} and use code {{2}} to get {{3}} off.",
+			"example": map[string]any{
+				"body_text": [][]string{
+					{"25OFF", "25%", "50%"},
+				},
+			},
+		},
+		{
+			"type": "FOOTER",
+			"text": "Use the buttons below to manage your subscriptions",
+		},
+		{
+			"type": "BUTTONS",
+			"buttons": []map[string]any{
+				{
+					"type": "QUICK_REPLY",
+					"text": "Unsubscribe from Promos",
+				},
+				{
+					"type": "QUICK_REPLY",
+					"text": "Unsubscribe from All",
+				},
+			},
+		},
+	}
+}

--- a/test/meta/whatsapp/write/main.go
+++ b/test/meta/whatsapp/write/main.go
@@ -22,12 +22,11 @@ type messageTemplatePayload struct {
 	Components []map[string]any `json:"components"`
 }
 
-type textMessagePayload struct {
+type sendMessagePayload struct {
 	MessagingProduct string         `json:"messaging_product"`
-	RecipientType    string         `json:"recipient_type"`
 	To               string         `json:"to"`
 	Type             string         `json:"type"`
-	Text             map[string]any `json:"text"`
+	Template         map[string]any `json:"template,omitempty"`
 }
 
 func main() {
@@ -36,10 +35,10 @@ func main() {
 
 	utils.SetupLogging()
 	conn := connTest.GetWhatsAppConnector(ctx)
-	slog.Info("Running message template create")
-	runMessageTemplateCreate(ctx, conn)
-	slog.Info("Running text message create")
-	runTextMessageCreate(ctx, conn)
+	// slog.Info("Running message template create")
+	// runMessageTemplateCreate(ctx, conn)
+	slog.Info("Running template message send")
+	runTextMessageCreate(ctx, conn, connTest.GetWhatsAppTo())
 }
 
 func runMessageTemplateCreate(ctx context.Context, conn connectors.WriteConnector) {
@@ -63,32 +62,41 @@ func runMessageTemplateCreate(ctx context.Context, conn connectors.WriteConnecto
 	utils.DumpJSON(createRes, os.Stdout)
 }
 
-func runTextMessageCreate(ctx context.Context, conn connectors.WriteConnector) {
-	to := os.Getenv("WHATSAPP_TO")
+func runTextMessageCreate(ctx context.Context, conn connectors.WriteConnector, to string) {
 	if to == "" {
-		slog.Info("Skipping text message create (set WHATSAPP_TO to run)")
+		slog.Info("Skipping template message send (set metadata.whatsappTo in meta-creds.json or META_WHATSAPP_TO to run)")
 		return
 	}
 
 	createRes, err := conn.Write(ctx, common.WriteParams{
 		ObjectName: "messages",
-		RecordData: textMessagePayload{
+		RecordData: sendMessagePayload{
 			MessagingProduct: "whatsapp",
-			RecipientType:    "individual",
 			To:               to,
-			Type:             "text",
-			Text: map[string]any{
-				"preview_url": true,
-				"body": "As requested, here's the link to our latest product: " +
-					"https://www.meta.com/quest/quest-3/",
+			Type:             "template",
+			Template: map[string]any{
+				"name": "jaspers_market_order_confirmation_v1",
+				"language": map[string]any{
+					"code": "en_US",
+				},
+				"components": []map[string]any{
+					{
+						"type": "body",
+						"parameters": []map[string]any{
+							{"type": "text", "text": "John Doe"},
+							{"type": "text", "text": "123456"},
+							{"type": "text", "text": "Jun 4, 2026"},
+						},
+					},
+				},
 			},
 		},
 	})
 	if err != nil {
-		utils.Fail("error creating text message", "error", err)
+		utils.Fail("error sending template message", "error", err)
 	}
 	if !createRes.Success {
-		utils.Fail("failed to create text message", "response", createRes)
+		utils.Fail("failed to send template message", "response", createRes)
 	}
 	utils.DumpJSON(createRes, os.Stdout)
 }


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

  
## Tests 

### Template

<img width="1211" height="329" alt="image" src="https://github.com/user-attachments/assets/f16b51a9-db45-4286-8e92-7a7053ae5522" />

### Message

<img width="1445" height="477" alt="image" src="https://github.com/user-attachments/assets/f70d3d48-55e8-4bde-bb8d-8e0bb9ff5684" />

