### PR TITLE
fix(hubspot): omit empty properties param for marketing campaign reads

### DIFF
--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -242,19 +243,19 @@ func (c *Connector) buildMarketingReadURL(
 			// top level of the response, not a campaign property. Drop it from the
 			// requested properties; the GUID still comes back at the top level and is
 			// surfaced into Fields by the FlattenNestedFields record transformer.
-			filtered := make([]string, 0, len(fields))
-			for _, f := range fields {
-				if strings.EqualFold(f, "id") {
-					continue
-				}
-
-				filtered = append(filtered, f)
-			}
-
-			fields = filtered
+			fields = slices.DeleteFunc(fields, func(f string) bool {
+				return strings.EqualFold(f, "id")
+			})
 		}
 
-		url.WithQueryParam("properties", strings.Join(fields, ","))
+		// Only set "properties" when at least one is requested. The Campaigns API
+		// rejects an empty properties param ("Forbidden properties: []"), which would
+		// otherwise happen when "id" was the only requested field and got filtered out
+		// above. Omitting it returns the record with its top-level fields (incl. id).
+		if len(fields) != 0 {
+			url.WithQueryParam("properties", strings.Join(fields, ","))
+		}
+
 		url.WithQueryParam("sort", "-updatedAt") // newest first
 	}
 


### PR DESCRIPTION
### Notes
When `id` is the only requested field on a marketing-campaigns read it is filtered out of the `properties=` query param (the Campaigns API rejects `id` there), leaving the param empty. HubSpot then rejects the request with `400 Forbidden properties: []`. Skip the param entirely when the filtered field list is empty, the response still returns the record's top-level fields, including `id`.

### Testing
#### Integration 
<img width="1606" height="809" alt="Screenshot 2026-06-16 at 17 19 35" src="https://github.com/user-attachments/assets/cbbfc25e-5331-4a00-b816-f2a58b5f22fe" />

#### Before the change
<img width="537" height="213" alt="Screenshot 2026-06-16 at 17 20 13" src="https://github.com/user-attachments/assets/e6883f97-2708-48ab-ba80-9e00343adb35" />
<img width="1605" height="565" alt="Screenshot 2026-06-16 at 17 19 45" src="https://github.com/user-attachments/assets/a47590c6-42c4-4609-b95d-15bdad897a25" />


#### After the change
<img width="1479" height="847" alt="Screenshot 2026-06-16 at 17 33 28" src="https://github.com/user-attachments/assets/e7ec388d-27c8-433c-94ef-d57c9fd0ca83" />
<img width="1588" height="712" alt="Screenshot 2026-06-16 at 17 33 13" src="https://github.com/user-attachments/assets/1b24fdf6-a0d9-4075-8103-9a662b6573f7" />
