### PR TITLE
[ENG-4036]feat: support Databook events.list read params

### DIFF
--- a/providers/google/internal/calendar/operations.go
+++ b/providers/google/internal/calendar/operations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/google/internal/core"
 	"github.com/spyzhov/ajson"
 )
 
@@ -51,24 +52,70 @@ func (a *Adapter) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error
 		return nil, err
 	}
 
-	url.WithQueryParam("maxResults", strconv.Itoa(defaultPageSize))
+	switch params.ObjectName {
+	case objectNameEvents:
+		applyEventsQueryParams(url, params)
+	case objectNameCalendarList:
+		url.WithQueryParam("maxResults", strconv.Itoa(defaultPageSize))
 
-	if params.ObjectName == objectNameCalendarList {
 		// This is the only object to support search by deleted items.
 		// https://developers.google.com/calendar/api/v3/reference/calendarList/list
 		if params.Deleted {
 			url.WithQueryParam("showDeleted", "true")
 		}
-	}
-
-	if params.ObjectName == objectNameEvents {
-		// https://developers.google.com/workspace/calendar/api/v3/reference/events/list
-		if !params.Since.IsZero() {
-			url.WithQueryParam("updatedMin", datautils.Time.FormatRFC3339inUTCWithMilliseconds(params.Since))
-		}
+	default:
+		url.WithQueryParam("maxResults", strconv.Itoa(defaultPageSize))
 	}
 
 	return url, nil
+}
+
+// applyEventsQueryParams sets the events.list query params shared by the primary-calendar
+// (buildReadURL) and all-calendars (buildEventsURLForCalendar) read paths.
+//
+// Defaults preserve the historical behavior: the default page size plus updatedMin derived
+// from ReadParams.Since. Additional tuning (time window, single-event expansion, deleted
+// events, ordering, event-type filter) is opt-in via the Google ReadParamsOpts carried on
+// ReadParams.Opts; an empty or mismatched Opts leaves only the defaults in place.
+//
+// https://developers.google.com/workspace/calendar/api/v3/reference/events/list
+func applyEventsQueryParams(url *urlbuilder.URL, params common.ReadParams) {
+	opts, _ := params.Opts.(core.ReadParamsOpts)
+
+	maxResults := defaultPageSize
+	if opts.MaxResults > 0 {
+		maxResults = opts.MaxResults
+	}
+
+	url.WithQueryParam("maxResults", strconv.Itoa(maxResults))
+
+	if !params.Since.IsZero() {
+		url.WithQueryParam("updatedMin", datautils.Time.FormatRFC3339inUTCWithMilliseconds(params.Since))
+	}
+
+	if !opts.TimeMin.IsZero() {
+		url.WithQueryParam("timeMin", datautils.Time.FormatRFC3339inUTCWithMilliseconds(opts.TimeMin))
+	}
+
+	if !opts.TimeMax.IsZero() {
+		url.WithQueryParam("timeMax", datautils.Time.FormatRFC3339inUTCWithMilliseconds(opts.TimeMax))
+	}
+
+	if opts.SingleEvents {
+		url.WithQueryParam("singleEvents", "true")
+	}
+
+	if opts.ShowDeleted {
+		url.WithQueryParam("showDeleted", "true")
+	}
+
+	if opts.OrderBy != "" {
+		url.WithQueryParam("orderBy", opts.OrderBy)
+	}
+
+	if len(opts.EventTypes) > 0 {
+		url.WithQueryParamList("eventTypes", opts.EventTypes)
+	}
 }
 
 func (a *Adapter) parseReadResponse(

--- a/providers/google/internal/calendar/read.go
+++ b/providers/google/internal/calendar/read.go
@@ -2,12 +2,13 @@ package calendar
 
 import (
 	"context"
-	"strconv"
+	"errors"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/internal/simultaneously"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/google/internal/core"
@@ -83,7 +84,8 @@ func (a *Adapter) readEventsAcrossCalendars(
 		return nil, err
 	}
 
-	merged := mergeAndDedupeEvents(perCalendar)
+	opts, _ := params.Opts.(core.ReadParamsOpts)
+	merged := mergeAndDedupeEvents(perCalendar, opts.SingleEvents)
 
 	return &common.ReadResult{
 		Rows:     int64(len(merged)),
@@ -157,7 +159,134 @@ func (a *Adapter) readAllEventPages(
 		pageParams.NextPage = result.NextPage
 	}
 
-	return rows, nil
+	// singleEvents expansion omits the series master; fetch it separately when requested.
+	masters, err := a.fetchSeriesMasters(ctx, calendarID, rows, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(rows, masters...), nil
+}
+
+// fetchSeriesMasters fetches the recurring-event master for each distinct recurringEventId
+// found among the instance rows and returns them as additional rows. It is a no-op unless
+// FetchSeriesMasters is set, because events.list with singleEvents=true expands recurring
+// events into instances and omits the series master (events.list never returns both).
+//
+// Masters are fetched from the same calendar the instances came from (an event id is scoped
+// to its calendar), concurrency-bounded like the per-calendar reads. A master that no longer
+// exists (404) is skipped rather than failing the whole read — its instances may still be
+// present as cancelled rows when showDeleted is set.
+//
+// https://developers.google.com/workspace/calendar/api/v3/reference/events/get
+func (a *Adapter) fetchSeriesMasters(
+	ctx context.Context, calendarID string, instances []common.ReadResultRow, params common.ReadParams,
+) ([]common.ReadResultRow, error) {
+	opts, _ := params.Opts.(core.ReadParamsOpts)
+	if !opts.FetchSeriesMasters {
+		return nil, nil
+	}
+
+	masterIDs := distinctRecurringEventIDs(instances)
+	if len(masterIDs) == 0 {
+		return nil, nil
+	}
+
+	// Each job writes only into its own slice index, so no locking is required. A nil entry
+	// marks a master that was skipped (not found).
+	fetched := make([]*common.ReadResultRow, len(masterIDs))
+	jobs := make([]simultaneously.Job, len(masterIDs))
+
+	for idx, masterID := range masterIDs {
+		jobs[idx] = func(ctx context.Context) error {
+			row, err := a.fetchEvent(ctx, calendarID, masterID, params.Fields)
+			if err != nil {
+				if errors.Is(err, common.ErrNotFound) {
+					return nil
+				}
+
+				return err
+			}
+
+			fetched[idx] = &row
+
+			return nil
+		}
+	}
+
+	if err := simultaneously.DoCtx(ctx, maxReadConcurrency, jobs...); err != nil {
+		return nil, err
+	}
+
+	masters := make([]common.ReadResultRow, 0, len(fetched))
+
+	for _, row := range fetched {
+		if row != nil {
+			masters = append(masters, *row)
+		}
+	}
+
+	return masters, nil
+}
+
+// distinctRecurringEventIDs returns the unique, non-empty recurringEventId values among the
+// rows. For an instance of a recurring event this field is the id of the series master, so
+// the result is the set of master ids to fetch (one per series, not one per instance).
+func distinctRecurringEventIDs(rows []common.ReadResultRow) []string {
+	seen := make(map[string]struct{})
+	ids := make([]string, 0, len(rows))
+
+	for _, row := range rows {
+		id := rawString(row, "recurringEventId")
+		if id == "" {
+			continue
+		}
+
+		if _, exists := seen[id]; exists {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+// fetchEvent fetches a single event by id (events.get) and returns it shaped like the list
+// rows — the same selected Fields plus the full Raw payload — so it merges and dedupes
+// consistently with instance rows.
+func (a *Adapter) fetchEvent(
+	ctx context.Context, calendarID, eventID string, fields datautils.StringSet,
+) (common.ReadResultRow, error) {
+	url, err := a.eventsBaseURL(calendarID)
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	url.AddPath(eventID)
+
+	resp, err := a.JSONHTTPClient().Get(ctx, url.String())
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	body, ok := resp.Body()
+	if !ok {
+		return common.ReadResultRow{}, common.ErrEmptyJSONHTTPResponse
+	}
+
+	record, err := jsonquery.Convertor.ObjectToMap(body)
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	rows, err := common.GetMarshaledData([]map[string]any{record}, fields.List())
+	if err != nil {
+		return common.ReadResultRow{}, err
+	}
+
+	return rows[0], nil
 }
 
 // buildEventsURLForCalendar builds the first-page events URL for the given calendar.
@@ -165,6 +294,18 @@ func (a *Adapter) readAllEventPages(
 func (a *Adapter) buildEventsURLForCalendar(
 	calendarID string, params common.ReadParams,
 ) (*urlbuilder.URL, error) {
+	url, err := a.eventsBaseURL(calendarID)
+	if err != nil {
+		return nil, err
+	}
+
+	applyEventsQueryParams(url, params)
+
+	return url, nil
+}
+
+// eventsBaseURL builds the events collection URL for a specific calendar id (no query params).
+func (a *Adapter) eventsBaseURL(calendarID string) (*urlbuilder.URL, error) {
 	objectPath, err := Schemas.FindURLPath(providers.ModuleGoogleCalendar, objectNameEvents)
 	if err != nil {
 		return nil, err
@@ -172,30 +313,18 @@ func (a *Adapter) buildEventsURLForCalendar(
 
 	objectPath = strings.ReplaceAll(objectPath, "{calendarId}", calendarID)
 
-	url, err := urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, objectPath)
-	if err != nil {
-		return nil, err
-	}
-
-	url.WithQueryParam("maxResults", strconv.Itoa(defaultPageSize))
-
-	// https://developers.google.com/workspace/calendar/api/v3/reference/events/list
-	if !params.Since.IsZero() {
-		url.WithQueryParam("updatedMin", datautils.Time.FormatRFC3339inUTCWithMilliseconds(params.Since))
-	}
-
-	return url, nil
+	return urlbuilder.New(a.ModuleInfo().BaseURL, apiVersion, objectPath)
 }
 
 // mergeAndDedupeEvents flattens per-calendar event rows into one list, dropping
 // duplicates that appear on more than one calendar. Insertion order is preserved.
-func mergeAndDedupeEvents(perCalendar [][]common.ReadResultRow) []common.ReadResultRow {
+func mergeAndDedupeEvents(perCalendar [][]common.ReadResultRow, singleEvents bool) []common.ReadResultRow {
 	merged := make([]common.ReadResultRow, 0)
 	seen := make(map[string]struct{})
 
 	for _, rows := range perCalendar {
 		for _, row := range rows {
-			key := eventDedupeKey(row)
+			key := eventDedupeKey(row, singleEvents)
 			if key != "" {
 				if _, exists := seen[key]; exists {
 					continue
@@ -211,9 +340,17 @@ func mergeAndDedupeEvents(perCalendar [][]common.ReadResultRow) []common.ReadRes
 	return merged
 }
 
-// eventDedupeKey identifies an event across calendars. It prefers iCalUID, which is
-// stable for the same event on different calendars, and falls back to the event id.
-func eventDedupeKey(row common.ReadResultRow) string {
+// eventDedupeKey identifies an event across calendars.
+//
+// With singleEvents expansion every instance of one recurring series shares a single iCalUID,
+// so we must key on the per-instance event id to keep the instances distinct (and to keep the
+// separately fetched series master, which has its own id). Otherwise we prefer iCalUID, which
+// is stable for the same event copied onto multiple calendars, and fall back to the event id.
+func eventDedupeKey(row common.ReadResultRow, singleEvents bool) string {
+	if singleEvents {
+		return rawString(row, "id")
+	}
+
 	if uid := rawString(row, "iCalUID"); uid != "" {
 		return uid
 	}

--- a/providers/google/internal/core/readparams.go
+++ b/providers/google/internal/core/readparams.go
@@ -1,14 +1,50 @@
 package core
 
+import "time"
+
 // ReadParamsOpts are Google-specific options for common.ReadParams.Opts.
 //
 // It lives in this shared leaf package so every Google module (calendar, mail,
 // contacts, ...) can assert it without importing the top-level google package,
 // which would create an import cycle. The google package re-exports it as
 // google.ReadParamsOpts for external callers.
+//
+// All fields below other than ReadEventsForAllCalendars tune the Google Calendar
+// "events" read; the calendar adapter maps them onto events.list query params (and
+// the series-master fan-out). They have no effect on other objects.
+// https://developers.google.com/workspace/calendar/api/v3/reference/events/list
 type ReadParamsOpts struct {
 	// ReadEventsForAllCalendars, when true, reads "events" from every calendar in the
 	// user's calendar list and merges the results into a single deduplicated list,
 	// instead of reading only the primary calendar. It has no effect on other objects.
 	ReadEventsForAllCalendars bool
+
+	// TimeMin and TimeMax bound the events.list window by event start time. Zero values
+	// are omitted, leaving the API default (unbounded).
+	TimeMin time.Time
+	TimeMax time.Time
+
+	// SingleEvents, when true, expands recurring events into individual instances
+	// (events.list singleEvents=true). The series master is not returned by the list in
+	// this mode; set FetchSeriesMasters to additionally fetch it.
+	SingleEvents bool
+
+	// ShowDeleted, when true, includes deleted/cancelled events (events.list showDeleted=true).
+	ShowDeleted bool
+
+	// MaxResults overrides the per-page size for events.list. Zero keeps the default.
+	MaxResults int
+
+	// EventTypes restricts the event types returned (events.list eventTypes, repeated). Empty keeps the default.
+	EventTypes []string
+
+	// OrderBy sets the events.list ordering ("startTime" or "updated"). Empty keeps the default.
+	// "startTime" is only valid together with SingleEvents.
+	OrderBy string
+
+	// FetchSeriesMasters, when true, additionally fetches each recurring series' master event
+	// (events.get on an instance's recurringEventId) and includes it in the results. This is
+	// only meaningful with SingleEvents, which expands instances and omits the series master.
+	// It is honored on the read-all-calendars path.
+	FetchSeriesMasters bool
 }

--- a/providers/google/read_test.go
+++ b/providers/google/read_test.go
@@ -385,6 +385,91 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 	}
 }
 
+func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	responseCalendarList := testutils.DataFromFile(t, "calendar/read/series-masters/calendarList.json")
+	responseEvents := testutils.DataFromFile(t, "calendar/read/series-masters/events.json")
+	responseMaster := testutils.DataFromFile(t, "calendar/read/series-masters/master.json")
+
+	timeMin := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	timeMax := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []testroutines.Read{
+		{
+			Name: "singleEvents opts set events.list params, dedupe by id, and fetch series masters",
+			Input: common.ReadParams{
+				ObjectName: "events",
+				Fields:     connectors.Fields("id", "summary"),
+				Opts: ReadParamsOpts{
+					ReadEventsForAllCalendars: true,
+					SingleEvents:              true,
+					ShowDeleted:               true,
+					FetchSeriesMasters:        true,
+					MaxResults:                250,
+					TimeMin:                   timeMin,
+					TimeMax:                   timeMax,
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If:   mockcond.Path("/calendar/v3/users/me/calendarList"),
+					Then: mockserver.Response(http.StatusOK, responseCalendarList),
+				}, {
+					// events.get for the recurring series master (exact path, evaluated before the list case).
+					If:   mockcond.Path("/calendar/v3/calendars/integration@test.com/events/master-1"),
+					Then: mockserver.Response(http.StatusOK, responseMaster),
+				}, {
+					// events.list carries the Databook-style query params.
+					If: mockcond.And{
+						mockcond.Path("/calendar/v3/calendars/integration@test.com/events"),
+						mockcond.QueryParam("singleEvents", "true"),
+						mockcond.QueryParam("showDeleted", "true"),
+						mockcond.QueryParam("maxResults", "250"),
+						mockcond.QueryParam("timeMin", "2026-01-01T00:00:00.000Z"),
+						mockcond.QueryParam("timeMax", "2026-04-01T00:00:00.000Z"),
+					},
+					Then: mockserver.Response(http.StatusOK, responseEvents),
+				}},
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				// Two instances share one iCalUID but have distinct ids, so dedupe-by-id keeps both;
+				// the standalone event and the separately fetched master are also kept (4 rows).
+				Rows: 4,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "master-1_20260101T090000Z", "summary": "Standup"},
+					Raw:    map[string]any{"recurringEventId": "master-1"},
+				}, {
+					Fields: map[string]any{"id": "master-1_20260102T090000Z", "summary": "Standup"},
+					Raw:    map[string]any{"recurringEventId": "master-1"},
+				}, {
+					Fields: map[string]any{"id": "solo-1", "summary": "1:1"},
+					Raw:    map[string]any{"iCalUID": "solo-1@google.com"},
+				}, {
+					Fields: map[string]any{"id": "master-1", "summary": "Standup"},
+					Raw:    map[string]any{"recurrence": []any{"RRULE:FREQ=DAILY"}},
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestCalendarConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
 func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 

--- a/providers/google/test/calendar/read/series-masters/calendarList.json
+++ b/providers/google/test/calendar/read/series-masters/calendarList.json
@@ -1,0 +1,12 @@
+{
+  "kind": "calendar#calendarList",
+  "items": [
+    {
+      "kind": "calendar#calendarListEntry",
+      "id": "integration@test.com",
+      "summary": "integration@test.com",
+      "primary": true,
+      "accessRole": "owner"
+    }
+  ]
+}

--- a/providers/google/test/calendar/read/series-masters/events.json
+++ b/providers/google/test/calendar/read/series-masters/events.json
@@ -1,0 +1,26 @@
+{
+  "kind": "calendar#events",
+  "summary": "integration@test.com",
+  "items": [
+    {
+      "kind": "calendar#event",
+      "id": "master-1_20260101T090000Z",
+      "iCalUID": "series-1@google.com",
+      "recurringEventId": "master-1",
+      "summary": "Standup"
+    },
+    {
+      "kind": "calendar#event",
+      "id": "master-1_20260102T090000Z",
+      "iCalUID": "series-1@google.com",
+      "recurringEventId": "master-1",
+      "summary": "Standup"
+    },
+    {
+      "kind": "calendar#event",
+      "id": "solo-1",
+      "iCalUID": "solo-1@google.com",
+      "summary": "1:1"
+    }
+  ]
+}

--- a/providers/google/test/calendar/read/series-masters/master.json
+++ b/providers/google/test/calendar/read/series-masters/master.json
@@ -1,0 +1,9 @@
+{
+  "kind": "calendar#event",
+  "id": "master-1",
+  "iCalUID": "series-1@google.com",
+  "summary": "Standup",
+  "recurrence": [
+    "RRULE:FREQ=DAILY"
+  ]
+}


### PR DESCRIPTION
### Notes 
Adds opt-in controls to the events read via common.ReadParams.Opts. All zero-valued by default no behavior change unless set. Builds on the existing all-calendars read.

#### Changes
- ReadParamsOpts: add `TimeMin`/`TimeMax`, `SingleEvents`, `ShowDeleted`, `MaxResults`, `EventTypes`, `OrderBy`, `FetchSeriesMasters` → mapped onto `events.list` query params.
- Shared `applyEventsQueryParams` helper used by both the primary and all-calendars read paths (no drift).
- Series-master fetch: `singleEvents=true` returns only instances and omits the master, so when `FetchSeriesMasters` is set we take each instance's recurringEventId (the master's id — "the id of the recurring event to which this instance belongs. Immutable.") and fetch it via events.get. 404s are skipped.
- Dedupe fix: dedupe by event id when singleEvents (instances of a series share one iCalUID); falls back to iCalUID otherwise.

### Testing
* Added Unit tests
* Deployed the change to the local along with the server changes and created a new connection and installed an integration
* Tested the change without white listing the projectID and verified no query params were attached in the request

<img width="1601" height="388" alt="Screenshot 2026-06-24 at 15 58 14" src="https://github.com/user-attachments/assets/915eccf3-9c07-423e-bf1a-41e56337e44e" />
<img width="1595" height="105" alt="Screenshot 2026-06-24 at 15 57 14" src="https://github.com/user-attachments/assets/c28a833f-7ed0-44ae-868d-ad7b6146ce4e" />

* Whitelisted the projectId and verified that he read requests we through with the requested query params and the read succeeded
* 
<img width="1559" height="106" alt="Screenshot 2026-06-24 at 15 18 28" src="https://github.com/user-attachments/assets/957cf6d5-13c0-4c33-9250-b8cbd79d940a" />
<img width="1512" height="80" alt="Screenshot 2026-06-24 at 15 15 39" src="https://github.com/user-attachments/assets/8ba5db8b-c12a-4735-b2ef-bee9e20ebbfc" />
<img width="1773" height="1008" alt="Screenshot 2026-06-24 at 15 14 29" src="https://github.com/user-attachments/assets/c42a6ddb-46fa-4e3f-b4bf-ce46331115fd" />
