### PR TITLE
[CON-3029] fix(connectwise): Patch Write and Region Prompt

### DIFF
--- a/providers/connectWise.go
+++ b/providers/connectWise.go
@@ -38,7 +38,7 @@ func init() {
 				Name:         "region",
 				DisplayName:  "Region",
 				DefaultValue: "na",
-				DocsURL:      "https://developer.connectwise.com/Products/ConnectWise_PSA/Developer_Guide",
+				Prompt:       "The subdomain of your ConnectWise site (for example, 'na' for 'https://na.myconnectwise.net')",
 			}, {
 				Name:        "clientId",
 				DisplayName: "Client ID",

--- a/providers/connectwise/write.go
+++ b/providers/connectwise/write.go
@@ -1,7 +1,10 @@
 package connectwise
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/amp-labs/connectors/common"
@@ -16,22 +19,30 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 
 	method := http.MethodPost
 
+	// By contract, WriteParams.RecordData holds the JSON payload.
+	// For updates, we may need to switch to PATCH (JSON Patch) or use PUT (replace).
+	data := params.RecordData
 	if params.IsUpdate() {
 		url.AddPath(params.RecordId)
 
-		if updateIsPatchMode(params) {
+		// If the incoming WriteParams.RecordData represents a JSON Patch payload, we must use HTTP PATCH.
+		// Important: the connector's internal contract requires RecordData
+		// to be a JSON object, not a top-level JSON array.
+		// However, ConnectWise provider expects a PATCH body as a bare JSON array.
+		if payload, ok := extractPatchPayload(params); ok {
 			method = http.MethodPatch
+			data = payload.Patch
 		} else {
 			method = http.MethodPut
 		}
 	}
 
-	reader, err := params.GetRecordReader()
+	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal record data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url.String(), reader)
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 	if err != nil {
 		return nil, err
 	}
@@ -72,14 +83,14 @@ func (c *Connector) parseWriteResponse(
 	}, nil
 }
 
-// updateIsPatchMode determines whether an update operation should use HTTP PATCH
+// extractPatchPayload determines whether an update operation should use HTTP PATCH
 // instead of PUT by checking if the payload is a JSON Patch array.
 // This means payloads structured with "op", "path", "value"
 // will trigger PATCH, while regular object payloads will use PUT.
 //
 // Example payload that triggers PATCH (JSON Patch):
 //
-//	[
+//	"patch": [
 //	  {"op": "replace", "path": "/firstName", "value": "Sims"},
 //	]
 //
@@ -88,24 +99,26 @@ func (c *Connector) parseWriteResponse(
 //	{
 //	  "lastName": "Sims"
 //	}
-func updateIsPatchMode(params common.WriteParams) bool {
+func extractPatchPayload(params common.WriteParams) (*patchPayload, bool) {
 	payload, err := common.RecordDataToStruct[patchPayload](params)
 	if err != nil {
-		return false
+		return nil, false
 	}
 
-	if len(payload) == 0 {
-		return false
+	if len(payload.Patch) == 0 {
+		return nil, false
 	}
 
-	if payload[0].Op != "" {
-		return true
+	if payload.Patch[0].Op != "" {
+		return &payload, true
 	}
 
-	return false
+	return nil, false
 }
 
-type patchPayload []patchOperationPayload
+type patchPayload struct {
+	Patch []patchOperationPayload `json:"patch"`
+}
 
 type patchOperationPayload struct {
 	Op    string `json:"op"`

--- a/providers/connectwise/write_test.go
+++ b/providers/connectwise/write_test.go
@@ -116,9 +116,11 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Input: common.WriteParams{
 				ObjectName: "contacts",
 				RecordId:   "57919",
-				RecordData: []any{
-					map[string]any{"op": "replace", "path": "/firstName", "value": "Sims"},
-					map[string]any{"op": "replace", "path": "/customFields/1/value", "value": true},
+				RecordData: map[string]any{
+					"patch": []any{
+						map[string]any{"op": "replace", "path": "/firstName", "value": "Sims"},
+						map[string]any{"op": "replace", "path": "/customFields/1/value", "value": true},
+					},
 				},
 			},
 			Server: mockserver.Conditional{

--- a/test/connectwise/write-delete/contacts/main.go
+++ b/test/connectwise/write-delete/contacts/main.go
@@ -19,7 +19,9 @@ type payload struct {
 	LastName  string `json:"lastName"`
 }
 
-type patchPayload []patchOperation
+type patchPayload struct {
+	Patch []patchOperation `json:"patch"`
+}
 
 type patchOperation struct {
 	Op    string `json:"op"`
@@ -78,7 +80,7 @@ func main() {
 			FirstName: firstName,
 			LastName:  lastName,
 		},
-		patchPayload{{
+		patchPayload{Patch: []patchOperation{{
 			// Not clear why this is needed. This was discovered by trial and error.
 			Op:    "replace",
 			Path:  "/customFields/1/value",
@@ -91,7 +93,7 @@ func main() {
 			Op:    "replace",
 			Path:  "/lastName",
 			Value: updatedLastName,
-		}},
+		}}},
 		testscenario.CRUDTestSuite{
 			ReadFields: datautils.NewSet("id", "firstName", "lastName"),
 			SearchBy: testscenario.Property{


### PR DESCRIPTION
# Description

### (1)
**Problem**: The patch JSON document is an array of operations. Ampersand's record data is an object and requires id to be non-empty.
**Solution**: Array will be passed on via "patch" property:

<img width="851" height="423" alt="image" src="https://github.com/user-attachments/assets/aa84b6d5-af31-43ac-81de-302a346f723e" />


### (2)
**Problem**: Bad description of `MetadataItemInput` "Region" argument.
**Solution**: Removed `DocsURL` which is too generic. Add Prompt stating that Region is a URL subdomain.

# Live Tests

<img width="356" height="518" alt="image" src="https://github.com/user-attachments/assets/f2274e3d-4e12-4142-ac25-f286d992d48d" />
