### PR TITLE
fix(fathom): handle list meetings endpoint breaking change

### DIFF
--- a/providers/fathom/enrich.go
+++ b/providers/fathom/enrich.go
@@ -12,17 +12,30 @@ import (
 	"github.com/amp-labs/connectors/internal/simultaneously"
 )
 
+const (
+	fieldDefaultSummary = "default_summary"
+	fieldTranscript     = "transcript"
+	fieldRecordingID    = "recording_id"
+)
+
 // Fathom has conservative rate limits for the recordings API.
 // https://developers.fathom.ai/api-overview#heavy-requests-rate-limits
 const maxConcurrentMeetingRecordingFetch = 4
 
+// enrichMeetingsWithRecordings fetches default_summary and/or transcript for each
+// meeting row from the recordings API. OAuth-connected apps cannot use
+// include_summary or include_transcript on the list-meetings endpoint, so these
+// fields are loaded per recording instead.
+//
+// Rows are mutated in place: each row's Fields and Raw maps are updated with the
+// fetched values. Fetches run concurrently, capped at maxConcurrentMeetingRecordingFetch.
 func (c *Connector) enrichMeetingsWithRecordings(
 	ctx context.Context,
 	rows []common.ReadResultRow,
 	fields datautils.StringSet,
 ) error {
-	needsSummary := fields.Has("default_summary")
-	needsTranscript := fields.Has("transcript")
+	needsSummary := fields.Has(fieldDefaultSummary)
+	needsTranscript := fields.Has(fieldTranscript)
 
 	if !needsSummary && !needsTranscript {
 		return nil
@@ -45,8 +58,8 @@ func (c *Connector) enrichMeetingsWithRecordings(
 					return fmt.Errorf("fetching summary for recording %s: %w", recordingID, err)
 				}
 
-				rows[idx].Fields["default_summary"] = summary
-				rows[idx].Raw["default_summary"] = summary
+				rows[idx].Fields[fieldDefaultSummary] = summary
+				rows[idx].Raw[fieldDefaultSummary] = summary
 			}
 
 			if needsTranscript {
@@ -55,8 +68,8 @@ func (c *Connector) enrichMeetingsWithRecordings(
 					return fmt.Errorf("fetching transcript for recording %s: %w", recordingID, err)
 				}
 
-				rows[idx].Fields["transcript"] = transcript
-				rows[idx].Raw["transcript"] = transcript
+				rows[idx].Fields[fieldTranscript] = transcript
+				rows[idx].Raw[fieldTranscript] = transcript
 			}
 
 			return nil
@@ -67,9 +80,9 @@ func (c *Connector) enrichMeetingsWithRecordings(
 }
 
 func recordingIDFromRaw(raw map[string]any) (string, error) {
-	value, ok := raw["recording_id"]
+	value, ok := raw[fieldRecordingID]
 	if !ok || value == nil {
-		return "", fmt.Errorf("%w: recording_id", common.ErrMissingExpectedValues)
+		return "", fmt.Errorf("%w: %s", common.ErrMissingExpectedValues, fieldRecordingID)
 	}
 
 	switch id := value.(type) {
@@ -82,7 +95,7 @@ func recordingIDFromRaw(raw map[string]any) (string, error) {
 	case json.Number:
 		return id.String(), nil
 	default:
-		return "", fmt.Errorf("unexpected recording_id type %T", value)
+		return "", fmt.Errorf("unexpected %s type %T", fieldRecordingID, value)
 	}
 }
 

--- a/providers/fathom/enrich.go
+++ b/providers/fathom/enrich.go
@@ -1,0 +1,152 @@
+package fathom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/simultaneously"
+)
+
+// Fathom has conservative rate limits for the recordings API.
+// https://developers.fathom.ai/api-overview#heavy-requests-rate-limits
+const maxConcurrentMeetingRecordingFetch = 4
+
+func (c *Connector) enrichMeetingsWithRecordings(
+	ctx context.Context,
+	rows []common.ReadResultRow,
+	fields datautils.StringSet,
+) error {
+	needsSummary := fields.Has("default_summary")
+	needsTranscript := fields.Has("transcript")
+
+	if !needsSummary && !needsTranscript {
+		return nil
+	}
+
+	jobs := make([]simultaneously.Job, len(rows))
+
+	for i := range rows {
+		idx := i
+
+		recordingID, err := recordingIDFromRaw(rows[i].Raw)
+		if err != nil {
+			return fmt.Errorf("enriching meeting at index %d: %w", idx, err)
+		}
+
+		jobs[idx] = func(ctx context.Context) error {
+			if needsSummary {
+				summary, err := c.fetchRecordingSummary(ctx, recordingID)
+				if err != nil {
+					return fmt.Errorf("fetching summary for recording %s: %w", recordingID, err)
+				}
+
+				rows[idx].Fields["default_summary"] = summary
+				rows[idx].Raw["default_summary"] = summary
+			}
+
+			if needsTranscript {
+				transcript, err := c.fetchRecordingTranscript(ctx, recordingID)
+				if err != nil {
+					return fmt.Errorf("fetching transcript for recording %s: %w", recordingID, err)
+				}
+
+				rows[idx].Fields["transcript"] = transcript
+				rows[idx].Raw["transcript"] = transcript
+			}
+
+			return nil
+		}
+	}
+
+	return simultaneously.DoCtx(ctx, maxConcurrentMeetingRecordingFetch, jobs...)
+}
+
+func recordingIDFromRaw(raw map[string]any) (string, error) {
+	value, ok := raw["recording_id"]
+	if !ok || value == nil {
+		return "", fmt.Errorf("%w: recording_id", common.ErrMissingExpectedValues)
+	}
+
+	switch id := value.(type) {
+	case float64:
+		return strconv.FormatFloat(id, 'f', -1, 64), nil
+	case int:
+		return strconv.Itoa(id), nil
+	case int64:
+		return strconv.FormatInt(id, 10), nil
+	case json.Number:
+		return id.String(), nil
+	default:
+		return "", fmt.Errorf("unexpected recording_id type %T", value)
+	}
+}
+
+// fetchRecordingSummary fetches the summary for a given recording ID.
+// https://developers.fathom.ai/api-reference/recordings/get-summary
+func (c *Connector) fetchRecordingSummary(ctx context.Context, recordingID string) (map[string]any, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, apiVersion, "recordings", recordingID, "summary")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := common.UnmarshalJSON[map[string]any](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	summary, ok := (*body)["summary"]
+	if !ok || summary == nil {
+		return nil, nil
+	}
+
+	summaryMap, ok := summary.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected summary type %T", summary)
+	}
+
+	return summaryMap, nil
+}
+
+// fetchRecordingTranscript fetches the transcript for a given recording ID.
+// https://developers.fathom.ai/api-reference/recordings/get-transcript
+func (c *Connector) fetchRecordingTranscript(ctx context.Context, recordingID string) (any, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, apiVersion, "recordings", recordingID, "transcript")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := common.UnmarshalJSON[map[string]any](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	transcript, ok := (*body)["transcript"]
+	if !ok {
+		return nil, nil
+	}
+
+	return transcript, nil
+}

--- a/providers/fathom/enrich.go
+++ b/providers/fathom/enrich.go
@@ -95,7 +95,7 @@ func recordingIDFromRaw(raw map[string]any) (string, error) {
 	case json.Number:
 		return id.String(), nil
 	default:
-		return "", fmt.Errorf("unexpected %s type %T", fieldRecordingID, value)
+		return "", fmt.Errorf("%w: %T", ErrUnexpectedRecordingIDType, value)
 	}
 }
 
@@ -118,17 +118,17 @@ func (c *Connector) fetchRecordingSummary(ctx context.Context, recordingID strin
 	}
 
 	if body == nil {
-		return nil, nil
+		return map[string]any{}, nil
 	}
 
 	summary, ok := (*body)["summary"]
 	if !ok || summary == nil {
-		return nil, nil
+		return map[string]any{}, nil
 	}
 
 	summaryMap, ok := summary.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected summary type %T", summary)
+		return nil, fmt.Errorf("%w: %T", ErrUnexpectedSummaryType, summary)
 	}
 
 	return summaryMap, nil
@@ -137,7 +137,9 @@ func (c *Connector) fetchRecordingSummary(ctx context.Context, recordingID strin
 // fetchRecordingTranscript fetches the transcript for a given recording ID.
 // https://developers.fathom.ai/api-reference/recordings/get-transcript
 func (c *Connector) fetchRecordingTranscript(ctx context.Context, recordingID string) (any, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, restAPIPrefix, apiVersion, "recordings", recordingID, "transcript")
+	url, err := urlbuilder.New(
+		c.ProviderInfo().BaseURL, restAPIPrefix, apiVersion, "recordings", recordingID, "transcript",
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -153,12 +155,12 @@ func (c *Connector) fetchRecordingTranscript(ctx context.Context, recordingID st
 	}
 
 	if body == nil {
-		return nil, nil
+		return []any{}, nil
 	}
 
 	transcript, ok := (*body)["transcript"]
-	if !ok {
-		return nil, nil
+	if !ok || transcript == nil {
+		return []any{}, nil
 	}
 
 	return transcript, nil

--- a/providers/fathom/errors.go
+++ b/providers/fathom/errors.go
@@ -1,0 +1,8 @@
+package fathom
+
+import "errors"
+
+var (
+	ErrUnexpectedRecordingIDType = errors.New("unexpected recording_id type")
+	ErrUnexpectedSummaryType     = errors.New("unexpected summary type")
+)

--- a/providers/fathom/handlers.go
+++ b/providers/fathom/handlers.go
@@ -129,8 +129,7 @@ func (c *Connector) parseReadResponse(
 		return nil, err
 	}
 
-	if params.ObjectName == "meetings" &&
-		(params.Fields.Has("default_summary") || params.Fields.Has("transcript")) {
+	if params.ObjectName == "meetings" {
 		if err := c.enrichMeetingsWithRecordings(ctx, result.Data, params.Fields); err != nil {
 			return nil, err
 		}

--- a/providers/fathom/handlers.go
+++ b/providers/fathom/handlers.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	restAPIPrefix = "external"
-	apiVersion    = "v1"
+	restAPIPrefix  = "external"
+	apiVersion     = "v1"
+	objectMeetings = "meetings"
 )
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
@@ -25,7 +26,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 		return nil, err
 	}
 
-	if objectName == "meetings" {
+	if objectName == objectMeetings {
 		// This will add query parameters to include additional data fields
 		// in the meetings API response.
 		addMeetingsQueryParams(url)
@@ -91,7 +92,7 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		return nil, err
 	}
 
-	if params.ObjectName == "meetings" {
+	if params.ObjectName == objectMeetings {
 		// This will add query parameters to include additional data fields
 		// in the meetings API response.
 		addMeetingsQueryParams(url)
@@ -129,7 +130,7 @@ func (c *Connector) parseReadResponse(
 		return nil, err
 	}
 
-	if params.ObjectName == "meetings" {
+	if params.ObjectName == objectMeetings {
 		if err := c.enrichMeetingsWithRecordings(ctx, result.Data, params.Fields); err != nil {
 			return nil, err
 		}

--- a/providers/fathom/handlers.go
+++ b/providers/fathom/handlers.go
@@ -118,13 +118,25 @@ func (c *Connector) parseReadResponse(
 	request *http.Request,
 	response *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
-	return common.ParseResult(
+	result, err := common.ParseResult(
 		response,
 		common.ExtractRecordsFromPath("items"),
 		nextRecordsURL(),
 		common.GetMarshaledData,
 		params.Fields,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.ObjectName == "meetings" &&
+		(params.Fields.Has("default_summary") || params.Fields.Has("transcript")) {
+		if err := c.enrichMeetingsWithRecordings(ctx, result.Data, params.Fields); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {

--- a/providers/fathom/read_test.go
+++ b/providers/fathom/read_test.go
@@ -17,6 +17,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseMeetingsFirst := testutils.DataFromFile(t, "meetings-first-page.json")
 	responseMeetingsSecond := testutils.DataFromFile(t, "meetings-second-page.json")
+	responseRecordingSummary := testutils.DataFromFile(t, "recording-summary.json")
+	responseRecordingTranscript := testutils.DataFromFile(t, "recording-transcript.json")
 
 	tests := []testroutines.Read{
 		{
@@ -61,6 +63,68 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"transcript":           nil,
 						"transcript_language":  "en",
 						"crm_matches":          nil,
+					},
+				}},
+				NextPage: "eyJ0ZWFtX2NhdsafyZGluZ19zdGFydGVkX2F0IjoiMjAyNS0wNi0zMFQyMDowMjozMi4wNTQ4MzBaIiwiaWQiOjMzODY0NTU0MH0sImNvbXBsZXRlZF9zb3VyY2VzIjpbInRlYW1fcm9sZV9jYWxscyIsImhvc3Rfc2hhcmVkX3RlYW1fcm9sZV9jYWxscyIsImNvbnRhY3RfdGVhbV9tZW1iZXJfY2FsbHMiLCJmb2xkZXJfdGVhbV9jYWxscyIsImZvbGRlcl90ZWFtX3JvbGVfY2FsbHMiLCJmb2xkZXJfaG9zdF9zaGFyZWRfdGVhbV9yb2xlX2NhbGxzIiwiZm9sZGVyX2NvbnRhY3RfdGVhbV9tZW1iZXJfY2FsbHMiXX0=", // nolint:lll
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read meetings with summary and transcript enrichment",
+			Input: common.ReadParams{
+				ObjectName: "meetings",
+				Fields:     connectors.Fields("title", "default_summary", "transcript"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If:   mockcond.Path("/external/v1/meetings"),
+					Then: mockserver.Response(http.StatusOK, responseMeetingsFirst),
+				}, {
+					If:   mockcond.Path("/external/v1/recordings/123456789/summary"),
+					Then: mockserver.Response(http.StatusOK, responseRecordingSummary),
+				}, {
+					If:   mockcond.Path("/external/v1/recordings/123456789/transcript"),
+					Then: mockserver.Response(http.StatusOK, responseRecordingTranscript),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"title": "Neo ayan catchup",
+						"default_summary": map[string]any{
+							"template_name":      "general",
+							"markdown_formatted": "## Summary\n\nWe reviewed Q1 OKRs.",
+						},
+						"transcript": []any{
+							map[string]any{
+								"speaker": map[string]any{
+									"display_name":                   "Alice Johnson",
+									"matched_calendar_invitee_email": "alice@acme.com",
+								},
+								"text":      "Let's revisit the budget allocations.",
+								"timestamp": "00:05:32",
+							},
+						},
+					},
+					Raw: map[string]any{
+						"default_summary": map[string]any{
+							"template_name":      "general",
+							"markdown_formatted": "## Summary\n\nWe reviewed Q1 OKRs.",
+						},
+						"transcript": []any{
+							map[string]any{
+								"speaker": map[string]any{
+									"display_name":                   "Alice Johnson",
+									"matched_calendar_invitee_email": "alice@acme.com",
+								},
+								"text":      "Let's revisit the budget allocations.",
+								"timestamp": "00:05:32",
+							},
+						},
 					},
 				}},
 				NextPage: "eyJ0ZWFtX2NhdsafyZGluZ19zdGFydGVkX2F0IjoiMjAyNS0wNi0zMFQyMDowMjozMi4wNTQ4MzBaIiwiaWQiOjMzODY0NTU0MH0sImNvbXBsZXRlZF9zb3VyY2VzIjpbInRlYW1fcm9sZV9jYWxscyIsImhvc3Rfc2hhcmVkX3RlYW1fcm9sZV9jYWxscyIsImNvbnRhY3RfdGVhbV9tZW1iZXJfY2FsbHMiLCJmb2xkZXJfdGVhbV9jYWxscyIsImZvbGRlcl90ZWFtX3JvbGVfY2FsbHMiLCJmb2xkZXJfaG9zdF9zaGFyZWRfdGVhbV9yb2xlX2NhbGxzIiwiZm9sZGVyX2NvbnRhY3RfdGVhbV9tZW1iZXJfY2FsbHMiXX0=", // nolint:lll

--- a/providers/fathom/test/meetings-first-page.json
+++ b/providers/fathom/test/meetings-first-page.json
@@ -1,6 +1,7 @@
 {
     "items": [
         {
+            "recording_id": 123456789,
             "title": "Neo ayan catchup",
             "meeting_title": "Nebo / ayan catchup",
             "url": "https://fathom.video/calls/368",

--- a/providers/fathom/test/meetings-second-page.json
+++ b/providers/fathom/test/meetings-second-page.json
@@ -1,6 +1,7 @@
 {
     "items": [
         {
+            "recording_id": 987654321,
             "title": "Kristy McCown",
             "meeting_title": "Kristy McCown and Ayan Barua",
             "url": "https://fathom.video/calls/392949",

--- a/providers/fathom/test/recording-summary.json
+++ b/providers/fathom/test/recording-summary.json
@@ -1,0 +1,6 @@
+{
+    "summary": {
+        "template_name": "general",
+        "markdown_formatted": "## Summary\n\nWe reviewed Q1 OKRs."
+    }
+}

--- a/providers/fathom/test/recording-transcript.json
+++ b/providers/fathom/test/recording-transcript.json
@@ -1,0 +1,12 @@
+{
+    "transcript": [
+        {
+            "speaker": {
+                "display_name": "Alice Johnson",
+                "matched_calendar_invitee_email": "alice@acme.com"
+            },
+            "text": "Let's revisit the budget allocations.",
+            "timestamp": "00:05:32"
+        }
+    ]
+}

--- a/providers/fathom/utils.go
+++ b/providers/fathom/utils.go
@@ -6,10 +6,8 @@ import (
 
 // addMeetingsQueryParams adds query parameters to enrich the meetings API response
 // with additional data fields. These parameters ensure we retrieve complete meeting
-// information including action items, CRM matches, summaries, and transcripts.
+// information including action items, CRM matches.
 func addMeetingsQueryParams(url *urlbuilder.URL) {
 	url.WithQueryParam("include_action_items", "true")
 	url.WithQueryParam("include_crm_matches", "true")
-	url.WithQueryParam("include_summary", "true")
-	url.WithQueryParam("include_transcript", "true")
 }

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -36,7 +36,7 @@ func InterpretJSONError(res *http.Response, body []byte) error {
 			return common.NewHTTPError(res.StatusCode, body, headers,
 				createError(common.ErrInvalidPaginationCursor, apiError))
 		}
-	// Hubspot sends us a 400 when the search endpoint returns over 10K records,
+		// Hubspot sends us a 400 when the search endpoint returns over 10K records,
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrBadRequest, apiError))
 	case http.StatusUnauthorized:
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrAccessToken, apiError))


### PR DESCRIPTION
Fathom made a breaking change where the ListMeetings endpoint no longer supports `include_meetings` and `include_summary` query params for OAuth connections, we now have to make independent API calls for each recording to fetch their transcript and summary. This PR revises the logic so that we are only making those calls if transcript or summary is explicitly requested

<img width="647" height="279" alt="Screenshot 2026-06-12 at 12 17 09 PM" src="https://github.com/user-attachments/assets/b8c824ca-3513-4df0-b9a4-5976ab9ce91c" />
