### PR TITLE
feat(connectwise): Read by IDs

### DIFF
--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/batch"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
 )
 
@@ -25,6 +26,8 @@ type Connector struct {
 	components.Reader
 	components.Writer
 	components.Deleter
+
+	batchAdapter *batch.Adapter // used for connectors.BatchRecordReaderConnector capabilities.
 
 	clientID string
 }
@@ -82,6 +85,8 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 			ErrorHandler:  errorHandler,
 		},
 	)
+
+	connector.batchAdapter = batch.NewAdapter(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
 
 	return connector, nil
 }

--- a/providers/connectwise/internal/batch/adapter.go
+++ b/providers/connectwise/internal/batch/adapter.go
@@ -1,0 +1,49 @@
+package batch
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
+)
+
+const apiVersion = "v4_6_release/apis/3.0"
+
+// ConnectWise docs state that there must be a limit for the URL length.
+// In practice, exceeding the URL size results in "414 Request URI Too Long".
+// > We recommend keeping the URL length of each request to a maximum of 2000 characters.
+// > This will ensure there are no compatibility issues with various servers and configurations.
+const maxURLSize = 1950
+
+// Adapter handles batched operations.
+type Adapter struct {
+	client       *common.JSONHTTPClient
+	providerInfo *providers.ProviderInfo
+
+	clientID string
+}
+
+// NewAdapter creates a new batch Adapter configured to fetch multiple records from ConnectWise API.
+func NewAdapter(jsonClient *common.JSONHTTPClient, providerInfo *providers.ProviderInfo, clientID string) *Adapter {
+	return &Adapter{
+		client:       jsonClient,
+		providerInfo: providerInfo,
+		clientID:     clientID,
+	}
+}
+
+func (a *Adapter) clientIdHeader() common.Header {
+	return common.Header{
+		Key:   "ClientId",
+		Value: a.clientID,
+	}
+}
+
+func (a *Adapter) getURL(objectName string) (*urlbuilder.URL, error) {
+	objectPath, err := metadata.Schemas.FindURLPath(common.ModuleRoot, objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return urlbuilder.New(a.providerInfo.BaseURL, apiVersion, objectPath)
+}

--- a/providers/connectwise/internal/batch/read.go
+++ b/providers/connectwise/internal/batch/read.go
@@ -1,0 +1,60 @@
+package batch
+
+import (
+	"context"
+	"errors"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
+)
+
+// Read performs a batch read for the requested object type and identifiers.
+func Read[B any](ctx context.Context,
+	adapter *Adapter,
+	objectName string,
+	identifiers []string,
+) ([]B, error) {
+	baseURL, err := adapter.getURL(objectName)
+	if err != nil {
+		return nil, err
+	}
+
+	urls, err := withIdentifiers(baseURL, identifiers, maxURLSize)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]parallelfetch.Task[int, readResponse[B]], len(urls))
+	for index, wrapper := range urls {
+		tasks[index] = func(ctx context.Context) (taskID int, data *readResponse[B], err error) {
+			res, err := adapter.client.Get(ctx, wrapper.URL, adapter.clientIdHeader())
+			if err != nil {
+				return index, nil, err
+			}
+
+			// Parse the response to obtain any API errors.
+			apiResponse, err := common.UnmarshalJSON[readResponse[B]](res)
+			if err != nil {
+				return index, nil, err
+			}
+
+			return index, apiResponse, nil
+		}
+	}
+
+	result := parallelfetch.Execute(ctx, tasks, -1)
+	if len(result.Errors) != 0 {
+		return nil, errors.Join(result.Errors.Values()...)
+	}
+
+	records := make([]B, 0)
+	for _, list := range result.Records {
+		records = append(records, list...)
+	}
+
+	return records, nil
+}
+
+// readResponse mirrors the ConnectWise read response which is array at the root level.
+// The generic is accepted to allow .
+type readResponse[B any] []B

--- a/providers/connectwise/internal/batch/read.go
+++ b/providers/connectwise/internal/batch/read.go
@@ -8,6 +8,10 @@ import (
 	"github.com/amp-labs/connectors/internal/parallelfetch"
 )
 
+// maxConcurrency is the number of goroutines that can be spawned to run multiple requests in parallel.
+// The number 3 is chosen at random.
+const maxConcurrency = 3
+
 // Read performs a batch read for the requested object type and identifiers.
 func Read[B any](ctx context.Context,
 	adapter *Adapter,
@@ -42,7 +46,7 @@ func Read[B any](ctx context.Context,
 		}
 	}
 
-	result := parallelfetch.Execute(ctx, tasks, -1)
+	result := parallelfetch.Execute(ctx, tasks, maxConcurrency)
 	if len(result.Errors) != 0 {
 		return nil, errors.Join(result.Errors.Values()...)
 	}

--- a/providers/connectwise/internal/batch/urls.go
+++ b/providers/connectwise/internal/batch/urls.go
@@ -95,7 +95,7 @@ func withIdentifiers(baseURL *urlbuilder.URL, identifiers []string, maxURLLength
 //   - First identifier has no preceding comma
 //
 // Returns ErrURLNotEnoughSpace if a single identifier exceeds maxSpace.
-func groupIdentifiersBySpace(identifiers []string, maxSpace int) ([]identifierGroup, error) {
+func groupIdentifiersBySpace(ids []string, maxSpace int) ([]identifierGroup, error) {
 	var (
 		groups = make([]identifierGroup, 0)
 		group  = identifierGroup{
@@ -104,7 +104,7 @@ func groupIdentifiersBySpace(identifiers []string, maxSpace int) ([]identifierGr
 		}
 	)
 
-	for _, identifier := range identifiers {
+	for _, identifier := range ids {
 		partSize := len(identifier)
 		if group.TotalSize != 0 {
 			// Add comma size for non-first items: ',' becomes '%2C' (3 characters).

--- a/providers/connectwise/internal/batch/urls.go
+++ b/providers/connectwise/internal/batch/urls.go
@@ -1,0 +1,144 @@
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// ErrURLNotEnoughSpace is returned when the base URL is already too long to accommodate
+// any identifiers in the 'conditions' query parameter.
+var ErrURLNotEnoughSpace = errors.New("URL is too long to add any identifiers in the 'conditions' query")
+
+// identifierGroup holds a batch of identifiers that fit within the available URL space.
+type identifierGroup struct {
+	// IDs is the list of identifiers in this group.
+	IDs []string
+	// TotalSize is the total character count of the encoded identifiers plus commas.
+	TotalSize int
+}
+
+type urlWrapper struct {
+	// URL is the complete URL with the 'conditions' query parameter containing the identifiers.
+	URL string
+	// estimatedSize is the expected length as calculated by the algorithm.
+	estimatedSize int
+}
+
+// withIdentifiers generates multiple URLs from a base URL by adding identifiers to the
+// 'conditions' query parameter (format: "id in (1,2,3)"). When the number of identifiers
+// would cause the URL to exceed maxURLLength, it splits them into multiple URLs.
+//
+// URL encoding is accounted for:
+//   - Comma ',' becomes '%2C' (3 characters instead of 1)
+//   - Parentheses '()' become '%28' and '%29' (3 characters each)
+//   - Space ' ' becomes '+' (1 character, same length)
+//
+// Parameters:
+//   - baseURL: The base URL with path any preexisting query params but without the 'conditions' query parameter
+//   - identifiers: List of identifier strings to include in the conditions
+//   - maxURLLength: Maximum allowed URL length (e.g., 2000 for ConnectWise API)
+//
+// Returns:
+//   - A slice of URLs
+//   - ErrURLNotEnoughSpace is returned if maxURLLength is too small to accommodate even a single identifier
+//   - One URL if so identifiers are set.
+func withIdentifiers(baseURL *urlbuilder.URL, identifiers []string, maxURLLength int) ([]urlWrapper, error) {
+	// Calculate available space for identifiers after accounting for base URL and existing query structure.
+	base := baseURL.String()
+	baseSize := len(base)
+
+	if len(identifiers) == 0 {
+		return []urlWrapper{{
+			URL:           baseURL.String(),
+			estimatedSize: baseSize,
+		}}, nil
+	}
+
+	// Fixed query parameter structure (encoded):
+	// "?conditions=id+in+%28%29" represents "?conditions=id in ()"
+	conditionsQuerySize := len("?conditions=id+in+%28%29")
+	reservedSize := baseSize + conditionsQuerySize
+	leftOverSpace := maxURLLength - reservedSize
+
+	// Group identifiers so each group fits within the available space.
+	identifierChunks, err := groupIdentifiersBySpace(identifiers, leftOverSpace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build URLs for each group of identifiers.
+	urls := make([]urlWrapper, 0)
+
+	for _, group := range identifierChunks {
+		url, err := urlbuilder.New(base)
+		if err != nil {
+			return nil, err
+		}
+		url.WithQueryParam("conditions", fmt.Sprintf("id in (%v)", strings.Join(group.IDs, ",")))
+		urls = append(urls, urlWrapper{
+			URL:           url.String(),
+			estimatedSize: group.TotalSize + reservedSize,
+		})
+	}
+
+	return urls, nil
+}
+
+// groupIdentifiersBySpace splits identifiers into groups where each group's total size
+// (identifiers plus encoded commas) does not exceed maxSpace.
+//
+// Encoding considerations:
+//   - Each comma between identifiers becomes '%2C' (3 characters)
+//   - First identifier has no preceding comma
+//
+// Returns ErrURLNotEnoughSpace if a single identifier exceeds maxSpace.
+func groupIdentifiersBySpace(identifiers []string, maxSpace int) ([]identifierGroup, error) {
+	var (
+		groups = make([]identifierGroup, 0)
+		group  = identifierGroup{
+			IDs:       make([]string, 0),
+			TotalSize: 0,
+		}
+	)
+
+	for _, identifier := range identifiers {
+		partSize := len(identifier)
+		if group.TotalSize != 0 {
+			// Add comma size for non-first items: ',' becomes '%2C' (3 characters).
+			partSize += 3
+		}
+
+		// Check if adding this identifier would exceed available space.
+		potentialSize := group.TotalSize + partSize
+		if potentialSize <= maxSpace {
+			// Safe to add identifier without exceeding the limit.
+			group.IDs = append(group.IDs, identifier)
+			group.TotalSize += partSize
+		} else {
+			if group.TotalSize == 0 || len(identifier) > maxSpace {
+				// This identifier cannot fit: either no items in current group yet,
+				// or single identifier itself exceeds maxSpace.
+				return nil, ErrURLNotEnoughSpace
+			}
+
+			// The current group is full; save it and start a new group.
+			groups = append(groups, group)
+
+			// Start new group with current identifier.
+			group = identifierGroup{
+				IDs:       []string{identifier},
+				TotalSize: len(identifier),
+			}
+		}
+	}
+
+	// Add the final group (likely not completely full).
+	if len(group.IDs) > 0 {
+		groups = append(groups, group)
+	}
+
+	return groups, nil
+}

--- a/providers/connectwise/internal/batch/urls_test.go
+++ b/providers/connectwise/internal/batch/urls_test.go
@@ -1,0 +1,122 @@
+package batch
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWithIdentifiers(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseURL      string
+		identifiers  []string
+		maxURLLength int
+		wantURLs     int
+		wantErr      error
+	}{
+		{
+			name:         "Empty identifiers",
+			baseURL:      "https://example.com",
+			identifiers:  []string{},
+			maxURLLength: 100,
+			wantURLs:     1,
+			wantErr:      nil,
+		},
+		{
+			name:         "Single identifier within limit",
+			baseURL:      "https://example.com",
+			identifiers:  []string{"123"},
+			maxURLLength: 100,
+			wantURLs:     1,
+			wantErr:      nil,
+		},
+		{
+			name:         "Single identifier exceeding limit",
+			baseURL:      "https://example.com",
+			identifiers:  []string{"1234567890"},
+			maxURLLength: 30, // Very small limit
+			wantURLs:     0,
+			wantErr:      ErrURLNotEnoughSpace,
+		},
+		{
+			name:         "Multiple identifiers fitting in one URL",
+			baseURL:      "https://example.com",
+			identifiers:  []string{"1", "2", "3"},
+			maxURLLength: 100,
+			wantURLs:     1,
+			wantErr:      nil,
+		},
+		{
+			name:         "Multiple identifiers split across URLs",
+			baseURL:      "https://example.com",
+			identifiers:  []string{"123", "456", "789", "_a_", "_b_", "_c_"},
+			maxURLLength: 50, // Should split them
+			wantURLs:     6,
+			wantErr:      nil,
+		},
+		{
+			name:        "Exact fit for multiple IDs",
+			baseURL:     "https://example.com",
+			identifiers: []string{"123", "456"},
+			// base: 19
+			// query: len("?conditions=id+in+%28%29") = 24
+			// total reserved: 43
+			// IDs: "123", "456"
+			// sizes: 3 + 3 (comma) + 3 = 9
+			// total expected: 43 + 9 = 52
+			maxURLLength: 52,
+			wantURLs:     1,
+			wantErr:      nil,
+		},
+		{
+			name:        "One ID fits, second doesn't",
+			baseURL:     "https://example.com",
+			identifiers: []string{"123", "456"},
+			// reserved: 43
+			// first ID: 3
+			// comma + second ID: 3 + 3 = 6
+			// total if both: 43 + 3 + 6 = 52
+			// if only first: 43 + 3 = 46
+			maxURLLength: 51,
+			wantURLs:     2,
+			wantErr:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := testutils.NewCompareResult()
+
+			baseURL, err := urlbuilder.New(tt.baseURL)
+			if err != nil {
+				t.Fatalf("Failed to create baseURL: %v", err)
+			}
+
+			got, err := withIdentifiers(baseURL, tt.identifiers, tt.maxURLLength)
+			if !result.AssertErr("err", tt.wantErr, err) {
+				result.Validate(t, tt.name)
+				return
+			}
+
+			result.Assert("number of URLs", len(got), tt.wantURLs)
+
+			// Verify URL validity and length
+			for _, u := range got {
+				result.Assert("procedure miscalculated URL size", len(u.URL), u.estimatedSize)
+
+				if len(u.URL) > tt.maxURLLength {
+					result.AddDiff("Generated URL exceeds max length: %d > %d", len(u.URL), tt.maxURLLength)
+				}
+
+				if _, err := url.Parse(u.URL); err != nil {
+					result.AddDiff("Generated invalid URL: %v", err)
+				}
+			}
+
+			result.Validate(t, tt.name)
+		})
+	}
+}

--- a/providers/connectwise/read-by-ids.go
+++ b/providers/connectwise/read-by-ids.go
@@ -1,0 +1,37 @@
+package connectwise
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/batch"
+)
+
+var _ connectors.BatchRecordReaderConnector = (*Connector)(nil)
+
+// GetRecordsByIds scoped reading of records given their ids.
+// nolint:revive
+func (c *Connector) GetRecordsByIds(ctx context.Context,
+	objectName string, recordIds []string,
+	fields []string, associations []string,
+) ([]common.ReadResultRow, error) {
+	if len(recordIds) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	// Ensure identifiers are non-repeating.
+	identifiers := datautils.NewSetFromList(recordIds).List()
+
+	batchResult, err := batch.Read[map[string]any](ctx, c.batchAdapter, objectName, identifiers)
+	if err != nil {
+		return nil, err
+	}
+
+	marshaler := readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id"))
+	uniqueFields := datautils.NewSetFromList(fields).List()
+
+	return marshaler(batchResult, uniqueFields)
+}

--- a/providers/connectwise/read-by-ids.go
+++ b/providers/connectwise/read-by-ids.go
@@ -23,9 +23,9 @@ func (c *Connector) GetRecordsByIds(ctx context.Context,
 	}
 
 	// Ensure identifiers are non-repeating.
-	identifiers := datautils.NewSetFromList(recordIds).List()
+	ids := datautils.NewSetFromList(recordIds).List()
 
-	batchResult, err := batch.Read[map[string]any](ctx, c.batchAdapter, objectName, identifiers)
+	batchResult, err := batch.Read[map[string]any](ctx, c.batchAdapter, objectName, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/connectwise/read-by-ids_test.go
+++ b/providers/connectwise/read-by-ids_test.go
@@ -1,0 +1,83 @@
+package connectwise
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseContacts := testutils.DataFromFile(t, "read/contacts-batch-by-ids.json")
+
+	tests := []testroutines.ReadByIds{
+		{
+			Name:         "Empty record identifiers",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Read contacts by identifiers",
+			Input: testroutines.ReadByIdsParams{
+				ObjectName: "contacts",
+				RecordIds:  []string{"57920", "57921", "57922"},
+				Fields:     []string{"firstName"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v4_6_release/apis/3.0/company/contacts"),
+					mockcond.Permute(
+						queryParam("conditions", "id in (%v)"),
+						"57920", "57921", "57922",
+					),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetReadByIds,
+			Expected: []common.ReadResultRow{{
+				Id:     "57920",
+				Fields: map[string]any{"firstname": "Maxime Schaefer [1]"},
+				Raw:    map[string]any{"lastName": "Wayne Blanda"},
+			}, {
+				Id:     "57921",
+				Fields: map[string]any{"firstname": "Roderick Rippin [2]"},
+				Raw:    map[string]any{"lastName": "Lemuel Hackett"},
+			}, {
+				Id:     "57922",
+				Fields: map[string]any{"firstname": "Randi Haag [3]"},
+				Raw:    map[string]any{"lastName": "Ferne Bradtke"},
+			}},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.BatchRecordReaderConnector, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}
+
+func queryParam(key, valueTemplate string) func(fields []string) mockcond.Condition {
+	return func(identifiers []string) mockcond.Condition {
+		param := fmt.Sprintf(valueTemplate, strings.Join(identifiers, ","))
+
+		return mockcond.QueryParam(key, param)
+	}
+}

--- a/providers/connectwise/test/read/contacts-batch-by-ids.json
+++ b/providers/connectwise/test/read/contacts-batch-by-ids.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 57920,
+    "firstName": "Maxime Schaefer [1]",
+    "lastName": "Wayne Blanda"
+  },
+  {
+    "id": 57921,
+    "firstName": "Roderick Rippin [2]",
+    "lastName": "Lemuel Hackett"
+  },
+  {
+    "id": 57922,
+    "firstName": "Randi Haag [3]",
+    "lastName": "Ferne Bradtke"
+  }
+]

--- a/test/connectwise/read-by-ids/contacts/main.go
+++ b/test/connectwise/read-by-ids/contacts/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"reflect"
+	"sort"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/go-test/deep"
+)
+
+func main() {
+	if err := run(); err != nil {
+		utils.Fail("test failed", "error", err)
+	}
+}
+
+func run() error {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	identifiers := make([]string, 3)
+
+	for index := range identifiers {
+		firstName := gofakeit.Name() + fmt.Sprintf(" [%v]", index+1)
+		lastName := gofakeit.Name()
+		contact, cleanup, err := testscenario.SetupRecord(ctx, conn, "contacts",
+			payload{
+				FirstName: firstName,
+				LastName:  lastName,
+			}, testscenario.RecordCreationRecipe{
+				ReadFields: datautils.NewSet("id", "firstName", "lastName"),
+				SearchBy: testscenario.Property{
+					Key:   "firstname",
+					Value: firstName,
+					Since: time.Now().Add(-10 * time.Second),
+				},
+				RecordIdentifierKey: "id",
+			})
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
+		identifiers[index] = contact.Id
+	}
+
+	res, err := conn.GetRecordsByIds(ctx,
+		"contacts", identifiers,
+		[]string{"firstName", "lastName"}, nil)
+	if err != nil {
+		return err
+	}
+
+	displayResults(res, identifiers)
+
+	return nil
+}
+
+func displayResults(res []common.ReadResultRow, expectedIdentifiers []string) {
+	actualIdentifiers := datautils.ForEach(res, func(row common.ReadResultRow) string {
+		return row.Id
+	})
+
+	sort.Strings(expectedIdentifiers)
+	sort.Strings(actualIdentifiers)
+
+	fmt.Println("========================")
+	if !reflect.DeepEqual(expectedIdentifiers, actualIdentifiers) {
+		diff := deep.Equal(expectedIdentifiers, actualIdentifiers)
+		fmt.Printf("Requested and returned record identifiers are mismatching\n\t%v\n", diff)
+	} else {
+		utils.DumpJSON(res, os.Stdout)
+	}
+	fmt.Println("========================")
+}
+
+type payload struct {
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}


### PR DESCRIPTION
# Description

Batch reading of records is done by using the conditions query parameter on the GET endpoint.

The challenge is the URL length limit. Very large URLs will be rejected, causing batch reads to fail. This makes batch reading a problem of grouping and partitioning identifiers across multiple URLs of acceptable size that won't return a bad request response.

Added unit tests to the procedure which groups identifiers.

# Live tests

Creating multiple contacts and then reading them by ids. At the end the test self cleans.

<img width="1175" height="1384" alt="Peek 2026-06-08 20-20" src="https://github.com/user-attachments/assets/83b08ec4-92ca-4d6b-8de2-fdc4f8cdd21f" />
