### PR TITLE
[CON-3312] feat(gong): attach shared users as flow associations

### DIFF
--- a/providers/gong/flows.go
+++ b/providers/gong/flows.go
@@ -106,24 +106,26 @@ func emptyFlowsResult() *common.ReadResult {
 	}
 }
 
-// mergeUserFlows adds a user's flows to the aggregate, deduplicating by id and
-// attaching the owning user to personal flows when requested.
+// mergeUserFlows adds a user's flows to the aggregate, keeping one row per flow
+// id and attaching every user the flow shows up for to its "users" association
+// when requested.
 //
 // Gong reports visibility relative to the queried email: a flow reads "Personal"
 // only in its owner's result set and "Shared" for everyone else who can see it.
 // The same flow id therefore shows up in several users' results with different
-// visibility, and users are fetched in an arbitrary order. So we can't just keep
-// the first copy we see: if a non-owner is fetched first we'd store the "Shared"
-// copy and never attach the owner. When this user owns the flow (their copy says
-// "Personal") we prefer that copy, overwriting any "Shared" one stored earlier,
-// so the owner association is reliable no matter what order users come back in.
+// visibility, and users are fetched in an arbitrary order. We keep one row per id
+// and accumulate users onto it: the owner (their copy says "Personal") plus
+// everyone it is shared with (their copy says "Shared"). For the row's own fields
+// we prefer the owner's "Personal" copy, so visibility reads "Personal" whenever
+// an owner exists no matter what order users come back in. Company flows aren't
+// tied to specific users, so they get no association.
 //
 // When readAllUsers is false we are in company-only mode, so flows that aren't
 // "Company" visibility are dropped.
 func mergeUserFlows(
 	aggregated map[string]common.ReadResultRow,
 	flows []common.ReadResultRow,
-	owner common.ReadResultRow,
+	user common.ReadResultRow,
 	includeUserAssoc bool,
 	readAllUsers bool,
 ) {
@@ -137,16 +139,26 @@ func mergeUserFlows(
 
 		ownsFlow := strings.EqualFold(visibility, "Personal")
 
-		// Already collected and this isn't the owner's copy: nothing to add.
-		if _, seen := aggregated[flow.Id]; seen && !ownsFlow {
-			continue
+		// We store one row per flow id. The same flow can arrive more than once
+		// (e.g. "Shared" from one user and "Personal" from its owner). We want the
+		// owner's copy so visibility shows "Personal", but we must not lose the
+		// users we already attached from the earlier copies.
+		row, seen := aggregated[flow.Id]
+		switch {
+		case !seen:
+			row = flow
+		case ownsFlow:
+			users := row.Associations
+			row = flow
+			row.Associations = users
 		}
 
-		if includeUserAssoc {
-			attachUserToPersonalFlow(&flow, owner)
+		// Attach this user to Personal and Shared flows.
+		if includeUserAssoc && !strings.EqualFold(visibility, "Company") {
+			attachUserToFlow(&row, user)
 		}
 
-		aggregated[flow.Id] = flow
+		aggregated[flow.Id] = row
 	}
 }
 
@@ -163,14 +175,10 @@ func wantsUserAssociation(associatedObjects []string) bool {
 	return false
 }
 
-// attachUserToPersonalFlow links a flow to the user who owns it, but only for
-// personal flows. Company and shared flows aren't tied to one person, so we skip them.
-func attachUserToPersonalFlow(flow *common.ReadResultRow, user common.ReadResultRow) {
-	visibility, _ := flow.Raw["visibility"].(string)
-	if !strings.EqualFold(visibility, "Personal") {
-		return
-	}
-
+// attachUserToFlow appends a user to the flow's "users" association. The caller
+// decides which flows qualify; today that is Personal (the owner) and Shared
+// (users it is shared with), but not Company.
+func attachUserToFlow(flow *common.ReadResultRow, user common.ReadResultRow) {
 	if flow.Associations == nil {
 		flow.Associations = make(map[string][]common.Association)
 	}

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -275,10 +275,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			// Bob is fetched first (read_users_bob_first.json) and his result set
 			// includes alice's flow 9000000000000001 as "Shared", because Gong
 			// reports visibility relative to the queried email. Alice is fetched
-			// second and sees that same id as "Personal". Expecting flow ...001 to
-			// come out "Personal" with alice attached proves the dedup prefers the
-			// owner's copy instead of keeping the non-owner's "Shared" one.
-			Name: "Flows: ReadFlowsForAllUsers reads every user and attaches each Personal flow's owner",
+			// second and sees that same id as "Personal". Flow ...001 comes out
+			// "Personal" (the owner's copy wins) with BOTH alice (owner) and bob
+			// (shared) attached, proving we accumulate every user a flow shows up for.
+			Name: "Flows: ReadFlowsForAllUsers attaches the owner and shared users to each flow",
 			Input: common.ReadParams{
 				ObjectName:        "flows",
 				Fields:            connectors.Fields("id", "name", "visibility"),
@@ -317,11 +317,17 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"visibility": "Personal",
 						"id":         "9000000000000001",
 					},
+					// alice owns it (Personal) and bob has it Shared, so both are attached.
 					Associations: map[string][]common.Association{
 						"users": {{
 							ObjectId: "8000000000000001",
 							Raw: map[string]any{
 								"emailAddress": "alice@example.com",
+							},
+						}, {
+							ObjectId: "8000000000000002",
+							Raw: map[string]any{
+								"emailAddress": "bob@example.com",
 							},
 						}},
 					},


### PR DESCRIPTION
Attach every user a flow shows up for to its users association, not just the owner. A Personal flow shared with others now lists the owner plus everyone it is shared with; Company flows still get no association.

Note on visibility: Gong reports visibility relative to whoever we query. A flow reads `Personal` only in its owner's result set and `Shared` for everyone else. Since we read all users, we usually hit the flow's owner, so the flow comes out `Personal`. A flow stays `Shared` only when its owner isn't among the users we read.


## Live Test result
```
time=2026-06-21T19:26:28.610+05:45 level=INFO msg="Reading flows with users association.."
{
  "Data": [
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "2532244818760665235",
        "name": "Amp-test-flows",
        "visibility": "Personal"
      },
      "Id": "2532244818760665235",
      "Raw": {
        "creationDate": "2026-06-03T14:18:10.674369Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "2532244818760665235",
        "name": "Amp-test-flows",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {},
      "Fields": {
        "id": "2891526548120464174",
        "name": "New flow",
        "visibility": "Company"
      },
      "Id": "2891526548120464174",
      "Raw": {
        "creationDate": "2026-06-16T09:00:19.520181Z",
        "exclusive": true,
        "folderId": "6221766187885464753",
        "folderName": "New folder",
        "id": "2891526548120464174",
        "name": "New flow",
        "visibility": "Company"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "3003900775403111488",
        "name": "New Personal Flow",
        "visibility": "Personal"
      },
      "Id": "3003900775403111488",
      "Raw": {
        "creationDate": "2026-06-10T09:38:00.756142Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "3003900775403111488",
        "name": "New Personal Flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "3583316463112713997",
        "name": "Deep flow",
        "visibility": "Personal"
      },
      "Id": "3583316463112713997",
      "Raw": {
        "creationDate": "2026-06-10T17:51:46.314142Z",
        "exclusive": true,
        "folderId": "3663694443832366722",
        "folderName": "Personal flows",
        "id": "3583316463112713997",
        "name": "Deep flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "3749632929933551771",
        "name": "thisisupdatedone",
        "visibility": "Shared"
      },
      "Id": "3749632929933551771",
      "Raw": {
        "creationDate": "2026-06-10T07:52:53.377687Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "3749632929933551771",
        "name": "thisisupdatedone",
        "visibility": "Shared"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "5321338733804837705",
        "name": "Amp-personal-flow",
        "visibility": "Personal"
      },
      "Id": "5321338733804837705",
      "Raw": {
        "creationDate": "2025-09-16T20:44:53.033610Z",
        "exclusive": true,
        "folderId": "3315090934568623048",
        "folderName": "Personal flows",
        "id": "5321338733804837705",
        "name": "Amp-personal-flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "6990573422660211932",
        "name": "New flow",
        "visibility": "Personal"
      },
      "Id": "6990573422660211932",
      "Raw": {
        "creationDate": "2026-06-10T09:54:23.714098Z",
        "exclusive": true,
        "folderId": "1740872046719265042",
        "folderName": "Perrr",
        "id": "6990573422660211932",
        "name": "New flow",
        "visibility": "Personal"
      }
    },
    {
      "Associations": {
        "users": [
          {
            "ObjectId": "1309263961237846110",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-04-23T08:56:32.621-07:00",
              "emailAddress": "andrey.kalmykov@sysintit.kz",
              "emailAliases": [],
              "extension": null,
              "firstName": "Andrey",
              "id": "1309263961237846110",
              "lastName": "Kalmykov",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/andrey.kalmykov?tkn=3wrZp_9FSpuSPP5WPvVAvw",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838136",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5325227444688816639",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2025-02-26T01:40:07.856-07:00",
              "emailAddress": "dipu@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Dipu",
              "id": "5325227444688816639",
              "lastName": "Ampersand",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/dipu.ampersand?tkn=gMH6GlrhR5uv-fXhoB2hCA",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-IN",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "5546479417125161989",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-13T10:38:37.821-07:00",
              "emailAddress": "josephkarage@gmail.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Joseph",
              "id": "5546479417125161989",
              "lastName": "Karage",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/joseph.karage?tkn=faHpOVX9SBa86_j42-Opyw",
              "personalMeetingUrls": [],
              "phoneNumber": null,
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": false,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": false
              },
              "spokenLanguages": [],
              "title": null,
              "trustedEmailAddress": null
            }
          },
          {
            "ObjectId": "7507723419942139347",
            "ProviderAssociationMetadata": {},
            "Raw": {
              "active": true,
              "conferencingProviders": null,
              "created": "2024-03-07T13:03:14.533-07:00",
              "emailAddress": "integration.user+gong1@withampersand.com",
              "emailAliases": [],
              "extension": null,
              "firstName": "Integration",
              "id": "7507723419942139347",
              "lastName": "User",
              "managerId": null,
              "meetingConsentPageUrl": "https://us-49467.join.gong.io/ampersand-partner/integration.user2?tkn=tOtwPHYvSbK4POQtTZhTMQ",
              "personalMeetingUrls": [],
              "phoneNumber": "+77051838137",
              "settings": {
                "emailsImported": true,
                "gongConnectEnabled": true,
                "nonRecordedMeetingsImported": true,
                "preventEmailImport": false,
                "preventWebConferenceRecording": false,
                "telephonyCallsImported": true,
                "webConferencesRecorded": true
              },
              "spokenLanguages": [
                {
                  "language": "en-US",
                  "primary": true
                }
              ],
              "title": null,
              "trustedEmailAddress": null
            }
          }
        ]
      },
      "Fields": {
        "id": "7022612481621549098",
        "name": "User Flow",
        "visibility": "Personal"
      },
      "Id": "7022612481621549098",
      "Raw": {
        "creationDate": "2026-06-10T17:53:11.696842Z",
        "exclusive": true,
        "folderId": "3663694443832366722",
        "folderName": "Personal flows",
        "id": "7022612481621549098",
        "name": "User Flow",
        "visibility": "Personal"
      }
    }
  ],
  "Done": true,
  "NextPage": "",
  "Rows": 8
}

```

