### PR TITLE
feat(connectwise): VerifyWebhookMessage

### DIFF
--- a/providers/connectWise.go
+++ b/providers/connectWise.go
@@ -30,6 +30,9 @@ func init() {
 			Subscribe: false,
 			Write:     false,
 		},
+		SubscribeRequirements: &SubscribeRequirements{
+			SubscribeByAPI: new(false),
+		},
 		Metadata: &ProviderMetadata{
 			Input: []MetadataItemInput{{
 				Name:         "region",

--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/batch"
 	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/webhook"
 )
 
 const apiVersion = "v4_6_release/apis/3.0"
@@ -26,6 +27,8 @@ type Connector struct {
 	components.Reader
 	components.Writer
 	components.Deleter
+	// TODO must use webhook.Verifier instead of webhook.NoopVerifier
+	*webhook.NoopVerifier
 
 	batchAdapter *batch.Adapter // used for connectors.BatchRecordReaderConnector capabilities.
 
@@ -87,6 +90,7 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 	)
 
 	connector.batchAdapter = batch.NewAdapter(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
+	connector.NoopVerifier = webhook.NewVerifier(connector.JSONHTTPClient(), connector.ProviderInfo(), clientID)
 
 	return connector, nil
 }

--- a/providers/connectwise/internal/webhook/test/event.json
+++ b/providers/connectwise/internal/webhook/test/event.json
@@ -1,0 +1,16 @@
+{
+  "MessageId": "cb67323f-43ba-4ef6-b471-6bb90e62ab6a",
+  "FromUrl": "sandbox-na.myconnectwise.net",
+  "CompanyId": "myCompany",
+  "MemberId": "Cobalt",
+  "Action": "added",
+  "Type": "contact",
+  "ID": 57937,
+  "ProductInstanceId": "639c96cab2eb560001dd1324",
+  "PartnerId": "61ddc2817bcddc0001c74208",
+  "Entity": "{\"id\":57937,\"firstName\":\"Joshua Marvin\",\"relationship\":{\"_info\":{\"relationship_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/relationships/\"}},\"inactiveFlag\":false,\"marriedFlag\":false,\"childrenFlag\":false,\"portalSecurityLevel\":1,\"disablePortalLoginFlag\":true,\"unsubscribeFlag\":false,\"mobileGuid\":\"ec0a580c-18a4-4706-9ea5-c79a7c4a0fe8\",\"defaultBillingFlag\":false,\"defaultFlag\":false,\"_info\":{\"lastUpdated\":\"2026-06-04T17:54:53Z\",\"updatedBy\":\"Aurasell\",\"communications_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/57937/communications\",\"notes_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/57937/notes\",\"tracks_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/57937/tracks\",\"portalSecurity_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/57937/portalSecurity\",\"activities_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/sales/activities?conditions=contact/id=57937\",\"documents_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/system/documents?recordType=Contact&recordId=57937\",\"configurations_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/configurations?conditions=contact/id=57937\",\"tickets_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/service/tickets?conditions=contact/id=57937\",\"opportunities_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/sales/opportunities?conditions=contact/id=57937\",\"projects_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/project/projects?conditions=contact/id=57937\",\"image_href\":\"https://na.myconnectwise.net/v2025_1//apis/3.0/company/contacts/57937/image?lastModified=2026-06-04T17:54:53Z\"}}",
+  "Metadata": {
+    "key_url": "{{testServerURL}}/v2025_1//system/callbackkey/index.rails?companyName=myCompany&id=89966c04-9889-46ad-8d5e-421103aca922"
+  },
+  "CallbackObjectRecId": 26567
+}

--- a/providers/connectwise/internal/webhook/verifier.go
+++ b/providers/connectwise/internal/webhook/verifier.go
@@ -1,0 +1,164 @@
+// Package webhook
+//
+// Temporary noop verifier: while the server-side authenticated client is not
+// implemented, this package returns a NoopVerifier from NewVerifier.
+// The full Verifier implementation is present and tested, but it is intentionally
+// not enabled in production until the server supports authenticated requests.
+//
+// To enable real verification once server authentication is available:
+// - Change NewVerifier to return newVerifier(...) instead of new(NoopVerifier).
+package webhook
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// var (
+//	ErrFetchSigningKey         = errors.New("failed to fetch signing key to verify webhook event")
+//	ErrMissingContentSignature = errors.New("missing x-content-signature header")
+//	ErrMissingKeyURL           = errors.New("missing key_url in event body")
+//)
+
+type NoopVerifier struct{}
+
+// NewVerifier constructs webhook message verifier.
+// ==================================================================================
+//
+// NOTE: temporary noop verifier!!!
+// The server does not currently provide an authenticated HTTP client required by Verifier.
+// NewVerifier therefore returns NoopVerifier.
+//
+// ==================================================================================.
+func NewVerifier(client *common.JSONHTTPClient, providerInfo *providers.ProviderInfo, clientID string) *NoopVerifier {
+	// At the moment the noop verifier is returned, this must be replaced with newVerifier.
+	return new(NoopVerifier)
+}
+
+func (v NoopVerifier) VerifyWebhookMessage(
+	ctx context.Context, request *common.WebhookRequest, params *common.VerificationParams,
+) (bool, error) {
+	return true, nil
+}
+
+// type Verifier struct {
+//	client       *common.JSONHTTPClient
+//	providerInfo *providers.ProviderInfo
+//
+//	clientID string
+//}
+//
+// func newVerifier(client *common.JSONHTTPClient, providerInfo *providers.ProviderInfo, clientID string) *Verifier {
+//	return &Verifier{
+//		client:       client,
+//		providerInfo: providerInfo,
+//		clientID:     clientID,
+//	}
+//}
+//
+//// VerifyWebhookMessage verifies a ConnectWise webhook callback using the
+//// x-content-signature header and the signing key referenced by the event's
+//// Metadata.key_url field.
+////
+//// It parses the raw request body to extract key_url, fetches the signing key,
+//// computes the expected signature from the raw body bytes, and compares the
+//// computed value with the received signature.
+////
+//// It returns true when the webhook signature is valid. If verification cannot
+//// be performed, it returns a non-nil error. If the signature is invalid, it
+//// returns (false, nil).
+// func (v Verifier) VerifyWebhookMessage(
+//	ctx context.Context, request *common.WebhookRequest, params *common.VerificationParams,
+// ) (bool, error) {
+//	receivedSignature := getHeaderValue(request.Headers, "X-Content-Signature")
+//	if receivedSignature == "" {
+//		return false, ErrMissingContentSignature
+//	}
+//
+//	var message messageFormat
+//	if err := json.Unmarshal(request.Body, &message); err != nil {
+//		return false, err
+//	}
+//
+//	keyURL := message.Metadata.KeyURL
+//	if keyURL == "" {
+//		return false, ErrMissingKeyURL
+//	}
+//
+//	sharedSecretKey, err := v.fetchSigningKey(ctx, keyURL)
+//	if err != nil {
+//		return false, err
+//	}
+//
+//	shaSum := sha256.Sum256([]byte(sharedSecretKey))
+//	mac := hmac.New(sha256.New, shaSum[:])
+//	mac.Write(request.Body)
+//	expectedSignature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+//
+//	if subtle.ConstantTimeCompare([]byte(expectedSignature), []byte(receivedSignature)) != 1 {
+//		return false, nil
+//	}
+//
+//	return true, nil
+//}
+//
+// func (v Verifier) fetchSigningKey(ctx context.Context, url string) (string, error) {
+//	resp, body, err := v.client.HTTPClient.Get(ctx, url, v.clientIdHeader())
+//	if err != nil {
+//		return "", fmt.Errorf("%w: %w", ErrFetchSigningKey, err)
+//	}
+//	defer resp.Body.Close()
+//
+//	if !httpkit.Status2xx(resp.StatusCode) {
+//		return "", fmt.Errorf("%w: HTTP code %v", ErrFetchSigningKey, resp.StatusCode)
+//	}
+//
+//	var response signingKeyResponse
+//	if err = json.Unmarshal(body, &response); err != nil {
+//		return "", fmt.Errorf("%w: %w", ErrFetchSigningKey, err)
+//	}
+//
+//	return response.SigningKey, nil
+//}
+//
+// type messageFormat struct {
+//	Metadata struct {
+//		KeyURL string `json:"key_url"`
+//	} `json:"Metadata"`
+//}
+//
+//// The event message the webhook will receive will contain "Metadata.key_url".
+//// By invoking the GET "<key_url>" the response you get will be signingKeyResponse.
+// type signingKeyResponse struct {
+//	SigningKey string `json:"signing_key"`
+//}
+//
+// func (v Verifier) clientIdHeader() common.Header {
+//	return common.Header{
+//		Key:   "ClientId",
+//		Value: v.clientID,
+//	}
+//}
+//
+// func getHeaderValue(headers http.Header, name string) string {
+//	if headers == nil {
+//		return ""
+//	}
+//
+//	if value := headers.Get(name); value != "" {
+//		return strings.TrimSpace(value)
+//	}
+//
+//	canonicalName := textproto.CanonicalMIMEHeaderKey(name)
+//	if values, ok := headers[canonicalName]; ok && len(values) > 0 {
+//		return strings.TrimSpace(values[0])
+//	}
+//
+//	if values, ok := headers[strings.ToLower(name)]; ok && len(values) > 0 {
+//		return strings.TrimSpace(values[0])
+//	}
+//
+//	return ""
+//}

--- a/providers/connectwise/internal/webhook/verifier_test.go
+++ b/providers/connectwise/internal/webhook/verifier_test.go
@@ -1,0 +1,139 @@
+package webhook
+
+//func TestVerifyWebhookMessage(t *testing.T) {
+//	t.Parallel()
+//
+//	const signingKey = "test-signing-key"
+//	eventMessage := testutils.DataFromFile(t, "event.json")
+//
+//	tests := []testroutines.TestCaseWebhookMessageVerification{
+//		{
+//			Name: "Valid signature",
+//			Input: testroutines.WebhookMessageVerificationParams{
+//				Request: &common.WebhookRequest{Body: eventMessage},
+//			},
+//			InputMutator: withSignatureHeader(signingKey),
+//			Server: mockserver.Conditional{
+//				Setup: mockserver.ContentText(),
+//				If: mockcond.And{
+//					mockcond.Path("/v2025_1//system/callbackkey/index.rails"),
+//					mockcond.QueryParam("companyName", "myCompany"),
+//					mockcond.QueryParam("id", "89966c04-9889-46ad-8d5e-421103aca922"),
+//					mockcond.Header(http.Header{"ClientId": []string{"test-client-id"}}),
+//				},
+//				Then: mockserver.ResponseChainedFuncs(
+//					mockserver.ContentText(),
+//					mockserver.ResponseString(http.StatusOK, `{"signing_key": "test-signing-key"}`),
+//				),
+//			}.Server(),
+//			Expected: true,
+//		},
+//		{
+//			Name: "Invalid signature",
+//			Input: testroutines.WebhookMessageVerificationParams{
+//				Request: &common.WebhookRequest{
+//					Headers: http.Header{"x-content-signature": []string{"mismatching-signature-from-provider"}},
+//					Body:    eventMessage,
+//				},
+//			},
+//			InputMutator: replaceServerURLInBody,
+//			Server: mockserver.Conditional{
+//				Setup: mockserver.ContentText(),
+//				If: mockcond.And{
+//					mockcond.Path("/v2025_1//system/callbackkey/index.rails"),
+//					mockcond.QueryParam("companyName", "myCompany"),
+//					mockcond.QueryParam("id", "89966c04-9889-46ad-8d5e-421103aca922"),
+//					mockcond.Header(http.Header{"ClientId": []string{"test-client-id"}}),
+//				},
+//				Then: mockserver.ResponseChainedFuncs(
+//					mockserver.ContentText(),
+//					mockserver.ResponseString(http.StatusOK, `{"signing_key": "test-signing-key"}`),
+//				),
+//			}.Server(),
+//			Expected: false,
+//		},
+//		{
+//			Name: "Missing signature header in input",
+//			Input: testroutines.WebhookMessageVerificationParams{
+//				Request: &common.WebhookRequest{Body: eventMessage},
+//			},
+//			InputMutator: replaceServerURLInBody,
+//			Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//				_ = json.NewEncoder(w).Encode(signingKeyResponse{
+//					SigningKey: signingKey,
+//				})
+//			})),
+//			Expected:     false,
+//			ExpectedErrs: []error{testutils.StringError("missing x-content-signature header")},
+//		},
+//		{
+//			Name: "Fetch signing key fails",
+//			Input: testroutines.WebhookMessageVerificationParams{
+//				Request: &common.WebhookRequest{Body: eventMessage},
+//			},
+//			InputMutator: withSignatureHeader(signingKey),
+//			Server: mockserver.Fixed{
+//				Setup:  mockserver.ContentText(),
+//				Always: mockserver.Response(http.StatusInternalServerError),
+//			}.Server(),
+//			Expected:     false,
+//			ExpectedErrs: []error{ErrFetchSigningKey},
+//		},
+//	}
+//
+//	for _, tt := range tests {
+//		t.Run(tt.Name, func(t *testing.T) {
+//			t.Parallel()
+//
+//			tt.Run(t, func() (testroutines.TestableWebhookMessageVerifier, error) {
+//				return constructTestVerifier(tt.Server)
+//			})
+//		})
+//	}
+//}
+//
+//func constructTestVerifier(server *httptest.Server) (*Verifier, error) {
+//	transport, err := components.NewTransport(providers.ConnectWise, common.ConnectorParams{
+//		AuthenticatedClient: server.Client(),
+//	})
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	transport.SetUnitTestMockServerBaseURL(server.URL)
+//
+//	verifier := NewVerifier(transport.JSONHTTPClient(), transport.ProviderInfo(), "test-client-id")
+//
+//	return verifier, nil
+//}
+//
+//func replaceServerURLInBody(
+//	server *httptest.Server, input testroutines.WebhookMessageVerificationParams,
+//) testroutines.WebhookMessageVerificationParams {
+//	// Body has the URL which should be stubbed so connector will make a call to the mock server.
+//	input.Request.Body = []byte(
+//		testroutines.ResolveTestServerURL(string(input.Request.Body), server.URL),
+//	)
+//	return input
+//}
+//
+//func withSignatureHeader(secretKey string) testroutines.InputMutator[testroutines.WebhookMessageVerificationParams] {
+//	return func(
+//		server *httptest.Server, input testroutines.WebhookMessageVerificationParams,
+//	) testroutines.WebhookMessageVerificationParams {
+//		input = replaceServerURLInBody(server, input)
+//
+//		// The body changes between test runs so we must compute the signature ourselves.
+//		shaSum := sha256.Sum256([]byte(secretKey))
+//		mac := hmac.New(sha256.New, shaSum[:])
+//		mac.Write(input.Request.Body)
+//		signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+//
+//		if input.Request.Headers == nil {
+//			input.Request.Headers = make(http.Header)
+//		}
+//		input.Request.Headers.Set("X-Content-Signature", signature)
+//
+//		return input
+//	}
+//}

--- a/test/connectwise/subscription/consumer/main.go
+++ b/test/connectwise/subscription/consumer/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	testscenario.RunWebhookConsumer(ctx, conn, testscenario.WebhookRouter{}, nil)
+}

--- a/test/utils/testscenario/webhook-messaging.go
+++ b/test/utils/testscenario/webhook-messaging.go
@@ -9,6 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
 )
 
 // WebhookRouter holds a set of conditional HTTP routes that dispatch webhook requests
@@ -42,7 +43,7 @@ type Route datautils.Pair[RoutingCondition, http.HandlerFunc]
 // is closed, the webhook server is shut down and the function returns.
 func RunWebhookConsumer(
 	ctx context.Context,
-	conn ConnectorWebhookSubscriber,
+	conn testroutines.TestableWebhookMessageVerifier,
 	webhookRouter WebhookRouter,
 	verificationParams *common.VerificationParams,
 ) {

--- a/test/utils/testscenario/webhook.go
+++ b/test/utils/testscenario/webhook.go
@@ -80,7 +80,8 @@ func waitForWebhookURLInput(ctx context.Context) (string, bool) {
 //
 // Webhook handler will send webhookMessageResult using go channel.
 func startWebhookHandler(
-	ctx context.Context, conn ConnectorWebhookSubscriber,
+	ctx context.Context,
+	conn testroutines.TestableWebhookMessageVerifier,
 	router WebhookRouter,
 	verificationParams *common.VerificationParams,
 	messageChannel chan webhookMessageResult,


### PR DESCRIPTION
# Description

Implemented webhook verification matching the documentation. Unit tests create the signature and pass it as a header, imitating what ConnectWise does:
* Obtain the signing key by making an API call.
* Produce the signature using that key.
* Verify the signature against the header.

<img width="1135" height="245" alt="image" src="https://github.com/user-attachments/assets/aada130f-2e7f-44c5-b737-8d9ec77bcd1a" />


