### PR TITLE
feat[ENG-3789]: catch HubSpot invalid pagination token errors

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -82,6 +82,11 @@ var (
 	// ErrCursorGone is returned when a cursor used for pagination is no longer valid.
 	ErrCursorGone error = newClassedErr("pagination cursor gone or expired", ErrorClassCursorGone)
 
+	// ErrInvalidPaginationCursor is returned when the provider rejected a pagination cursor
+	// as malformed/unparseable (e.g. HubSpot returning "Cannot deserialize value of type `int`
+	// from String ...")
+	ErrInvalidPaginationCursor error = errors.New("pagination cursor has an invalid format")
+
 	// ErrResultsLimitExceeded is returned when a search query exceeds the provider's
 	// maximum result limit (e.g., HubSpot's 10,000 record search limit).
 	ErrResultsLimitExceeded error = newClassedErr("results limit exceeded", ErrorClassRateLimited)

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -18,7 +18,7 @@ const hubspotMigrationStatusCode = 477
 // search/list APIs reject the supplied pagination cursor as unparseable.
 // This is caused by the pagination cursor being not the appropriate type
 // for the API (because Search and List APIs use different pagination tokens).
-const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type `int` from String"
+const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type"
 
 // InterpretJSONError interprets the error response from Hubspot
 // as per https://developers.hubspot.com/docs/api/error-handling.

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -18,7 +18,7 @@ const hubspotMigrationStatusCode = 477
 // search/list APIs reject the supplied pagination cursor as unparseable.
 // This is caused by the pagination cursor being not the appropriate type
 // for the API (because Search and List APIs use different pagination tokens).
-const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type `int` from String "
+const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type `int` from String"
 
 // InterpretJSONError interprets the error response from Hubspot
 // as per https://developers.hubspot.com/docs/api/error-handling.

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -12,6 +13,12 @@ import (
 // HubSpot returns 477 while a hub is being migrated between data hosting locations.
 // Migrations resolve in hours, so it is a retryable error.
 const hubspotMigrationStatusCode = 477
+
+// invalidPaginationCursorMessageSubstring is the message HubSpot returns when its
+// search/list APIs reject the supplied pagination cursor as unparseable.
+// This is caused by the pagination cursor being not the appropriate type
+// for the API (because Search and List APIs use different pagination tokens).
+const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type `int` from String "
 
 // InterpretJSONError interprets the error response from Hubspot
 // as per https://developers.hubspot.com/docs/api/error-handling.
@@ -24,8 +31,12 @@ func InterpretJSONError(res *http.Response, body []byte) error {
 	}
 
 	switch res.StatusCode {
-	// Hubspot sends us a 400 when the search endpoint returns over 10K records.
 	case http.StatusBadRequest:
+		if strings.Contains(apiError.Message, invalidPaginationCursorMessageSubstring) {
+			return common.NewHTTPError(res.StatusCode, body, headers,
+				createError(common.ErrInvalidPaginationCursor, apiError))
+		}
+	// Hubspot sends us a 400 when the search endpoint returns over 10K records,
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrBadRequest, apiError))
 	case http.StatusUnauthorized:
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrAccessToken, apiError))


### PR DESCRIPTION
Sample error from HubSpot:  `HTTP status 400: bad request: Invalid input JSON on line 1, column 10: Cannot deserialize value of type int from String \"https://api.hubapi.com/crm/objects/v3/contacts?limit=100\u0026after=70680725625\u0026properties ....`
