### PR TITLE
[CON-3309] feat(google-calendar): add support to read events from all the calendars

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/google/internal/calendar"
 	"github.com/amp-labs/connectors/providers/google/internal/contacts"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
 	"github.com/amp-labs/connectors/providers/google/internal/mail"
 )
 
@@ -16,6 +17,13 @@ var (
 	_ connectors.SubscribeConnector              = &Connector{}
 	_ connectors.SubscriptionMaintainerConnector = &Connector{}
 )
+
+// ReadParamsOpts are Google-specific options for common.ReadParams.Opts.
+// Assign a value of this type to ReadParams.Opts to opt into bespoke read behavior.
+//
+// It is defined in the shared internal/core package so individual Google modules
+// can consume it without importing this package (which would create a cycle).
+type ReadParamsOpts = core.ReadParamsOpts
 
 // GmailSubscribeRequest is the request payload for Gmail watch subscriptions.
 type GmailSubscribeRequest = mail.WatchRequest

--- a/providers/google/internal/calendar/read.go
+++ b/providers/google/internal/calendar/read.go
@@ -1,0 +1,231 @@
+package calendar
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/simultaneously"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
+)
+
+// maxReadConcurrency bounds how many calendars we read events from at once.
+//
+// The Calendar API allows 600 queries per minute per user (10 qps) and rate limits
+// bursts via a sliding window, so we keep parallelism well below that ceiling to
+// avoid 403/429 usageLimits responses.
+// https://developers.google.com/workspace/calendar/api/guides/quota
+const maxReadConcurrency = 5
+
+// Read overrides the default HTTP reader. When ReadParams.Opts requests events from
+// all calendars it reads across the whole calendar list and merges the results;
+// otherwise it delegates to the standard reader, which reads only the primary calendar.
+func (a *Adapter) Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
+	if !shouldReadEventsForAllCalendars(params) {
+		return a.Reader.Read(ctx, params)
+	}
+
+	return a.readEventsAcrossCalendars(ctx, params)
+}
+
+// shouldReadEventsForAllCalendars reports whether params opts into reading events from
+// every calendar. It is false unless the object is "events" and ReadParams.Opts asserts
+// to ReadParamsOpts with the flag set; an empty or mismatched Opts keeps default behavior.
+func shouldReadEventsForAllCalendars(params common.ReadParams) bool {
+	if params.ObjectName != objectNameEvents {
+		return false
+	}
+
+	opts, ok := params.Opts.(core.ReadParamsOpts)
+	if !ok {
+		return false
+	}
+
+	return opts.ReadEventsForAllCalendars
+}
+
+// readEventsAcrossCalendars lists every calendar, reads each one's events concurrently
+// (bounded by maxReadConcurrency), then merges them into a single deduplicated result.
+func (a *Adapter) readEventsAcrossCalendars(
+	ctx context.Context, params common.ReadParams,
+) (*common.ReadResult, error) {
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	calendarIDs, err := a.listAllCalendarIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Each job writes only into its own slice index, so no locking is required.
+	perCalendar := make([][]common.ReadResultRow, len(calendarIDs))
+	jobs := make([]simultaneously.Job, len(calendarIDs))
+
+	for i, calendarID := range calendarIDs {
+		jobs[i] = func(ctx context.Context) error {
+			rows, err := a.readAllEventPages(ctx, calendarID, params)
+			if err != nil {
+				return err
+			}
+
+			perCalendar[i] = rows
+
+			return nil
+		}
+	}
+
+	if err := simultaneously.DoCtx(ctx, maxReadConcurrency, jobs...); err != nil {
+		return nil, err
+	}
+
+	merged := mergeAndDedupeEvents(perCalendar)
+
+	return &common.ReadResult{
+		Rows:     int64(len(merged)),
+		Data:     merged,
+		NextPage: "",
+		Done:     true,
+	}, nil
+}
+
+// listAllCalendarIDs drains the calendarList object and returns every calendar's ID.
+func (a *Adapter) listAllCalendarIDs(ctx context.Context) ([]string, error) {
+	listParams := common.ReadParams{
+		ObjectName: objectNameCalendarList,
+		Fields:     datautils.NewStringSet("id"),
+	}
+
+	var ids []string
+
+	for {
+		result, err := a.Reader.Read(ctx, listParams)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, row := range result.Data {
+			if id := rawString(row, "id"); id != "" {
+				ids = append(ids, id)
+			}
+		}
+
+		if result.Done || result.NextPage == "" {
+			break
+		}
+
+		listParams.NextPage = result.NextPage
+	}
+
+	return ids, nil
+}
+
+// readAllEventPages drains every page of events for a single calendar.
+//
+// It reuses the standard HTTP reader by seeding ReadParams.NextPage with the
+// per-calendar events URL; buildReadURL returns NextPage verbatim, so the reader
+// (and its pagination) stays scoped to this calendar.
+func (a *Adapter) readAllEventPages(
+	ctx context.Context, calendarID string, params common.ReadParams,
+) ([]common.ReadResultRow, error) {
+	url, err := a.buildEventsURLForCalendar(calendarID, params)
+	if err != nil {
+		return nil, err
+	}
+
+	pageParams := params
+	pageParams.NextPage = common.NextPageToken(url.String())
+
+	var rows []common.ReadResultRow
+
+	for {
+		result, err := a.Reader.Read(ctx, pageParams)
+		if err != nil {
+			return nil, err
+		}
+
+		rows = append(rows, result.Data...)
+
+		if result.Done || result.NextPage == "" {
+			break
+		}
+
+		pageParams.NextPage = result.NextPage
+	}
+
+	return rows, nil
+}
+
+// buildEventsURLForCalendar builds the first-page events URL for the given calendar.
+// It mirrors the events-specific query params applied in buildReadURL.
+func (a *Adapter) buildEventsURLForCalendar(
+	calendarID string, params common.ReadParams,
+) (*urlbuilder.URL, error) {
+	objectPath, err := Schemas.FindURLPath(providers.ModuleGoogleCalendar, objectNameEvents)
+	if err != nil {
+		return nil, err
+	}
+
+	objectPath = strings.ReplaceAll(objectPath, "{calendarId}", calendarID)
+
+	url, err := urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, objectPath)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("maxResults", strconv.Itoa(defaultPageSize))
+
+	// https://developers.google.com/workspace/calendar/api/v3/reference/events/list
+	if !params.Since.IsZero() {
+		url.WithQueryParam("updatedMin", datautils.Time.FormatRFC3339inUTCWithMilliseconds(params.Since))
+	}
+
+	return url, nil
+}
+
+// mergeAndDedupeEvents flattens per-calendar event rows into one list, dropping
+// duplicates that appear on more than one calendar. Insertion order is preserved.
+func mergeAndDedupeEvents(perCalendar [][]common.ReadResultRow) []common.ReadResultRow {
+	merged := make([]common.ReadResultRow, 0)
+	seen := make(map[string]struct{})
+
+	for _, rows := range perCalendar {
+		for _, row := range rows {
+			key := eventDedupeKey(row)
+			if key != "" {
+				if _, exists := seen[key]; exists {
+					continue
+				}
+
+				seen[key] = struct{}{}
+			}
+
+			merged = append(merged, row)
+		}
+	}
+
+	return merged
+}
+
+// eventDedupeKey identifies an event across calendars. It prefers iCalUID, which is
+// stable for the same event on different calendars, and falls back to the event id.
+func eventDedupeKey(row common.ReadResultRow) string {
+	if uid := rawString(row, "iCalUID"); uid != "" {
+		return uid
+	}
+
+	return rawString(row, "id")
+}
+
+// rawString returns the string value at key in the row's raw payload, or "".
+func rawString(row common.ReadResultRow, key string) string {
+	if value, ok := row.Raw[key].(string); ok {
+		return value
+	}
+
+	return ""
+}

--- a/providers/google/internal/core/readparams.go
+++ b/providers/google/internal/core/readparams.go
@@ -1,0 +1,14 @@
+package core
+
+// ReadParamsOpts are Google-specific options for common.ReadParams.Opts.
+//
+// It lives in this shared leaf package so every Google module (calendar, mail,
+// contacts, ...) can assert it without importing the top-level google package,
+// which would create an import cycle. The google package re-exports it as
+// google.ReadParamsOpts for external callers.
+type ReadParamsOpts struct {
+	// ReadEventsForAllCalendars, when true, reads "events" from every calendar in the
+	// user's calendar list and merges the results into a single deduplicated list,
+	// instead of reading only the primary calendar. It has no effect on other objects.
+	ReadEventsForAllCalendars bool
+}

--- a/providers/google/read_test.go
+++ b/providers/google/read_test.go
@@ -299,6 +299,92 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	}
 }
 
+func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	responseCalendarList := testutils.DataFromFile(t, "calendar/read/all-calendars/calendarList.json")
+	responseEventsPrimary := testutils.DataFromFile(t, "calendar/read/all-calendars/events-primary.json")
+	responseEventsTeam := testutils.DataFromFile(t, "calendar/read/all-calendars/events-team.json")
+	responseEventsLastPage := testutils.DataFromFile(t, "calendar/read/events/2-last-page.json")
+
+	tests := []testroutines.Read{
+		{
+			Name: "Opts present but flag disabled reads only the primary calendar",
+			Input: common.ReadParams{
+				ObjectName: "events",
+				Fields:     connectors.Fields("id"),
+				Opts:       ReadParamsOpts{ReadEventsForAllCalendars: false},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/calendar/v3/calendars/primary/events"),
+				Then:  mockserver.Response(http.StatusOK, responseEventsLastPage),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "p3nkh1hg41683vdhlcq4k12iso"},
+					Raw:    map[string]any{"iCalUID": "p3nkh1hg41683vdhlcq4k12iso@google.com"},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read events across all calendars merges and dedupes",
+			Input: common.ReadParams{
+				ObjectName: "events",
+				Fields:     connectors.Fields("id", "summary"),
+				Opts:       ReadParamsOpts{ReadEventsForAllCalendars: true},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If:   mockcond.Path("/calendar/v3/users/me/calendarList"),
+					Then: mockserver.Response(http.StatusOK, responseCalendarList),
+				}, {
+					If:   mockcond.Path("/calendar/v3/calendars/integration@test.com/events"),
+					Then: mockserver.Response(http.StatusOK, responseEventsPrimary),
+				}, {
+					If:   mockcond.Path("/calendar/v3/calendars/team@test.com/events"),
+					Then: mockserver.Response(http.StatusOK, responseEventsTeam),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				// event-shared appears on both calendars (same iCalUID) and is deduped.
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "event-a", "summary": "Standup"},
+					Raw:    map[string]any{"iCalUID": "event-a@google.com"},
+				}, {
+					Fields: map[string]any{"id": "event-shared", "summary": "All Hands"},
+					Raw:    map[string]any{"iCalUID": "event-shared@google.com"},
+				}, {
+					Fields: map[string]any{"id": "event-c", "summary": "Team Sync"},
+					Raw:    map[string]any{"iCalUID": "event-c@google.com"},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestCalendarConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
 func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 

--- a/providers/google/test/calendar/read/all-calendars/calendarList.json
+++ b/providers/google/test/calendar/read/all-calendars/calendarList.json
@@ -1,0 +1,21 @@
+{
+  "kind": "calendar#calendarList",
+  "etag": "\"p32g95jc3lmf8m0o\"",
+  "items": [
+    {
+      "kind": "calendar#calendarListEntry",
+      "etag": "\"1738271077677000\"",
+      "id": "integration@test.com",
+      "summary": "integration@test.com",
+      "primary": true,
+      "accessRole": "owner"
+    },
+    {
+      "kind": "calendar#calendarListEntry",
+      "etag": "\"1738271077677001\"",
+      "id": "team@test.com",
+      "summary": "Team Calendar",
+      "accessRole": "writer"
+    }
+  ]
+}

--- a/providers/google/test/calendar/read/all-calendars/events-primary.json
+++ b/providers/google/test/calendar/read/all-calendars/events-primary.json
@@ -1,0 +1,19 @@
+{
+  "kind": "calendar#events",
+  "etag": "\"p33gabc\"",
+  "summary": "integration@test.com",
+  "items": [
+    {
+      "kind": "calendar#event",
+      "id": "event-a",
+      "iCalUID": "event-a@google.com",
+      "summary": "Standup"
+    },
+    {
+      "kind": "calendar#event",
+      "id": "event-shared",
+      "iCalUID": "event-shared@google.com",
+      "summary": "All Hands"
+    }
+  ]
+}

--- a/providers/google/test/calendar/read/all-calendars/events-team.json
+++ b/providers/google/test/calendar/read/all-calendars/events-team.json
@@ -1,0 +1,19 @@
+{
+  "kind": "calendar#events",
+  "etag": "\"p33gdef\"",
+  "summary": "Team Calendar",
+  "items": [
+    {
+      "kind": "calendar#event",
+      "id": "event-shared-copy",
+      "iCalUID": "event-shared@google.com",
+      "summary": "All Hands"
+    },
+    {
+      "kind": "calendar#event",
+      "id": "event-c",
+      "iCalUID": "event-c@google.com",
+      "summary": "Team Sync"
+    }
+  ]
+}

--- a/test/google/calendar/read/events-all-calendars/main.go
+++ b/test/google/calendar/read/events-all-calendars/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/google"
+	connTest "github.com/amp-labs/connectors/test/google"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetGoogleCalendarConnector(ctx)
+
+	fields := connectors.Fields("id", "summary", "iCalUID")
+
+	// Read events from every calendar in the user's calendar list, merged and deduped.
+	allCalendarsEvents, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "events",
+		Fields:     fields,
+		Opts:       google.ReadParamsOpts{ReadEventsForAllCalendars: true},
+	})
+	if err != nil {
+		utils.Fail("error reading events for all calendars", "error", err)
+	}
+
+	slog.Info("Reading events for all calendars...", "allCalendarsRows", allCalendarsEvents.Rows)
+
+	utils.DumpJSON(allCalendarsEvents, os.Stdout)
+}

--- a/test/google/calendar/read/events/main.go
+++ b/test/google/calendar/read/events/main.go
@@ -32,6 +32,6 @@ func main() {
 		utils.Fail("error reading from connector", "error", err)
 	}
 
-	slog.Info("Reading...")
+	slog.Info("Reading events from primary calendars", "read events", res.Rows)
 	utils.DumpJSON(res, os.Stdout)
 }


### PR DESCRIPTION
Live Tests:
Reading without common.ReadParams.Opts. read events from primary calendars only.
We get 17 events.
<img width="1405" height="120" alt="Screenshot 2026-06-16 at 15 24 53" src="https://github.com/user-attachments/assets/9af6e1b7-b17b-4705-a856-6eb72f2b5044" />
<img width="1210" height="802" alt="Screenshot 2026-06-16 at 15 25 20" src="https://github.com/user-attachments/assets/42648594-4498-47fe-82e7-c40aff640ff6" />

Explicityly adding the common.ReadParams.Opts. and setting AllCalendars field to true.
We get 1472 events.
<img width="1357" height="39" alt="Screenshot 2026-06-16 at 15 27 29" src="https://github.com/user-attachments/assets/f041ecc2-0621-48db-82be-3297f3091cb5" />
<img width="1207" height="817" alt="Screenshot 2026-06-16 at 15 27 47" src="https://github.com/user-attachments/assets/2f1179b6-ce9f-4cd5-b759-7fb5a97cef77" />
 