### PR TITLE
docs(fathom): Update Fathom docs URL

### DIFF
--- a/providers/Fathom.go
+++ b/providers/Fathom.go
@@ -12,7 +12,7 @@ func init() {
 			Header: &ApiKeyOptsHeader{
 				Name: "X-Api-Key",
 			},
-			DocsURL: "https://docs.fathom.ai",
+			DocsURL: "https://developers.fathom.ai/quickstart",
 		},
 		Support: Support{
 			BulkWrite: BulkWriteSupport{


### PR DESCRIPTION
previous URL wasn't the right one for instructing users on finding API key, `docsURL` isn't for linking API docs, it's for linking to a page that instructs end users on to how to generate an API key. 