### PR TITLE
feat(connectwise): Remove Subscription

### DIFF
--- a/internal/components/subscriptions.go
+++ b/internal/components/subscriptions.go
@@ -54,3 +54,23 @@ func (s SubscriptionInputOutput[I, O]) TypedSubscriptionRequest(params common.Su
 
 	return input, nil
 }
+
+// TypedSubscriptionResult extracts and casts subscription.Result into the concrete output type O.
+//
+// It provides a safe way to recover the typed result from the
+// non-generic SubscriptionResult, returning an error if the underlying
+// type does not match.
+func (s SubscriptionInputOutput[I, O]) TypedSubscriptionResult(subscription common.SubscriptionResult) (O, error) {
+	var output O
+
+	if subscription.Result != nil {
+		var ok bool
+
+		output, ok = subscription.Result.(O)
+		if !ok {
+			return output, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionRequestType, output, subscription.Result)
+		}
+	}
+
+	return output, nil
+}

--- a/providers/connectwise/internal/subscriber/delete.go
+++ b/providers/connectwise/internal/subscriber/delete.go
@@ -2,12 +2,44 @@ package subscriber
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/httpkit"
 	"github.com/amp-labs/connectors/internal/parallelfetch"
 )
+
+// DeleteSubscription removes all remote subscriptions for objects specified in previousResult.
+func (s Strategy) DeleteSubscription(
+	ctx context.Context,
+	previousResult common.SubscriptionResult,
+) error {
+	subscriptionResult, err := s.TypedSubscriptionResult(previousResult)
+	if err != nil {
+		return err
+	}
+
+	webhooksToRemove := make([]int, len(subscriptionResult.ObjectWebhooks))
+
+	index := 0
+	for _, webhook := range subscriptionResult.ObjectWebhooks {
+		webhooksToRemove[index] = webhook.ID
+		index += 1
+	}
+
+	if len(webhooksToRemove) == 0 {
+		return nil
+	}
+
+	result := s.removeSubscriptionsByIDs(ctx, webhooksToRemove)
+	if len(result.Errors) != 0 {
+		return errors.Join(result.Errors.Values()...)
+	}
+
+	return nil
+}
 
 func (s Strategy) removeSubscriptionsByIDs(
 	ctx context.Context, identifiers []int,

--- a/providers/connectwise/internal/subscriber/delete_test.go
+++ b/providers/connectwise/internal/subscriber/delete_test.go
@@ -1,0 +1,78 @@
+package subscriber
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+)
+
+func TestDelete(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testroutines.TestCaseDeleteSubscription{
+		{
+			Name: "Failer to delete any callback",
+			Input: common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
+						"contacts":        {ID: 0},
+						"project/tickets": {ID: 0},
+					},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodDELETE(),
+				Then:  mockserver.Response(http.StatusInternalServerError),
+			}.Server(),
+			Expected:     testroutines.None{},
+			ExpectedErrs: []error{common.ErrServer},
+		},
+		{
+			Name: "Successfully remove subscriptions to contacts and tickets.",
+			Input: common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
+						"contacts":        {ID: 26571},
+						"project/tickets": {ID: 26572},
+					},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.MethodDELETE(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26571"),
+						mockcond.Header(http.Header{"ClientId": []string{"test-client-id"}}),
+					},
+					Then: mockserver.Response(http.StatusNoContent),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodDELETE(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26572"),
+						mockcond.Header(http.Header{"ClientId": []string{"test-client-id"}}),
+					},
+					Then: mockserver.Response(http.StatusNoContent),
+				}},
+			}.Server(),
+			Expected:     testroutines.None{},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testroutines.TestableSubscriptionRemover, error) {
+				return constructTestStrategy(tt.Server)
+			})
+		})
+	}
+}


### PR DESCRIPTION
# Live Tests

Subscription test triggers deletion as a "cleanup". After making an API call in postman there are no subscriptions so deletion works correclty.

<img width="402" height="509" alt="image" src="https://github.com/user-attachments/assets/50dc8af9-e5f7-42c4-a824-7921f15a4eda" />
