### PR TITLE
[CON-3308] feat(gong): support reading all users flows or only company flows

### DIFF
--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -64,7 +64,6 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 			continue
 		}
 
-		// Company-only mode keeps just the "Company" visibility flows.
 		mergeUserFlows(aggregated, flows, user, includeUserAssoc, readAllUsers)
 
 		if !readAllUsers {

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -31,6 +31,9 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 
 	includeUserAssoc := wantsUserAssociation(config.AssociatedObjects)
 
+	readOpts, isReadOptsOk := config.Opts.(ReadParamsOpts)
+	readAllUsers := isReadOptsOk && readOpts.ReadFlowsForAllUsers
+
 	// Collect every user's flows into one map keyed by flow id.
 	// Company and shared flows show up for many users, so the map drops the repeats.
 	aggregated := make(map[string]common.ReadResultRow)
@@ -61,9 +64,15 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 			continue
 		}
 
-		mergeUserFlows(aggregated, flows, user, includeUserAssoc)
-		// Temp solution to only fetch one user's flows to prevent API consumption issues.
-		break
+		// Company-only mode keeps just the "Company" visibility flows.
+		mergeUserFlows(aggregated, flows, user, includeUserAssoc, readAllUsers)
+
+		if !readAllUsers {
+			// When ReadFlowsForAllUsers is false,
+			// We only read flows with visiblity "Company". so we can break after the first user.
+			// We treat failed readOpts assertion as false ReadFlowsForAllUsers.
+			break
+		}
 	}
 
 	if len(aggregated) == 0 {
@@ -109,14 +118,24 @@ func emptyFlowsResult() *common.ReadResult {
 // copy and never attach the owner. When this user owns the flow (their copy says
 // "Personal") we prefer that copy, overwriting any "Shared" one stored earlier,
 // so the owner association is reliable no matter what order users come back in.
+//
+// When readAllUsers is false we are in company-only mode, so flows that aren't
+// "Company" visibility are dropped.
 func mergeUserFlows(
 	aggregated map[string]common.ReadResultRow,
 	flows []common.ReadResultRow,
 	owner common.ReadResultRow,
 	includeUserAssoc bool,
+	readAllUsers bool,
 ) {
 	for _, flow := range flows {
 		visibility, _ := flow.Raw["visibility"].(string)
+
+		// Company-only mode: skip anything that isn't a company flow.
+		if !readAllUsers && !strings.EqualFold(visibility, "Company") {
+			continue
+		}
+
 		ownsFlow := strings.EqualFold(visibility, "Personal")
 
 		// Already collected and this isn't the owner's copy: nothing to add.

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -19,7 +19,7 @@ import (
 // appear in multiple users' result sets while personal flows are unique to their owner.
 // Some users may not have engage license or may not be added to flows, so we handle errors gracefully.
 // ref: https://gong.app.gong.io/settings/api/documentation#get-/v2/flows
-func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { // nolint:lll,cyclop
+func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) { // nolint:lll,cyclop,funlen
 	users, err := c.fetchAllUsers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch users: %w", err)
@@ -69,7 +69,7 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 
 		if !readAllUsers {
 			// When ReadFlowsForAllUsers is false,
-			// We only read flows with visiblity "Company". so we can break after the first user.
+			// We only read flows with visibility "Company". so we can break after the first user.
 			// We treat failed readOpts assertion as false ReadFlowsForAllUsers.
 			break
 		}

--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -69,7 +69,7 @@ func (c *Connector) readFlows(ctx context.Context, config common.ReadParams) (*c
 
 		if !readAllUsers {
 			// When ReadFlowsForAllUsers is false,
-			// We only read flows with visibility "Company". so we can break after the first user.
+			// We only read flows with visibility "Company", so we only need to read flows from one user.
 			// We treat failed readOpts assertion as false ReadFlowsForAllUsers.
 			break
 		}

--- a/providers/gong/read.go
+++ b/providers/gong/read.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spyzhov/ajson"
 )
 
-type ReadParamsOpts struct { 
-  ReadFlowsForAllUsers bool // Whether to read for all users, or just read company flows.
+type ReadParamsOpts struct {
+	ReadFlowsForAllUsers bool // Whether to read for all users, or just read company flows.
 }
 
 func (c *Connector) Read(ctx context.Context, config common.ReadParams) (*common.ReadResult, error) {

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -270,200 +270,138 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Expected:     &common.ReadResult{Done: true, Rows: 0, Data: nil},
 			ExpectedErrs: nil,
 		},
-		// {
-		// 	// Bob is fetched first (read_users_bob_first.json) and his result set
-		// 	// includes alice's flow 9000000000000001 as "Shared", because Gong
-		// 	// reports visibility relative to the queried email. Alice is fetched
-		// 	// second and sees that same id as "Personal". Expecting flow ...001 to
-		// 	// come out "Personal" with alice attached proves the dedup prefers the
-		// 	// owner's copy instead of keeping the non-owner's "Shared" one.
-		// 	Name: "Flows: AssociatedObjects=users attaches each Personal flow's owner",
-		// 	Input: common.ReadParams{
-		// 		ObjectName:        "flows",
-		// 		Fields:            connectors.Fields("id", "name", "visibility"),
-		// 		AssociatedObjects: []string{"users"},
-		// 	},
-		// 	Server: mockserver.Switch{
-		// 		Setup: mockserver.ContentJSON(),
-		// 		Cases: []mockserver.Case{{
-		// 			If:   mockcond.Path("/v2/users"),
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_bob_first.json")),
-		// 		}, {
-		// 			If: mockcond.And{
-		// 				mockcond.Path("/v2/flows"),
-		// 				mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
-		// 			},
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
-		// 		}, {
-		// 			If: mockcond.And{
-		// 				mockcond.Path("/v2/flows"),
-		// 				mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
-		// 			},
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
-		// 		}},
-		// 	}.Server(),
-		// 	Comparator: testroutines.ComparatorSubsetRead,
-		// 	Expected: &common.ReadResult{
-		// 		Rows: 3,
-		// 		Data: []common.ReadResultRow{{
-		// 			Id: "9000000000000001",
-		// 			Fields: map[string]any{
-		// 				"visibility": "Personal",
-		// 				"id":         "9000000000000001",
-		// 			},
-		// 			Raw: map[string]any{
-		// 				"visibility": "Personal",
-		// 				"id":         "9000000000000001",
-		// 			},
-		// 			Associations: map[string][]common.Association{
-		// 				"users": {{
-		// 					ObjectId: "8000000000000001",
-		// 					Raw: map[string]any{
-		// 						"emailAddress": "alice@example.com",
-		// 					},
-		// 				}},
-		// 			},
-		// 		}, {
-		// 			Id: "9000000000000002",
-		// 			Fields: map[string]any{
-		// 				"visibility": "Personal",
-		// 				"id":         "9000000000000002",
-		// 			},
-		// 			Raw: map[string]any{
-		// 				"visibility": "Personal",
-		// 				"id":         "9000000000000002",
-		// 			},
-		// 			Associations: map[string][]common.Association{
-		// 				"users": {{
-		// 					ObjectId: "8000000000000002",
-		// 					Raw: map[string]any{
-		// 						"id":           "8000000000000002",
-		// 						"emailAddress": "bob@example.com",
-		// 						"firstName":    "Bob",
-		// 						"lastName":     "Brown",
-		// 						"active":       true,
-		// 						"title":        "Sales Engineer",
-		// 					},
-		// 				}},
-		// 			},
-		// 		}, {
-		// 			Id: "9000000000000099",
-		// 			Fields: map[string]any{
-		// 				"id":         "9000000000000099",
-		// 				"visibility": "Company",
-		// 			},
-
-		// 			Raw: map[string]any{
-		// 				"id":         "9000000000000099",
-		// 				"visibility": "Company",
-		// 			},
-		// 			// Company flows: no user association.
-		// 		}},
-		// 		Done: true,
-		// 	},
-		// 	ExpectedErrs: nil,
-		// },
-		// {
-		// 	Name: "Flows: users with multiple pages, every page's users get their flows fetched",
-		// 	Input: common.ReadParams{
-		// 		ObjectName: "flows",
-		// 		Fields:     connectors.Fields("id", "name", "visibility"),
-		// 	},
-		// 	Server: mockserver.Switch{
-		// 		Setup: mockserver.ContentJSON(),
-		// 		Cases: []mockserver.Case{{
-		// 			// users page 2 (cursor present) must be matched before the page 1 fallback
-		// 			If: mockcond.And{
-		// 				mockcond.Path("/v2/users"),
-		// 				mockcond.QueryParam("cursor", "USERS_PAGE_2"),
-		// 			},
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page2.json")),
-		// 		}, {
-		// 			If:   mockcond.Path("/v2/users"),
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page1.json")),
-		// 		}, {
-		// 			If: mockcond.And{
-		// 				mockcond.Path("/v2/flows"),
-		// 				mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
-		// 			},
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
-		// 		}, {
-		// 			If: mockcond.And{
-		// 				mockcond.Path("/v2/flows"),
-		// 				mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
-		// 			},
-		// 			Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
-		// 		}},
-		// 	}.Server(),
-		// 	Comparator: testroutines.ComparatorSubsetRead,
-		// 	Expected: &common.ReadResult{
-		// 		Rows: 3,
-		// 		Data: []common.ReadResultRow{{
-		// 			Id: "9000000000000001",
-		// 			Fields: map[string]any{
-		// 				"id":         "9000000000000001",
-		// 				"visibility": "Personal",
-		// 			},
-		// 			Raw: map[string]any{
-		// 				"id":         "9000000000000001",
-		// 				"visibility": "Personal",
-		// 			},
-		// 		}, {
-		// 			// bob lives on users page 2 — proves we followed the users cursor
-		// 			Id: "9000000000000002",
-		// 			Fields: map[string]any{
-		// 				"id":         "9000000000000002",
-		// 				"visibility": "Personal",
-		// 			},
-		// 			Raw: map[string]any{
-		// 				"id":         "9000000000000002",
-		// 				"visibility": "Personal",
-		// 			},
-		// 		}, {
-		// 			Id: "9000000000000099",
-		// 			Fields: map[string]any{
-		// 				"id":         "9000000000000099",
-		// 				"visibility": "Company",
-		// 			},
-		// 			Raw: map[string]any{
-		// 				"id":         "9000000000000099",
-		// 				"visibility": "Company",
-		// 			},
-		// 		}},
-		// 		Done: true,
-		// 	},
-		// 	ExpectedErrs: nil,
-		// },
 		{
-			Name: "Flows: a single user's flows with multiple pages, all pages are fetched",
+			// ReadFlowsForAllUsers is true, so we read every active user's flows.
+			// Bob is fetched first (read_users_bob_first.json) and his result set
+			// includes alice's flow 9000000000000001 as "Shared", because Gong
+			// reports visibility relative to the queried email. Alice is fetched
+			// second and sees that same id as "Personal". Expecting flow ...001 to
+			// come out "Personal" with alice attached proves the dedup prefers the
+			// owner's copy instead of keeping the non-owner's "Shared" one.
+			Name: "Flows: ReadFlowsForAllUsers reads every user and attaches each Personal flow's owner",
 			Input: common.ReadParams{
-				ObjectName: "flows",
-				Fields:     connectors.Fields("id", "name", "visibility"),
+				ObjectName:        "flows",
+				Fields:            connectors.Fields("id", "name", "visibility"),
+				AssociatedObjects: []string{"users"},
+				Opts:              ReadParamsOpts{ReadFlowsForAllUsers: true},
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
 				Cases: []mockserver.Case{{
-					// alice flows page 2 (cursor present) must be matched before the page 1 fallback
-					If: mockcond.And{
-						mockcond.Path("/v2/flows"),
-						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
-						mockcond.QueryParam("cursor", "FLOWS_PAGE_2"),
-					},
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice_page2.json")),
-				}, {
-					If: mockcond.And{
-						mockcond.Path("/v2/flows"),
-						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
-					},
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice_page1.json")),
-				}, {
 					If:   mockcond.Path("/v2/users"),
-					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_alice_only.json")),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_bob_first.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
 				}},
 			}.Server(),
 			Comparator: testroutines.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
-				Rows: 2,
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000001",
+					Fields: map[string]any{
+						"visibility": "Personal",
+						"id":         "9000000000000001",
+					},
+					Raw: map[string]any{
+						"visibility": "Personal",
+						"id":         "9000000000000001",
+					},
+					Associations: map[string][]common.Association{
+						"users": {{
+							ObjectId: "8000000000000001",
+							Raw: map[string]any{
+								"emailAddress": "alice@example.com",
+							},
+						}},
+					},
+				}, {
+					Id: "9000000000000002",
+					Fields: map[string]any{
+						"visibility": "Personal",
+						"id":         "9000000000000002",
+					},
+					Raw: map[string]any{
+						"visibility": "Personal",
+						"id":         "9000000000000002",
+					},
+					Associations: map[string][]common.Association{
+						"users": {{
+							ObjectId: "8000000000000002",
+							Raw: map[string]any{
+								"id":           "8000000000000002",
+								"emailAddress": "bob@example.com",
+								"firstName":    "Bob",
+								"lastName":     "Brown",
+								"active":       true,
+								"title":        "Sales Engineer",
+							},
+						}},
+					},
+				}, {
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+					// Company flows: no user association.
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// ReadFlowsForAllUsers is true, so users are read across every page
+			// and each page's users get their flows fetched.
+			Name: "Flows: ReadFlowsForAllUsers follows the users cursor across pages",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name", "visibility"),
+				Opts:       ReadParamsOpts{ReadFlowsForAllUsers: true},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					// users page 2 (cursor present) must be matched before the page 1 fallback
+					If: mockcond.And{
+						mockcond.Path("/v2/users"),
+						mockcond.QueryParam("cursor", "USERS_PAGE_2"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page2.json")),
+				}, {
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_page1.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "bob@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 3,
 				Data: []common.ReadResultRow{{
 					Id: "9000000000000001",
 					Fields: map[string]any{
@@ -475,15 +413,65 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"visibility": "Personal",
 					},
 				}, {
-					// this flow is only on page 2 — proves we followed the flows cursor
-					Id: "9000000000000003",
+					// bob lives on users page 2 — proves we followed the users cursor
+					Id: "9000000000000002",
 					Fields: map[string]any{
-						"id":         "9000000000000003",
+						"id":         "9000000000000002",
 						"visibility": "Personal",
 					},
 					Raw: map[string]any{
-						"id":         "9000000000000003",
+						"id":         "9000000000000002",
 						"visibility": "Personal",
+					},
+				}, {
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// ReadFlowsForAllUsers is false (the default). We read only the first
+			// active user's flows and keep just the "Company" visibility ones, so
+			// alice's Personal flow is dropped and only the Company flow remains.
+			Name: "Flows: company-only mode reads one user and returns only Company flows",
+			Input: common.ReadParams{
+				ObjectName: "flows",
+				Fields:     connectors.Fields("id", "name", "visibility"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.Path("/v2/flows"),
+						mockcond.QueryParam("flowOwnerEmail", "alice@example.com"),
+					},
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_alice.json")),
+				}, {
+					If:   mockcond.Path("/v2/users"),
+					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_alice_only.json")),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Id: "9000000000000099",
+					Fields: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
+					},
+					Raw: map[string]any{
+						"id":         "9000000000000099",
+						"visibility": "Company",
 					},
 				}},
 				Done: true,

--- a/test/gong/read/flows/read.go
+++ b/test/gong/read/flows/read.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/gong"
 	connTest "github.com/amp-labs/connectors/test/gong"
 	"github.com/amp-labs/connectors/test/utils"
 )
@@ -27,6 +28,7 @@ func main() {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "flows",
 		Fields:     connectors.Fields("id", "name", "visibility"),
+		Opts:       gong.ReadParamsOpts{ReadFlowsForAllUsers: true},
 	})
 	if err != nil {
 		utils.Fail("error reading from Gong", "error", err)
@@ -38,6 +40,7 @@ func main() {
 	resWithAssoc, err := conn.Read(ctx, common.ReadParams{
 		ObjectName:        "flows",
 		Fields:            connectors.Fields("id", "name", "visibility"),
+		Opts:              gong.ReadParamsOpts{ReadFlowsForAllUsers: true},
 		AssociatedObjects: []string{"users"},
 	})
 	if err != nil {
@@ -45,4 +48,17 @@ func main() {
 	}
 
 	utils.DumpJSON(resWithAssoc, os.Stdout)
+
+	slog.Info("Reading flows with ReadFlowsForAllUsers false")
+	res, err = conn.Read(ctx, common.ReadParams{
+		ObjectName: "flows",
+		Fields:     connectors.Fields("id", "name", "visibility"),
+		Opts:       gong.ReadParamsOpts{ReadFlowsForAllUsers: false},
+	})
+	if err != nil {
+		utils.Fail("error reading from Gong", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
 }


### PR DESCRIPTION
Flows read now depends on `ReadParams.Opts`:

- if `ReadFlowsForAllUsers` is `true` → read every flow for all active users.
- if `ReadFlowsForAllUsers` is `false` → read only `Company` flows. (we just the first active user and stop).
- if `Opts` is missing or the wrong type → fall back to the company-only behavior (same as `false`).


## Test Result

```
time=2026-06-16T14:47:23.032+05:45 level=INFO msg="Reading flows with ReadFlowsForAllUsers false"
time=2026-06-16T14:47:23.032+05:45 level=DEBUG msg="HTTP request" method=GET url=https://api.gong.io/v2/users correlationId=1b9cc8c5-02e7-4609-a404-6bd092d48016 headers.Accept=application/json
time=2026-06-16T14:47:23.448+05:45 level=DEBUG msg="HTTP response" details="map[correlationId:1b9cc8c5-02e7-4609-a404-6bd092d48016 headers:[Server: cloudflare Content-Type: application/json;charset=UTF-8 Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted> X-Traceid: 6lz8zza2n0y820ykns4 X-Content-Type-Options: nosniff X-Ratelimit-Remaining: 17 X-Gong-Service-Version: PublicApiServer:17.main.19319 Vary: accept-encoding Cf-Cache-Status: DYNAMIC Date: Tue, 16 Jun 2026 09:02:23 GMT Strict-Transport-Security: max-age=63072000; includeSubDomains; preload Cf-Ray: a0c8a2a22a7658b9-KTM] method:GET status:200 url:https://api.gong.io/v2/users]"
time=2026-06-16T14:47:23.448+05:45 level=DEBUG msg="HTTP request" method=GET url="https://api.gong.io/v2/flows?flowOwnerEmail=andrey.kalmykov%40sysintit.kz" correlationId=b0575aca-fdc1-47bf-8579-60e221cd4c75 headers.Accept=application/json
time=2026-06-16T14:47:24.733+05:45 level=DEBUG msg="HTTP response" details="map[correlationId:b0575aca-fdc1-47bf-8579-60e221cd4c75 headers:[X-Gong-Service-Version: PublicApiServer:17.main.19319 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload X-Ratelimit-Remaining: 17 X-Traceid: 3u4qdt43mji81byzzt1 X-Content-Type-Options: nosniff Cf-Cache-Status: DYNAMIC Content-Type: application/json;charset=UTF-8 Server: cloudflare Vary: accept-encoding Cf-Ray: a0c8a2a4b86c58b9-KTM Date: Tue, 16 Jun 2026 09:02:24 GMT Set-Cookie: <redacted> Set-Cookie: <redacted> Set-Cookie: <redacted>] method:GET status:200 url:https://api.gong.io/v2/flows?flowOwnerEmail=andrey.kalmykov%40sysintit.kz]"
{
  "Data": [
    {
      "Associations": {},
      "Fields": {
        "id": "2891526548120464174",
        "name": "New flow",
        "visibility": "Company"
      },
      "Id": "2891526548120464174",
      "Raw": {
        "creationDate": "2026-06-16T09:00:19.520181Z",
        "exclusive": true,
        "folderId": "6221766187885464753",
        "folderName": "New folder",
        "id": "2891526548120464174",
        "name": "New flow",
        "visibility": "Company"
      }
    }
  ],
  "Done": true,
  "NextPage": "",
  "Rows": 1
}

```