### PR TITLE
feat(utils): Add SubscriptionHelper package

### DIFF
--- a/common/subscriptionhelper/event-segments.go
+++ b/common/subscriptionhelper/event-segments.go
@@ -1,0 +1,78 @@
+// Package subscriptionhelper provides utilities for categorizing object subscription events
+// based on their existing and desired states. This allows determining the appropriate
+// action (create, keep, update, remove) for each object subscription.
+package subscriptionhelper
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+type (
+	ObjectName   = common.ObjectName
+	ObjectEvents = common.ObjectEvents
+)
+
+// EventSegments categorizes subscription events into four action categories:
+//   - ToCreate: Objects that exist in desired state but not in existing state
+//   - ToKeep: Objects that exist in both states with identical event configurations
+//   - ToUpdate: Objects that exist in both states but with different event configurations
+//   - ToRemove: Objects that exist in existing state but not in desired state
+type EventSegments struct {
+	ToCreate datautils.Map[ObjectName, ObjectEvents]
+	ToKeep   datautils.Map[ObjectName, ObjectEvents]
+	ToUpdate datautils.Map[ObjectName, ObjectEvents]
+	ToRemove datautils.Map[ObjectName, ObjectEvents]
+}
+
+// SegmentSubscriptionEvents compares previous (existing) and new (desired) object subscription events
+// and categorizes them into EventSegments based on the required action for each object.
+//
+// The categorization logic:
+//   - Objects in newEvents but not in prevEvents → ToCreate
+//   - Objects in prevEvents but not in newEvents → ToRemove
+//   - Objects in both with equal event configuration → ToKeep
+//   - Objects in both with different event configuration → ToUpdate
+//
+// Parameters:
+//   - prevEvents: The existing subscription events (current state)
+//   - newEvents: The desired subscription events (target state)
+//
+// Returns:
+//   - EventSegments containing the categorized events for each action type
+func SegmentSubscriptionEvents(
+	prevEvents datautils.Map[ObjectName, ObjectEvents],
+	newEvents datautils.Map[ObjectName, ObjectEvents],
+) EventSegments {
+	prevEventsMap := datautils.FromMap(prevEvents)
+	newEventsMap := datautils.FromMap(newEvents)
+
+	currentObjects := prevEventsMap.KeySet()
+	desiredObjects := newEventsMap.KeySet()
+
+	objectsToCreate := desiredObjects.Subtract(currentObjects)
+	objectsToRemove := currentObjects.Subtract(desiredObjects)
+	objectsIntersection := currentObjects.Intersection(desiredObjects)
+
+	toCreate := newEventsMap.ShallowSubset(objectsToCreate)
+	toRemove := prevEventsMap.ShallowSubset(objectsToRemove)
+	toKeep := make(datautils.Map[ObjectName, ObjectEvents])
+	toUpdate := make(datautils.Map[ObjectName, ObjectEvents])
+
+	// For object intersection we need to sort them into Keep or Update categories.
+	// If values are the same then we mark them as to Keep, otherwise some Update is needed.
+	for _, name := range objectsIntersection {
+		if prevEvents[name].Equals(newEvents[name]) {
+			toKeep[name] = newEvents[name]
+		} else {
+			toUpdate[name] = newEvents[name]
+		}
+	}
+
+	return EventSegments{
+		ToCreate: toCreate,
+		ToKeep:   toKeep,
+		ToUpdate: toUpdate,
+		ToRemove: toRemove,
+	}
+}

--- a/common/subscriptionhelper/event-segments_test.go
+++ b/common/subscriptionhelper/event-segments_test.go
@@ -1,0 +1,213 @@
+package subscriptionhelper
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestSegmentSubscriptionEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		prevEvents map[ObjectName]ObjectEvents
+		newEvents  map[ObjectName]ObjectEvents
+		expected   EventSegments
+	}{
+		{
+			name:       "Empty events",
+			prevEvents: nil,
+			newEvents:  nil,
+			expected:   EventSegments{},
+		},
+		{
+			name:       "Create only",
+			prevEvents: nil,
+			newEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"email"},
+				},
+			},
+			expected: EventSegments{
+				ToCreate: map[ObjectName]ObjectEvents{
+					"User": {
+						Events:      []common.SubscriptionEventType{"create"},
+						WatchFields: []string{"email"},
+					},
+				},
+			},
+		},
+		{
+			name: "Remove only",
+			prevEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"email"},
+				},
+			},
+			newEvents: nil,
+			expected: EventSegments{
+				ToRemove: map[ObjectName]ObjectEvents{
+					"User": {
+						Events:      []common.SubscriptionEventType{"create"},
+						WatchFields: []string{"email"},
+					},
+				},
+			},
+		},
+		{
+			name: "Keep only",
+			prevEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"email"},
+				},
+			},
+			newEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"email"},
+				},
+			},
+			expected: EventSegments{
+				ToKeep: map[ObjectName]ObjectEvents{
+					"User": {
+						Events:      []common.SubscriptionEventType{"create"},
+						WatchFields: []string{"email"},
+					},
+				},
+			},
+		},
+		{
+			name: "Update only - different Events",
+			prevEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"email"},
+				},
+			},
+			newEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"create", "update"},
+					WatchFields: []string{"email"},
+				},
+			},
+			expected: EventSegments{
+				ToUpdate: map[ObjectName]ObjectEvents{
+					"User": {
+						Events:      []common.SubscriptionEventType{"create", "update"},
+						WatchFields: []string{"email"},
+					},
+				},
+			},
+		},
+		{
+			name: "Update only - different WatchFields",
+			prevEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"update"},
+					WatchFields: []string{"email"},
+				},
+			},
+			newEvents: map[ObjectName]ObjectEvents{
+				"User": {
+					Events:      []common.SubscriptionEventType{"update"},
+					WatchFields: []string{"email", "name"},
+				},
+			},
+			expected: EventSegments{
+				ToUpdate: map[ObjectName]ObjectEvents{
+					"User": {
+						Events:      []common.SubscriptionEventType{"update"},
+						WatchFields: []string{"email", "name"},
+					},
+				},
+			},
+		},
+		{
+			name: "Mixed operations",
+			prevEvents: map[ObjectName]ObjectEvents{
+				"ObjToKeep": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"field1"},
+				},
+				"ObjToUpdate": {
+					Events:      []common.SubscriptionEventType{"update"},
+					WatchFields: []string{"field2"},
+				},
+				"ObjToRemove": {
+					Events:      []common.SubscriptionEventType{"delete"},
+					WatchFields: []string{"field3"},
+				},
+			},
+			newEvents: map[ObjectName]ObjectEvents{
+				"ObjToKeep": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"field1"},
+				},
+				"ObjToUpdate": {
+					Events:      []common.SubscriptionEventType{"update"},
+					WatchFields: []string{"field2", "field2_updated"},
+				},
+				"ObjToCreate": {
+					Events:      []common.SubscriptionEventType{"create"},
+					WatchFields: []string{"field4"},
+				},
+			},
+			expected: EventSegments{
+				ToCreate: map[ObjectName]ObjectEvents{
+					"ObjToCreate": {
+						Events:      []common.SubscriptionEventType{"create"},
+						WatchFields: []string{"field4"},
+					},
+				},
+				ToKeep: map[ObjectName]ObjectEvents{
+					"ObjToKeep": {
+						Events:      []common.SubscriptionEventType{"create"},
+						WatchFields: []string{"field1"},
+					},
+				},
+				ToUpdate: map[ObjectName]ObjectEvents{
+					"ObjToUpdate": {
+						Events:      []common.SubscriptionEventType{"update"},
+						WatchFields: []string{"field2", "field2_updated"},
+					},
+				},
+				ToRemove: map[ObjectName]ObjectEvents{
+					"ObjToRemove": {
+						Events:      []common.SubscriptionEventType{"delete"},
+						WatchFields: []string{"field3"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := testutils.NewCompareResult()
+			got := SegmentSubscriptionEvents(tt.prevEvents, tt.newEvents)
+
+			if tt.expected.ToCreate == nil {
+				tt.expected.ToCreate = make(map[ObjectName]ObjectEvents)
+			}
+			if tt.expected.ToKeep == nil {
+				tt.expected.ToKeep = make(map[ObjectName]ObjectEvents)
+			}
+			if tt.expected.ToUpdate == nil {
+				tt.expected.ToUpdate = make(map[ObjectName]ObjectEvents)
+			}
+			if tt.expected.ToRemove == nil {
+				tt.expected.ToRemove = make(map[ObjectName]ObjectEvents)
+			}
+
+			result.Assert("ToCreate", tt.expected.ToCreate, got.ToCreate)
+			result.Assert("ToKeep", tt.expected.ToKeep, got.ToKeep)
+			result.Assert("ToUpdate", tt.expected.ToUpdate, got.ToUpdate)
+			result.Assert("ToRemove", tt.expected.ToRemove, got.ToRemove)
+
+			result.Validate(t, tt.name)
+		})
+	}
+}

--- a/common/types.go
+++ b/common/types.go
@@ -88,7 +88,7 @@ var (
 
 	// ErrInvalidPaginationCursor is returned when the provider rejected a pagination cursor
 	// as malformed/unparseable (e.g. HubSpot returning "Cannot deserialize value of type `int`
-	// from String ...")
+	// from String ...").
 	ErrInvalidPaginationCursor error = errors.New("pagination cursor has an invalid format")
 
 	// ErrResultsLimitExceeded is returned when a search query exceeds the provider's
@@ -853,7 +853,7 @@ type SubscriptionRegistrationParams struct {
 type ObjectEvents struct {
 	// ["create", "update", "delete"] our regular CRUD operation events
 	// we translate to provider-specific names contact.creation
-	Events []SubscriptionEventType
+	Events SubscriptionEventTypes
 	// ["email", "fax"] fields to watch for an update subscription
 	WatchFields []string
 	// true if all fields should be watched for an update subscription
@@ -862,6 +862,44 @@ type ObjectEvents struct {
 	// any non CRUD operations with provider specific event names
 	// eg)  ["contact.merged"] for hubspot or ["jira_issue:restored", "jira_issue:archived"] for jira.
 	PassThroughEvents []string
+}
+
+// SubscriptionEventTypes is a list of subscription event types representing the operations to subscribe to.
+type SubscriptionEventTypes []SubscriptionEventType
+
+// Equals checks if two SubscriptionEventTypes lists contain the same event types.
+// The comparison is order-independent.
+func (t SubscriptionEventTypes) Equals(otherTypes SubscriptionEventTypes) bool {
+	if len(t) != len(otherTypes) {
+		return false
+	}
+
+	first := datautils.NewSetFromList(t)
+	second := datautils.NewSetFromList(otherTypes)
+
+	return first.Equals(second)
+}
+
+// Equals checks if two ObjectEvents configurations are identical.
+// All fields must match: WatchFieldsAll, Events, WatchFields, and PassThroughEvents.
+func (o ObjectEvents) Equals(other ObjectEvents) bool {
+	if o.WatchFieldsAll != other.WatchFieldsAll {
+		return false
+	}
+
+	if !o.Events.Equals(other.Events) {
+		return false
+	}
+
+	if !datautils.NewSetFromList(o.WatchFields).Equals(datautils.NewSetFromList(other.WatchFields)) {
+		return false
+	}
+
+	if !datautils.NewSetFromList(o.PassThroughEvents).Equals(datautils.NewSetFromList(other.PassThroughEvents)) {
+		return false
+	}
+
+	return true
 }
 
 type ObjectName string

--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -35,6 +35,20 @@ func (m Map[K, V]) ShallowCopy() Map[K, V] {
 	return result
 }
 
+// ShallowSubset creates a shallow subset of the map containing only the specified keys.
+// It copies references to the values for the given keys without cloning nested or
+// referenced objects. Use this when you need a smaller map containing specific entries,
+// not deep copies of the values.
+func (m Map[K, V]) ShallowSubset(keys []K) Map[K, V] {
+	result := make(Map[K, V])
+
+	for _, key := range keys {
+		result[key] = m[key]
+	}
+
+	return result
+}
+
 func init() {
 	gob.Register(Map[string, any]{})
 }

--- a/internal/datautils/set.go
+++ b/internal/datautils/set.go
@@ -137,3 +137,22 @@ func (s Set[T]) HasExtra(allowed Set[T]) bool {
 
 	return false
 }
+
+// Equals checks if two sets are equal by comparing their contents.
+// Two sets are considered equal if they have the same length and contain
+// exactly the same elements.
+func (s Set[T]) Equals(other Set[T]) bool {
+	// Must be of the same length.
+	if len(s) != len(other) {
+		return false
+	}
+
+	// Every key must be present.
+	for key := range s {
+		if !other.Has(key) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -15,7 +15,7 @@ import (
 const hubspotMigrationStatusCode = 477
 
 // invalidPaginationCursorMessageSubstring is the message HubSpot returns when its
-// search/list APIs reject the supplied pagination cursor as unparseable.
+// search/list APIs reject the supplied pagination cursor as unparsable.
 // This is caused by the pagination cursor being not the appropriate type
 // for the API (because Search and List APIs use different pagination tokens).
 const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type"
@@ -36,7 +36,7 @@ func InterpretJSONError(res *http.Response, body []byte) error {
 			return common.NewHTTPError(res.StatusCode, body, headers,
 				createError(common.ErrInvalidPaginationCursor, apiError))
 		}
-	// Hubspot sends us a 400 when the search endpoint returns over 10K records,
+		// Hubspot sends us a 400 when the search endpoint returns over 10K records,
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrBadRequest, apiError))
 	case http.StatusUnauthorized:
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrAccessToken, apiError))


### PR DESCRIPTION
# Description

Given previous and new event objects we can categorize them into 4 categories:
* object subscriptions **to create**
* object subscriptions **to update**
* object subscriptions **to keep**
* object subscriptions **to remove**