### PR TITLE
[CON-3285] fix(breezyHR): Metadata Fix

### DIFF
--- a/providers/breezy/metadata/schemas.json
+++ b/providers/breezy/metadata/schemas.json
@@ -34,6 +34,16 @@
               "displayName": "Member Count",
               "valueType": "int",
               "providerType": "integer"
+            },
+            "creation_date": {
+              "displayName": "Creation Date",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "updated_date": {
+              "displayName": "Updated Date",
+              "valueType": "datetime",
+              "providerType": "datetime"
             }
           }
         },


### PR DESCRIPTION
Live GET /v3/companies responses include these timestamp fields; 
declaring them keeps metadata-vs-read validation aligned with the API payload.


