### PR TITLE
[CON-3317] feat(square): add proxy 

### DIFF
--- a/providers/square.go
+++ b/providers/square.go
@@ -1,0 +1,95 @@
+package providers
+
+const (
+	Square        Provider = "square"
+	SquareSandbox Provider = "squareSandbox"
+)
+
+//nolint:funlen
+func init() {
+	SetInfo(Square, ProviderInfo{
+		DisplayName: "Square",
+		AuthType:    Oauth2,
+		BaseURL:     "https://connect.squareup.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType: AuthorizationCode,
+			AuthURL:   "https://connect.squareup.com/oauth2/authorize",
+			AuthURLParams: map[string]string{
+				"session": "true",
+			},
+			TokenURL:                  "https://connect.squareup.com/oauth2/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			DocsURL:                   "https://developer.squareup.com/docs/oauth-api/overview",
+			TokenMetadataFields: TokenMetadataFields{
+				ConsumerRefField: "merchant_id",
+			},
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270338/media/squareup.com_1782270337.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270357/media/squareup.com_1782270356.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270287/media/squareup.com_1782270286.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270322/media/squareup.com_1782270321.svg",
+			},
+		},
+
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+
+	SetInfo(SquareSandbox, ProviderInfo{
+		DisplayName: "Square Sandbox",
+		AuthType:    Oauth2,
+		BaseURL:     "https://connect.squareupsandbox.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://connect.squareupsandbox.com/oauth2/authorize",
+			TokenURL:                  "https://connect.squareupsandbox.com/oauth2/token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: false,
+			DocsURL:                   "https://developer.squareup.com/docs/devtools/sandbox/overview",
+			TokenMetadataFields: TokenMetadataFields{
+				ConsumerRefField: "merchant_id",
+			},
+		},
+
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270338/media/squareup.com_1782270337.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270357/media/squareup.com_1782270356.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270287/media/squareup.com_1782270286.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782270322/media/squareup.com_1782270321.svg",
+			},
+		},
+
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}

--- a/providers/square.go
+++ b/providers/square.go
@@ -14,6 +14,9 @@ func init() {
 		Oauth2Opts: &Oauth2Opts{
 			GrantType: AuthorizationCode,
 			AuthURL:   "https://connect.squareup.com/oauth2/authorize",
+			// Square requires the `session` query param to be set to `true`
+			// to help ensure that sellers with multiple Square accounts use the correct account to authorize.
+			/// Ref: https://developer.squareup.com/docs/oauth-api/create-urls-for-square-authorization
 			AuthURLParams: map[string]string{
 				"session": "true",
 			},


### PR DESCRIPTION
# Configuration
OAuth

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
URL: http://localhost:4444/v2/payments
<img width="1472" height="993" alt="image" src="https://github.com/user-attachments/assets/f2748154-10ef-4ce4-a396-4c31cf375da6" />



### POST
URL: http://localhost:4444/v2/payments
<img width="1472" height="1002" alt="image" src="https://github.com/user-attachments/assets/4cbf6ea2-cff8-4acf-8cd4-2b3f6748f24f" />


### DELETE
URL: http://localhost:4444/v2/merchants/custom-attribute-definitions/oerfoiasjofas
<img width="1471" height="295" alt="image" src="https://github.com/user-attachments/assets/f9ee66e6-12e2-49b0-a132-fcdf3fcd6bb7" />


## Pagination
Procore uses `cursor` and `limit` for pagination.

First Page
<img width="1470" height="529" alt="image" src="https://github.com/user-attachments/assets/b39383f7-90b4-4138-b1c6-455b80bfa75f" />



Next Page
<img width="1474" height="1006" alt="image" src="https://github.com/user-attachments/assets/09c75000-e5b4-43f5-a906-763e846d442d" />









# Logo & Icons

## Regular Icon
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1782270287/media/squareup.com_1782270286.svg"/>

## Dark Icon
<img width="806" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1782270338/media/squareup.com_1782270337.svg"/>


## Regular Logo

<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1782270322/media/squareup.com_1782270321.svg" />


## Dark Logo

<img width="1229" alt="image" src="https://res.cloudinary.com/dycvts6vp/image/upload/v1782270357/media/squareup.com_1782270356.svg" />
