### PR TITLE
[CON-3355] feat: add wealthbox provider

### DIFF
--- a/providers/wealthbox.go
+++ b/providers/wealthbox.go
@@ -1,0 +1,40 @@
+package providers
+
+const Wealthbox Provider = "wealthbox"
+
+func init() {
+	SetInfo(Wealthbox, ProviderInfo{
+		DisplayName: "Wealthbox",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.crmworkspace.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name: "ACCESS_TOKEN",
+			},
+			DocsURL: "https://dev.wealthbox.com/#topics-authentication",
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782311753/media/wealthbox.com_1782311752.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782311574/media/wealthbox.com_1782311569.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782311753/media/wealthbox.com_1782311752.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1782311574/media/wealthbox.com_1782311569.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [x] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [ ] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ]  They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing
### GET
<img width="1461" height="755" alt="Screenshot 2026-06-25 at 12 16 43" src="https://github.com/user-attachments/assets/2ccf87b1-ff23-4c69-a409-4af9d8ff1fed" />


### POST
<img width="1465" height="718" alt="Screenshot 2026-06-25 at 12 08 31" src="https://github.com/user-attachments/assets/abb3967c-01e5-4a5b-a6b3-05353c59392d" />

### PUT
<img width="1464" height="756" alt="Screenshot 2026-06-25 at 12 07 16" src="https://github.com/user-attachments/assets/234b83fe-3176-48ca-a532-2ffc02bad422" />


### DELETE
<img width="1468" height="718" alt="Screenshot 2026-06-25 at 12 13 15" src="https://github.com/user-attachments/assets/3161611a-8fca-4e71-a9d5-2e1380f30826" />

## Pagination
<img width="1461" height="730" alt="Screenshot 2026-06-25 at 12 20 29" src="https://github.com/user-attachments/assets/11d75c99-811a-4d1a-84b9-27c9eab9d25b" />


# Logo & Icons
The logos & Icon selected. are one theme only.  The tool returned only these
<img width="1464" height="880" alt="Screenshot 2026-06-24 at 17 35 24" src="https://github.com/user-attachments/assets/073fe9b2-1320-489e-a549-a6f1f95dfc53" />

