### PR TITLE
fix(acculynx): use pageStartIndex for contacts/contact-types/jobs-inv…

### DIFF
--- a/providers/acculynx/incremental.go
+++ b/providers/acculynx/incremental.go
@@ -53,12 +53,17 @@ var objectReadSpecs = datautils.NewDefaultMap(map[string]objectReadSpec{
 	"company-settings/job-file-settings/work-types":          {pagination: paginationOffsetRecord},
 	"company-settings/leads/lead-sources":                    {pagination: paginationOffsetRecord},
 
+	// pageStartIndex is the AccuLynx-side offset for these endpoints, advanced
+	// by the per-page record count (see advancePagination). Verified via
+	// metadata/queryParamStats.json — pageNumber is not an accepted param on
+	// any /api/v2 list endpoint, so previously routing these through
+	// paginationPageNumber caused the connector to loop on page 1 (AccuLynx
+	// silently ignores pageNumber and returns the first page every time).
 	"estimates":              {pagination: paginationOffsetPage},
 	"calendars/appointments": {pagination: paginationOffsetPage},
-
-	"contacts":               {pagination: paginationPageNumber},
-	"contacts/contact-types": {pagination: paginationPageNumber},
-	"jobs/invoices":          {pagination: paginationPageNumber},
+	"contacts":               {pagination: paginationOffsetPage},
+	"contacts/contact-types": {pagination: paginationOffsetPage},
+	"jobs/invoices":          {pagination: paginationOffsetPage},
 
 	"acculynx/countries":        {pagination: paginationNone},
 	"acculynx/units-of-measure": {pagination: paginationNone},

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -346,7 +346,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						If: mockcond.And{
 							mockcond.MethodGET(),
 							mockcond.Path("/api/v2/jobs/job-001/invoices"),
-							mockcond.QueryParam("pageNumber", "1"),
+							mockcond.QueryParam("pageStartIndex", "0"),
 						},
 						Then: mockserver.Response(http.StatusOK, jobInvoicesPage1Response),
 					},
@@ -354,7 +354,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						If: mockcond.And{
 							mockcond.MethodGET(),
 							mockcond.Path("/api/v2/jobs/job-001/invoices"),
-							mockcond.QueryParam("pageNumber", "2"),
+							mockcond.QueryParam("pageStartIndex", "2"),
 						},
 						Then: mockserver.Response(http.StatusOK, jobInvoicesPage2Response),
 					},


### PR DESCRIPTION
 ## Summary
  - AccuLynx's `/api/v2` list endpoints accept `pageStartIndex`, not `pageNumber` (verified against `metadata/queryParamStats.json` and the OpenAPI spec).
  - `contacts`, `contacts/contact-types`, and `jobs/invoices` were configured with `paginationPageNumber`, so the connector sent `?pageNumber=N` — silently ignored by AccuLynx,
  which kept returning the first page on every request. The connector saw a full page each iteration, never hit its `records < pageSize` exit condition, and looped forever on
  records 1–25 without ever fetching records 26+. 
  - Switched these three objects to `paginationOffsetPage` — the same style already used by `estimates` and `calendars/appointments`.
  
  ## Test plan
  - [x] `go test ./providers/acculynx/...` — all 11 `TestRead` subtests pass
  - [x] `make lint` — 0 issues
  - [x] Updated `jobs/invoices` unit test to assert `pageStartIndex=0` / `pageStartIndex=2` instead of `pageNumber=1` / `pageNumber=2`
