### PR TITLE
[CON-3295] fix(slack): Remove connector-side filtering users.conversations

### DIFF
--- a/providers/slack/support.go
+++ b/providers/slack/support.go
@@ -47,12 +47,15 @@ var objectsReadViaPost = datautils.NewSet( //nolint:gochecknoglobals
 // to the JSON field used for comparison. Slack has no server-side date filter params,
 // so filtering is done in memory after each page is fetched. All Slack timestamps are
 // Unix epoch seconds.
+//
+// Some objects are excluded from connector-side filtering because the filtering would miss
+// records that should be returned for clients:
+//   - users.conversations (field: "created")
 var objectsWithConnectorSideFilter = datautils.Map[string, string]{ //nolint:gochecknoglobals
-	"conversations":       "updated",
-	"files":               "created",
-	"usergroups":          "date_update",
-	"users.conversations": "created",
-	"users":               "updated",
+	"conversations": "updated",
+	"files":         "created",
+	"usergroups":    "date_update",
+	"users":         "updated",
 }
 
 // objectsUsingAddSuffix contains write objects whose Slack API endpoint uses the ".add" method suffix.


### PR DESCRIPTION
# Description

Removed `users.conversations` object from connector side filtering. It used "created" field which is the only timebased field that is usable for filtering.

However, the creation time would miss important records. Its common to use created field if updated field is missing, I left a comment just in case, so it is not re-introduced by mistake.