### PR TITLE
chore(providers): Constructors to use components.Init

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -88,7 +88,7 @@ var (
 
 	// ErrInvalidPaginationCursor is returned when the provider rejected a pagination cursor
 	// as malformed/unparseable (e.g. HubSpot returning "Cannot deserialize value of type `int`
-	// from String ...")
+	// from String ...").
 	ErrInvalidPaginationCursor error = errors.New("pagination cursor has an invalid format")
 
 	// ErrResultsLimitExceeded is returned when a search query exceeds the provider's

--- a/internal/components/connector.go
+++ b/internal/components/connector.go
@@ -11,10 +11,6 @@ import (
 
 var ErrSupportNotConfigured = errors.New("support not configured")
 
-// ConnectorConstructor is a function that constructs a connector from a connector and an endpoint supportregistry.
-// TODO: Convert this to a type alias for easier usage when we go to go1.24: https://go.dev/doc/go1.24#language
-type ConnectorConstructor[T any] func(*Connector) (*T, error)
-
 // ConnectorConstructorWithParams is a function type for creating a connector instance
 // by building on a base Connector.
 //
@@ -48,21 +44,6 @@ var (
 	_ connectors.Connector      = (*Connector)(nil)
 	_ connectors.ProxyConnector = (*Connector)(nil)
 )
-
-// Initialize initializes a connector with the given provider and parameters
-// by using Connector as a base type. It runs the constructor with the connector
-// and returns the connector as the specified T type.
-//
-// Deprecated: use Init.
-func Initialize[T any](
-	provider providers.Provider,
-	params common.ConnectorParams,
-	constructor ConnectorConstructor[T],
-) (conn *T, err error) {
-	return Init(provider, params, func(_ common.ConnectorParams, connector *Connector) (*T, error) {
-		return constructor(connector)
-	})
-}
 
 // Init initializes a connector with the given provider and parameters
 // by using Connector as a base type. It runs the constructor with the connector

--- a/providers/acculynx/connector.go
+++ b/providers/acculynx/connector.go
@@ -37,10 +37,10 @@ type Connector struct {
 
 // NewConnector creates a new AccuLynx connector.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.AccuLynx, params, constructor)
+	return components.Init(providers.AccuLynx, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/acuityscheduling/connector.go
+++ b/providers/acuityscheduling/connector.go
@@ -24,11 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.AcuityScheduling, params, constructor)
+	return components.Init(providers.AcuityScheduling, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/aha/connector.go
+++ b/providers/aha/connector.go
@@ -26,12 +26,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Aha, params, constructor)
+	return components.Init(providers.Aha, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/aircall/connector.go
+++ b/providers/aircall/connector.go
@@ -29,11 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Aircall, params, constructor)
+	return components.Init(providers.Aircall, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/amplitude/connector.go
+++ b/providers/amplitude/connector.go
@@ -22,11 +22,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Amplitude, params, constructor)
+	return components.Init(providers.Amplitude, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/ashby/connector.go
+++ b/providers/ashby/connector.go
@@ -25,12 +25,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Ashby, params, constructor)
+	return components.Init(providers.Ashby, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/avoma/connector.go
+++ b/providers/avoma/connector.go
@@ -25,11 +25,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Avoma, params, constructor)
+	return components.Init(providers.Avoma, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/aws/connector.go
+++ b/providers/aws/connector.go
@@ -32,28 +32,15 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.AWS, params,
-		func(connector *components.Connector) (*Connector, error) {
-			var expectedMetadataKeys []string
-			if params.Module == providers.ModuleAWSIdentityCenter {
-				expectedMetadataKeys = []string{"region", "identityStoreId", "instanceARN"}
-			}
-
-			return constructor(connector, expectedMetadataKeys)
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.region = params.Metadata["region"]
-	conn.identityStoreId = params.Metadata["identityStoreId"]
-	conn.instanceARN = params.Metadata["instanceARN"]
-
-	return conn, nil
+	return components.Init(providers.AWS, params, constructor)
 }
 
-func constructor(base *components.Connector, expectedMetadataKeys []string) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) { // nolint:funlen
+	var expectedMetadataKeys []string
+	if params.Module == providers.ModuleAWSIdentityCenter {
+		expectedMetadataKeys = []string{"region", "identityStoreId", "instanceARN"}
+	}
+
 	connector := &Connector{
 		Connector: base,
 		RequireModule: common.RequireModule{
@@ -64,6 +51,9 @@ func constructor(base *components.Connector, expectedMetadataKeys []string) (*Co
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: expectedMetadataKeys,
 		},
+		region:          params.Metadata["region"],
+		identityStoreId: params.Metadata["identityStoreId"],
+		instanceARN:     params.Metadata["instanceARN"],
 	}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/bentley/connector.go
+++ b/providers/bentley/connector.go
@@ -25,11 +25,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Bentley, params, constructor)
+	return components.Init(providers.Bentley, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/bigquery/connector.go
+++ b/providers/bigquery/connector.go
@@ -88,10 +88,14 @@ type Connector struct {
 //	    },
 //	})
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.BigQuery, params, constructor)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize connector: %w", err)
-	}
+	return components.Init(providers.BigQuery, params, constructor)
+}
+
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewDelegateSchemaProvider(connector.listObjectMetadata)
+	connector.Reader = reader.NewDelegateReader(connector.Read)
 
 	if err := validateAndApplyAuth(connector, params); err != nil {
 		return nil, err
@@ -141,15 +145,6 @@ func extractMetadata(connector *Connector, params common.ConnectorParams) error 
 	connector.timestampColumn = tsCol
 
 	return nil
-}
-
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
-
-	connector.SchemaProvider = schema.NewDelegateSchemaProvider(connector.listObjectMetadata)
-	connector.Reader = reader.NewDelegateReader(connector.Read)
-
-	return connector, nil
 }
 
 // Close closes the BigQuery client connections.

--- a/providers/bitbucket/connector.go
+++ b/providers/bitbucket/connector.go
@@ -43,18 +43,14 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Bitbucket, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	connector.Workspace = params.Workspace
-
-	return connector, nil
+	return components.Init(providers.Bitbucket, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector: base,
+		Workspace: params.Workspace,
+	}
 
 	// Bitbucket's OpenAPI files don't cover all API resources,
 	// so we fall back to querying objects and populating fields.

--- a/providers/blackbaud/connector.go
+++ b/providers/blackbaud/connector.go
@@ -29,19 +29,14 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.Blackbaud, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.SubscriptionKey = params.Metadata["bbApiSubscriptionKey"]
-
-	return conn, nil
+	return components.Init(providers.Blackbaud, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector:       base,
+		SubscriptionKey: params.Metadata["bbApiSubscriptionKey"],
+	}
 
 	// Set the metadata provider for the connector
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/blueshift/connector.go
+++ b/providers/blueshift/connector.go
@@ -27,12 +27,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Blueshift, params, constructor)
+	return components.Init(providers.Blueshift, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/braintree/connector.go
+++ b/providers/braintree/connector.go
@@ -27,11 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Braintree, params, constructor)
+	return components.Init(providers.Braintree, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider using GraphQL introspection

--- a/providers/braze/connector.go
+++ b/providers/braze/connector.go
@@ -34,11 +34,10 @@ const (
 )
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Braze, params, constructor)
+	return components.Init(providers.Braze, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/breakcold/connector.go
+++ b/providers/breakcold/connector.go
@@ -29,11 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Breakcold, params, constructor)
+	return components.Init(providers.Breakcold, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/brevo/connector.go
+++ b/providers/brevo/connector.go
@@ -25,12 +25,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Brevo, params, constructor)
+	return components.Init(providers.Brevo, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/calendly/connector.go
+++ b/providers/calendly/connector.go
@@ -44,21 +44,17 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.Calendly, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	authMetadata := NewAuthMetadataVars(params.Metadata)
-
-	conn.orgURI = authMetadata.OrganizationURI
-	conn.userURI = authMetadata.UserURI
-
-	return conn, nil
+	return components.Init(providers.Calendly, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	authMetadata := NewAuthMetadataVars(params.Metadata)
+
+	connector := &Connector{
+		Connector: base,
+		orgURI:    authMetadata.OrganizationURI,
+		userURI:   authMetadata.UserURI,
+	}
 
 	// Set the metadata provider for the connector
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), schemas)

--- a/providers/callrail/connector.go
+++ b/providers/callrail/connector.go
@@ -26,20 +26,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.CallRail, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	authMetadata := NewAuthMetadataVars(params.Metadata)
-
-	conn.accountId = authMetadata.AccountID
-
-	return conn, nil
+	return components.Init(providers.CallRail, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	authMetadata := NewAuthMetadataVars(params.Metadata)
+
+	connector := &Connector{
+		Connector: base,
+		accountId: authMetadata.AccountID,
+	}
 
 	// Set the metadata provider for the connector
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/campaignmonitor/connector.go
+++ b/providers/campaignmonitor/connector.go
@@ -27,16 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.CampaignMonitor, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	return conn, nil
+	return components.Init(providers.CampaignMonitor, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/capsule/connector.go
+++ b/providers/capsule/connector.go
@@ -27,11 +27,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Capsule, params, constructor)
+	return components.Init(providers.Capsule, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/chargebee/connector.go
+++ b/providers/chargebee/connector.go
@@ -25,11 +25,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Chargebee, params, constructor)
+	return components.Init(providers.Chargebee, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/chargeover/connector.go
+++ b/providers/chargeover/connector.go
@@ -25,11 +25,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.ChargeOver, params, constructor)
+	return components.Init(providers.ChargeOver, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/chorus/connector.go
+++ b/providers/chorus/connector.go
@@ -29,11 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Chorus, params, constructor)
+	return components.Init(providers.Chorus, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/claricopilot/connector.go
+++ b/providers/claricopilot/connector.go
@@ -24,12 +24,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.ClariCopilot, params, constructor)
+	return components.Init(providers.ClariCopilot, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/clickup/connector.go
+++ b/providers/clickup/connector.go
@@ -23,12 +23,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.ClickUp, params, constructor)
+	return components.Init(providers.ClickUp, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/cloudtalk/connector.go
+++ b/providers/cloudtalk/connector.go
@@ -27,11 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.CloudTalk, params, constructor)
+	return components.Init(providers.CloudTalk, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -26,22 +26,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.ConnectWise, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	connector.clientID = params.Metadata["clientId"]
-
-	return connector, nil
+	return components.Init(providers.ConnectWise, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"clientId"},
 		},
+		clientID: params.Metadata["clientId"],
 	}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)

--- a/providers/copper/connector.go
+++ b/providers/copper/connector.go
@@ -35,22 +35,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Copper, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	connector.userEmail = params.Metadata["userEmail"]
-
-	return connector, nil
+	return components.Init(providers.Copper, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"userEmail"},
 		},
+		userEmail: params.Metadata["userEmail"],
 	}
 
 	errorHandler := interpreter.ErrorHandler{

--- a/providers/devrev/connector.go
+++ b/providers/devrev/connector.go
@@ -22,10 +22,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.DevRev, params, constructor)
+	return components.Init(providers.DevRev, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/dixa/connector.go
+++ b/providers/dixa/connector.go
@@ -45,11 +45,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Dixa, params, constructor)
+	return components.Init(providers.Dixa, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/drift/connector.go
+++ b/providers/drift/connector.go
@@ -40,10 +40,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Drift, params, constructor)
+	return components.Init(providers.Drift, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/dropboxsign/connector.go
+++ b/providers/dropboxsign/connector.go
@@ -24,11 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.DropboxSign, params, constructor)
+	return components.Init(providers.DropboxSign, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/dynamicsbusiness/connector.go
+++ b/providers/dynamicsbusiness/connector.go
@@ -40,25 +40,19 @@ const (
 )
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.DynamicsBusinessCentral, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.tenantID = params.Workspace
-	conn.companyID = params.Metadata[metadataKeyCompanyID]
-	conn.environmentName = params.Metadata[metadataKeyEnvironmentName]
-
-	return conn, nil
+	return components.Init(providers.DynamicsBusinessCentral, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{metadataKeyCompanyID, metadataKeyEnvironmentName},
 		},
 		incrementalRegistry: datautils.NewCache[string, bool](),
+		tenantID:            params.Workspace,
+		companyID:           params.Metadata[metadataKeyCompanyID],
+		environmentName:     params.Metadata[metadataKeyEnvironmentName],
 	}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/fastspring/connector.go
+++ b/providers/fastspring/connector.go
@@ -22,10 +22,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.FastSpring, params, constructor)
+	return components.Init(providers.FastSpring, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/fathom/connector.go
+++ b/providers/fathom/connector.go
@@ -24,11 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Fathom, params, constructor)
+	return components.Init(providers.Fathom, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/fireflies/connector.go
+++ b/providers/fireflies/connector.go
@@ -29,11 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Fireflies, params, constructor)
+	return components.Init(providers.Fireflies, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/flatfile/connector.go
+++ b/providers/flatfile/connector.go
@@ -40,11 +40,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Flatfile, params, constructor)
+	return components.Init(providers.Flatfile, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/fourfour/connector.go
+++ b/providers/fourfour/connector.go
@@ -22,11 +22,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.FourFour, params, constructor)
+	return components.Init(providers.FourFour, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/front/connector.go
+++ b/providers/front/connector.go
@@ -40,12 +40,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Front, params, constructor)
+	return components.Init(providers.Front, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/g2/connector.go
+++ b/providers/g2/connector.go
@@ -44,22 +44,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.G2, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	connector.productId = params.Metadata["subjectProductId"]
-
-	return connector, nil
+	return components.Init(providers.G2, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"subjectProductId"},
 		},
+		productId: params.Metadata["subjectProductId"],
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/getresponse/connector.go
+++ b/providers/getresponse/connector.go
@@ -23,10 +23,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.GetResponse, params, constructor)
+	return components.Init(providers.GetResponse, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/github/connector.go
+++ b/providers/github/connector.go
@@ -27,12 +27,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Github, params, constructor)
+	return components.Init(providers.Github, params, constructor)
 }
 
 //nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/gitlab/connector.go
+++ b/providers/gitlab/connector.go
@@ -42,10 +42,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.GitLab, params, constructor)
+	return components.Init(providers.GitLab, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// GitLab's OpenAPI files don't cover all API resources,

--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -46,8 +46,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 // provider name. This allows twin providers like GoogleWorkspaceDelegation to reuse the
 // same connector implementation with a different auth configuration.
 func NewConnectorForProvider(provider providers.Provider, params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(provider, params,
-		func(base *components.Connector) (*Connector, error) {
+	connector, err := components.Init(provider, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/google/internal/calendar/adapter.go
+++ b/providers/google/internal/calendar/adapter.go
@@ -26,10 +26,10 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Google, params, constructor)
+	return components.Init(providers.Google, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/google/internal/contacts/adapter.go
+++ b/providers/google/internal/contacts/adapter.go
@@ -26,10 +26,10 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Google, params, constructor)
+	return components.Init(providers.Google, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/google/internal/mail/adapter.go
+++ b/providers/google/internal/mail/adapter.go
@@ -24,10 +24,10 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Google, params, constructor)
+	return components.Init(providers.Google, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/gorgias/connector.go
+++ b/providers/gorgias/connector.go
@@ -28,11 +28,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Gorgias, params, constructor)
+	return components.Init(providers.Gorgias, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/goto/connector.go
+++ b/providers/goto/connector.go
@@ -38,8 +38,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 		params.Module = providers.ModuleGoTo
 	}
 
-	conn, err := components.Initialize(providers.GoTo, params,
-		func(base *components.Connector) (*Connector, error) {
+	conn, err := components.Init(providers.GoTo, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/goto/internal/gotocore/adapter.go
+++ b/providers/goto/internal/gotocore/adapter.go
@@ -43,7 +43,7 @@ const (
 )
 
 func NewAdapter(params common.ConnectorParams, accountKey string) (*Adapter, error) {
-	adapter, err := components.Initialize(providers.GoTo, params, constructor)
+	adapter, err := components.Init(providers.GoTo, params, constructor)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func NewAdapter(params common.ConnectorParams, accountKey string) (*Adapter, err
 	return adapter, nil
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{Connector: base}
 
 	adapter.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/granola/connector.go
+++ b/providers/granola/connector.go
@@ -19,10 +19,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Granola, params, constructor)
+	return components.Init(providers.Granola, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/groove/connector.go
+++ b/providers/groove/connector.go
@@ -26,10 +26,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Groove, params, constructor)
+	return components.Init(providers.Groove, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/gusto/connector.go
+++ b/providers/gusto/connector.go
@@ -36,61 +36,59 @@ type Connector struct {
 
 // NewConnector creates a new Gusto connector for the production environment.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Gusto, params, constructor(params))
+	return components.Init(providers.Gusto, params, constructor)
 }
 
 // NewDemoConnector creates a new Gusto connector for the sandbox/demo environment.
 func NewDemoConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.GustoDemo, params, constructor(params))
+	return components.Init(providers.GustoDemo, params, constructor)
 }
 
-func constructor(params common.ConnectorParams) func(*components.Connector) (*Connector, error) {
-	return func(base *components.Connector) (*Connector, error) {
-		authMetadata := NewAuthMetadataVars(params.Metadata)
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	authMetadata := NewAuthMetadataVars(params.Metadata)
 
-		connector := &Connector{
-			Connector: base,
-			companyId: authMetadata.CompanyId,
-		}
-
-		connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
-			connector.ProviderContext.Module(),
-			metadata.Schemas,
-		)
-
-		connector.Reader = reader.NewHTTPReader(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.ReadHandlers{
-				BuildRequest:  connector.buildReadRequest,
-				ParseResponse: connector.parseReadResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
-
-		connector.Writer = writer.NewHTTPWriter(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.WriteHandlers{
-				BuildRequest:  connector.buildWriteRequest,
-				ParseResponse: connector.parseWriteResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
-
-		connector.Deleter = deleter.NewHTTPDeleter(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.DeleteHandlers{
-				BuildRequest:  connector.buildDeleteRequest,
-				ParseResponse: connector.parseDeleteResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
-
-		return connector, nil
+	connector := &Connector{
+		Connector: base,
+		companyId: authMetadata.CompanyId,
 	}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
+		connector.ProviderContext.Module(),
+		metadata.Schemas,
+	)
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return connector, nil
 }

--- a/providers/happyfox/connector.go
+++ b/providers/happyfox/connector.go
@@ -24,10 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.HappyFox, params, constructor)
+	return components.Init(providers.HappyFox, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/helpscoutmailbox/connector.go
+++ b/providers/helpscoutmailbox/connector.go
@@ -29,10 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.HelpScoutMailbox, params, constructor)
+	return components.Init(providers.HelpScoutMailbox, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/heyreach/connector.go
+++ b/providers/heyreach/connector.go
@@ -27,11 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.HeyReach, params, constructor)
+	return components.Init(providers.HeyReach, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/highlevelstandard/connector.go
+++ b/providers/highlevelstandard/connector.go
@@ -45,19 +45,14 @@ const (
 //	while standard (non-white-label) apps are visible under the HighLevel domain based on
 //	distribution type but not under white-label domains.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.HighLevelStandard, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.locationId = params.Metadata[metadataKeyLocationID]
-
-	return conn, nil
+	return components.Init(providers.HighLevelStandard, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) { // nolint:funlen
+	connector := &Connector{
+		Connector:  base,
+		locationId: params.Metadata[metadataKeyLocationID],
+	}
 
 	// Set the metadata provider for the connector
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/highlevelwhitelabel/connector.go
+++ b/providers/highlevelwhitelabel/connector.go
@@ -45,19 +45,14 @@ const (
 //	While standard (non-white-label) apps are visible under the HighLevel domain based on
 //	distribution type but not under white-label domains.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.HighLevelWhiteLabel, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.locationId = params.Metadata[metadataKeyLocationID]
-
-	return conn, nil
+	return components.Init(providers.HighLevelWhiteLabel, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) { // nolint:funlen
+	connector := &Connector{
+		Connector:  base,
+		locationId: params.Metadata[metadataKeyLocationID],
+	}
 
 	// Set the metadata provider for the connector
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/housecallPro/connector.go
+++ b/providers/housecallPro/connector.go
@@ -28,10 +28,10 @@ var (
 )
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.HousecallPro, params, constructor)
+	return components.Init(providers.HousecallPro, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/hubspot/connector.go
+++ b/providers/hubspot/connector.go
@@ -47,10 +47,10 @@ var _ connectors.WebhookVerifierConnector = &Connector{}
 // NewConnector returns a new Hubspot connector.
 // Hubspot connector still owns CRM functionality. Not every CRM feature is located under `crm` package.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Hubspot, params, constructor)
+	return components.Init(providers.Hubspot, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/hubspot/internal/core/errors.go
+++ b/providers/hubspot/internal/core/errors.go
@@ -15,7 +15,7 @@ import (
 const hubspotMigrationStatusCode = 477
 
 // invalidPaginationCursorMessageSubstring is the message HubSpot returns when its
-// search/list APIs reject the supplied pagination cursor as unparseable.
+// search/list APIs reject the supplied pagination cursor as unparsable.
 // This is caused by the pagination cursor being not the appropriate type
 // for the API (because Search and List APIs use different pagination tokens).
 const invalidPaginationCursorMessageSubstring = "Cannot deserialize value of type"
@@ -36,7 +36,7 @@ func InterpretJSONError(res *http.Response, body []byte) error {
 			return common.NewHTTPError(res.StatusCode, body, headers,
 				createError(common.ErrInvalidPaginationCursor, apiError))
 		}
-	// Hubspot sends us a 400 when the search endpoint returns over 10K records,
+		// Hubspot sends us a 400 when the search endpoint returns over 10K records,
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrBadRequest, apiError))
 	case http.StatusUnauthorized:
 		return common.NewHTTPError(res.StatusCode, body, headers, createError(common.ErrAccessToken, apiError))

--- a/providers/hunter/connector.go
+++ b/providers/hunter/connector.go
@@ -26,10 +26,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Hunter, params, constructor)
+	return components.Init(providers.Hunter, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/insightly/connector.go
+++ b/providers/insightly/connector.go
@@ -27,10 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Insightly, params, constructor)
+	return components.Init(providers.Insightly, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	errorHandler := interpreter.ErrorHandler{}.Handle

--- a/providers/instantlyai/connector.go
+++ b/providers/instantlyai/connector.go
@@ -33,10 +33,10 @@ const apiVersion = "v2"
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	return components.Initialize(providers.InstantlyAI, params, constructor)
+	return components.Init(providers.InstantlyAI, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/jobber/connector.go
+++ b/providers/jobber/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	return components.Initialize(providers.Jobber, params, constructor)
+	return components.Init(providers.Jobber, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/justcall/connector.go
+++ b/providers/justcall/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.JustCall, params, constructor)
+	return components.Init(providers.JustCall, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(common.ModuleRoot, metadata.Schemas)

--- a/providers/kaseyavsax/connector.go
+++ b/providers/kaseyavsax/connector.go
@@ -27,10 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.KaseyaVSAX, params, constructor)
+	return components.Init(providers.KaseyaVSAX, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/lemlist/connector.go
+++ b/providers/lemlist/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Lemlist, params, constructor)
+	return components.Init(providers.Lemlist, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/lever/connector.go
+++ b/providers/lever/connector.go
@@ -29,16 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.Lever, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	return conn, nil
+	return components.Init(providers.Lever, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/linear/connector.go
+++ b/providers/linear/connector.go
@@ -25,11 +25,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Linear, params, constructor)
+	return components.Init(providers.Linear, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/linkedin/connector.go
+++ b/providers/linkedin/connector.go
@@ -24,8 +24,8 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.LinkedIn, params,
-		func(base *components.Connector) (*Connector, error) {
+	connector, err := components.Init(providers.LinkedIn, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/linkedin/internal/ads/adapter.go
+++ b/providers/linkedin/internal/ads/adapter.go
@@ -39,23 +39,17 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	conn, err := components.Initialize(providers.LinkedIn, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.AdAccountId = params.Metadata["adAccountId"]
-
-	return conn, nil
+	return components.Init(providers.LinkedIn, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"adAccountId"},
 		},
+		AdAccountId: params.Metadata["adAccountId"],
 	}
 
 	// LinkedIn's OpenAPI files only cover the adAnalytics object.

--- a/providers/linkedin/internal/platform/adapter.go
+++ b/providers/linkedin/internal/platform/adapter.go
@@ -18,10 +18,10 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.LinkedIn, params, constructor)
+	return components.Init(providers.LinkedIn, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/livestorm/connector.go
+++ b/providers/livestorm/connector.go
@@ -23,10 +23,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Livestorm, params, constructor)
+	return components.Init(providers.Livestorm, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/loxo/connector.go
+++ b/providers/loxo/connector.go
@@ -34,23 +34,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.Loxo, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.AgencySlug = params.Metadata["agencySlug"]
-
-	return conn, nil
+	return components.Init(providers.Loxo, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"agencySlug"},
 		},
+		AgencySlug: params.Metadata["agencySlug"],
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/meta/connector.go
+++ b/providers/meta/connector.go
@@ -18,8 +18,8 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Meta, params,
-		func(base *components.Connector) (*Connector, error) {
+	connector, err := components.Init(providers.Meta, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/meta/internal/whatsapp/adapter.go
+++ b/providers/meta/internal/whatsapp/adapter.go
@@ -23,18 +23,10 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	adapter, err := components.Initialize(providers.Meta, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	adapter.whatsappAccountId = params.Metadata[metadataKeyWhatsAppAccountID]
-	adapter.phoneNumberId = params.Metadata[metadataKeyPhoneNumberID]
-
-	return adapter, nil
+	return components.Init(providers.Meta, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
@@ -43,6 +35,8 @@ func constructor(base *components.Connector) (*Adapter, error) {
 				metadataKeyPhoneNumberID,
 			},
 		},
+		whatsappAccountId: params.Metadata[metadataKeyWhatsAppAccountID],
+		phoneNumberId:     params.Metadata[metadataKeyPhoneNumberID],
 	}
 
 	registry := components.NewEmptyEndpointRegistry()

--- a/providers/microsoft/connector.go
+++ b/providers/microsoft/connector.go
@@ -43,11 +43,11 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 // to reuse the same connector implementation with a different auth
 // configuration.
 func NewConnectorForProvider(provider providers.Provider, params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(provider, params, constructor)
+	return components.Init(provider, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/mixmax/connector.go
+++ b/providers/mixmax/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Mixmax, params, constructor)
+	return components.Init(providers.Mixmax, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/monday/connector.go
+++ b/providers/monday/connector.go
@@ -31,11 +31,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Monday, params, constructor)
+	return components.Init(providers.Monday, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/netsuite/connector.go
+++ b/providers/netsuite/connector.go
@@ -38,8 +38,8 @@ type Connector struct {
 // NewConnector is a connector constructor.
 // API Reference: https://td2972271.app.netsuite.com/app/help/helpcenter.nl?fid=section_158151234003.html
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Netsuite, params,
-		func(base *components.Connector) (*Connector, error) {
+	connector, err := components.Init(providers.Netsuite, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/netsuite/internal/restapi/adapter.go
+++ b/providers/netsuite/internal/restapi/adapter.go
@@ -24,15 +24,15 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Netsuite, params, constructor)
+	return components.Init(providers.Netsuite, params, constructor)
 }
 
 // NewAdapterForProvider creates an adapter for a given provider (e.g. NetsuiteM2M).
 func NewAdapterForProvider(provider providers.Provider, params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(provider, params, constructor)
+	return components.Init(provider, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/netsuite/internal/restlet/adapter.go
+++ b/providers/netsuite/internal/restlet/adapter.go
@@ -34,95 +34,93 @@ type Adapter struct {
 // NewAdapter creates a RESTlet adapter. It reads scriptId and deployId
 // from params.Metadata to construct the RESTlet URL.
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) { //nolint:funlen
-	return newAdapter(providers.Netsuite, params)
+	return components.Init(providers.Netsuite, params, constructor)
 }
 
 // NewAdapterForProvider creates an adapter for a given provider (e.g. NetsuiteM2M).
 func NewAdapterForProvider(provider providers.Provider, params common.ConnectorParams) (*Adapter, error) {
-	return newAdapter(provider, params)
+	return components.Init(provider, params, constructor)
 }
 
-func newAdapter(provider providers.Provider, params common.ConnectorParams) (*Adapter, error) { //nolint:funlen
-	return components.Initialize(provider, params, func(base *components.Connector) (*Adapter, error) {
-		var scriptURL, scriptId, deployId string
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) { // nolint:funlen
+	var scriptURL, scriptId, deployId string
 
-		var ok bool //nolint:varnamelen
+	var ok bool //nolint:varnamelen
 
-		// If scriptURL is provided, use it to build the restlet URL.
-		scriptURL, ok = params.Metadata["scriptURL"]
-		if !ok {
-			// If scriptURL is not provided, use scriptId and deployId to build the restlet URL.
-			scriptId, ok = params.Metadata["scriptId"]
-			if !ok || scriptId == "" {
-				return nil, fmt.Errorf("%w: scriptId", ErrMissingMetadata)
-			}
-
-			deployId, ok = params.Metadata["deployId"]
-			if !ok || deployId == "" {
-				return nil, fmt.Errorf("%w: deployId", ErrMissingMetadata)
-			}
+	// If scriptURL is provided, use it to build the restlet URL.
+	scriptURL, ok = params.Metadata["scriptURL"]
+	if !ok {
+		// If scriptURL is not provided, use scriptId and deployId to build the restlet URL.
+		scriptId, ok = params.Metadata["scriptId"]
+		if !ok || scriptId == "" {
+			return nil, fmt.Errorf("%w: scriptId", ErrMissingMetadata)
 		}
 
-		baseURL := base.ModuleInfo().BaseURL
-
-		restletURL, err := buildRestletURL(baseURL, scriptURL, scriptId, deployId)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build restlet URL: %w", err)
+		deployId, ok = params.Metadata["deployId"]
+		if !ok || deployId == "" {
+			return nil, fmt.Errorf("%w: deployId", ErrMissingMetadata)
 		}
+	}
 
-		adapter := &Adapter{
-			Connector:  base,
-			restletURL: restletURL,
-		}
+	baseURL := base.ModuleInfo().BaseURL
 
-		registry := components.NewEmptyEndpointRegistry()
-		httpClient := adapter.HTTPClient().Client
+	restletURL, err := buildRestletURL(baseURL, scriptURL, scriptId, deployId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build restlet URL: %w", err)
+	}
 
-		adapter.SchemaProvider = schema.NewObjectSchemaProvider(
-			httpClient,
-			schema.FetchModeSerial,
-			operations.SingleObjectMetadataHandlers{
-				BuildRequest:  adapter.buildObjectMetadataRequest,
-				ParseResponse: adapter.parseObjectMetadataResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
+	adapter := &Adapter{
+		Connector:  base,
+		restletURL: restletURL,
+	}
 
-		adapter.Reader = reader.NewHTTPReader(
-			httpClient,
-			registry,
-			adapter.ProviderContext.Module(),
-			operations.ReadHandlers{
-				BuildRequest:  adapter.buildReadRequest,
-				ParseResponse: adapter.parseReadResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
+	registry := components.NewEmptyEndpointRegistry()
+	httpClient := adapter.HTTPClient().Client
 
-		adapter.Writer = writer.NewHTTPWriter(
-			httpClient,
-			registry,
-			adapter.ProviderContext.Module(),
-			operations.WriteHandlers{
-				BuildRequest:  adapter.buildWriteRequest,
-				ParseResponse: adapter.parseWriteResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
+	adapter.SchemaProvider = schema.NewObjectSchemaProvider(
+		httpClient,
+		schema.FetchModeSerial,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  adapter.buildObjectMetadataRequest,
+			ParseResponse: adapter.parseObjectMetadataResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
 
-		adapter.Deleter = deleter.NewHTTPDeleter(
-			httpClient,
-			registry,
-			adapter.ProviderContext.Module(),
-			operations.DeleteHandlers{
-				BuildRequest:  adapter.buildDeleteRequest,
-				ParseResponse: adapter.parseDeleteResponse,
-				ErrorHandler:  common.InterpretError,
-			},
-		)
+	adapter.Reader = reader.NewHTTPReader(
+		httpClient,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  adapter.buildReadRequest,
+			ParseResponse: adapter.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
 
-		return adapter, nil
-	})
+	adapter.Writer = writer.NewHTTPWriter(
+		httpClient,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  adapter.buildWriteRequest,
+			ParseResponse: adapter.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	adapter.Deleter = deleter.NewHTTPDeleter(
+		httpClient,
+		registry,
+		adapter.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  adapter.buildDeleteRequest,
+			ParseResponse: adapter.parseDeleteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	return adapter, nil
 }
 
 func buildRestletURL(baseURL, scriptURL, scriptId, deployId string) (string, error) {

--- a/providers/netsuite/internal/suiteql/adapter.go
+++ b/providers/netsuite/internal/suiteql/adapter.go
@@ -20,15 +20,15 @@ type Adapter struct {
 }
 
 func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(providers.Netsuite, params, constructor)
+	return components.Init(providers.Netsuite, params, constructor)
 }
 
 // NewAdapterForProvider creates an adapter for a given provider (e.g. NetsuiteM2M).
 func NewAdapterForProvider(provider providers.Provider, params common.ConnectorParams) (*Adapter, error) {
-	return components.Initialize(provider, params, constructor)
+	return components.Init(provider, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 	}

--- a/providers/netsuite/m2m/connector.go
+++ b/providers/netsuite/m2m/connector.go
@@ -33,8 +33,8 @@ type Connector struct {
 
 // NewConnector creates a new NetSuite M2M connector.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.NetsuiteM2M, params,
-		func(base *components.Connector) (*Connector, error) {
+	connector, err := components.Init(providers.NetsuiteM2M, params,
+		func(_ common.ConnectorParams, base *components.Connector) (*Connector, error) {
 			return &Connector{Connector: base}, nil
 		},
 	)

--- a/providers/nutshell/connector.go
+++ b/providers/nutshell/connector.go
@@ -27,10 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Nutshell, params, constructor)
+	return components.Init(providers.Nutshell, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/odoo/connector.go
+++ b/providers/odoo/connector.go
@@ -17,10 +17,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Odoo, params, constructor)
+	return components.Init(providers.Odoo, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewDelegateSchemaProvider(connector.listObjectMetadata)

--- a/providers/okta/connector.go
+++ b/providers/okta/connector.go
@@ -36,10 +36,10 @@ type Connector struct {
 
 // NewConnector creates a new Okta connector.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Okta, params, constructor)
+	return components.Init(providers.Okta, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/outplay/connector.go
+++ b/providers/outplay/connector.go
@@ -24,10 +24,10 @@ type Connector struct {
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	return components.Initialize(providers.Outplay, params, constructor)
+	return components.Init(providers.Outplay, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/paddle/connector.go
+++ b/providers/paddle/connector.go
@@ -24,10 +24,10 @@ type Connector struct {
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	// Create base connector with provider info
-	return components.Initialize(providers.Paddle, params, constructor)
+	return components.Init(providers.Paddle, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/phoneburner/connector.go
+++ b/providers/phoneburner/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.PhoneBurner, params, constructor)
+	return components.Init(providers.PhoneBurner, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/pinterest/connector.go
+++ b/providers/pinterest/connector.go
@@ -29,11 +29,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Pinterest, params, constructor)
+	return components.Init(providers.Pinterest, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/pipeliner/connector.go
+++ b/providers/pipeliner/connector.go
@@ -27,58 +27,56 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Pipeliner, params, makeConstructor(params))
+	return components.Init(providers.Pipeliner, params, constructor)
 }
 
-func makeConstructor(params common.ConnectorParams) components.ConnectorConstructor[Connector] {
-	return func(base *components.Connector) (*Connector, error) {
-		connector := &Connector{
-			Connector: base,
-			workspace: params.Workspace,
-		}
-
-		connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
-
-		errorHandler := interpreter.ErrorHandler{
-			JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
-		}.Handle
-
-		connector.Reader = reader.NewHTTPReader(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.ReadHandlers{
-				BuildRequest:  connector.buildReadRequest,
-				ParseResponse: connector.parseReadResponse,
-				ErrorHandler:  errorHandler,
-			},
-		)
-
-		connector.Writer = writer.NewHTTPWriter(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.WriteHandlers{
-				BuildRequest:  connector.buildWriteRequest,
-				ParseResponse: connector.parseWriteResponse,
-				ErrorHandler:  errorHandler,
-			},
-		)
-
-		// Set the deleter for the connector
-		connector.Deleter = deleter.NewHTTPDeleter(
-			connector.HTTPClient().Client,
-			components.NewEmptyEndpointRegistry(),
-			connector.ProviderContext.Module(),
-			operations.DeleteHandlers{
-				BuildRequest:  connector.buildDeleteRequest,
-				ParseResponse: connector.parseDeleteResponse,
-				ErrorHandler:  errorHandler,
-			},
-		)
-
-		return connector, nil
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector: base,
+		workspace: params.Workspace,
 	}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)
+
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
+	}.Handle
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
+	// Set the deleter for the connector
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
+	return connector, nil
 }
 
 func (c *Connector) getURL(objectName, recordID string) (*urlbuilder.URL, error) {

--- a/providers/podium/connector.go
+++ b/providers/podium/connector.go
@@ -26,10 +26,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Podium, params, constructor)
+	return components.Init(providers.Podium, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/procore/connector.go
+++ b/providers/procore/connector.go
@@ -31,33 +31,20 @@ type Connector struct {
 const metadataKeyCompany = "company"
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.Procore, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.companyId = params.Metadata[metadataKeyCompany]
-
-	return conn, nil
+	return components.Init(providers.Procore, params, constructor)
 }
 
 func NewSandboxConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.ProcoreSandbox, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.companyId = params.Metadata[metadataKeyCompany]
-
-	return conn, nil
+	return components.Init(providers.ProcoreSandbox, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{metadataKeyCompany},
 		},
+		companyId: params.Metadata[metadataKeyCompany],
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/pylon/connectors.go
+++ b/providers/pylon/connectors.go
@@ -24,11 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Pylon, params, constructor)
+	return components.Init(providers.Pylon, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/quickbooks/connector.go
+++ b/providers/quickbooks/connector.go
@@ -48,29 +48,18 @@ func resolveWorkspace(params common.ConnectorParams) string {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.QuickBooks, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.Workspace = resolveWorkspace(params)
-
-	return conn, nil
+	return components.Init(providers.QuickBooks, params, constructor)
 }
 
 func NewSandboxConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.QuickbooksSandbox, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.Workspace = resolveWorkspace(params)
-
-	return conn, nil
+	return components.Init(providers.QuickbooksSandbox, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{
+		Connector: base,
+		Workspace: resolveWorkspace(params),
+	}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(
 		connector.HTTPClient().Client,

--- a/providers/recurly/connector.go
+++ b/providers/recurly/connector.go
@@ -24,11 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Recurly, params, constructor)
+	return components.Init(providers.Recurly, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/revenuecat/connector.go
+++ b/providers/revenuecat/connector.go
@@ -30,22 +30,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.RevenueCat, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.ProjectID = params.Metadata["project_id"]
-
-	return conn, nil
+	return components.Init(providers.RevenueCat, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{"project_id"},
 		},
+		ProjectID: params.Metadata["project_id"],
 	}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/ringcentral/connector.go
+++ b/providers/ringcentral/connector.go
@@ -26,11 +26,10 @@ const (
 )
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.RingCentral, params, constructor)
+	return components.Init(providers.RingCentral, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/sageintacct/connector.go
+++ b/providers/sageintacct/connector.go
@@ -24,10 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.SageIntacct, params, constructor)
+	return components.Init(providers.SageIntacct, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/salesfinity/connector.go
+++ b/providers/salesfinity/connector.go
@@ -23,10 +23,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Salesfinity, params, constructor)
+	return components.Init(providers.Salesfinity, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/salesflare/connector.go
+++ b/providers/salesflare/connector.go
@@ -26,10 +26,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Salesflare, params, constructor)
+	return components.Init(providers.Salesflare, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/salesforce/internal/crm/adapter.go
+++ b/providers/salesforce/internal/crm/adapter.go
@@ -40,10 +40,10 @@ type Adapter struct {
 // adapter under a different provider name. Pass providers.Salesforce for the
 // default Salesforce connector.
 func NewAdapter(params *common.ConnectorParams, provider providers.Provider) (*Adapter, error) {
-	return components.Initialize(provider, *params, constructor)
+	return components.Init(provider, *params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{Connector: base}
 
 	adapter.Deleter = deleter.NewHTTPDeleter(

--- a/providers/salesforce/internal/pardot/adapter.go
+++ b/providers/salesforce/internal/pardot/adapter.go
@@ -35,22 +35,16 @@ type Adapter struct {
 // adapter under a different provider name. Pass providers.Salesforce for the
 // default Salesforce connector.
 func NewAdapter(params *common.ConnectorParams, provider providers.Provider) (*Adapter, error) {
-	adapter, err := components.Initialize(provider, *params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	adapter.businessUnitID = params.Metadata[MetadataKeyBusinessUnitID]
-
-	return adapter, nil
+	return components.Init(provider, *params, constructor)
 }
 
-func constructor(base *components.Connector) (*Adapter, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
 		RequireMetadata: common.RequireMetadata{
 			ExpectedMetadataKeys: []string{MetadataKeyBusinessUnitID},
 		},
+		businessUnitID: params.Metadata[MetadataKeyBusinessUnitID],
 	}
 
 	errorHandler := errorHandlerFunc

--- a/providers/seismic/connector.go
+++ b/providers/seismic/connector.go
@@ -42,12 +42,12 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	if params.Module == "" {
 		params.Module = providers.ModuleSeismicReporting
 	}
-	// Create base connector with provider info
-	return components.Initialize(providers.Seismic, params, constructor)
+
+	return components.Init(providers.Seismic, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/sellsy/connector.go
+++ b/providers/sellsy/connector.go
@@ -27,10 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Sellsy, params, constructor)
+	return components.Init(providers.Sellsy, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
 	}

--- a/providers/servicenow/connector.go
+++ b/providers/servicenow/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.ServiceNow, params, constructor)
+	return components.Init(providers.ServiceNow, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/shopify/connector.go
+++ b/providers/shopify/connector.go
@@ -30,11 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Shopify, params, constructor)
+	return components.Init(providers.Shopify, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/slack/connector.go
+++ b/providers/slack/connector.go
@@ -26,20 +26,16 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Slack, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	authMetadata := NewAuthMetadataVars(params.Metadata)
-
-	connector.teamId = authMetadata.TeamId
-
-	return connector, nil
+	return components.Init(providers.Slack, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
-	connector := &Connector{Connector: base}
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	authMetadata := NewAuthMetadataVars(params.Metadata)
+
+	connector := &Connector{
+		Connector: base,
+		teamId:    authMetadata.TeamId,
+	}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(
 		connector.HTTPClient().Client,

--- a/providers/smartleadv2/connector.go
+++ b/providers/smartleadv2/connector.go
@@ -45,12 +45,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Smartlead, params, constructor)
+	return components.Init(providers.Smartlead, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/snapchatads/connector.go
+++ b/providers/snapchatads/connector.go
@@ -33,29 +33,21 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	conn, err := components.Initialize(providers.SnapchatAds, params, constructor)
-	if err != nil {
-		return nil, err
-	}
-
-	conn.Client = &common.JSONHTTPClient{
-		HTTPClient: &common.HTTPClient{
-			Client: params.AuthenticatedClient,
-		},
-	}
-
-	authMetadata := NewAuthMetadataVars(params.Metadata)
-
-	conn.organizationId = authMetadata.OrganizationId
-
-	return conn, nil
+	return components.Init(providers.SnapchatAds, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	authMetadata := NewAuthMetadataVars(params.Metadata)
+
 	connector := &Connector{
 		Connector: base,
+		Client: &common.JSONHTTPClient{
+			HTTPClient: &common.HTTPClient{
+				Client: params.AuthenticatedClient,
+			},
+		},
+		organizationId: authMetadata.OrganizationId,
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/snowflake/connector.go
+++ b/providers/snowflake/connector.go
@@ -66,19 +66,19 @@ type Connector struct {
 //   - Figure out permissions needed for write.
 //   - Pagination.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	connector, err := components.Initialize(providers.Snowflake, params, constructor)
+	connector, err := components.Init(providers.Snowflake, params, constructor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize connector: %w", err)
 	}
 
-	if err := connector.setup(context.Background(), params); err != nil {
+	if err = connector.setup(context.Background(), params); err != nil {
 		return nil, fmt.Errorf("failed to setup connector: %w", err)
 	}
 
 	return connector, nil
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewDelegateSchemaProvider(connector.listObjectMetadata)

--- a/providers/solarwinds/connector.go
+++ b/providers/solarwinds/connector.go
@@ -40,12 +40,11 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.SolarWindsServiceDesk, params, constructor)
+	return components.Init(providers.SolarWindsServiceDesk, params, constructor)
 }
 
 // nolint:funlen
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/supersend/connector.go
+++ b/providers/supersend/connector.go
@@ -23,10 +23,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.SuperSend, params, constructor)
+	return components.Init(providers.SuperSend, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/talkdesk/connector.go
+++ b/providers/talkdesk/connector.go
@@ -41,11 +41,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	// Create base connector with provider info
-	return components.Initialize(providers.Talkdesk, params, constructor)
+	return components.Init(providers.Talkdesk, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/teamleader/connector.go
+++ b/providers/teamleader/connector.go
@@ -24,10 +24,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Teamleader, params, constructor)
+	return components.Init(providers.Teamleader, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector

--- a/providers/teamwork/connector.go
+++ b/providers/teamwork/connector.go
@@ -30,10 +30,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Teamwork, params, constructor)
+	return components.Init(providers.Teamwork, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(connector.ProviderContext.Module(), metadata.Schemas)

--- a/providers/webex/connector.go
+++ b/providers/webex/connector.go
@@ -21,10 +21,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.Webex, params, constructor)
+	return components.Init(providers.Webex, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/xero/connector.go
+++ b/providers/xero/connector.go
@@ -29,7 +29,7 @@ type Connector struct {
 
 // NewConnector.
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	conn, err := components.Initialize(providers.Xero, params, constructor)
+	conn, err := components.Init(providers.Xero, params, constructor)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 	return conn, nil
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/zendeskchat/connector.go
+++ b/providers/zendeskchat/connector.go
@@ -27,10 +27,10 @@ type Connector struct {
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
-	return components.Initialize(providers.ZendeskChat, params, constructor)
+	return components.Init(providers.ZendeskChat, params, constructor)
 }
 
-func constructor(base *components.Connector) (*Connector, error) {
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{Connector: base}
 
 	// Set the metadata provider for the connector


### PR DESCRIPTION
# Description

This is a follow up to https://github.com/amp-labs/connectors/pull/2677.

Changes:
* All connectors that initialize components now use Init.
* The `components.Initialize` is removed.

Constructors that were setting the values post factum now have the natural order. Example:
<img width="1042" height="471" alt="image" src="https://github.com/user-attachments/assets/8cf9b66b-bb75-4c2b-b6e0-d7215ec06cd7" />
