### PR TITLE
fix(acculynx): startDate/endDate filter fix

### DIFF
--- a/providers/acculynx/incremental.go
+++ b/providers/acculynx/incremental.go
@@ -116,15 +116,10 @@ func applyJobsIncrementalFilter(url *urlbuilder.URL, params common.ReadParams) {
 		return
 	}
 
+	since, until := pairedDateWindow(params.Since, params.Until)
 	url.WithQueryParam("dateFilterType", "ModifiedDate")
-
-	if !params.Since.IsZero() {
-		url.WithQueryParam("startDate", params.Since.Format(time.DateOnly))
-	}
-
-	if !params.Until.IsZero() {
-		url.WithQueryParam("endDate", params.Until.Format(time.DateOnly))
-	}
+	url.WithQueryParam("startDate", since.Format(time.DateOnly))
+	url.WithQueryParam("endDate", until.Format(time.DateOnly))
 }
 
 // applyHistoryDateWindow pushes Since/Until into AccuLynx's server-side
@@ -143,11 +138,28 @@ func applyHistoryDateWindow(url *urlbuilder.URL, params common.ReadParams) {
 		return
 	}
 
-	if !params.Since.IsZero() {
-		url.WithQueryParam("startDate", params.Since.Format(time.DateOnly))
+	since, until := pairedDateWindow(params.Since, params.Until)
+	url.WithQueryParam("startDate", since.Format(time.DateOnly))
+	url.WithQueryParam("endDate", until.Format(time.DateOnly))
+}
+
+// pairedDateWindow normalizes a Since/Until pair so both bounds are always
+// present. AccuLynx returns HTTP 400 ("Start Date and End Date do not have
+// the same format") on /jobs and /jobs/{id}/history when only one of
+// startDate / endDate is sent. Missing bounds default to:
+//   - Until → time.Now().UTC()
+//   - Since → Unix epoch (predates AccuLynx; safely covers all history)
+//
+// The connector-side time filter still enforces precise bounds on the
+// response, so widening upstream when a bound is missing is safe.
+func pairedDateWindow(since, until time.Time) (time.Time, time.Time) {
+	if until.IsZero() {
+		until = time.Now().UTC()
 	}
 
-	if !params.Until.IsZero() {
-		url.WithQueryParam("endDate", params.Until.Format(time.DateOnly))
+	if since.IsZero() {
+		since = time.Unix(0, 0).UTC()
 	}
+
+	return since, until
 }

--- a/providers/acculynx/incremental_test.go
+++ b/providers/acculynx/incremental_test.go
@@ -1,0 +1,147 @@
+package acculynx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// TestPairedDateWindow verifies the defaulting logic that protects /jobs and
+// /jobs/{id}/history against AccuLynx's HTTP 400 when only one of
+// startDate / endDate is sent.
+func TestPairedDateWindow(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	fixedSince := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	fixedUntil := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	epoch := time.Unix(0, 0).UTC()
+
+	tests := []struct {
+		name                    string
+		since, until            time.Time
+		wantSince               time.Time
+		wantUntilDefaultedToNow bool
+	}{
+		{
+			name:      "both set — pass through unchanged",
+			since:     fixedSince,
+			until:     fixedUntil,
+			wantSince: fixedSince,
+		},
+		{
+			name:                    "only Since set — Until defaults to now (platform backfill shape)",
+			since:                   fixedSince,
+			until:                   time.Time{},
+			wantSince:               fixedSince,
+			wantUntilDefaultedToNow: true,
+		},
+		{
+			name:      "only Until set — Since defaults to epoch",
+			since:     time.Time{},
+			until:     fixedUntil,
+			wantSince: epoch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := time.Now().UTC()
+			gotSince, gotUntil := pairedDateWindow(tt.since, tt.until)
+			after := time.Now().UTC()
+
+			if !gotSince.Equal(tt.wantSince) {
+				t.Errorf("since = %v, want %v", gotSince, tt.wantSince)
+			}
+
+			if gotUntil.IsZero() {
+				t.Fatal("until should never be zero after pairedDateWindow")
+			}
+
+			if tt.wantUntilDefaultedToNow {
+				if gotUntil.Before(before) || gotUntil.After(after) {
+					t.Errorf("until = %v, want time.Now()-ish (between %v and %v)",
+						gotUntil, before, after)
+				}
+			} else if !tt.until.IsZero() && !gotUntil.Equal(tt.until) {
+				t.Errorf("until = %v, want %v (unchanged)", gotUntil, tt.until)
+			}
+		})
+	}
+}
+
+// TestApplyJobsIncrementalFilter_OnlySinceSet is the regression test for the
+// production HTTP 400 caused by sending startDate without endDate. The bug
+// shipped because no unit or live test exercised the platform's backfill
+// param shape (Since set, Until zero).
+func TestApplyJobsIncrementalFilter_OnlySinceSet(t *testing.T) {
+	t.Parallel()
+
+	u, err := urlbuilder.New("https://api.acculynx.com", "/api/v2/jobs")
+	if err != nil {
+		t.Fatalf("urlbuilder: %v", err)
+	}
+
+	params := common.ReadParams{
+		ObjectName: "jobs",
+		Since:      time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC),
+		// Until is intentionally zero — matches platform backfill shape.
+	}
+
+	applyJobsIncrementalFilter(u, params)
+
+	assertQueryParam(t, u, "dateFilterType", "ModifiedDate")
+	assertQueryParam(t, u, "startDate", "2026-05-26")
+	assertQueryParamPresent(t, u, "endDate")
+}
+
+// TestApplyHistoryDateWindow_OnlySinceSet mirrors the jobs regression test for
+// /jobs/{id}/history. Same code pattern as applyJobsIncrementalFilter, same
+// defensive defaulting required.
+func TestApplyHistoryDateWindow_OnlySinceSet(t *testing.T) {
+	t.Parallel()
+
+	u, err := urlbuilder.New("https://api.acculynx.com", "/api/v2/jobs/some-id/history")
+	if err != nil {
+		t.Fatalf("urlbuilder: %v", err)
+	}
+
+	params := common.ReadParams{
+		ObjectName: "jobs/history",
+		Since:      time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC),
+	}
+
+	applyHistoryDateWindow(u, params)
+
+	assertQueryParam(t, u, "startDate", "2026-05-26")
+	assertQueryParamPresent(t, u, "endDate")
+}
+
+func assertQueryParam(t *testing.T, u *urlbuilder.URL, key, want string) {
+	t.Helper()
+
+	got, ok := u.GetFirstQueryParam(key)
+	if !ok {
+		t.Fatalf("query param %q missing; URL = %s", key, u.String())
+	}
+
+	if got != want {
+		t.Errorf("query param %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertQueryParamPresent(t *testing.T, u *urlbuilder.URL, key string) {
+	t.Helper()
+
+	got, ok := u.GetFirstQueryParam(key)
+	if !ok {
+		t.Fatalf("query param %q missing; URL = %s", key, u.String())
+	}
+
+	if got == "" {
+		t.Errorf("query param %q is present but empty; URL = %s", key, u.String())
+	}
+}

--- a/test/acculynx/read/main.go
+++ b/test/acculynx/read/main.go
@@ -91,6 +91,18 @@ func main() {
 	if err := testIncrementalRead(ctx, conn, "jobs"); err != nil {
 		slog.Error(err.Error())
 	}
+
+	// Regression: platform sends Since set + Until zero on backfills. /jobs
+	// and /jobs/{id}/history return HTTP 400 when only one of startDate /
+	// endDate is sent. Exercise the exact param shape here so a regression
+	// surfaces in live testing rather than in production.
+	for _, obj := range []string{"jobs", "jobs/history"} {
+		slog.Info("Testing backfill-shape incremental read (Since set, Until zero)", "object", obj)
+
+		if err := testBackfillShapeRead(ctx, conn, obj); err != nil {
+			slog.Error(err.Error())
+		}
+	}
 }
 
 func testRead(ctx context.Context, conn *acculynx.Connector, objectName string) error {
@@ -172,6 +184,35 @@ func testIncrementalRead(ctx context.Context, conn *acculynx.Connector, objectNa
 	}
 
 	slog.Info("Incremental read result", "object", objectName, "rows", res.Rows)
+	utils.DumpJSON(res, os.Stdout)
+
+	return nil
+}
+
+// testBackfillShapeRead mirrors the platform's backfill param shape: Since set,
+// Until zero. Before the date-filter fix, this combination produced HTTP 400
+// from AccuLynx ("Start Date and End Date do not have the same format").
+func testBackfillShapeRead(ctx context.Context, conn *acculynx.Connector, objectName string) error {
+	since := time.Now().AddDate(0, 0, -15)
+
+	params := common.ReadParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields("id"),
+		Since:      since,
+		// Until intentionally left as zero value.
+	}
+
+	slog.Info("Reading with backfill shape",
+		"object", objectName,
+		"since", since.Format(time.RFC3339),
+		"until", "zero")
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return fmt.Errorf("error reading %s with backfill shape: %w", objectName, err)
+	}
+
+	slog.Info("Backfill-shape read result", "object", objectName, "rows", res.Rows)
 	utils.DumpJSON(res, os.Stdout)
 
 	return nil


### PR DESCRIPTION
## Summary
  - AccuLynx's `/jobs` and `/jobs/{id}/history` endpoints return HTTP 400 (`"Start Date and End Date do not have the same format"`) when only one of `startDate` / `endDate` is
  sent.
  - The Ampersand platform fires incremental reads with `Since` set and `Until` zero (the standard backfill shape), which the connector previously translated to sending `startDate`
   alone — triggering the 400.
  - Added a `pairedDateWindow()` helper that always sends both bounds. When `Until` is zero it defaults to `time.Now().UTC()`; when `Since` is zero it defaults to Unix epoch. The
  connector-side time filter still enforces precise bounds on the response, so widening upstream is safe.

  ## How it was tested
  - **Unit tests** (`providers/acculynx/incremental_test.go`) covering `pairedDateWindow` directly, plus `applyJobsIncrementalFilter` and `applyHistoryDateWindow` for the full
  Since-set/Until-zero, Until-set/Since-zero, and both-set cases.
  - **Live-tenant regression** in `test/acculynx/read/main.go` (`testBackfillShapeRead`) that exercises the exact platform shape (`Since` set, `Until` zero) against a real AccuLynx
   tenant for both `jobs` and `jobs/history`. Before the fix this reproduces the HTTP 400; after the fix both objects read cleanly.
  - **Caught during deep-integration testing** — the dashboard Operations log surfaced the exact `"Start Date and End Date do not have the same format"` 400 from AccuLynx, which is
   what motivated this fix.
  - `go test ./providers/acculynx/...` passes, `make lint` reports 0 issues