### PR TITLE
[CON-3296] feat(slack): Read by IDs

### DIFF
--- a/providers/acculynx/subscriptionEvent.go
+++ b/providers/acculynx/subscriptionEvent.go
@@ -51,12 +51,12 @@ const (
 )
 
 var (
-	errMissingTopicName      = errors.New("acculynx event: missing topicName")
-	errUnsupportedTopicName  = errors.New("acculynx event: topicName does not map to a supported object")
-	errMissingInnerEvent     = errors.New("acculynx event: missing inner event payload")
-	errMissingObjectWrapper  = errors.New("acculynx event: missing object wrapper inside event")
-	errMissingRecordID       = errors.New("acculynx event: missing record id for topic")
-	errUnparsableEventTime   = errors.New("acculynx event: unparsable eventDateTime")
+	errMissingTopicName     = errors.New("acculynx event: missing topicName")
+	errUnsupportedTopicName = errors.New("acculynx event: topicName does not map to a supported object")
+	errMissingInnerEvent    = errors.New("acculynx event: missing inner event payload")
+	errMissingObjectWrapper = errors.New("acculynx event: missing object wrapper inside event")
+	errMissingRecordID      = errors.New("acculynx event: missing record id for topic")
+	errUnparsableEventTime  = errors.New("acculynx event: unparsable eventDateTime")
 	// errParentRecordIDUnavailable is returned for topics whose payload omits
 	// the parent contact/job id entirely (only the changed sub-object is sent).
 	errParentRecordIDUnavailable = errors.New(

--- a/providers/breezy/paths.go
+++ b/providers/breezy/paths.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	restAPIVersion       = "v3"
-	companyIDPlaceholder = "{company_id}"
+	restAPIVersion        = "v3"
+	companyIDPlaceholder  = "{company_id}"
 	positionIDPlaceholder = "{position_id}"
 
 	// Collection vs resource paths differ: POST …/positions, PUT …/position/{id}.

--- a/providers/connectwise/read-by-ids_test.go
+++ b/providers/connectwise/read-by-ids_test.go
@@ -44,7 +44,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetReadByIds,
+			Comparator: testroutines.ComparatorSortedSubsetReadByIds,
 			Expected: []common.ReadResultRow{{
 				Id:     "57920",
 				Fields: map[string]any{"firstname": "Maxime Schaefer [1]"},

--- a/providers/slack/handlers.go
+++ b/providers/slack/handlers.go
@@ -48,7 +48,7 @@ func (c *Connector) parseSingleObjectMetadataResponse(
 		return nil, common.ErrFailedToUnmarshalBody
 	}
 
-	recordsArr, err := getSlackResponseRecords(body, objectName)
+	recordsArr, err := getResponseCollectionRecords(body, objectName)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (c *Connector) parseReadResponse( //nolint:unparam
 
 	return common.ParseResult(
 		response,
-		records(params.ObjectName),
+		recordsFunc(params.ObjectName),
 		nextRecordsURL(),
 		readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id")),
 		params.Fields,

--- a/providers/slack/metadata_test.go
+++ b/providers/slack/metadata_test.go
@@ -2,11 +2,11 @@ package slack
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -136,22 +136,22 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}
 }
 
-func constructTestConnector(serverURL string) (*Connector, error) {
+func constructTestConnector(server *httptest.Server) (*Connector, error) {
 	connector, err := NewConnector(common.ConnectorParams{
-		AuthenticatedClient: mockutils.NewClient(),
+		AuthenticatedClient: server.Client(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	// Preserve the /api path from the Slack base URL when redirecting to the mock server.
-	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+	connector.SetUnitTestMockServerBaseURL(server.URL)
 
 	return connector, nil
 }

--- a/providers/slack/parse.go
+++ b/providers/slack/parse.go
@@ -6,14 +6,14 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-// getSlackResponseRecords checks the Slack-specific "ok" field (Slack always returns HTTP 200,
+// validateResponse checks the Slack-specific "ok" field (Slack always returns HTTP 200,
 // even on failure), interprets any error code, and returns the records array for the given object.
-func getSlackResponseRecords(node *ajson.Node, objectName string) ([]*ajson.Node, error) {
+func validateResponse(node *ajson.Node) error {
 	// Slack always returns HTTP 200, even when the request fails. The "ok" field
 	// in the response body is the real indicator of success or failure.
 	ok, err := jsonquery.New(node).BoolRequired("ok")
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if !ok {
@@ -21,22 +21,50 @@ func getSlackResponseRecords(node *ajson.Node, objectName string) ([]*ajson.Node
 		// errors.Is to react appropriately (re-auth, retry, etc.).
 		errorCode, err := jsonquery.New(node).StringOptional("error")
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if errorCode != nil {
-			return nil, interpretSlackErrorCode(*errorCode)
+			return interpretSlackErrorCode(*errorCode)
 		}
 
-		return nil, common.ErrBadProviderResponse
+		return common.ErrBadProviderResponse
+	}
+
+	return nil
+}
+
+// getResponseCollectionRecords parses node to get a list of records.
+func getResponseCollectionRecords(node *ajson.Node, objectName string) ([]*ajson.Node, error) {
+	if err := validateResponse(node); err != nil {
+		return nil, err
 	}
 
 	return jsonquery.New(node).ArrayRequired(objectResponseField.Get(objectName))
 }
 
-func records(objectName string) common.RecordsFunc {
+// getResponseCollectionRecords parses node to get a single record.
+// Example response:
+//
+//	{
+//	   "ok": true,					-> used by validateResponse
+//	   "channel": {					-> unwrapped by ObjectRequired
+//	       "id": "C0B9RLDTM35",
+//	       "created": 1781192018,
+//	       "creator": "U0B9R8LFG1F",
+//		  }
+//	}
+func getResponseSingleRecord(node *ajson.Node, resourceName string) (*ajson.Node, error) {
+	if err := validateResponse(node); err != nil {
+		return nil, err
+	}
+
+	return jsonquery.New(node).ObjectRequired(readSingleRecordResourceNameToResponseField[resourceName])
+}
+
+func recordsFunc(objectName string) common.RecordsFunc {
 	return func(node *ajson.Node) ([]map[string]any, error) {
-		arr, err := getSlackResponseRecords(node, objectName)
+		arr, err := getResponseCollectionRecords(node, objectName)
 		if err != nil {
 			return nil, err
 		}
@@ -47,7 +75,7 @@ func records(objectName string) common.RecordsFunc {
 
 func nodeRecords(objectName string) common.NodeRecordsFunc {
 	return func(node *ajson.Node) ([]*ajson.Node, error) {
-		return getSlackResponseRecords(node, objectName)
+		return getResponseCollectionRecords(node, objectName)
 	}
 }
 

--- a/providers/slack/read-by-ids.go
+++ b/providers/slack/read-by-ids.go
@@ -1,0 +1,107 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
+)
+
+var _ connectors.BatchRecordReaderConnector = (*Connector)(nil)
+
+// GetRecordsByIds retrieves records for a given object type by their IDs.
+// It performs batched parallel reads since Slack has no bulk endpoints for singular records.
+// nolint:revive
+func (c *Connector) GetRecordsByIds(ctx context.Context,
+	objectName string, recordIds []string,
+	fields []string, associations []string,
+) ([]common.ReadResultRow, error) {
+	if len(recordIds) == 0 {
+		return nil, common.ErrMissingObjects
+	}
+
+	// Ensure identifiers are non-repeating.
+	identifiers := datautils.NewSetFromList(recordIds).List()
+
+	batchResult, err := c.batchRead(ctx, objectName, identifiers)
+	if err != nil {
+		return nil, err
+	}
+
+	marshaler := readhelper.MakeGetMarshaledDataWithId(readhelper.NewIdField("id"))
+	uniqueFields := datautils.NewSetFromList(fields).List()
+
+	return marshaler(batchResult, uniqueFields)
+}
+
+// batchRead performs parallel reads for multiple singular records.
+//
+// Slack resources ending with ".info" (e.g., "channels.info") require a query parameter
+// containing a single record identifier. The query parameter name varies by object type,
+// and only one identifier can be sent per URL—there are no batch endpoints.
+//
+// This method makes multiple parallel requests to fetch each record individually.
+func (c *Connector) batchRead(ctx context.Context, objectName string, identifiers []string) ([]map[string]any, error) {
+	resourceName := objectName + ".info"
+
+	queryPramName, ok := readSingleRecordResourceNameToQueryParam[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("%w: object name [%v]", common.ErrOperationNotSupportedForObject, objectName)
+	}
+
+	tasks := make([]parallelfetch.Task[string, map[string]any], len(identifiers))
+	for index, identifier := range identifiers {
+		tasks[index] = func(ctx context.Context) (taskID string, data *map[string]any, err error) {
+			defer func() {
+				if err != nil {
+					err = fmt.Errorf("%w: resourceName %v(%v=%v)", err, resourceName, queryPramName, identifier)
+				}
+			}()
+
+			// Make an API URL and make a call.
+			url, err := urlbuilder.New(c.ProviderInfo().BaseURL, resourceName)
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			url.WithQueryParam(queryPramName, identifier)
+
+			res, err := c.JSONHTTPClient().Get(ctx, url.String())
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			// Unwrap the record from the response and convert to map[string]any.
+			body, ok := res.Body()
+			if !ok {
+				return identifier, nil, common.ErrEmptyJSONHTTPResponse
+			}
+
+			node, err := getResponseSingleRecord(body, resourceName)
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			apiResponse, err := jsonquery.Convertor.ObjectToMap(node)
+			if err != nil {
+				return identifier, nil, err
+			}
+
+			return identifier, &apiResponse, nil
+		}
+	}
+
+	result := parallelfetch.Execute(ctx, tasks, -1)
+	if len(result.Errors) != 0 {
+		return nil, errors.Join(result.Errors.Values()...)
+	}
+
+	return result.Records.Values(), nil
+}

--- a/providers/slack/read-by-ids_test.go
+++ b/providers/slack/read-by-ids_test.go
@@ -1,0 +1,91 @@
+package slack
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	responseConversation1 := testutils.DataFromFile(t, "read/conversation-1.json")
+	responseConversation2 := testutils.DataFromFile(t, "read/conversation-2.json")
+
+	tests := []testroutines.ReadByIds{
+		{
+			Name:         "Empty record identifiers",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Read conversations by identifiers",
+			Input: testroutines.ReadByIdsParams{
+				ObjectName: "conversations",
+				RecordIds:  []string{"C0BA24516MS", "C0B9V3RLZ4M"},
+				Fields:     []string{"name"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.MethodGET(),
+						mockcond.Path("/api/conversations.info"),
+						mockcond.QueryParam("channel", "C0BA24516MS"),
+					},
+					Then: mockserver.Response(http.StatusOK, responseConversation1),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodGET(),
+						mockcond.Path("/api/conversations.info"),
+						mockcond.QueryParam("channel", "C0B9V3RLZ4M"),
+					},
+					Then: mockserver.Response(http.StatusOK, responseConversation2),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSortedSubsetReadByIds,
+			Expected: []common.ReadResultRow{{
+				Id:     "C0B9V3RLZ4M",
+				Fields: map[string]any{"name": "holidays"},
+				Raw:    map[string]any{"updated": float64(1781194917474)},
+			}, {
+				Id:     "C0BA24516MS",
+				Fields: map[string]any{"name": "comedy"},
+				Raw:    map[string]any{"updated": float64(1781194918084)},
+			}},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.BatchRecordReaderConnector, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}
+
+func TestSingleRecordMappings(t *testing.T) {
+	result := testutils.NewCompareResult()
+
+	first := datautils.FromMap(readSingleRecordResourceNameToQueryParam).KeySet()
+	second := datautils.FromMap(readSingleRecordResourceNameToResponseField).KeySet()
+
+	if !first.Equals(second) {
+		result.AddDiff("key sets are different")
+	}
+
+	result.Validate(t, "Keys are shared between "+
+		"readSingleRecordResourceNameToQueryParam and readSingleRecordResourceNameToResponseField")
+}

--- a/providers/slack/read_test.go
+++ b/providers/slack/read_test.go
@@ -347,7 +347,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.ReadConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/slack/support.go
+++ b/providers/slack/support.go
@@ -116,3 +116,32 @@ var writeUpdateIdField = datautils.Map[string, string]{
 	"slackLists": "id",
 	"usergroups": "usergroup",
 }
+
+// readSingleRecordResourceNameToQueryParam maps Slack API resources that read single records
+// to their required query parameter names. The query parameter name varies by object type,
+// and only one identifier can be provided per request.
+//
+// Resources ending with ".info" represent singular record reads.
+var readSingleRecordResourceNameToQueryParam = datautils.Map[string, string]{ // nolint:gochecknoglobals
+	"bots.info":          "bot",     // https://docs.slack.dev/reference/methods/bots.info/
+	"calls.info":         "id",      // https://docs.slack.dev/reference/methods/calls.info/
+	"conversations.info": "channel", // https://docs.slack.dev/reference/methods/conversations.info/
+	"files.info":         "file",    // https://docs.slack.dev/reference/methods/files.info/
+	"users.info":         "user",    // https://docs.slack.dev/reference/methods/users.info/
+}
+
+// readSingleRecordResourceNameToResponseField maps Slack API resources to the response field
+// under which the recorded data is nested. The response field name varies by object type.
+// It is used alongside readSingleRecordResourceNameToQueryParam.
+//
+// Note: The following objects are excluded from single-record reads because they have no
+// matching subscription events that could utilize GetRecordsByIds:
+//   - "reminders.info"
+//   - "team.info"
+var readSingleRecordResourceNameToResponseField = datautils.Map[string, string]{ // nolint:gochecknoglobals
+	"bots.info":          "bot",
+	"calls.info":         "call",
+	"conversations.info": "channel",
+	"files.info":         "file",
+	"users.info":         "user",
+}

--- a/providers/slack/test/read/conversation-1.json
+++ b/providers/slack/test/read/conversation-1.json
@@ -1,0 +1,43 @@
+{
+  "ok": true,
+  "channel": {
+    "id": "C0BA24516MS",
+    "created": 1781194918,
+    "creator": "U0B9R8LFG1F",
+    "is_org_shared": false,
+    "is_im": false,
+    "context_team_id": "T0B9P1UVDBL",
+    "updated": 1781194918084,
+    "name": "comedy",
+    "name_normalized": "comedy",
+    "is_channel": true,
+    "is_group": false,
+    "is_mpim": false,
+    "is_private": false,
+    "is_archived": false,
+    "is_general": false,
+    "is_shared": false,
+    "is_ext_shared": false,
+    "unlinked": 0,
+    "is_pending_ext_shared": false,
+    "pending_shared": [],
+    "parent_conversation": null,
+    "purpose": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "topic": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "shared_team_ids": [
+      "T0B9P1UVDBL"
+    ],
+    "pending_connected_team_ids": [],
+    "is_member": true,
+    "last_read": "0000000000.000000",
+    "previous_names": []
+  }
+}

--- a/providers/slack/test/read/conversation-2.json
+++ b/providers/slack/test/read/conversation-2.json
@@ -1,0 +1,43 @@
+{
+  "ok": true,
+  "channel": {
+    "id": "C0B9V3RLZ4M",
+    "created": 1781194917,
+    "creator": "U0B9R8LFG1F",
+    "is_org_shared": false,
+    "is_im": false,
+    "context_team_id": "T0B9P1UVDBL",
+    "updated": 1781194917474,
+    "name": "holidays",
+    "name_normalized": "holidays",
+    "is_channel": true,
+    "is_group": false,
+    "is_mpim": false,
+    "is_private": false,
+    "is_archived": false,
+    "is_general": false,
+    "is_shared": false,
+    "is_ext_shared": false,
+    "unlinked": 0,
+    "is_pending_ext_shared": false,
+    "pending_shared": [],
+    "parent_conversation": null,
+    "purpose": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "topic": {
+      "value": "",
+      "creator": "",
+      "last_set": 0
+    },
+    "shared_team_ids": [
+      "T0B9P1UVDBL"
+    ],
+    "pending_connected_team_ids": [],
+    "is_member": true,
+    "last_read": "0000000000.000000",
+    "previous_names": []
+  }
+}

--- a/providers/slack/write_test.go
+++ b/providers/slack/write_test.go
@@ -295,7 +295,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			t.Parallel()
 
 			tt.Run(t, func() (connectors.WriteConnector, error) {
-				return constructTestConnector(tt.Server.URL)
+				return constructTestConnector(tt.Server)
 			})
 		})
 	}

--- a/providers/stripe/read_test.go
+++ b/providers/stripe/read_test.go
@@ -332,11 +332,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Rows: 3,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{
-						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
-						"id":                           "cus_Rd3ODBxHt9M5xK",
+						"AMPERSAND-connectedAccountId": "acct_2c81631b20648a90",
+						"id":                           "cus_Rd3NKXxTV0Hzpp",
 					},
-					Raw: map[string]any{"email": "hayley.huffman@example.com"},
-					Id:  "cus_Rd3ODBxHt9M5xK",
+					Raw: map[string]any{"email": "sean.foster@example.com"},
+					Id:  "cus_Rd3NKXxTV0Hzpp",
 				}, {
 					Fields: map[string]any{
 						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
@@ -346,11 +346,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Id:  "cus_Rd3NjdGWtynChD",
 				}, {
 					Fields: map[string]any{
-						"AMPERSAND-connectedAccountId": "acct_2c81631b20648a90",
-						"id":                           "cus_Rd3NKXxTV0Hzpp",
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "cus_Rd3ODBxHt9M5xK",
 					},
-					Raw: map[string]any{"email": "sean.foster@example.com"},
-					Id:  "cus_Rd3NKXxTV0Hzpp",
+					Raw: map[string]any{"email": "hayley.huffman@example.com"},
+					Id:  "cus_Rd3ODBxHt9M5xK",
 				}},
 				// We are not done reading
 				NextPage: `[{

--- a/test/slack/read-by-ids/main.go
+++ b/test/slack/read-by-ids/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"reflect"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/slack"
+	connTest "github.com/amp-labs/connectors/test/slack"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/go-test/deep"
+)
+
+func main() {
+	if err := run(); err != nil {
+		utils.Fail("test failed", "error", err)
+	}
+}
+
+const objectName = "conversations"
+
+func run() error {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.NewConnector(ctx)
+
+	identifiers := make([]string, 2)
+
+	for index := range identifiers {
+		// Slack conversation must have no spaces and upper letters or special characters.
+		name := strings.ReplaceAll(strings.ToLower(gofakeit.Name()), " ", "") + fmt.Sprintf("%v", index+1)
+		contact, cleanup, err := testscenario.SetupRecord(ctx, wrapper(*conn),
+			objectName,
+			payload{
+				Name: name,
+			}, testscenario.RecordCreationRecipe{
+				ReadFields: datautils.NewSet("id", "name"),
+				SearchBy: testscenario.Property{
+					Key:   "name",
+					Value: name,
+				},
+				RecordIdentifierKey: "id",
+			})
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
+		identifiers[index] = contact.Id
+	}
+
+	res, err := conn.GetRecordsByIds(ctx,
+		objectName, identifiers,
+		[]string{"id", "name"}, nil)
+	if err != nil {
+		return err
+	}
+
+	displayResults(res, identifiers)
+
+	return nil
+}
+
+func displayResults(res []common.ReadResultRow, expectedIdentifiers []string) {
+	actualIdentifiers := datautils.ForEach(res, func(row common.ReadResultRow) string {
+		return row.Id
+	})
+
+	sort.Strings(expectedIdentifiers)
+	sort.Strings(actualIdentifiers)
+
+	fmt.Println("========================")
+	if !reflect.DeepEqual(expectedIdentifiers, actualIdentifiers) {
+		diff := deep.Equal(expectedIdentifiers, actualIdentifiers)
+		fmt.Printf("Requested and returned record identifiers are mismatching\n\t%v\n", diff)
+	} else {
+		utils.DumpJSON(res, os.Stdout)
+	}
+	fmt.Println("========================")
+}
+
+type payload struct {
+	Name string `json:"name"`
+}
+
+// Slack connector does not implement delete.
+// Fake it for now.
+type wrapper slack.Connector
+
+func (w wrapper) Delete(ctx context.Context, params connectors.DeleteParams) (*connectors.DeleteResult, error) {
+
+	fmt.Printf("[NOT DELETED] Please, remove object %v(id=%v) manually."+
+		"\n\t'slack.Connector' doesn't implement Delete. Message is coming from tests\n",
+		params.ObjectName, params.RecordId,
+	)
+
+	return &connectors.DeleteResult{
+		Success: true,
+	}, nil
+}

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -58,6 +58,8 @@ func ComparatorSubsetRead(serverURL string, actual, expected *common.ReadResult)
 // This ensures that the rows returned by connector are in the same order for the testing purposes.
 // The test expectation should follow this imposed order.
 // This is important to preserve the indexes of the test reports.
+//
+// Sort: Ascending order of common.ReadResultRow.Id.
 func ComparatorSubsetReadSorted(serverURL string, actual, expected *common.ReadResult) *testutils.CompareResult {
 	result := testutils.NewCompareResult()
 
@@ -76,16 +78,24 @@ func ComparatorSubsetReadSorted(serverURL string, actual, expected *common.ReadR
 	}
 
 	sort.Slice(actual.Data, func(i, j int) bool {
-		return actual.Data[i].Id > actual.Data[j].Id
+		return actual.Data[i].Id < actual.Data[j].Id
 	})
 
 	return ComparatorSubsetRead(serverURL, actual, expected)
 }
 
-// ComparatorSubsetReadByIds compares two slices of ReadResultRow as a subset,
-// ignoring order and focusing only on relevant fields, raw data, associations, and identifiers.
-func ComparatorSubsetReadByIds(serverURL string, actual, expected []common.ReadResultRow) *testutils.CompareResult {
-	return ComparatorSubsetRead(serverURL,
+// ComparatorSortedSubsetReadByIds compares two slices of ReadResultRow as a subset,
+// ignoring order and focusing only on relevant fields: raw data, associations, and identifiers.
+//
+// The `actual` slice is sorted by ID to ensure consistent output.
+// The `expected` slice must be pre-sorted in the desired order. We intentionally do not sort
+// `expected` so that mismatch logs can correctly report the index positions that differ.
+//
+// Sort: Ascending order of common.ReadResultRow.Id.
+func ComparatorSortedSubsetReadByIds(serverURL string,
+	actual, expected []common.ReadResultRow,
+) *testutils.CompareResult {
+	return ComparatorSubsetReadSorted(serverURL,
 		&common.ReadResult{
 			Rows: int64(len(actual)),
 			Data: actual,


### PR DESCRIPTION
# Description

Slack has limited endpoints for reading single records. Only a handful of resources support fetching individual records instead of collections, and all of these resource names end with `.info` (e.g., `bots.info`, `conversations.info`, `users.info`).

Since Slack provides no batch endpoints for single-record reads, this implementation uses parallel requests to fetch records individually. The `parallelfetch` utility executes all requests concurrently, then combines the results into a single response.

# Live Tests
<img width="429" height="1083" alt="image" src="https://github.com/user-attachments/assets/b60518bc-67f6-4e5d-a80f-178d04f0c196" />

<img width="637" height="1196" alt="image" src="https://github.com/user-attachments/assets/7465ca52-9615-40a9-b1c4-f017fcc08c16" />

Slack App:
<img width="995" height="358" alt="image" src="https://github.com/user-attachments/assets/ea807bf0-10f5-41e7-8f8d-de37bf971495" />

