### PR TITLE
[CON-3253] feat: add zoominfo write connector

### DIFF
--- a/providers/zoominfo/connector.go
+++ b/providers/zoominfo/connector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -24,6 +25,7 @@ type Connector struct {
 	// Supported operations
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -59,6 +61,17 @@ func constructor(base *components.Connector) (*Connector, error) {
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		registry,
+		common.ModuleRoot,
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/zoominfo/connector.go
+++ b/providers/zoominfo/connector.go
@@ -68,7 +68,7 @@ func constructor(base *components.Connector) (*Connector, error) {
 	connector.Writer = writer.NewHTTPWriter(
 		connector.HTTPClient().Client,
 		registry,
-		common.ModuleRoot,
+		connector.Module(),
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,

--- a/providers/zoominfo/metadata.go
+++ b/providers/zoominfo/metadata.go
@@ -220,14 +220,14 @@ func flattenRecord(record map[string]any) map[string]any {
 	out := make(map[string]any, len(record))
 
 	for key, value := range record {
-		if key == "attributes" {
+		if key == attributesField {
 			continue
 		}
 
 		out[key] = value
 	}
 
-	if attrs, ok := record["attributes"].(map[string]any); ok {
+	if attrs, ok := record[attributesField].(map[string]any); ok {
 		maps.Copy(out, attrs)
 	}
 

--- a/providers/zoominfo/objects.go
+++ b/providers/zoominfo/objects.go
@@ -29,6 +29,26 @@ const (
 	entityScoop   = "scoop"
 )
 
+// Object names shared between the read (getObjects) and write (writeObjects)
+// registries, plus their JSON:API resource types, hoisted to constants to avoid
+// repeated string literals.
+const (
+	objCustomerBuyerPersonas = "customer-buyer-personas"
+	objCustomerCompetitors   = "customer-competitors"
+	objIdealCompanyProfile   = "ideal-company-profile"
+	objProducts              = "products"
+	objAudiences             = "audiences"
+	objAudienceFolders       = "audience-folders"
+	objIndustries            = "industries"
+
+	typeAudience             = "Audience"
+	typeCustomerBuyerPersona = "CustomerBuyerPersona"
+
+	// attributesField is the JSON:API key whose contents are flattened to the
+	// record's top level.
+	attributesField = "attributes"
+)
+
 // Constants for the lookup/{search,enrich} field-discovery endpoints.
 const (
 	segLookup = "lookup"
@@ -120,7 +140,7 @@ var lookupObjects = []string{ //nolint:gochecknoglobals
 	"departments",
 	"employee-count",
 	"hashtags",
-	"industries",
+	objIndustries,
 	"intent-topics",
 	"job-functions",
 	"job-titles",
@@ -189,17 +209,17 @@ var getObjects = map[string]getDef{ //nolint:gochecknoglobals
 	"usage": {segments: []string{dataAPIPath, "users", "usage"}, displayName: "Usage"},
 
 	// GTM Copilot configuration (entitlement-gated).
-	"customer-buyer-personas": {
-		segments: []string{copilotAPIPath, "customer-buyer-personas"}, displayName: "Customer Buyer Personas",
+	objCustomerBuyerPersonas: {
+		segments: []string{copilotAPIPath, objCustomerBuyerPersonas}, displayName: "Customer Buyer Personas",
 	},
-	"customer-competitors": {
-		segments: []string{copilotAPIPath, "customer-competitors"}, displayName: "Customer Competitors",
+	objCustomerCompetitors: {
+		segments: []string{copilotAPIPath, objCustomerCompetitors}, displayName: "Customer Competitors",
 	},
-	"ideal-company-profile": {
-		segments: []string{copilotAPIPath, "ideal-company-profile"}, displayName: "Ideal Company Profile",
+	objIdealCompanyProfile: {
+		segments: []string{copilotAPIPath, objIdealCompanyProfile}, displayName: "Ideal Company Profile",
 	},
-	"products": {
-		segments: []string{copilotAPIPath, "products"}, displayName: "Products",
+	objProducts: {
+		segments: []string{copilotAPIPath, objProducts}, displayName: "Products",
 	},
 
 	// Agent surface.
@@ -207,8 +227,62 @@ var getObjects = map[string]getDef{ //nolint:gochecknoglobals
 	"pulses":      {segments: []string{agentAPIPath, "pulses"}, displayName: "Pulses", paginated: true},
 
 	// GTM Studio audiences.
-	"audiences":        {segments: []string{studioAPIPath, "audiences"}, displayName: "Audiences", paginated: true},
-	"audience-folders": {segments: []string{studioAPIPath, "folders"}, displayName: "Audience Folders", paginated: true},
+	objAudiences:       {segments: []string{studioAPIPath, objAudiences}, displayName: "Audiences", paginated: true},
+	objAudienceFolders: {segments: []string{studioAPIPath, "folders"}, displayName: "Audience Folders", paginated: true},
+}
+
+// writeStyle classifies how an object's create/update is issued.
+type writeStyle int
+
+const (
+	// styleUpsert: a single POST to the collection both creates and updates; the
+	// id of an existing record is carried in the JSON:API body (data.id). Used by
+	// the GTM Copilot configuration objects.
+	styleUpsert writeStyle = iota
+	// styleCreateUpdate: POST the collection to create, PATCH {collection}/{id} to
+	// update. Used by the GTM Studio objects.
+	styleCreateUpdate
+)
+
+// writeDef describes a writable (create/update/delete) ZoomInfo object.
+type writeDef struct {
+	// segments are the collection path segments after BaseURL, including the
+	// version prefix (e.g. {copilotAPIPath, "customer-buyer-personas"}).
+	segments []string
+	// recordType is the JSON:API data.type for the request body.
+	recordType string
+	// style selects the create/update mechanism.
+	style writeStyle
+}
+
+// writeObjects enumerates objects that support create/update/delete. Delete is
+// always DELETE {collection}/{id} (204 on success) regardless of style. Paths,
+// data.type strings, and styles are verified against https://docs.zoominfo.com/reference.
+// All are entitlement-gated (api:gtm-config:manage / api:audience:manage).
+var writeObjects = map[string]writeDef{ //nolint:gochecknoglobals
+	// GTM Copilot configuration — upsert (data.id in body for update).
+	objCustomerBuyerPersonas: {
+		segments:   []string{copilotAPIPath, objCustomerBuyerPersonas},
+		recordType: typeCustomerBuyerPersona,
+		style:      styleUpsert,
+	},
+	objCustomerCompetitors: {
+		segments: []string{copilotAPIPath, objCustomerCompetitors}, recordType: "CustomerCompetitor", style: styleUpsert,
+	},
+	objIdealCompanyProfile: {
+		segments: []string{copilotAPIPath, objIdealCompanyProfile}, recordType: "IdealCompanySegment", style: styleUpsert,
+	},
+	objProducts: {
+		segments: []string{copilotAPIPath, objProducts}, recordType: "OrganizationOffering", style: styleUpsert,
+	},
+
+	// GTM Studio — create (POST) / update (PATCH {id}).
+	objAudiences: {
+		segments: []string{studioAPIPath, objAudiences}, recordType: typeAudience, style: styleCreateUpdate,
+	},
+	objAudienceFolders: {
+		segments: []string{studioAPIPath, "folders"}, recordType: "Folder", style: styleCreateUpdate,
+	},
 }
 
 // kindOf returns the objectKind for the given object name, or kindUnknown if the

--- a/providers/zoominfo/objects.go
+++ b/providers/zoominfo/objects.go
@@ -29,10 +29,34 @@ const (
 	entityScoop   = "scoop"
 )
 
-// Object names shared between the read (getObjects) and write (writeObjects)
-// registries, plus their JSON:API resource types, hoisted to constants to avoid
-// repeated string literals.
+// obj* and type* live on two different axes and are NOT interchangeable:
+//
+//   - obj* is the connector-facing object name — the key callers pass in
+//     ReadParams/WriteParams.ObjectName and the key these registries are keyed
+//     by. It is plural and kebab-cased, and usually (but not always) doubles as
+//     the URL path segment.
+//   - type* is ZoomInfo's JSON:API resource type — the `data.type` member sent
+//     in a create/update request body and echoed in the response. It is
+//     singular and PascalCase.
+//
+// So a single audiences write uses both, in different positions:
+//
+//	POST /gtm/studio/v1/audiences        <- objAudiences (path)
+//	{"data":{"type":"Audience", ...}}    <- typeAudience (body)
+//
+// Both are declared because neither can be mechanically derived from the other —
+// singularizing and PascalCasing the object name is wrong often enough that
+// ZoomInfo's own naming rules it out. Counter-examples in writeObjects below:
+// objProducts ("products") has data.type "OrganizationOffering",
+// objIdealCompanyProfile ("ideal-company-profile") has "IdealCompanySegment",
+// and objAudienceFolders ("audience-folders") is served at path segment
+// "folders" with data.type "Folder" — three independent strings for one object.
+//
+// Only the two type* values reused across more than one registry entry are
+// hoisted here; the single-use ones stay inline in writeObjects.
 const (
+	// Object names shared between the read (getObjects) and write (writeObjects)
+	// registries.
 	objCustomerBuyerPersonas = "customer-buyer-personas"
 	objCustomerCompetitors   = "customer-competitors"
 	objIdealCompanyProfile   = "ideal-company-profile"
@@ -41,6 +65,8 @@ const (
 	objAudienceFolders       = "audience-folders"
 	objIndustries            = "industries"
 
+	// JSON:API data.type values, referenced by writeObjects and asserted in the
+	// write tests.
 	typeAudience             = "Audience"
 	typeCustomerBuyerPersona = "CustomerBuyerPersona"
 
@@ -247,9 +273,13 @@ const (
 // writeDef describes a writable (create/update/delete) ZoomInfo object.
 type writeDef struct {
 	// segments are the collection path segments after BaseURL, including the
-	// version prefix (e.g. {copilotAPIPath, "customer-buyer-personas"}).
+	// version prefix (e.g. {copilotAPIPath, "customer-buyer-personas"}). The
+	// trailing segment is not always the object name — audience-folders is
+	// served at "folders".
 	segments []string
-	// recordType is the JSON:API data.type for the request body.
+	// recordType is the JSON:API data.type for the request body — a separate,
+	// singular PascalCase string that ZoomInfo does not derive from the object
+	// name or the path (see the obj*/type* note above).
 	recordType string
 	// style selects the create/update mechanism.
 	style writeStyle

--- a/providers/zoominfo/read.go
+++ b/providers/zoominfo/read.go
@@ -124,7 +124,7 @@ func (c *Connector) parseReadResponse(
 		response,
 		getRecords,
 		nextPageFromMeta,
-		common.MakeMarshaledDataFunc(common.FlattenNestedFields("attributes")),
+		common.MakeMarshaledDataFunc(common.FlattenNestedFields(attributesField)),
 		params.Fields,
 	)
 }

--- a/providers/zoominfo/read_test.go
+++ b/providers/zoominfo/read_test.go
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 		},
 		{
 			Name:  "Lookup object reads a single unpaginated page",
-			Input: common.ReadParams{ObjectName: "industries", Fields: connectors.Fields("name")},
+			Input: common.ReadParams{ObjectName: objIndustries, Fields: connectors.Fields("name")},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If:    mockcond.Path("/gtm/data/v1/lookup/industries"),

--- a/providers/zoominfo/supports.go
+++ b/providers/zoominfo/supports.go
@@ -10,12 +10,17 @@ import (
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{"*"}
+	writeSupport := []string{"*"}
 
 	return components.EndpointRegistryInput{
 		common.ModuleRoot: {
 			{
 				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
 				Support:  components.ReadSupport,
+			},
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(writeSupport, ",")),
+				Support:  components.WriteSupport,
 			},
 		},
 	}

--- a/providers/zoominfo/supports.go
+++ b/providers/zoominfo/supports.go
@@ -2,6 +2,8 @@ package zoominfo
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -10,7 +12,16 @@ import (
 
 func supportedOperations() components.EndpointRegistryInput {
 	readSupport := []string{"*"}
-	writeSupport := []string{"*"}
+
+	// Write support is derived from writeObjects rather than restated as a
+	// literal, because that map is the real authority: buildWriteRequest cannot
+	// build a request without an entry in it. Restating the names here would
+	// admit two drift bugs — a registry name with no map entry reaches
+	// buildWriteRequest and fails there, and a map entry missing from the
+	// registry is silently unreachable. Deriving makes both impossible.
+	// Sorted only so the compiled glob is deterministic; match order is
+	// irrelevant.
+	writeSupport := slices.Sorted(maps.Keys(writeObjects))
 
 	return components.EndpointRegistryInput{
 		common.ModuleRoot: {

--- a/providers/zoominfo/test/write-audience.json
+++ b/providers/zoominfo/test/write-audience.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "type": "Audience",
+    "attributes": {
+      "name": "Q1 Prospects",
+      "type": "CONTACT",
+      "recordCount": 0,
+      "origin": "CUSTOM"
+    }
+  }
+}

--- a/providers/zoominfo/test/write-buyer-persona.json
+++ b/providers/zoominfo/test/write-buyer-persona.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "bp_12345",
+    "type": "CustomerBuyerPersona",
+    "attributes": {
+      "name": "VP of Engineering",
+      "description": "Technical decision maker"
+    }
+  }
+}

--- a/providers/zoominfo/write.go
+++ b/providers/zoominfo/write.go
@@ -1,0 +1,112 @@
+package zoominfo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+)
+
+// writeRequestBody is the JSON:API envelope for create/update. id is included
+// only for upsert-style updates (omitted on create).
+type writeRequestBody struct {
+	Data writeRequestData `json:"data"`
+}
+
+type writeRequestData struct {
+	Type       string `json:"type"`
+	ID         string `json:"id,omitempty"`
+	Attributes any    `json:"attributes"`
+}
+
+// buildWriteRequest creates or updates a writable object. The request shape
+// depends on the object's write style:
+//   - upsert (Copilot config): POST {collection}; an existing RecordId is carried
+//     in the JSON:API body as data.id.
+//   - createUpdate (Studio): POST {collection} to create; PATCH {collection}/{id}
+//     to update.
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	def, ok := writeObjects[params.ObjectName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", common.ErrObjectNotSupported, params.ObjectName)
+	}
+
+	method := http.MethodPost
+	segments := def.segments
+	body := writeRequestData{Type: def.recordType, Attributes: params.RecordData}
+
+	if params.RecordId != "" {
+		switch def.style {
+		case styleUpsert:
+			// Same collection endpoint; the id travels in the body.
+			body.ID = params.RecordId
+		case styleCreateUpdate:
+			method = http.MethodPatch
+
+			segments = append(append([]string{}, def.segments...), params.RecordId)
+		}
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, segments...)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(writeRequestBody{Data: body})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", jsonAPIMediaType)
+	req.Header.Set("Content-Type", jsonAPIMediaType)
+
+	return req, nil
+}
+
+// parseWriteResponse reads the created/updated resource's id (and data) from the
+// JSON:API response. Some updates may return 204 with no body, in which case the
+// caller's RecordId is echoed back.
+func (c *Connector) parseWriteResponse(
+	ctx context.Context,
+	params common.WriteParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		return &common.WriteResult{Success: true, RecordId: params.RecordId}, nil
+	}
+
+	recordID, err := jsonquery.New(body, "data").StrWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	dataNode, err := jsonquery.New(body).ObjectOptional("data")
+	if err != nil {
+		return nil, err
+	}
+
+	var data map[string]any
+	if dataNode != nil {
+		if data, err = jsonquery.Convertor.ObjectToMap(dataNode); err != nil {
+			return nil, err
+		}
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     data,
+	}, nil
+}

--- a/providers/zoominfo/write.go
+++ b/providers/zoominfo/write.go
@@ -31,9 +31,23 @@ type writeRequestData struct {
 //   - createUpdate (Studio): POST {collection} to create; PATCH {collection}/{id}
 //     to update.
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	// This lookup is a data fetch, not a support check: def carries the three
+	// pieces of per-object data needed to build the request at all — the
+	// collection path (segments), the JSON:API data.type (recordType), and the
+	// create/update mechanism (style). None of it is derivable from the object
+	// name, so there is no request to build without it.
+	//
+	// Unsupported object names are already rejected upstream by the endpoint
+	// registry, which supports.go derives from this same map, so !ok is not a
+	// caller error — it can only mean those two have diverged. It is reported as
+	// a broken invariant rather than "object not supported", which would blame
+	// the caller for an object the registry just vouched for. Keeping the branch
+	// stops a future registry change from silently POSTing an empty data.type
+	// against the bare BaseURL.
 	def, ok := writeObjects[params.ObjectName]
 	if !ok {
-		return nil, fmt.Errorf("%w: %q", common.ErrObjectNotSupported, params.ObjectName)
+		return nil, fmt.Errorf("%w: %q is registered for write support but missing from writeObjects",
+			common.ErrInvalidImplementation, params.ObjectName)
 	}
 
 	method := http.MethodPost

--- a/providers/zoominfo/write_test.go
+++ b/providers/zoominfo/write_test.go
@@ -1,0 +1,165 @@
+package zoominfo
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { // nolint:funlen
+	t.Parallel()
+
+	audienceResponse := testutils.DataFromFile(t, "write-audience.json")
+	buyerPersonaResponse := testutils.DataFromFile(t, "write-buyer-persona.json")
+
+	tests := []testroutines.Write{
+		{
+			Name:         "Write object must be included",
+			Input:        common.WriteParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Unsupported (read-only) object is rejected",
+			Input:        common.WriteParams{ObjectName: objIndustries, RecordData: map[string]any{}},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrObjectNotSupported},
+		},
+		{
+			Name: "Studio create: POST collection (audiences)",
+			Input: common.WriteParams{
+				ObjectName: objAudiences,
+				RecordData: map[string]any{"name": "Q1 Prospects", "type": "CONTACT", "origin": "CUSTOM"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/gtm/studio/v1/audiences"),
+					mockcond.MethodPOST(),
+					mockcond.Body(
+						`{"data":{"type":"Audience","attributes":` +
+							`{"name":"Q1 Prospects","origin":"CUSTOM","type":"CONTACT"}}}`,
+					),
+				},
+				Then: mockserver.Response(http.StatusOK, audienceResponse),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "550e8400-e29b-41d4-a716-446655440000",
+				Data: map[string]any{
+					"id":   "550e8400-e29b-41d4-a716-446655440000",
+					"type": typeAudience,
+					"attributes": map[string]any{
+						"name": "Q1 Prospects", "type": "CONTACT", "recordCount": float64(0), "origin": "CUSTOM",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Studio update: PATCH collection/{id} (audiences)",
+			Input: common.WriteParams{
+				ObjectName: objAudiences,
+				RecordId:   "550e8400-e29b-41d4-a716-446655440000",
+				RecordData: map[string]any{"name": "Renamed"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/gtm/studio/v1/audiences/550e8400-e29b-41d4-a716-446655440000"),
+					mockcond.MethodPATCH(),
+					mockcond.Body(`{"data":{"type":"Audience","attributes":{"name":"Renamed"}}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, audienceResponse),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "550e8400-e29b-41d4-a716-446655440000",
+				Data: map[string]any{
+					"id":   "550e8400-e29b-41d4-a716-446655440000",
+					"type": typeAudience,
+					"attributes": map[string]any{
+						"name": "Q1 Prospects", "type": "CONTACT", "recordCount": float64(0), "origin": "CUSTOM",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Copilot upsert create: POST collection without id (customer-buyer-personas)",
+			Input: common.WriteParams{
+				ObjectName: objCustomerBuyerPersonas,
+				RecordData: map[string]any{"name": "VP of Engineering"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/gtm/copilot/v1/customer-buyer-personas"),
+					mockcond.MethodPOST(),
+					mockcond.Body(`{"data":{"type":"CustomerBuyerPersona","attributes":{"name":"VP of Engineering"}}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, buyerPersonaResponse),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "bp_12345",
+				Data: map[string]any{
+					"id":   "bp_12345",
+					"type": typeCustomerBuyerPersona,
+					"attributes": map[string]any{
+						"name": "VP of Engineering", "description": "Technical decision maker",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Copilot upsert update: POST collection with id in body (customer-buyer-personas)",
+			Input: common.WriteParams{
+				ObjectName: objCustomerBuyerPersonas,
+				RecordId:   "bp_12345",
+				RecordData: map[string]any{"description": "Updated"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/gtm/copilot/v1/customer-buyer-personas"),
+					mockcond.MethodPOST(),
+					mockcond.Body(
+						`{"data":{"type":"CustomerBuyerPersona","id":"bp_12345",` +
+							`"attributes":{"description":"Updated"}}}`,
+					),
+				},
+				Then: mockserver.Response(http.StatusOK, buyerPersonaResponse),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "bp_12345",
+				Data: map[string]any{
+					"id":   "bp_12345",
+					"type": typeCustomerBuyerPersona,
+					"attributes": map[string]any{
+						"name": "VP of Engineering", "description": "Technical decision maker",
+					},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.WriteConnector, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/zoominfo/write_test.go
+++ b/providers/zoominfo/write_test.go
@@ -4,11 +4,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen
 	audienceResponse := testutils.DataFromFile(t, "write-audience.json")
 	buyerPersonaResponse := testutils.DataFromFile(t, "write-buyer-persona.json")
 
-	tests := []testroutines.Write{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Input:        common.WriteParams{},
@@ -26,10 +25,12 @@ func TestWrite(t *testing.T) { // nolint:funlen
 			ExpectedErrs: []error{common.ErrMissingObjects},
 		},
 		{
+			// Rejected by the endpoint registry, which supports.go derives from
+			// writeObjects — read-only objects never reach buildWriteRequest.
 			Name:         "Unsupported (read-only) object is rejected",
 			Input:        common.WriteParams{ObjectName: objIndustries, RecordData: map[string]any{}},
 			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrObjectNotSupported},
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
 		},
 		{
 			Name: "Studio create: POST collection (audiences)",
@@ -157,7 +158,7 @@ func TestWrite(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/test/zoominfo/write/main.go
+++ b/test/zoominfo/write/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/amp-labs/connectors/common"
+	zi "github.com/amp-labs/connectors/providers/zoominfo"
+	connTest "github.com/amp-labs/connectors/test/zoominfo"
+)
+
+// This harness exercises Write (create + update) across every writable ZoomInfo
+// object, covering both write styles:
+//   - GTM Studio (audiences, audience-folders): POST to create, PATCH /{id} to update.
+//   - GTM Copilot config (customer-buyer-personas, customer-competitors,
+//     ideal-company-profile, products): upsert via POST (id in body for update).
+//
+// NOTE: all write objects are entitlement-gated; without the relevant product the
+// API returns 403. The harness logs each result/error and continues so every
+// object is attempted (a 403, not a 404, still confirms request routing).
+//
+// Run: go run ./test/zoominfo/write
+func main() {
+	ctx := context.Background()
+	conn := connTest.GetZoomInfoConnector(ctx)
+
+	for _, test := range []func(context.Context, *zi.Connector) error{
+		testCreateAudience,
+		testUpdateAudience,
+		testCreateAudienceFolder,
+		testUpsertCustomerBuyerPersona,
+		testUpsertCustomerCompetitor,
+		testUpsertIdealCompanyProfile,
+		testUpsertProduct,
+	} {
+		if err := test(ctx, conn); err != nil {
+			slog.Error(err.Error())
+		}
+	}
+}
+
+func testCreateAudience(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "audiences",
+		RecordData: map[string]any{"name": "Ampersand smoke test", "type": "CONTACT", "origin": "CUSTOM"},
+	})
+}
+
+func testUpdateAudience(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "audiences",
+		RecordId:   "550e8400-e29b-41d4-a716-446655440000",
+		RecordData: map[string]any{"name": "Ampersand smoke test (renamed)"},
+	})
+}
+
+func testCreateAudienceFolder(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "audience-folders",
+		RecordData: map[string]any{"name": "Ampersand smoke folder", "description": "created by smoke test"},
+	})
+}
+
+func testUpsertCustomerBuyerPersona(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "customer-buyer-personas",
+		RecordData: map[string]any{"name": "Smoke Persona", "description": "created by smoke test"},
+	})
+}
+
+func testUpsertCustomerCompetitor(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "customer-competitors",
+		RecordData: map[string]any{"name": "Smoke Competitor"},
+	})
+}
+
+func testUpsertIdealCompanyProfile(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "ideal-company-profile",
+		RecordData: map[string]any{"name": "Smoke ICP"},
+	})
+}
+
+func testUpsertProduct(ctx context.Context, conn *zi.Connector) error {
+	return write(ctx, conn, common.WriteParams{
+		ObjectName: "products",
+		RecordData: map[string]any{"name": "Smoke Product"},
+	})
+}
+
+func write(ctx context.Context, conn *zi.Connector, params common.WriteParams) error {
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to write %s: %w", params.ObjectName, err)
+	}
+
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(jsonStr)
+	_, _ = os.Stdout.WriteString("\n")
+
+	return nil
+}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

Live Tests:
<img width="1412" height="778" alt="Screenshot 2026-06-12 at 15 28 28" src="https://github.com/user-attachments/assets/31d83273-7a4b-4636-b3e0-5ae237569d18" />
