### PR TITLE
[CON-3261] feat: add servicenowPKCE connector

### DIFF
--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -1,6 +1,9 @@
 package providers
 
-const ServiceNow Provider = "serviceNow"
+const (
+	ServiceNow     Provider = "serviceNow"
+	ServiceNowPKCE Provider = "serviceNowPKCE"
+)
 
 func init() {
 	// ServiceNow configuration
@@ -43,6 +46,59 @@ func init() {
 			Search: SearchSupport{
 				Operators: SearchOperators{
 					Equals: true,
+				},
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Instance",
+				},
+			},
+		},
+	})
+
+	// ServiceNow configuration
+	SetInfo(ServiceNowPKCE, ProviderInfo{
+		DisplayName: "ServiceNow",
+		AuthType:    Oauth2,
+		BaseURL:     "https://{{.workspace}}.service-now.com",
+		Oauth2Opts: &Oauth2Opts{
+			AuthURL:                   "https://{{.workspace}}.service-now.com/oauth_auth.do",
+			TokenURL:                  "https://{{.workspace}}.service-now.com/oauth_token.do",
+			ExplicitScopesRequired:    false,
+			ExplicitWorkspaceRequired: true,
+			GrantType:                 AuthorizationCodePKCE,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1724169123/media/tn5f6xh2nbb3bops7bsn.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1724169123/media/tn5f6xh2nbb3bops7bsn.png",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722405162/media/const%20ServiceNow%20Provider%20%3D%20%22serviceNow%22_1722405162.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1722405162/media/const%20ServiceNow%20Provider%20%3D%20%22serviceNow%22_1722405162.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+			Search: SearchSupport{
+				Operators: SearchOperators{
+					Equals: false,
 				},
 			},
 		},

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -54,6 +54,7 @@ func init() { //nolint:funlen
 				{
 					Name:        "workspace",
 					DisplayName: "Instance",
+					Prompt:      "Please provide your instance ID — for example, dev1234 — taken from the URL https://dev1234.servicenow.com.", //nolint: lll
 				},
 			},
 		},
@@ -107,6 +108,7 @@ func init() { //nolint:funlen
 				{
 					Name:        "workspace",
 					DisplayName: "Instance",
+					Prompt:      "Please provide your instance Name — for example, dev1234 if your base URL: https://dev1234.service-now.com.", //nolint: lll
 				},
 			},
 		},

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -5,7 +5,7 @@ const (
 	ServiceNowPKCE Provider = "serviceNowPKCE"
 )
 
-func init() {
+func init() { //nolint:lll
 	// ServiceNow configuration
 	SetInfo(ServiceNow, ProviderInfo{
 		DisplayName: "ServiceNow",

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -5,8 +5,7 @@ const (
 	ServiceNowPKCE Provider = "serviceNowPKCE"
 )
 
-//nolint:lll
-func init() {
+func init() { //nolint:funlen
 	// ServiceNow configuration
 	SetInfo(ServiceNow, ProviderInfo{
 		DisplayName: "ServiceNow",

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -5,7 +5,8 @@ const (
 	ServiceNowPKCE Provider = "serviceNowPKCE"
 )
 
-func init() { //nolint:lll
+//nolint:lll
+func init() {
 	// ServiceNow configuration
 	SetInfo(ServiceNow, ProviderInfo{
 		DisplayName: "ServiceNow",
@@ -61,7 +62,7 @@ func init() { //nolint:lll
 
 	// ServiceNow configuration
 	SetInfo(ServiceNowPKCE, ProviderInfo{
-		DisplayName: "ServiceNow",
+		DisplayName: "ServiceNow PKCE",
 		AuthType:    Oauth2,
 		BaseURL:     "https://{{.workspace}}.service-now.com",
 		Oauth2Opts: &Oauth2Opts{

--- a/providers/serviceNow.go
+++ b/providers/serviceNow.go
@@ -54,7 +54,7 @@ func init() { //nolint:funlen
 				{
 					Name:        "workspace",
 					DisplayName: "Instance",
-					Prompt:      "Please provide your instance ID — for example, dev1234 — taken from the URL https://dev1234.servicenow.com.", //nolint: lll
+					Prompt:      "Please provide your instance Name — for example, dev1234 if your instance base URL: https://dev1234.service-now.com.", //nolint: lll
 				},
 			},
 		},


### PR DESCRIPTION
As recommended here: https://linear.app/ampersand/issue/CON-3261/research-and-implement-new-servicenow-oauth-apps

The private apps in serviceNow use the Authorizatin Code Grant, by default. For public apps its necessary to use Authorization code with PKCE grant. This adds a servicenow connector that supports Authorization code grant with PKCE.
I have tested this with the localhost proxy, works as expected.

### GET
<img width="1469" height="853" alt="Screenshot 2026-06-19 at 18 44 19" src="https://github.com/user-attachments/assets/e61b673e-2341-4564-8b68-8e486d2f4af2" />


### POST
<img width="1464" height="769" alt="Screenshot 2026-06-18 at 18 34 32" src="https://github.com/user-attachments/assets/516933c8-02ee-4912-901f-2beaefa425fd" />

### PUT
<img width="1461" height="768" alt="Screenshot 2026-06-18 at 18 36 06" src="https://github.com/user-attachments/assets/4b792d1c-1b39-467a-a7c8-34b793630c57" />