### PR TITLE
feat:expose campaignId

### DIFF
--- a/providers/hubspot/internal/metadata/schemas.json
+++ b/providers/hubspot/internal/metadata/schemas.json
@@ -147,7 +147,7 @@
               "providerType": "String"
             },
             "id": {
-              "displayName": "Campaign ID (GUID)",
+              "displayName": "Campaign ID",
               "valueType": "string",
               "providerType": "String"
             },

--- a/providers/hubspot/internal/metadata/schemas.json
+++ b/providers/hubspot/internal/metadata/schemas.json
@@ -146,6 +146,11 @@
               "valueType": "string",
               "providerType": "String"
             },
+            "id": {
+              "displayName": "Campaign ID (GUID)",
+              "valueType": "string",
+              "providerType": "String"
+            },
             "hs_budget_items_sum_amount": {
               "displayName": "The sum of all budget items",
               "valueType": "string",

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -234,7 +234,27 @@ func (c *Connector) buildMarketingReadURL(
 		// This object does not have such query params. For consistency, it is reflected here.
 		// Sending non-existent query params is not considered an error by provider.
 	} else {
-		url.WithQueryParam("properties", strings.Join(params.Fields.List(), ","))
+		fields := params.Fields.List()
+
+		if params.ObjectName == core.ObjectMarketingCampaigns {
+			// The Campaigns API rejects "id" in the properties param ("Forbidden
+			// properties: [id]") because "id" is the record identifier returned at the
+			// top level of the response, not a campaign property. Drop it from the
+			// requested properties; the GUID still comes back at the top level and is
+			// surfaced into Fields by the FlattenNestedFields record transformer.
+			filtered := make([]string, 0, len(fields))
+			for _, f := range fields {
+				if strings.EqualFold(f, "id") {
+					continue
+				}
+
+				filtered = append(filtered, f)
+			}
+
+			fields = filtered
+		}
+
+		url.WithQueryParam("properties", strings.Join(fields, ","))
 		url.WithQueryParam("sort", "-updatedAt") // newest first
 	}
 


### PR DESCRIPTION
### Notes
Customers could only map a campaign's integer `hs_object_id`, but HubSpot keys campaigns (and the campaign references on events, e.g. form-submission `hs_matched_campaign_and_assets`) by the GUID, hence there was no way to join events back to their source campaign.

This surfaces the campaign's top-level ID (the GUID) as a mappable field:
  - `schemas.json` — advertise id ("Campaign ID") on marketing-campaigns.
  - `read.go` — exclude id from the campaigns properties= query param. The Campaigns API rejects id there
 ` (Forbidden properties: [id])`. The GUID is returned at the top level of the response and surfaced into fields by the existing FlattenNestedFields transformer.

 ### Testing
* Added campaignId as a field in the integration and verified that the reads are successful and the payload returns it as a mapped field 
<img width="904" height="855" alt="Screenshot 2026-06-16 at 16 09 26" src="https://github.com/user-attachments/assets/eaa6c476-222e-4768-9df0-549de1ed9ec1" />
<img width="844" height="714" alt="Screenshot 2026-06-16 at 16 09 09" src="https://github.com/user-attachments/assets/26b8fcd1-8869-4ddc-a801-68b8d551e010" />

<img width="1131" height="805" alt="Screenshot 2026-06-16 at 16 16 40" src="https://github.com/user-attachments/assets/6acecf1b-7171-4796-bc67-60ba6d57643d" />
