### PR TITLE
[ENG-2921] feat: add `ErrFieldNotFound` sentinel for field visibility errors

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -73,6 +73,10 @@ var (
 	// ErrBadRequest is returned when we get a 400 response from the provider.
 	ErrBadRequest error = newClassedErr("bad request", ErrorClassBadRequest)
 
+	// ErrFieldNotFound is returned when a requested field was not found or is not
+	// accessible on the object. It is a subset of ErrBadRequest.
+	ErrFieldNotFound = errors.New("field not found or not accessible")
+
 	// ErrConflict is returned when we get a 409 response from the provider.
 	ErrConflict = errors.New("conflict")
 

--- a/providers/salesforce/internal/crm/core/errors.go
+++ b/providers/salesforce/internal/crm/core/errors.go
@@ -43,11 +43,11 @@ var noSuchColumnRe = regexp.MustCompile(
 	`No such column '([^']*)' on (?:entity '([^']*)'|sobject of type (\w+))`)
 
 // fieldNotFoundGuidance explains the two causes of a "No such column" error
-// (incorrect field name, or missing field-level visibility) and how to fix
-// each. It is appended to every formatted field-not-found message.
+// (incorrect field name, or missing field-level visibility) It is appended to
+// every formatted field-not-found message.
 //
 //nolint:lll
-const fieldNotFoundGuidance = " This usually means either the field name is incorrect (custom field names must end in '__c'), or the connected Salesforce user lacks field-level visibility for this field. To resolve it, verify the field's API name, or grant the user 'Visible' access to the field via their profile or a permission set."
+const fieldNotFoundGuidance = " This usually means either the field name is incorrect (custom field names must end in '__c'), or the connected Salesforce user lacks field-level visibility for this field."
 
 // formatFieldNotFoundMessage turns a Salesforce "No such column" error into a
 // customer-facing message: it restates the problem in Salesforce admin
@@ -88,7 +88,13 @@ type fieldNotFoundError struct {
 }
 
 func (e *fieldNotFoundError) Error() string { return e.msg }
-func (e *fieldNotFoundError) Unwrap() error { return common.ErrBadRequest }
+
+// Unwrap returns both sentinels so callers can match the specific
+// ErrFieldNotFound case while existing errors.Is(err, ErrBadRequest) checks
+// continue to hold.
+func (e *fieldNotFoundError) Unwrap() []error {
+	return []error{common.ErrFieldNotFound, common.ErrBadRequest}
+}
 
 func interpretJSONError(res *http.Response, body []byte) error { // nolint:cyclop
 	var errs []jsonError


### PR DESCRIPTION
In the server repo, we are introducing a sampling feature, which will do a one-record read during an installation create/update for validation. For Salesforce visibility errors specifically, we want to return a `problem.Remedy` that links to the Salesforce troubleshooting guide. In order to detect if that's the error that we get during sampling, we introduce a `ErrFieldNotFound` error type that we can match on in the server repo. We continue to wrap this error as a `ErrBadRequest` so that code which relies on matching against this will continue to work.

**Testing:**

<img width="1488" height="805" alt="Screenshot 2026-06-04 at 4 57 41 PM" src="https://github.com/user-attachments/assets/fb8796da-811b-4388-b246-de1f06d48980" />