### PR TITLE
CON[3211] feat(acculynx): enable Read, Write

### DIFF
--- a/providers/accuLynx.go
+++ b/providers/accuLynx.go
@@ -23,9 +23,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: true,
-			Write:     false,
+			Write:     true,
 		},
 		SubscribeRequirements: &SubscribeRequirements{
 			// AccuLynx supports creating webhook subscriptions via API.


### PR DESCRIPTION
# Installation
  MailMonkey using API Key (AccuLynx auth is `ApiKey` — Bearer token in the `Authorization` header).

  # Conventions

  - [x] Connector uses `internal/components`
  - [x] Metadata uses V2 metadata format
  - [x] Read supports pagination
  - [x] Read supports incremental sync
  - [x] Raw response is returned as is, no formatting or flattening is performed.
  - [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
  - [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
  - [x] Custom fields, if not human readable names, are resolved to readable names.
  - [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
  - [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
  - [ ] Modules are only being added because:
    - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
    - [ ] Different base URLs
    - [ ] Object name collisions (same object name exists in two or more modules)

  > Modules section is intentionally unchecked — AccuLynx is a single-module connector (`https://api.acculynx.com` for all objects).

  # Read and Write
  - [x] Insert screenshot of metadata fields from read object installation.
  
<img width="1705" height="944" alt="image" src="https://github.com/user-attachments/assets/3679ab80-1e55-4036-afb4-993018ed4ef7" />


  - [x] Insert screenshot of Svix destination.

<img width="1476" height="944" alt="image" src="https://github.com/user-attachments/assets/dd4e49f7-416c-4e60-b75a-9ec925fd2803" />
<img width="1476" height="944" alt="image" src="https://github.com/user-attachments/assets/4e4d5392-2190-4faa-92b1-30c9248acc19" />
<img width="1476" height="944" alt="image" src="https://github.com/user-attachments/assets/8038777f-c20b-4537-9dc6-ef67ba8bd954" />
<img width="1476" height="944" alt="image" src="https://github.com/user-attachments/assets/9d7b5f1e-ee06-41d7-8697-a7caf4a2c9c5" />



  - [x] Screenshot of operations on dashboard.
  
<img width="1434" height="480" alt="image" src="https://github.com/user-attachments/assets/9c25a173-d544-4543-a68b-947033abb2f0" />
<img width="1413" height="867" alt="image" src="https://github.com/user-attachments/assets/4765b9e6-063e-468b-bd1b-d689a3c2469a" />
<img width="1413" height="867" alt="image" src="https://github.com/user-attachments/assets/bd89ca1b-a26f-4a33-96b7-5b41040d81f0" />
<img width="1413" height="867" alt="image" src="https://github.com/user-attachments/assets/f6f6708b-4a5a-4335-b125-e4eb0f4b2af2" />
<img width="1413" height="867" alt="image" src="https://github.com/user-attachments/assets/297b34a9-2430-46f7-97f3-7b0706ab805f" />


  # Write
  - [x] Insert screenshot of dashboard.

<img width="1398" height="288" alt="image" src="https://github.com/user-attachments/assets/b7188678-951c-4eb0-b858-519241f42950" />

  - [x] Insert screenshot of HTTP call.
       
<img width="1413" height="966" alt="image" src="https://github.com/user-attachments/assets/814a1fb3-6ece-48e4-ac4a-c7f5a40359db" />
<img width="1413" height="966" alt="image" src="https://github.com/user-attachments/assets/3a096a41-12d8-45a8-8f53-b01365246427" />
<img width="1413" height="704" alt="image" src="https://github.com/user-attachments/assets/44269a58-c513-495c-a7bb-099d68275a85" />
<img width="1413" height="704" alt="image" src="https://github.com/user-attachments/assets/de83ba58-fddb-439e-9d8d-d24a1ecc42dd" />

# Subscribe 

  - [x] Screenshot of operations on dashboard.
  
<img width="1425" height="639" alt="image" src="https://github.com/user-attachments/assets/f2c1ef8c-e5de-4440-8e52-fc31fbc2fe4a" />
<img width="1434" height="893" alt="image" src="https://github.com/user-attachments/assets/b001ee58-ae2a-4de8-bfd1-5f955d4783d7" />
<img width="1434" height="893" alt="image" src="https://github.com/user-attachments/assets/60b21df0-35ae-4068-8706-dc0b4c94d6a5" />

  - [x] Insert screenshot of Acculynx subscribed objects.
  
<img width="1724" height="1037" alt="image" src="https://github.com/user-attachments/assets/432d323c-6d34-498c-8c28-98ce4df2af13" />
<img width="1724" height="1037" alt="image" src="https://github.com/user-attachments/assets/c4206cd7-0307-432e-bfc9-e450e2abce06" />

  
  - [x] Insert screenshot of Svix destination.
<img width="1728" height="1092" alt="Screenshot 2026-06-30 at 6 30 52 PM" src="https://github.com/user-attachments/assets/c4dcc3a6-d08f-4eb0-8591-dea7a545460a" />
<img width="1728" height="1092" alt="Screenshot 2026-06-30 at 6 30 58 PM" src="https://github.com/user-attachments/assets/27a583b2-06d6-4924-b145-3064181aeab2" />
<img width="1728" height="1092" alt="Screenshot 2026-06-30 at 6 31 05 PM" src="https://github.com/user-attachments/assets/cedd4cf8-c58c-4fc8-a531-38dbc57954bf" />
<img width="1728" height="1092" alt="Screenshot 2026-06-30 at 6 31 10 PM" src="https://github.com/user-attachments/assets/eca1e8eb-d991-42b1-adcb-a051eaea47ee" />
<img width="1728" height="1049" alt="Screenshot 2026-06-30 at 6 52 03 PM" src="https://github.com/user-attachments/assets/8e7daebe-448b-4c46-99ee-e02904873207" />
<img width="1728" height="1049" alt="Screenshot 2026-06-30 at 6 52 16 PM" src="https://github.com/user-attachments/assets/560b355b-fae1-4491-8f1c-25bec77fcc6f" />
<img width="1728" height="1049" alt="Screenshot 2026-06-30 at 6 52 25 PM" src="https://github.com/user-attachments/assets/4e72168e-9894-45c3-aa43-4734260b1916" />
<img width="1728" height="1049" alt="Screenshot 2026-06-30 at 6 52 28 PM" src="https://github.com/user-attachments/assets/81edb276-68a3-4a17-b68a-47e2253d2c35" />







