### PR TITLE
fix(components): Init to sanitize params

### DIFF
--- a/internal/components/connector.go
+++ b/internal/components/connector.go
@@ -77,10 +77,8 @@ func Init[T any](
 		conn = nil
 	})
 
-	// Default module is always the root module
-	if params.Module == "" {
-		params.Module = common.ModuleRoot
-	}
+	// Undeclared properties are set to empty values and default values.
+	params = prepareParams(params)
 
 	transport, err := NewTransport(provider, params)
 	if err != nil {
@@ -101,6 +99,20 @@ func Init[T any](
 	}
 
 	return conn, nil
+}
+
+func prepareParams(params common.ConnectorParams) common.ConnectorParams {
+	// Default module is always the root module
+	if params.Module == "" {
+		params.Module = common.ModuleRoot
+	}
+
+	// Init empty metadata map to avoid nil pointer dereference.
+	if params.Metadata == nil {
+		params.Metadata = make(map[string]string)
+	}
+
+	return params
 }
 
 // JSONHTTPClient returns the connector's JSON-capable HTTP client.


### PR DESCRIPTION
# Background

This PR continues the work discussed in https://github.com/amp-labs/connectors/pull/2775#discussion_r3416662374 and relates to https://github.com/amp-labs/connectors/pull/3078.

# Description

Previous init flow:
* Call constructor.
* Validate params; if params.Metadata is an empty map, return an error.
* Use params.Metadata to set Connector properties.
* Finish initialization.

New init flow:
* Call constructor (constructor is allowed to read/use params.Metadata).
* Validate params; if params.Metadata is an empty map, return an error.
* Finish initialization.

The constructor must be free to access and use `params.Metadata` during construction. To guarantee that, `params.Metadata` must be initialized before the constructor runs to **avoid panic**. The call `params = prepareParams(params)` ensures `params.Metadata` (and any other normalization) is set up for constructor use.

Validation remains in place: we still validate required fields. Validation can still fail if fields are empty strings or otherwise invalid (`common.ValidateParameters` uses interfaces as "tags" on the Connector struct).