### PR TITLE
[CON-3336] feat(jump): Add proxy

### DIFF
--- a/providers/jump.go
+++ b/providers/jump.go
@@ -1,0 +1,42 @@
+package providers
+
+const Jump Provider = "jump"
+
+func init() {
+	SetInfo(Jump, ProviderInfo{
+		DisplayName: "Jump",
+		AuthType:    ApiKey,
+		BaseURL:     "https://my.jumpapp.com/enterprise/graphql",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://my.jumpapp.com/enterprise/documentation/authentication",
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782351055/media/jumpapp.com_1782351055.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782351024/media/jumpapp.com_1782351023.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782351055/media/jumpapp.com_1782351055.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782351024/media/jumpapp.com_1782351023.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Configuration


# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [x] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [x] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ]  They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
## Testing
  
### Query
  
<img width="1625" height="881" alt="Screenshot from 2026-06-25 03-55-54" src="https://github.com/user-attachments/assets/1366e31d-3200-4a76-a5b4-98733d2e1e8b" />
<img width="1292" height="888" alt="image" src="https://github.com/user-attachments/assets/271acc9c-4966-4ebd-9533-abf3c1adee1d" />

### Mutation
<img width="1292" height="888" alt="Screenshot from 2026-06-25 04-48-40" src="https://github.com/user-attachments/assets/d7d93cd6-1abc-4eec-84fa-2e4ebb6d9f53" />

### Errors

<img width="1620" height="839" alt="Screenshot from 2026-06-25 04-52-15" src="https://github.com/user-attachments/assets/5d88a35d-283c-4739-beaa-7916fd33a211" />
<img width="1620" height="839" alt="Screenshot from 2026-06-25 04-51-56" src="https://github.com/user-attachments/assets/3b83706d-4a49-4087-888f-aaa258371402" />
