### PR TITLE
feat(connectwise): Create Subscribtion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,5 @@ output/
 /apex
 test/salesforce/apex/apex
 /subscribe
-subscriber
+./subscriber
 test/salesforce/subscribe/subscribe

--- a/common/validation.go
+++ b/common/validation.go
@@ -142,3 +142,11 @@ func (p SearchParams) ValidateParams(withRequiredFields bool) error {
 
 	return nil
 }
+
+func (p SubscribeParams) ValidateParams() error {
+	if len(p.SubscriptionEvents) == 0 {
+		return ErrMissingObjects
+	}
+
+	return nil
+}

--- a/providers/acculynx/write_test.go
+++ b/providers/acculynx/write_test.go
@@ -3,6 +3,7 @@ package acculynx
 import (
 	_ "embed"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
@@ -487,22 +488,22 @@ func TestWrite(t *testing.T) { //nolint:funlen
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestWriteConnector(tt.Server.URL)
+				return constructTestWriteConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestWriteConnector(serverURL string) (*Connector, error) {
+func constructTestWriteConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
 		Module:              common.ModuleRoot,
-		AuthenticatedClient: &http.Client{},
+		AuthenticatedClient: server.Client(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	connector.SetUnitTestBaseURL(serverURL)
+	connector.SetUnitTestMockServerBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -13,10 +13,19 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/batch"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/subscriber"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/webhook"
 )
 
 const apiVersion = "v4_6_release/apis/3.0"
+
+// Type Exports.
+type (
+	SubscribeRequest     = subscriber.Request
+	SubscribeResponse    = subscriber.Result
+	SubscriptionResource = subscriber.SubscriptionResource
+	subscribeStrategy    = subscriber.Strategy
+)
 
 type Connector struct {
 	*components.Connector
@@ -29,6 +38,7 @@ type Connector struct {
 	components.Deleter
 	// TODO must use webhook.Verifier instead of webhook.NoopVerifier
 	*webhook.NoopVerifier
+	*subscribeStrategy
 
 	batchAdapter *batch.Adapter // used for connectors.BatchRecordReaderConnector capabilities.
 
@@ -91,6 +101,7 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 
 	connector.batchAdapter = batch.NewAdapter(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
 	connector.NoopVerifier = webhook.NewVerifier(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
+	connector.subscribeStrategy = subscriber.NewStrategy(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
 
 	return connector, nil
 }

--- a/providers/connectwise/internal/subscriber/create.go
+++ b/providers/connectwise/internal/subscriber/create.go
@@ -1,0 +1,262 @@
+package subscriber
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
+)
+
+// maxConcurrency is the maximum number of goroutines that will run
+// concurrently when creating subscriptions. The value is chosen arbitrarily.
+const maxConcurrency = 3
+
+func (s Strategy) Subscribe(
+	ctx context.Context,
+	params common.SubscribeParams,
+) (*common.SubscriptionResult, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	input, err := s.TypedSubscriptionRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := s.getSubscriptionURL()
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionURL := url.String()
+
+	tasks := make([]parallelfetch.Task[common.ObjectName, SubscriptionResource], len(params.SubscriptionEvents))
+
+	index := 0
+	for objectName := range params.SubscriptionEvents {
+		tasks[index], err = s.newTaskCreateSubscription(objectName, subscriptionURL, input)
+		if err != nil {
+			return nil, err
+		}
+
+		index += 1
+	}
+
+	createResult := parallelfetch.Execute(ctx, tasks, maxConcurrency)
+	state := getStateFromCreateResponse(createResult)
+
+	if len(createResult.Errors) != 0 {
+		// Some requests failed; initiate rollback.
+		return s.rollbackSubscriptionCreation(ctx, params, state, createResult)
+	}
+
+	return &common.SubscriptionResult{
+		Result: Result{
+			ObjectWebhooks: createResult.Records,
+		},
+		ObjectEvents: state,
+		Status:       common.SubscriptionStatusSuccess,
+	}, nil
+}
+
+// getStateFromCreateResponse extracts the subscription state from batch responses.
+// Successful responses set the events state; errors result in empty ObjectEvents state.
+func getStateFromCreateResponse(
+	subscriptions parallelfetch.Result[common.ObjectName, SubscriptionResource],
+) map[common.ObjectName]common.ObjectEvents {
+	result := make(map[common.ObjectName]common.ObjectEvents)
+
+	for _, subscription := range subscriptions.Records {
+		// Map successful subscription to its events.
+		objectName := webhookObjectTypeToObjectName[subscription.ObjectType]
+		result[objectName] = common.ObjectEvents{
+			Events: []common.SubscriptionEventType{
+				common.SubscriptionEventTypeCreate,
+				common.SubscriptionEventTypeUpdate,
+				common.SubscriptionEventTypeDelete,
+			},
+			WatchFields:       nil,
+			WatchFieldsAll:    false,
+			PassThroughEvents: nil,
+		}
+	}
+
+	for objectName := range subscriptions.Errors {
+		// Failed requests yield no subscription.
+		result[objectName] = common.ObjectEvents{}
+	}
+
+	return result
+}
+
+// rollbackSubscriptionCreation deletes successfully created subscriptions on partial failure.
+// It updates state to reflect remaining subscriptions after attempted rollback.
+// Returns appropriate status based on rollback success.
+func (s Strategy) rollbackSubscriptionCreation(
+	ctx context.Context,
+	params common.SubscribeParams,
+	state map[common.ObjectName]common.ObjectEvents,
+	partialCreation parallelfetch.Result[common.ObjectName, SubscriptionResource],
+) (*common.SubscriptionResult, error) {
+	requestsRegistry := make(datautils.Map[int, common.ObjectName])
+	for objectName, subscription := range partialCreation.Records {
+		requestsRegistry[subscription.ID] = objectName
+	}
+
+	removeResult := s.removeSubscriptionsByIDs(ctx, requestsRegistry.Keys())
+	if len(removeResult.Errors) == 0 {
+		// Full rollback succeeded.
+		objectNames := datautils.FromMap(params.SubscriptionEvents).Keys()
+
+		events := make(map[common.ObjectName]common.ObjectEvents)
+		for _, objectName := range objectNames {
+			events[objectName] = common.ObjectEvents{}
+		}
+
+		return &common.SubscriptionResult{
+			Result: Result{
+				ObjectWebhooks: make(map[common.ObjectName]SubscriptionResource),
+			},
+			ObjectEvents: events,
+			Status:       common.SubscriptionStatusFailed,
+		}, nil
+	}
+
+	// Partial rollback; track remaining subscriptions.
+	existingObjects := datautils.NewSet[common.ObjectName]()
+
+	for requestID := range removeResult.Errors {
+		objectName := requestsRegistry[requestID]
+		existingObjects.AddOne(objectName)
+	}
+
+	allObjects := datautils.FromMap(params.SubscriptionEvents).KeySet()
+	removedObjects := allObjects.Subtract(existingObjects)
+
+	// Clear state for successfully removed objects.
+	for _, objectName := range removedObjects {
+		state[objectName] = common.ObjectEvents{}
+	}
+
+	remainingWebhooks := make(map[common.ObjectName]SubscriptionResource)
+	for name := range existingObjects {
+		remainingWebhooks[name] = partialCreation.Records[name]
+	}
+
+	return &common.SubscriptionResult{
+		Result: Result{
+			ObjectWebhooks: remainingWebhooks,
+		},
+		ObjectEvents: state,
+		Status:       common.SubscriptionStatusFailedToRollback,
+	}, nil
+}
+
+func (s Strategy) newTaskCreateSubscription(objectName common.ObjectName,
+	url string,
+	input Request,
+) (parallelfetch.Task[common.ObjectName, SubscriptionResource], error) {
+	objectType, found := objectNameToWebhookObjectType[objectName]
+	if !found {
+		return nil, fmt.Errorf("%w: cannot subscribe to '%v' object", common.ErrObjectNotSupported, objectName)
+	}
+
+	return func(ctx context.Context) (taskID common.ObjectName, data *SubscriptionResource, err error) {
+		body := SubscriptionResource{
+			// Webhook must end with recordId without the value.
+			// The ConnectWise will append the record identifier as a raw string when sending the event.
+			WebhookURL:     input.WebhookURL + "?recordId=",
+			ObjectType:     objectType,
+			ObjectLevel:    "owner",
+			PayloadVersion: messageVersion,
+		}
+
+		resp, err := s.client.Post(ctx, url, body, s.clientIdHeader())
+		if err != nil {
+			return objectName, nil, err
+		}
+
+		subscription, err := common.UnmarshalJSON[SubscriptionResource](resp)
+		if err != nil {
+			return objectName, nil, err
+		}
+
+		return objectName, subscription, nil
+	}, nil
+}
+
+// SubscriptionResource models a ConnectWise callback (subscription) returned by
+// the /system/callbacks endpoint. The ConnectWise API refers to these as
+// "CallbackEntries" and the same JSON shape is returned for GET/POST/PATCH/PUT.
+//
+// Reference: https://developer.connectwise.com/Products/ConnectWise_PSA/REST#/CallbackEntries
+type SubscriptionResource struct {
+	// Callback properties.
+	ID           int    `json:"id"`
+	InactiveFlag bool   `json:"inactiveFlag"`
+	WebhookURL   string `json:"url"`
+
+	// Object configurations.
+	// ObjectID is required even if we send 0 for the owner.
+	// When ObjectLevel is not "owner", you typically need to specify
+	// a parent ID or context ID to subscribe the object to.
+	ObjectID   int    `json:"objectId"`
+	ObjectType string `json:"type"`
+	// ObjectLevel specifies how granular the subscription should be.
+	// It can be used alongside ObjectID, but the connector doesn't support that.
+	ObjectLevel    string `json:"level"`
+	PayloadVersion string `json:"payloadVersion"`
+
+	// Miscellaneous properties.
+	// MemberID is the person who created the callback.
+	MemberID int `json:"memberId"`
+	// IsSelfSuppressedFlag indicates whether the callback creator receives messages.
+	IsSelfSuppressedFlag bool   `json:"isSelfSuppressedFlag"`
+	ConnectWiseID        string `json:"connectWiseID"`
+}
+
+// objectNameToWebhookObjectType maps ConnectWise connector object names
+// to their corresponding callback/webhook object type names.
+var objectNameToWebhookObjectType = map[common.ObjectName]string{ // nolint:gochecknoglobals
+	"activities":      "activity",
+	"agreements":      "agreement",
+	"catalog":         "productcatalog",
+	"companies":       "company",
+	"configurations":  "configuration",
+	"contacts":        "contact",
+	"expense/entries": "expense",
+	"invoices":        "invoice",
+	// "service/tickets" also maps to Ticket.
+	// To avoid complex mapping only one ObjectName will be accepted by the Subscribe action.
+	"project/tickets":     "ticket",
+	"projects":            "project",
+	"purchaseorders":      "purchaseorder",
+	"sales/opportunities": "opportunity",
+	"schedule/entries":    "schedule",
+	// Not supported:
+	// Site:	"/company/companies/{parentId}/sites"
+	"system/members": "member",
+	"time/entries":   "time",
+}
+
+// webhookObjectTypeToObjectName is the reverse mapping of objectNameToWebhookObjectType.
+var webhookObjectTypeToObjectName = map[string]common.ObjectName{ // nolint:gochecknoglobals
+	"activity":       "activities",
+	"agreement":      "agreements",
+	"productcatalog": "catalog",
+	"company":        "companies",
+	"configuration":  "configurations",
+	"contact":        "contacts",
+	"expense":        "expense/entries",
+	"invoice":        "invoices",
+	"ticket":         "project/tickets",
+	"project":        "projects",
+	"purchaseorder":  "purchaseorders",
+	"opportunity":    "sales/opportunities",
+	"schedule":       "schedule/entries",
+	"member":         "system/members",
+	"time":           "time/entries",
+}

--- a/providers/connectwise/internal/subscriber/create_test.go
+++ b/providers/connectwise/internal/subscriber/create_test.go
@@ -1,0 +1,290 @@
+package subscriber
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestCreate(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	requestWebhookForContacts := testutils.DataFromFile(t, "create/contacts/request.json")
+	responseWebhookForContacts := testutils.DataFromFile(t, "create/contacts/response.json")
+	requestWebhookForTickets := testutils.DataFromFile(t, "create/tickets/request.json")
+	responseWebhookForTickets := testutils.DataFromFile(t, "create/tickets/response.json")
+	errorCreateBadRequest1 := testutils.DataFromFile(t, "create/create-webhook-bad-request-1.json")
+	errorCreateBadRequest2 := testutils.DataFromFile(t, "create/create-webhook-bad-request-2.json")
+	deleteWebhookFailed := testutils.DataFromFile(t, "create/remove-webhook-failed.json")
+
+	eventTypesCUD := []common.SubscriptionEventType{
+		common.SubscriptionEventTypeCreate,
+		common.SubscriptionEventTypeUpdate,
+		common.SubscriptionEventTypeDelete,
+	}
+
+	tests := []testroutines.TestCaseCreateSubscription{
+		{
+			Name: "Creating subscription to contacts and tickets successfully",
+			Input: common.SubscribeParams{
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts":        {Events: eventTypesCUD},
+					"project/tickets": {Events: eventTypesCUD},
+				},
+				Request: Request{
+					WebhookURL: "https://test.com/webhook",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForContacts),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForContacts),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForTickets),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForTickets),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
+						"project/tickets": {
+							ID:         26552,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "ticket",
+						},
+						"contacts": {
+							ID:         26559,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "contact",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts": {
+						Events:            eventTypesCUD,
+						WatchFields:       nil,
+						WatchFieldsAll:    false,
+						PassThroughEvents: nil,
+					},
+					"project/tickets": {
+						Events:            eventTypesCUD,
+						WatchFields:       nil,
+						WatchFieldsAll:    false,
+						PassThroughEvents: nil,
+					},
+				},
+				Status: common.SubscriptionStatusSuccess,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Ticket creation failed and then failed to rollback contacts.",
+			Input: common.SubscribeParams{
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts":        {Events: eventTypesCUD},
+					"project/tickets": {Events: eventTypesCUD},
+				},
+				Request: Request{
+					WebhookURL: "https://test.com/webhook",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForContacts),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForContacts),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForTickets),
+					},
+					Then: mockserver.Response(http.StatusBadRequest, errorCreateBadRequest1),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodDELETE(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26559"),
+					},
+					Then: mockserver.Response(http.StatusBadRequest, deleteWebhookFailed),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
+						// Contacts webhook still exists.
+						"contacts": {
+							ID:         26559,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "contact",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts": {
+						Events:            eventTypesCUD, // contact subscription remains because couldn't remove it.
+						WatchFields:       nil,
+						WatchFieldsAll:    false,
+						PassThroughEvents: nil,
+					},
+					"project/tickets": {},
+				},
+				Status: common.SubscriptionStatusFailedToRollback,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Successfully rolled back creation of tickets when subscription to contacts failed",
+			Input: common.SubscribeParams{
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts":        {Events: eventTypesCUD},
+					"project/tickets": {Events: eventTypesCUD},
+				},
+				Request: Request{
+					WebhookURL: "https://test.com/webhook",
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForContacts),
+					},
+					Then: mockserver.Response(http.StatusBadRequest, errorCreateBadRequest2),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForTickets),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForTickets),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodDELETE(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26552"),
+					},
+					Then: mockserver.Response(http.StatusNoContent),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts":        {}, // Contacts removed successfully.
+					"project/tickets": {},
+				},
+				Status: common.SubscriptionStatusFailed,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testroutines.TestableSubscriptionCreator, error) {
+				return constructTestStrategy(tt.Server)
+			})
+		})
+	}
+}
+
+func TestObjectTypeMappings(t *testing.T) {
+	t.Parallel()
+
+	result := testutils.NewCompareResult()
+
+	// Both maps must be of the same length.
+	result.Assert("map size", len(webhookObjectTypeToObjectName), len(objectNameToWebhookObjectType))
+
+	for key, value := range objectNameToWebhookObjectType {
+		result.Assert(fmt.Sprintf("pair [%v:%v]", key, value),
+			key, webhookObjectTypeToObjectName[value])
+	}
+
+	result.Validate(t, "ObjectType mapping should be consistent both ways")
+}
+
+func compareResult(expectedResult, actualResult any) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+
+	expectedOutput, ok := expectedResult.(Result)
+	if !ok {
+		result.AddDiff("expectedResult is not of type Result")
+	}
+
+	actualOutput, ok := actualResult.(Result)
+	if !ok {
+		result.AddDiff("actualResult is not of type Result")
+	}
+
+	if !result.Assert("Result.ObjectWebhooks length",
+		len(expectedOutput.ObjectWebhooks), len(actualOutput.ObjectWebhooks)) {
+		return result
+	}
+
+	for key, expectedValue := range expectedOutput.ObjectWebhooks {
+		actualValue, ok := actualOutput.ObjectWebhooks[key]
+		if !ok {
+			actualKeys := make([]string, 0)
+			for name := range actualOutput.ObjectWebhooks {
+				actualKeys = append(actualKeys, name.String())
+			}
+			result.AddDiff("Result.ObjectWebhooks is missing key [%v], but have (%v)",
+				key, strings.Join(actualKeys, ","))
+
+			continue
+		}
+
+		result.Assert(fmt.Sprintf("Result.ObjectWebhooks[%v].ID", key), expectedValue.ID, actualValue.ID)
+		result.Assert(fmt.Sprintf("Result.ObjectWebhooks[%v].ObjectType", key),
+			expectedValue.ObjectType, actualValue.ObjectType)
+		result.Assert(fmt.Sprintf("Result.ObjectWebhooks[%v].WebhookURL", key),
+			expectedValue.WebhookURL, actualValue.WebhookURL)
+	}
+
+	return result
+}
+
+func constructTestStrategy(server *httptest.Server) (*Strategy, error) {
+	transport, err := components.NewTransport(providers.ConnectWise, common.ConnectorParams{
+		AuthenticatedClient: server.Client(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	transport.SetUnitTestMockServerBaseURL(server.URL)
+
+	strategy := NewStrategy(transport.JSONHTTPClient(), transport.ProviderInfo(), "test-client-id")
+
+	return strategy, nil
+}

--- a/providers/connectwise/internal/subscriber/delete.go
+++ b/providers/connectwise/internal/subscriber/delete.go
@@ -1,0 +1,39 @@
+package subscriber
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/amp-labs/connectors/internal/httpkit"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
+)
+
+func (s Strategy) removeSubscriptionsByIDs(
+	ctx context.Context, identifiers []int,
+) parallelfetch.Result[int, any] {
+	tasks := make([]parallelfetch.Task[int, any], len(identifiers))
+	for index, identifier := range identifiers {
+		tasks[index] = func(ctx context.Context) (taskID int, data *any, err error) {
+			url, err := s.getSubscriptionURL()
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			url.AddPath(strconv.Itoa(identifier))
+
+			resp, err := s.client.Delete(ctx, url.String(), s.clientIdHeader())
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			if !httpkit.Status2xx(resp.Code) {
+				return identifier, nil, fmt.Errorf("failed to remove subscription with id=%d", taskID) // nolint:err113
+			}
+
+			return identifier, new(any), nil
+		}
+	}
+
+	return parallelfetch.Execute(ctx, tasks, -1)
+}

--- a/providers/connectwise/internal/subscriber/strategy.go
+++ b/providers/connectwise/internal/subscriber/strategy.go
@@ -1,0 +1,62 @@
+package subscriber
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers"
+)
+
+const (
+	apiVersion     = "v4_6_release/apis/3.0"
+	messageVersion = "3.0.0"
+)
+
+// Strategy implements subscription lifecycle operations.
+//
+// It embeds SubscriptionInputOutput to provide type-safe handling of
+// subscription input/output while conforming to the non-generic connectors.SubscribeConnector interface.
+type Strategy struct {
+	components.SubscriptionInputOutput[Request, Result]
+
+	client       *common.JSONHTTPClient
+	providerInfo *providers.ProviderInfo
+
+	clientID string
+}
+
+// NewStrategy constructs a Strategy with required dependencies.
+func NewStrategy(client *common.JSONHTTPClient, providerInfo *providers.ProviderInfo, clientID string) *Strategy {
+	return &Strategy{
+		client:       client,
+		providerInfo: providerInfo,
+		clientID:     clientID,
+	}
+}
+
+// Request defines the subscription request payload for the webhook provider.
+type Request struct {
+	// WebhookURL is the endpoint where webhook messages will be delivered.
+	WebhookURL string
+}
+
+// Result represents the subscription result payload.
+type Result struct {
+	// ObjectWebhooks maps object names to their associated webhook resources.
+	ObjectWebhooks map[common.ObjectName]SubscriptionResource
+}
+
+// getSubscriptionURL builds the Microsoft Graph endpoint for subscription operations.
+//
+// Docs:
+// https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks?tabs=http#subscription-request
+func (s Strategy) getSubscriptionURL() (*urlbuilder.URL, error) {
+	return urlbuilder.New(s.providerInfo.BaseURL, apiVersion, "system/callbacks")
+}
+
+func (s Strategy) clientIdHeader() common.Header {
+	return common.Header{
+		Key:   "ClientId",
+		Value: s.clientID,
+	}
+}

--- a/providers/connectwise/internal/subscriber/test/create/contacts/request.json
+++ b/providers/connectwise/internal/subscriber/test/create/contacts/request.json
@@ -1,0 +1,12 @@
+{
+  "id": 0,
+  "inactiveFlag": false,
+  "url": "https://test.com/webhook?recordId=",
+  "objectId": 0,
+  "type": "contact",
+  "level": "owner",
+  "payloadVersion": "3.0.0",
+  "memberId": 0,
+  "isSelfSuppressedFlag": false,
+  "connectWiseID": ""
+}

--- a/providers/connectwise/internal/subscriber/test/create/contacts/response.json
+++ b/providers/connectwise/internal/subscriber/test/create/contacts/response.json
@@ -1,0 +1,17 @@
+{
+  "id": 26559,
+  "url": "https://test.com/webhook?recordId=",
+  "objectId": 1,
+  "type": "contact",
+  "level": "owner",
+  "memberId": 243,
+  "payloadVersion": "3.0.0",
+  "inactiveFlag": false,
+  "isSoapCallbackFlag": false,
+  "isSelfSuppressedFlag": false,
+  "connectWiseID": "1bdefdcc-3860-f111-aa6d-d25dfe3c7792",
+  "_info": {
+    "lastUpdated": "2026-06-04T17:14:20Z",
+    "updatedBy": "Cobalt"
+  }
+}

--- a/providers/connectwise/internal/subscriber/test/create/create-webhook-bad-request-1.json
+++ b/providers/connectwise/internal/subscriber/test/create/create-webhook-bad-request-1.json
@@ -1,0 +1,18 @@
+{
+  "code": "InvalidObject",
+  "message": "callbackEntry object is invalid",
+  "errors": [
+    {
+      "code": "InvalidField",
+      "message": "Invalid URL",
+      "resource": "callbackEntry",
+      "field": "url"
+    },
+    {
+      "code": "InvalidObject",
+      "message": "Unrecognized level for type, see documentation for supported levels for each type",
+      "resource": "callbackEntry",
+      "field": "level"
+    }
+  ]
+}

--- a/providers/connectwise/internal/subscriber/test/create/create-webhook-bad-request-2.json
+++ b/providers/connectwise/internal/subscriber/test/create/create-webhook-bad-request-2.json
@@ -1,0 +1,12 @@
+{
+  "code": "InvalidObject",
+  "message": "callbackEntry object is invalid",
+  "errors": [
+    {
+      "code": "ObjectExists",
+      "message": "A matching callback entry already exists",
+      "resource": "callbackEntry",
+      "field": "objectId"
+    }
+  ]
+}

--- a/providers/connectwise/internal/subscriber/test/create/remove-webhook-failed.json
+++ b/providers/connectwise/internal/subscriber/test/create/remove-webhook-failed.json
@@ -1,0 +1,4 @@
+{
+  "code": "ConnectWiseApi",
+  "message": "The endpoint does not exist."
+}

--- a/providers/connectwise/internal/subscriber/test/create/tickets/request.json
+++ b/providers/connectwise/internal/subscriber/test/create/tickets/request.json
@@ -1,0 +1,12 @@
+{
+  "id": 0,
+  "inactiveFlag": false,
+  "url": "https://test.com/webhook?recordId=",
+  "objectId": 0,
+  "type": "ticket",
+  "level": "owner",
+  "payloadVersion": "3.0.0",
+  "memberId": 0,
+  "isSelfSuppressedFlag": false,
+  "connectWiseID": ""
+}

--- a/providers/connectwise/internal/subscriber/test/create/tickets/response.json
+++ b/providers/connectwise/internal/subscriber/test/create/tickets/response.json
@@ -1,0 +1,17 @@
+{
+  "id": 26552,
+  "url": "https://test.com/webhook?recordId=",
+  "objectId": 1,
+  "type": "ticket",
+  "level": "owner",
+  "memberId": 243,
+  "payloadVersion": "3.0.0",
+  "inactiveFlag": false,
+  "isSoapCallbackFlag": false,
+  "isSelfSuppressedFlag": false,
+  "connectWiseID": "5a6f7d74-a45f-f111-aa6d-d25dfe3c7792",
+  "_info": {
+    "lastUpdated": "2026-06-03T23:32:20Z",
+    "updatedBy": "Cobalt"
+  }
+}

--- a/test/connectwise/subscription/contacts/main.go
+++ b/test/connectwise/subscription/contacts/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/connectwise"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	firstName := gofakeit.Name()
+	updatedFirstName := gofakeit.Name()
+
+	testscenario.ValidateSubscribeReceiveEvents(ctx, conn,
+		testscenario.SubscribeReceiveEventsSuite{
+			SubscribeParamBuilder: func(webhookURL string) *common.SubscribeParams {
+				return &common.SubscribeParams{
+					Request: connectwise.SubscribeRequest{
+						WebhookURL: webhookURL,
+					},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"contacts": {
+							Events:            []common.SubscriptionEventType{},
+							WatchFields:       nil,
+							WatchFieldsAll:    false,
+							PassThroughEvents: nil,
+						},
+					},
+				}
+			},
+			ExpectedWebhookCalls: 3,
+			Operations: []testscenario.ConnectorOperation{
+				/* Create Contact */ {
+					ObjectName: "contacts",
+					Method:     testscenario.ConnectorMethodCreate,
+					Payload:    contact{FirstName: firstName},
+				},
+				/* Update Contact */ {
+					ObjectName: "contacts",
+					Method:     testscenario.ConnectorMethodUpdate,
+					Payload:    contact{FirstName: updatedFirstName},
+					SearchProcedure: testscenario.SearchProcedure{
+						ReadFields:          datautils.NewSet("id", "firstName"),
+						RecordIdentifierKey: "id",
+						SearchBy: testscenario.Property{
+							Key:   "firstname",
+							Value: firstName,
+							Since: time.Now().Add(-10 * time.Second),
+						},
+					},
+				},
+				/* Remove Contact */ {
+					ObjectName: "contacts",
+					Method:     testscenario.ConnectorMethodDelete,
+					SearchProcedure: testscenario.SearchProcedure{
+						ReadFields:          datautils.NewSet("id", "firstName"),
+						RecordIdentifierKey: "id",
+						SearchBy: testscenario.Property{
+							Key:   "firstname",
+							Value: updatedFirstName,
+							Since: time.Now().Add(-10 * time.Second),
+						},
+					},
+				},
+			},
+			WebhookRouter:          testscenario.WebhookRouter{},
+			VerificationParams:     nil,
+			AutoRemoveSubscription: true,
+		},
+	)
+}
+
+type contact struct {
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}

--- a/test/connectwise/subscription/tickets/main.go
+++ b/test/connectwise/subscription/tickets/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/connectwise"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+// Phase identifier is used to create tickets.
+const phaseID = 3
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	ticketSummary := gofakeit.Name()
+
+	testscenario.ValidateSubscribeReceiveEvents(ctx, conn,
+		testscenario.SubscribeReceiveEventsSuite{
+			SubscribeParamBuilder: func(webhookURL string) *common.SubscribeParams {
+				return &common.SubscribeParams{
+					Request: connectwise.SubscribeRequest{
+						WebhookURL: webhookURL,
+					},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"project/tickets": {
+							Events:            []common.SubscriptionEventType{},
+							WatchFields:       nil,
+							WatchFieldsAll:    false,
+							PassThroughEvents: nil,
+						},
+					},
+				}
+			},
+			ExpectedWebhookCalls: 2,
+			Operations: []testscenario.ConnectorOperation{
+				/* Create Ticket */ {
+					ObjectName: "project/tickets",
+					Method:     testscenario.ConnectorMethodCreate,
+					Payload:    ticket{Summary: ticketSummary, Phase: phase{ID: phaseID}},
+					SearchProcedure: testscenario.SearchProcedure{
+						ReadFields:          datautils.NewSet("id", "summary"),
+						RecordIdentifierKey: "id",
+						SearchBy: testscenario.Property{
+							Key:   "summary",
+							Value: ticketSummary,
+							Since: time.Now().Add(-10 * time.Second),
+						},
+					},
+				},
+				/* Remove Ticket */ {
+					ObjectName: "project/tickets",
+					Method:     testscenario.ConnectorMethodDelete,
+					SearchProcedure: testscenario.SearchProcedure{
+						ReadFields:          datautils.NewSet("id", "summary"),
+						RecordIdentifierKey: "id",
+						SearchBy: testscenario.Property{
+							Key:   "summary",
+							Value: ticketSummary,
+							Since: time.Now().Add(-10 * time.Second),
+						},
+					},
+				},
+			},
+			WebhookRouter:          testscenario.WebhookRouter{},
+			VerificationParams:     nil,
+			AutoRemoveSubscription: true,
+		},
+	)
+}
+
+type ticket struct {
+	Summary string `json:"summary"`
+	Phase   phase  `json:"phase"`
+}
+
+type phase struct {
+	ID int `json:"id"`
+}


### PR DESCRIPTION
# Description
The Subscription Output contains a mapping from object name to SystemCallback, the ConnectWise resource representing a webhook.

## Subscription behavior
* Create, Update, and Delete operations are all subscribed to. There is no granularity.
* The webhook URL includes a recordId query parameter at the end because ConnectWise appends the ID to this URL (treating it as a string). Ex: "https://somedomain?recordId=".
* The webhook is set to level: owner, which means:
> When set to owner, all ConnectWise PSA <contacts/tickets/projects/etc> are returned.

I created 2 username+password pairs: one used to create the webhook, and the other to trigger operations. The events arrived as expected. This validation was necessary because the memberId in the system-callback resource and the term "owner" raised some doubts.

# Live tests

### Tickets

<img width="688" height="526" alt="image" src="https://github.com/user-attachments/assets/1c82f4ff-703d-40db-a4e5-486107f5f734" />

<img width="798" height="579" alt="image" src="https://github.com/user-attachments/assets/2731ae96-78fa-4731-9d54-96ac28a5a8a3" />

<img width="527" height="1185" alt="image" src="https://github.com/user-attachments/assets/27757f9c-721d-4c85-bb81-6613fec31adb" />

### Contacts

<img width="554" height="332" alt="image" src="https://github.com/user-attachments/assets/dd5f6e6c-4d29-49f6-96db-290f2c302208" />

<img width="553" height="111" alt="image" src="https://github.com/user-attachments/assets/e623a439-0294-4bef-a808-92c41df4c9c3" />

<img width="398" height="96" alt="image" src="https://github.com/user-attachments/assets/1ef2cddb-9776-4093-92fd-401f59e4a2bf" />

<img width="378" height="90" alt="image" src="https://github.com/user-attachments/assets/645b1e16-d4ef-4b28-afba-1d5f4f246353" />
