### PR TITLE
feat: Add ReadParams.Opts to support bespoke parameters

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -220,8 +220,12 @@ type ReadParams struct {
 
 	// Additional options for the read operation that the connector may support.
 	// This optional map is used for bespoke connector-specific parameters.
-	Opts map[string]any // optional
+	Opts ReadParamOpts // optional
 }
+
+// Each connector that supports ReadParams.Opts should define its own type and assert it.
+// e.g. gong.ReadParamOpts
+type ReadParamOpts any
 
 func (p ReadParams) IsFirstPage() bool {
 	return p.NextPage.String() == ""

--- a/common/types.go
+++ b/common/types.go
@@ -220,12 +220,12 @@ type ReadParams struct {
 
 	// Additional options for the read operation that the connector may support.
 	// This optional map is used for bespoke connector-specific parameters.
-	Opts ReadParamOpts // optional
+	Opts ReadParamsOpts // optional
 }
 
 // Each connector that supports ReadParams.Opts should define its own type and assert it.
 // e.g. gong.ReadParamOpts
-type ReadParamOpts any
+type ReadParamsOpts any
 
 func (p ReadParams) IsFirstPage() bool {
 	return p.NextPage.String() == ""

--- a/common/types.go
+++ b/common/types.go
@@ -217,6 +217,10 @@ type ReadParams struct {
 
 	// PageSize specifies the # of records to request when making a read request.
 	PageSize int // optional
+
+	// Additional options for the read operation that the connector may support.
+	// This optional map is used for bespoke connector-specific parameters.
+	Opts map[string]any // optional
 }
 
 func (p ReadParams) IsFirstPage() bool {

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-type ReadParamOpts struct { 
+type ReadParamsOpts struct { 
   ReadFlowsForAllUsers bool // Whether to read for all users, or just read company flows.
 }
 

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
+type ReadParamOpts struct { 
+  ReadFlowsForAllUsers bool // Whether to read for all users, or just read company flows.
+}
+
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {
 	if err := config.ValidateParams(true); err != nil {
 		return nil, err


### PR DESCRIPTION
We sometimes need a way to pass in an additional parameter to affect how a read operation works that is outside of our standard supported parameters like filters or associations. This new field is meant for bespoke parameters that only make sense for a single connector, and does not need an abstraction.