### PR TITLE
[CON-3273] feat(breezyhr): Added proxy connector

### DIFF
--- a/providers/breezy.go
+++ b/providers/breezy.go
@@ -40,7 +40,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     true,
+			Proxy:     false,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,

--- a/providers/breezy.go
+++ b/providers/breezy.go
@@ -8,7 +8,7 @@ func init() {
 	SetInfo(Breezy, ProviderInfo{
 		DisplayName: "Breezy HR",
 		AuthType:    ApiKey,
-		BaseURL:     "https://api.breezy.hr/v3",
+		BaseURL:     "https://api.breezy.hr",
 		ApiKeyOpts: &ApiKeyOpts{
 			AttachmentType: Header,
 			Header: &ApiKeyOptsHeader{

--- a/providers/breezy.go
+++ b/providers/breezy.go
@@ -1,0 +1,49 @@
+package providers
+
+import "net/http"
+
+const Breezy Provider = "breezy"
+
+func init() {
+	SetInfo(Breezy, ProviderInfo{
+		DisplayName: "Breezy HR",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.breezy.hr/v3",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "",
+			},
+			DocsURL: "https://developer.breezy.hr/reference/authorization",
+		},
+		AuthHealthCheck: &AuthHealthCheck{
+			Method:             http.MethodGet,
+			SuccessStatusCodes: []int{http.StatusOK},
+			Url:                "https://api.breezy.hr/v3/companies",
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}

--- a/providers/breezy.go
+++ b/providers/breezy.go
@@ -25,12 +25,12 @@ func init() {
 		//nolint:lll
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.jpg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.svg",
+				IconURL: "",
+				LogoURL: "",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.jpg",
-				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1780944000/media/breezy.hr_1780944000.svg",
+				IconURL: "",
+				LogoURL: "",
 			},
 		},
 		Support: Support{

--- a/providers/breezy.go
+++ b/providers/breezy.go
@@ -25,12 +25,12 @@ func init() {
 		//nolint:lll
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "",
-				LogoURL: "",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1781523563/media/breezy.hr_1781523562.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1781284996/breezy_hr_logo_dark_jckpzm.png",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "",
-				LogoURL: "",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1781523563/media/breezy.hr_1781523562.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1781285012/breezy_hr_logo_light_gugdnv.png",
 			},
 		},
 		Support: Support{


### PR DESCRIPTION
## Description

Adds Breezy HR to the provider catalog with API key (access token) authentication so the connector can call Breezy’s REST API. Proxy and other support flags are left disabled until proxy integration testing is done.

## Summary

- Registered Breezy HR in the provider registry with API key auth (access token sent directly in the Authorization header, no Bearer prefix per [Breezy docs](https://developer.breezy.hr/reference/authorization)).
- Set Base URL to https://api.breezy.hr/v3.
- Set ApiKeyOpts.DocsURL to the Breezy authorization docs for credential setup.
- Added AuthHealthCheck on GET /v3/companies to validate credentials.
- Set Proxy: true; left Read, Write, Subscribe, and BulkWrite as false per initial proxy-only scope.
- Added placeholder Media URLs for icon and logo (dark and regular); replace with final assets when available.

## Assets
- Breezy HR Logo Light: – (Not available in retool search)
<img width="932" height="200" alt="61b0cb5c16638c1667c39bc8_breezyhr-dark-logo@2x" src="https://github.com/user-attachments/assets/74170aa5-d8d1-41f3-b2c1-c21e700c0bb3" />

- Breezy HR Logo Dark (Same as light as for dark doesn't exits): – (Not available in retool search)
<img width="932" height="200" alt="61b0cb5c16638c1667c39bc8_breezyhr-dark-logo@2x" src="https://github.com/user-attachments/assets/74170aa5-d8d1-41f3-b2c1-c21e700c0bb3" />

- Breezy HR Icon (Regular): – (Non-transparent background) [Retool link]( https://res.cloudinary.com/dycvts6vp/image/upload/v1780915573/media/breezy.hr_1780915572.jpg)

## Conventions

- Provider name: breezy
- Single module (N/A for proxy-only).
- Base URL includes API version path: https://api.breezy.hr/v3
- DocsURL points to user-facing docs: [Breezy API – Authorization](https://developer.breezy.hr/reference/authorization)
- No required metadata variables (API key only).
- OAuth2/workspace: N/A (API key auth).
- Basic smoke: go test ./providers/...
- Docs and logos: placeholders in catalog; icon/logo URLs to be replaced by implementer.

## GET - Ccompanies

URL: http://localhost:4444/companies

<img width="955" height="461" alt="Screenshot 2026-06-09 at 2 34 51 PM" src="https://github.com/user-attachments/assets/cff36d3b-1345-4d50-bfda-f1a9c94152b7" />


## POST - Position

URL: http://localhost:4444/v3/company/efec2f2ad125/positions

<img width="943" height="846" alt="Screenshot 2026-06-09 at 3 25 20 PM" src="https://github.com/user-attachments/assets/98f3cbfe-46e2-4123-b303-d3aa16f806c9" />

## PATCH - Position

URL: https://api.breezy.hr/v3/company/efec2f2ad125/position/7c0f4480e261

<img width="968" height="858" alt="Screenshot 2026-06-09 at 3 35 19 PM" src="https://github.com/user-attachments/assets/42c4e285-e69a-430f-86c5-48f9a205649b" />

