### PR TITLE
fix(salesforce): suppress false-positive semgrep finding in UpdateSubscription

### DIFF
--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -528,6 +528,11 @@ func (c *Connector) UpdateSubscription(
 		}
 	}
 
+	// executeUpdateSubscription always returns a non-nil progress (created upfront)
+	// and a non-nil result (built via buildPartialUpdateResult on every error path),
+	// so using them in the error branch below cannot nil-panic.
+	// this suppresses the false positive.
+	// nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 	result, progress, execErr := c.executeUpdateSubscription(ctx, params, previousResult, prevState, req)
 	if execErr != nil {
 		rollbackErr := c.rollbackUpdateSubscription(ctx, progress)


### PR DESCRIPTION
  Context: 
 Why it's a false positive: 
 executeUpdateSubscription is built on the partial result on error design and never returns nil for either value on the error path.
  - progress is created upfront (#LN574) and returned in every path.
  - result always comes from buildPartialUpdateResult (#LN685), which always returns a non nil struct.