### PR TITLE
feat(connectwise): Update Subscription

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -1010,6 +1010,62 @@ const (
 	SubscriptionStatusFailedToRollback SubscriptionStatus = "failed_to_rollback"
 )
 
+// Resolve combines multiple subscription statuses and returns the most severe status.
+// The priority order (from worst to best) is:
+//  1. failed_to_rollback (worst - error occurred AND cleanup failed)
+//  2. failed (error occurred but cleanup succeeded)
+//  3. pending (registration in progress)
+//  4. success (best - registration completed successfully)
+//
+// If any status in the input is failed_to_rollback, the result is failed_to_rollback.
+// If any status is failed (and no failed_to_rollback), the result is failed.
+// If all statuses are pending, the result is pending.
+// Only if all statuses are success, the result is success.
+//
+// Parameters:
+//   - others: One or more additional subscription statuses to merge with the current status
+//
+// Returns:
+//   - The most severe status among all inputs
+//
+// Example:
+//
+//	status := SubscriptionStatusSuccess
+//	status.Merge(SubscriptionStatusSuccess, SubscriptionStatusFailed) // returns SubscriptionStatusFailed
+func (s SubscriptionStatus) Resolve(others ...SubscriptionStatus) SubscriptionStatus {
+	if len(others) == 0 {
+		return s
+	}
+
+	// Define priority: lower number = higher priority (more severe)
+	priority := map[SubscriptionStatus]int{
+		SubscriptionStatusFailedToRollback: 1,
+		SubscriptionStatusFailed:           2, // nolint:mnd
+		SubscriptionStatusPending:          3, // nolint:mnd
+		SubscriptionStatusSuccess:          4, // nolint:mnd
+	}
+
+	// Start with the current status's priority
+	minPriority := priority[s]
+
+	// Find the most severe status (lowest priority number)
+	for _, other := range others {
+		if otherPriority := priority[other]; otherPriority < minPriority {
+			minPriority = otherPriority
+		}
+	}
+
+	// Return the status with the lowest priority number
+	for status, prio := range priority {
+		if prio == minPriority {
+			return status
+		}
+	}
+
+	// Fallback (should never reach here if all statuses are valid)
+	return s
+}
+
 type SearchFilter struct {
 	// multiple filters are joined by `and` by default.
 	FieldFilters []FieldFilter `json:"fieldFilters" validate:"required,dive"`

--- a/providers/connectwise/internal/subscriber/create.go
+++ b/providers/connectwise/internal/subscriber/create.go
@@ -34,8 +34,8 @@ func (s Strategy) Subscribe(
 	subscriptionURL := url.String()
 
 	tasks := make([]parallelfetch.Task[common.ObjectName, SubscriptionResource], len(params.SubscriptionEvents))
-
 	index := 0
+
 	for objectName := range params.SubscriptionEvents {
 		tasks[index], err = s.newTaskCreateSubscription(objectName, subscriptionURL, input)
 		if err != nil {

--- a/providers/connectwise/internal/subscriber/create.go
+++ b/providers/connectwise/internal/subscriber/create.go
@@ -21,11 +21,18 @@ func (s Strategy) Subscribe(
 		return nil, err
 	}
 
-	input, err := s.TypedSubscriptionRequest(params)
+	request, err := s.TypedSubscriptionRequest(params)
 	if err != nil {
 		return nil, err
 	}
 
+	return s.createSubscription(ctx, request, params.SubscriptionEvents)
+}
+
+func (s Strategy) createSubscription(ctx context.Context,
+	request Request,
+	subscriptionEvents datautils.Map[common.ObjectName, common.ObjectEvents],
+) (*common.SubscriptionResult, error) {
 	url, err := s.getSubscriptionURL()
 	if err != nil {
 		return nil, err
@@ -33,11 +40,11 @@ func (s Strategy) Subscribe(
 
 	subscriptionURL := url.String()
 
-	tasks := make([]parallelfetch.Task[common.ObjectName, SubscriptionResource], len(params.SubscriptionEvents))
+	tasks := make([]parallelfetch.Task[common.ObjectName, SubscriptionResource], len(subscriptionEvents))
 	index := 0
 
-	for objectName := range params.SubscriptionEvents {
-		tasks[index], err = s.newTaskCreateSubscription(objectName, subscriptionURL, input)
+	for objectName := range subscriptionEvents {
+		tasks[index], err = s.newTaskCreateSubscription(objectName, subscriptionURL, request)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +57,7 @@ func (s Strategy) Subscribe(
 
 	if len(createResult.Errors) != 0 {
 		// Some requests failed; initiate rollback.
-		return s.rollbackSubscriptionCreation(ctx, params, state, createResult)
+		return s.rollbackSubscriptionCreation(ctx, subscriptionEvents, state, createResult)
 	}
 
 	return &common.SubscriptionResult{
@@ -97,7 +104,7 @@ func getStateFromCreateResponse(
 // Returns appropriate status based on rollback success.
 func (s Strategy) rollbackSubscriptionCreation(
 	ctx context.Context,
-	params common.SubscribeParams,
+	subscriptionEvents datautils.Map[common.ObjectName, common.ObjectEvents],
 	state map[common.ObjectName]common.ObjectEvents,
 	partialCreation parallelfetch.Result[common.ObjectName, SubscriptionResource],
 ) (*common.SubscriptionResult, error) {
@@ -109,7 +116,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 	removeResult := s.removeSubscriptionsByIDs(ctx, requestsRegistry.Keys())
 	if len(removeResult.Errors) == 0 {
 		// Full rollback succeeded.
-		objectNames := datautils.FromMap(params.SubscriptionEvents).Keys()
+		objectNames := datautils.FromMap(subscriptionEvents).Keys()
 
 		events := make(map[common.ObjectName]common.ObjectEvents)
 		for _, objectName := range objectNames {
@@ -133,7 +140,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 		existingObjects.AddOne(objectName)
 	}
 
-	allObjects := datautils.FromMap(params.SubscriptionEvents).KeySet()
+	allObjects := datautils.FromMap(subscriptionEvents).KeySet()
 	removedObjects := allObjects.Subtract(existingObjects)
 
 	// Clear state for successfully removed objects.
@@ -157,7 +164,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 
 func (s Strategy) newTaskCreateSubscription(objectName common.ObjectName,
 	url string,
-	input Request,
+	request Request,
 ) (parallelfetch.Task[common.ObjectName, SubscriptionResource], error) {
 	objectType, found := objectNameToWebhookObjectType[objectName]
 	if !found {
@@ -168,7 +175,7 @@ func (s Strategy) newTaskCreateSubscription(objectName common.ObjectName,
 		body := SubscriptionResource{
 			// Webhook must end with recordId without the value.
 			// The ConnectWise will append the record identifier as a raw string when sending the event.
-			WebhookURL:     input.WebhookURL + "?recordId=",
+			WebhookURL:     request.WebhookURL + "?recordId=",
 			ObjectType:     objectType,
 			ObjectLevel:    "owner",
 			PayloadVersion: messageVersion,

--- a/providers/connectwise/internal/subscriber/update.go
+++ b/providers/connectwise/internal/subscriber/update.go
@@ -1,0 +1,117 @@
+package subscriber
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/subscriptionhelper"
+	"github.com/amp-labs/connectors/internal/datautils"
+)
+
+// UpdateSubscription updates object subscriptions by comparing previous and desired states,
+// then creating new subscriptions and removing obsolete ones as needed.
+//
+// The update process segments subscription events into four categories:
+//   - ToUpdate: Objects where event types differ (e.g., SubscriptionEventType changes).
+//     Note: ConnectWise webhook definitions don't have mutable fields to change, so these
+//     are effectively treated like ToKeep (no action taken). The final output always includes
+//     Create/Update/Delete events regardless of what the user requested.
+//   - ToKeep: Objects with identical events in both states. ConnectWise doesn't need
+//     webhook refreshing, so no action is taken.
+//   - ToCreate: Objects in desired state but not in previous state. New subscriptions
+//     are created for these objects.
+//   - ToRemove: Objects in previous state but not in desired state. Subscriptions
+//     are removed for these objects.
+//
+// Only ToCreate and ToRemove require actual action. ToUpdate and ToKeep are passive.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control
+//   - params: Subscription parameters containing the desired subscription events
+//   - previousResult: The result from the previous subscription operation (existing state)
+//
+// Returns:
+//   - *common.SubscriptionResult: The result of the update operation containing:
+//   - Output.ObjectWebhooks: Combined webhooks after create and remove operations
+//   - ObjectEvents: Combined events after create and remove operations
+//   - Status: Merged status from create and remove operations (failed_to_rollback or failed if any operation failed)
+//   - error: Any error encountered during the update process
+func (s Strategy) UpdateSubscription( // nolint:cyclop,funlen
+	ctx context.Context,
+	params common.SubscribeParams,
+	previousResult *common.SubscriptionResult,
+) (*common.SubscriptionResult, error) {
+	// Segment subscription events into ToCreate, ToKeep, ToUpdate, and ToRemove categories.
+	segmentEvents := subscriptionhelper.SegmentSubscriptionEvents(
+		previousResult.ObjectEvents, params.SubscriptionEvents,
+	)
+
+	// Cast subscription input/output into local typed representations.
+	subsInput, err := s.TypedSubscriptionRequest(params)
+	if err != nil {
+		return nil, err
+	}
+
+	prevOutput, err := s.TypedSubscriptionResult(*previousResult)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create Event subscriptions for objects that need new subscriptions.
+	createSubsResult, err := s.createSubscription(ctx, subsInput, segmentEvents.ToCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := createSubsResult.Result.(Result)
+	if !ok {
+		return nil, fmt.Errorf("%w: common.SubscriptionResult.Result cannot be cast to connectwise.Result",
+			common.ErrInvalidImplementation)
+	}
+
+	// Merge newly created webhooks and events with existing ones.
+	combinedWebhooks := datautils.MergeMaps(prevOutput.ObjectWebhooks, result.ObjectWebhooks)
+	combinedEvents := datautils.MergeMaps(previousResult.ObjectEvents, createSubsResult.ObjectEvents)
+
+	// Delete Event subscriptions for objects that need to be removed.
+	webhooksToRemove := make([]int, 0)
+	for _, webhook := range datautils.FromMap(prevOutput.ObjectWebhooks).ShallowSubset(segmentEvents.ToRemove.Keys()) {
+		webhooksToRemove = append(webhooksToRemove, webhook.ID)
+	}
+
+	removeResult := s.removeSubscriptionsByIDs(ctx, webhooksToRemove)
+
+	// Track which objects were successfully deleted by matching removed subscription IDs.
+	deletedObjects := make(datautils.Set[common.ObjectName])
+
+	for deletedSubID := range removeResult.Records {
+		for name, webhook := range combinedWebhooks {
+			if webhook.ID == deletedSubID {
+				deletedObjects.AddOne(name)
+			}
+		}
+	}
+
+	// Remove deleted objects from combined webhooks and events maps.
+	for name := range deletedObjects {
+		delete(combinedWebhooks, name)
+		delete(combinedEvents, name)
+	}
+
+	// Determine remove operation status based on errors.
+	removeStatus := common.SubscriptionStatusSuccess
+	if len(removeResult.Errors) != 0 {
+		removeStatus = common.SubscriptionStatusFailed
+	}
+
+	// Merge create and remove statuses to get the final combined status.
+	// If either operation failed, the combined status reflects the failure.
+	combinedStatus := createSubsResult.Status.Resolve(removeStatus)
+
+	return &common.SubscriptionResult{
+		Result:       Result{ObjectWebhooks: combinedWebhooks},
+		ObjectEvents: combinedEvents,
+		Status:       combinedStatus,
+	}, nil
+}

--- a/providers/connectwise/internal/subscriber/update_test.go
+++ b/providers/connectwise/internal/subscriber/update_test.go
@@ -1,0 +1,216 @@
+package subscriber
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	requestWebhookForContacts := testutils.DataFromFile(t, "create/contacts/request.json")
+	responseWebhookForContacts := testutils.DataFromFile(t, "create/contacts/response.json")
+	requestWebhookForTickets := testutils.DataFromFile(t, "create/tickets/request.json")
+	responseWebhookForTickets := testutils.DataFromFile(t, "create/tickets/response.json")
+	errorCreateBadRequest1 := testutils.DataFromFile(t, "create/create-webhook-bad-request-1.json")
+	deleteWebhookFailed := testutils.DataFromFile(t, "create/remove-webhook-failed.json")
+
+	eventTypesCUD := []common.SubscriptionEventType{
+		common.SubscriptionEventTypeCreate,
+		common.SubscriptionEventTypeUpdate,
+		common.SubscriptionEventTypeDelete,
+	}
+
+	tests := []testroutines.TestCaseUpdateSubscription{
+		{
+			Name: "SubscriptionStatusSuccess: Successfully update by creating one and removing one",
+			Input: testroutines.UpdateSubscriptionParams{
+				Params: common.SubscribeParams{
+					Request: Params{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"project/tickets": {Events: eventTypesCUD},
+					},
+				},
+				PreviousResult: &common.SubscriptionResult{
+					Result: Result{
+						ObjectWebhooks: map[common.ObjectName]SystemCallback{
+							"contacts": {
+								ID:         26559,
+								WebhookURL: "https://test.com/webhook?recordId=",
+								ObjectType: "contact",
+							},
+						},
+					},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"contacts": {Events: eventTypesCUD},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForTickets),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForTickets),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodDELETE(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26559"),
+					},
+					Then: mockserver.Response(http.StatusNoContent),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+						"project/tickets": {
+							ID:         26552,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "ticket",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"project/tickets": {Events: eventTypesCUD},
+				},
+				Status: common.SubscriptionStatusSuccess,
+			},
+		},
+		{
+			Name: "SubscriptionStatusFailed: Create fails (with rollback) and delete succeeds",
+			Input: testroutines.UpdateSubscriptionParams{
+				Params: common.SubscribeParams{
+					Request: Params{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"contacts":        {Events: eventTypesCUD},
+						"project/tickets": {Events: eventTypesCUD},
+					},
+				},
+				PreviousResult: &common.SubscriptionResult{
+					Result: Result{
+						ObjectWebhooks: map[common.ObjectName]SystemCallback{
+							"contacts": {
+								ID:         26559,
+								WebhookURL: "https://test.com/webhook?recordId=",
+								ObjectType: "contact",
+							},
+						},
+					},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"contacts": {Events: eventTypesCUD},
+					},
+					Status: common.SubscriptionStatusSuccess,
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				// contacts is already there, so it won't be in ToCreate.
+				// ToCreate will only have project/tickets. For this case it will fail.
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+					mockcond.BodyBytes(requestWebhookForTickets),
+				},
+				Then: mockserver.Response(http.StatusBadRequest, errorCreateBadRequest1),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+						"contacts": {
+							ID:         26559,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "contact",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					"contacts":        {Events: eventTypesCUD},
+					"project/tickets": {}, // not created but succeeded to rollback
+				},
+				Status: common.SubscriptionStatusFailed,
+			},
+		},
+		{
+			Name: "SubscriptionStatusFailedToRollback: Create fails and rollback fails",
+			Input: testroutines.UpdateSubscriptionParams{
+				Params: common.SubscribeParams{
+					Request: Params{WebhookURL: "https://test.com/webhook"},
+					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+						"contacts":        {Events: eventTypesCUD},
+						"project/tickets": {Events: eventTypesCUD},
+						"activities":      {Events: eventTypesCUD},
+					},
+				},
+				PreviousResult: &common.SubscriptionResult{
+					Result:       Result{},
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{},
+					Status:       common.SubscriptionStatusSuccess,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodPOST(), // only contacts create will succeed
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+						mockcond.BodyBytes(requestWebhookForContacts),
+					},
+					Then: mockserver.Response(http.StatusOK, responseWebhookForContacts),
+				}, {
+					If: mockcond.And{ // any other create will fail
+						mockcond.MethodPOST(),
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks"),
+					},
+					Then: mockserver.Response(http.StatusBadRequest, errorCreateBadRequest1),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodDELETE(), // rollback will fail
+						mockcond.Path("/v4_6_release/apis/3.0/system/callbacks/26559"),
+					},
+					Then: mockserver.Response(http.StatusBadRequest, deleteWebhookFailed),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Expected: &common.SubscriptionResult{
+				Result: Result{
+					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+						"contacts": { // couldn't rollback creation.
+							ID:         26559,
+							WebhookURL: "https://test.com/webhook?recordId=",
+							ObjectType: "contact",
+						},
+					},
+				},
+				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+					// successful creation and failed to rollback, so it remains
+					"contacts":        {Events: eventTypesCUD},
+					"project/tickets": {}, // not created
+					"activities":      {}, // not created
+				},
+				Status: common.SubscriptionStatusFailedToRollback,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testroutines.TestableSubscriptionUpdater, error) {
+				return constructTestStrategy(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/connectwise/internal/subscriber/update_test.go
+++ b/providers/connectwise/internal/subscriber/update_test.go
@@ -32,14 +32,14 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusSuccess: Successfully update by creating one and removing one",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Params{WebhookURL: "https://test.com/webhook"},
+					Request: Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"project/tickets": {Events: eventTypesCUD},
 					},
 				},
 				PreviousResult: &common.SubscriptionResult{
 					Result: Result{
-						ObjectWebhooks: map[common.ObjectName]SystemCallback{
+						ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 							"contacts": {
 								ID:         26559,
 								WebhookURL: "https://test.com/webhook?recordId=",
@@ -73,7 +73,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: Result{
-					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"project/tickets": {
 							ID:         26552,
 							WebhookURL: "https://test.com/webhook?recordId=",
@@ -91,7 +91,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusFailed: Create fails (with rollback) and delete succeeds",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Params{WebhookURL: "https://test.com/webhook"},
+					Request: Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"contacts":        {Events: eventTypesCUD},
 						"project/tickets": {Events: eventTypesCUD},
@@ -99,7 +99,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 				},
 				PreviousResult: &common.SubscriptionResult{
 					Result: Result{
-						ObjectWebhooks: map[common.ObjectName]SystemCallback{
+						ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 							"contacts": {
 								ID:         26559,
 								WebhookURL: "https://test.com/webhook?recordId=",
@@ -127,7 +127,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: Result{
-					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts": {
 							ID:         26559,
 							WebhookURL: "https://test.com/webhook?recordId=",
@@ -146,7 +146,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusFailedToRollback: Create fails and rollback fails",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Params{WebhookURL: "https://test.com/webhook"},
+					Request: Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"contacts":        {Events: eventTypesCUD},
 						"project/tickets": {Events: eventTypesCUD},
@@ -185,7 +185,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: Result{
-					ObjectWebhooks: map[common.ObjectName]SystemCallback{
+					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts": { // couldn't rollback creation.
 							ID:         26559,
 							WebhookURL: "https://test.com/webhook?recordId=",

--- a/test/connectwise/subscription/update/main.go
+++ b/test/connectwise/subscription/update/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/connectwise"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	testscenario.SubscriptionCreateUpdateDelete(ctx, conn,
+		func(webhookURL string) *common.SubscribeParams {
+			return &common.SubscribeParams{
+				Request: connectwise.SubscribeRequest{
+					WebhookURL: webhookURL,
+				},
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"projects": {},
+					"invoices": {},
+				},
+			}
+		},
+		func(webhookURL string) *common.SubscribeParams {
+			return &common.SubscribeParams{
+				Request: connectwise.SubscribeRequest{
+					WebhookURL: webhookURL,
+				},
+				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+					"invoices":        {},
+					"project/tickets": {},
+					"contacts":        {},
+				},
+			}
+		},
+	)
+}


### PR DESCRIPTION
# Description

UpdateSubscription is managing what objects to create and to remove. There is no applicalbe concept of "update" for ConnectWise. (Unless we want to update the webhook, not sure if that should be considered.)

# Live Tests

<img width="690" height="651" alt="image" src="https://github.com/user-attachments/assets/55ec52a6-0ac7-492a-b3c9-00c1edd90bce" />

List of webhooks after create:
<img width="510" height="660" alt="image" src="https://github.com/user-attachments/assets/c30aa991-f6a8-4d90-9017-45803107aea2" />

List of webhooks after update:
<img width="496" height="961" alt="image" src="https://github.com/user-attachments/assets/18a5a1ed-4b8a-440a-b8af-f506e7050535" />

At the end of the script execution all webhooks are removed.