### PR TITLE
[CON-2232] feat: enable zoominfo proxy connector

### DIFF
--- a/providers/zoominfo.go
+++ b/providers/zoominfo.go
@@ -35,7 +35,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
<img width="1451" height="809" alt="Screenshot 2026-06-04 at 14 57 41" src="https://github.com/user-attachments/assets/3c6a72d0-9017-4012-a8c6-6291ae06bca4" />

## POST
<img width="1461" height="768" alt="Screenshot 2026-06-04 at 15 00 16" src="https://github.com/user-attachments/assets/a6da2bec-e8ce-4c04-8558-d1825a1c7390" />


## PATCH & DELETE
Few objects support these, and their in an Enterprise API.

## Invalid requests
Wrong verb applied, 
<img width="1463" height="541" alt="Screenshot 2026-06-04 at 15 01 11" src="https://github.com/user-attachments/assets/ad4ec4f4-54ca-4ab8-99fe-a99caee6dfa3" />

invalid path.
<img width="1461" height="436" alt="Screenshot 2026-06-04 at 15 01 43" src="https://github.com/user-attachments/assets/f79abfdc-469f-46e9-977a-c386a2fc70ef" />


<img width="1161" height="749" alt="Screenshot 2026-06-04 at 15 27 39" src="https://github.com/user-attachments/assets/9ae86147-b60e-4457-bc64-fa124fae616d" />

## Successful console operation (operation & events)
<img width="1166" height="611" alt="Screenshot 2026-06-04 at 15 28 03" src="https://github.com/user-attachments/assets/aff08105-c7fe-4366-addd-4246bf8de98f" />

## Failed console operation (operation & events)
<img width="1162" height="781" alt="Screenshot 2026-06-04 at 15 28 19" src="https://github.com/user-attachments/assets/1e06cc95-5366-49fb-8d64-c5f2a44c9adf" />

Somehow (permission issue) comes back with 401 instead of 403.