### PR TITLE
fix(gong): prefer owner's Personal copy when deduping flows

### DIFF
--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -91,8 +91,17 @@ func emptyFlowsResult() *common.ReadResult {
 	}
 }
 
-// mergeUserFlows adds a user's flows to the aggregate, skipping ids already
-// collected and attaching the owning user to personal flows when requested.
+// mergeUserFlows adds a user's flows to the aggregate, deduplicating by id and
+// attaching the owning user to personal flows when requested.
+//
+// Gong reports visibility relative to the queried email: a flow reads "Personal"
+// only in its owner's result set and "Shared" for everyone else who can see it.
+// The same flow id therefore shows up in several users' results with different
+// visibility, and users are fetched in an arbitrary order. So we can't just keep
+// the first copy we see: if a non-owner is fetched first we'd store the "Shared"
+// copy and never attach the owner. When this user owns the flow (their copy says
+// "Personal") we prefer that copy, overwriting any "Shared" one stored earlier,
+// so the owner association is reliable no matter what order users come back in.
 func mergeUserFlows(
 	aggregated map[string]common.ReadResultRow,
 	flows []common.ReadResultRow,
@@ -100,8 +109,11 @@ func mergeUserFlows(
 	includeUserAssoc bool,
 ) {
 	for _, flow := range flows {
-		_, seen := aggregated[flow.Id]
-		if seen {
+		visibility, _ := flow.Raw["visibility"].(string)
+		ownsFlow := strings.EqualFold(visibility, "Personal")
+
+		// Already collected and this isn't the owner's copy: nothing to add.
+		if _, seen := aggregated[flow.Id]; seen && !ownsFlow {
 			continue
 		}
 

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -271,6 +271,12 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
+			// Bob is fetched first (read_users_bob_first.json) and his result set
+			// includes alice's flow 9000000000000001 as "Shared", because Gong
+			// reports visibility relative to the queried email. Alice is fetched
+			// second and sees that same id as "Personal". Expecting flow ...001 to
+			// come out "Personal" with alice attached proves the dedup prefers the
+			// owner's copy instead of keeping the non-owner's "Shared" one.
 			Name: "Flows: AssociatedObjects=users attaches each Personal flow's owner",
 			Input: common.ReadParams{
 				ObjectName:        "flows",
@@ -281,7 +287,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				Setup: mockserver.ContentJSON(),
 				Cases: []mockserver.Case{{
 					If:   mockcond.Path("/v2/users"),
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "get-records-users.json")),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_bob_first.json")),
 				}, {
 					If: mockcond.And{
 						mockcond.Path("/v2/flows"),

--- a/providers/gong/test/read_flows_bob.json
+++ b/providers/gong/test/read_flows_bob.json
@@ -1,8 +1,8 @@
 {
   "requestId": "b1b2c3d4e5f6g7h8i9j0",
   "records": {
-    "totalRecords": 2,
-    "currentPageSize": 2,
+    "totalRecords": 3,
+    "currentPageSize": 3,
     "currentPageNumber": 0
   },
   "flows": [
@@ -13,6 +13,15 @@
       "folderName": "My Folder",
       "visibility": "Personal",
       "creationDate": "2025-01-16T11:00:00Z",
+      "exclusive": false
+    },
+    {
+      "id": "9000000000000001",
+      "name": "Alice's Personal Outreach",
+      "folderId": "7000000000000001",
+      "folderName": "My Folder",
+      "visibility": "Shared",
+      "creationDate": "2025-01-15T10:00:00Z",
       "exclusive": false
     },
     {

--- a/providers/gong/test/read_users_bob_first.json
+++ b/providers/gong/test/read_users_bob_first.json
@@ -1,0 +1,26 @@
+{
+  "requestId": "users-bob-first",
+  "records": {
+    "totalRecords": 2,
+    "currentPageSize": 2,
+    "currentPageNumber": 0
+  },
+  "users": [
+    {
+      "id": "8000000000000002",
+      "emailAddress": "bob@example.com",
+      "firstName": "Bob",
+      "lastName": "Brown",
+      "active": true,
+      "title": "Sales Engineer"
+    },
+    {
+      "id": "8000000000000001",
+      "emailAddress": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Anderson",
+      "active": true,
+      "title": "Account Executive"
+    }
+  ]
+}


### PR DESCRIPTION
## What was wrong

When reading `flows`, we fetch every user and ask Gong for each user's flows, then merge them into one list (dedup by id).

The problem: Gong returns a flow's `visibility` **based on who is asking**.
- The owner sees their flow as `Personal`.
- Everyone else who can see it gets `Shared`.

So the same flow shows up many times with different visibility. The old code kept the **first** copy it saw. If a non-owner was fetched first, we stored the `Shared` copy and never attached the owner. The user association was missing, and it only worked by luck of fetch order.

## The fix

Now we prefer the **owner's `Personal` copy**. If we already stored a `Shared` copy from someone else, the owner's copy overwrites it. So the flow ends up `Personal` with the correct user attached, no matter what order users are fetched in.

## Live Test

```
{
  "Data": [
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "2532244818760665235",
        "name": "Amp-test-flows",
        "visibility": "Personal"
      },
      "Id": "2532244818760665235",
      "Raw": {
        "creationDate": "2026-06-03T14:18:10.674369Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "2532244818760665235",
        "name": "Amp-test-flows",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "3003900775403111488",
        "name": "New Personal Flow",
        "visibility": "Personal"
      },
      "Id": "3003900775403111488",
      "Raw": {
        "creationDate": "2026-06-10T09:38:00.756142Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "3003900775403111488",
        "name": "New Personal Flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "3583316463112713997",
        "name": "Deep flow",
        "visibility": "Personal"
      },
      "Id": "3583316463112713997",
      "Raw": {
        "creationDate": "2026-06-10T17:51:46.314142Z",
        "exclusive": true,
        "folderId": "3663694443832366722",
        "folderName": "Personal flows",
        "id": "3583316463112713997",
        "name": "Deep flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {},
      "Fields": {
        "id": "3749632929933551771",
        "name": "thisisupdatedone",
        "visibility": "Shared"
      },
      "Id": "3749632929933551771",
      "Raw": {
        "creationDate": "2026-06-10T07:52:53.377687Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "3749632929933551771",
        "name": "thisisupdatedone",
        "visibility": "Shared"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "5321338733804837705",
        "name": "Amp-personal-flow",
        "visibility": "Personal"
      },
      "Id": "5321338733804837705",
      "Raw": {
        "creationDate": "2025-09-16T20:44:53.033610Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "5321338733804837705",
        "name": "Amp-personal-flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "6990573422660211932",
        "name": "New flow",
        "visibility": "Personal"
      },
      "Id": "6990573422660211932",
      "Raw": {
        "creationDate": "2026-06-10T09:54:23.714098Z",
        "exclusive": true,
        "folderId": "1740872046719265042",
        "folderName": "Perrr",
        "id": "6990573422660211932",
        "name": "New flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "7022612481621549098",
        "name": "User Flow",
        "visibility": "Personal"
      },
      "Id": "7022612481621549098",
      "Raw": {
        "creationDate": "2026-06-10T17:53:11.696842Z",
        "exclusive": true,
        "folderId": "3663694443832366722",
        "folderName": "Personal flows",
        "id": "7022612481621549098",
        "name": "User Flow",
        "visibility": "Personal"
      }
    }
  ],
  "Done": true,
  "NextPage": "",
  "Rows": 7
}
```
