### PR TITLE
fix(connectwise): Pointer to Subs.Request and Subs.Result

### DIFF
--- a/internal/components/subscriptions.go
+++ b/internal/components/subscriptions.go
@@ -7,7 +7,12 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-var ErrInvalidSubscriptionRequestType = errors.New("request type of common.SubscribeParams is invalid")
+var (
+	ErrInvalidSubscriptionRequestType = errors.New("request type of common.SubscribeParams is invalid")
+	ErrInvalidSubscriptionResultType  = errors.New("result type of common.SubscriptionResult is invalid")
+	ErrMissingSubscriptionRequest     = errors.New("common.SubscribeParams.Request is missing")
+	ErrMissingSubscriptionResult      = errors.New("common.SubscriptionResult.Result is missing")
+)
 
 // SubscriptionInputOutput is a generic helper that provides out-of-the-box,
 // type-safe implementations of the EmptySubscriptionParams and
@@ -40,16 +45,14 @@ func (SubscriptionInputOutput[I, O]) EmptySubscriptionResult() *common.Subscript
 // It provides a safe way to recover the typed request from the
 // non-generic SubscribeParams, returning an error if the underlying
 // type does not match.
-func (s SubscriptionInputOutput[I, O]) TypedSubscriptionRequest(params common.SubscribeParams) (I, error) {
-	var input I
+func (s SubscriptionInputOutput[I, O]) TypedSubscriptionRequest(params common.SubscribeParams) (*I, error) {
+	if params.Request == nil {
+		return nil, ErrMissingSubscriptionRequest
+	}
 
-	if params.Request != nil {
-		var ok bool
-
-		input, ok = params.Request.(I)
-		if !ok {
-			return input, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionRequestType, input, params.Request)
-		}
+	input, ok := params.Request.(*I)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionRequestType, input, params.Request)
 	}
 
 	return input, nil
@@ -60,16 +63,14 @@ func (s SubscriptionInputOutput[I, O]) TypedSubscriptionRequest(params common.Su
 // It provides a safe way to recover the typed result from the
 // non-generic SubscriptionResult, returning an error if the underlying
 // type does not match.
-func (s SubscriptionInputOutput[I, O]) TypedSubscriptionResult(subscription common.SubscriptionResult) (O, error) {
-	var output O
+func (s SubscriptionInputOutput[I, O]) TypedSubscriptionResult(subscription common.SubscriptionResult) (*O, error) {
+	if subscription.Result == nil {
+		return nil, ErrMissingSubscriptionResult
+	}
 
-	if subscription.Result != nil {
-		var ok bool
-
-		output, ok = subscription.Result.(O)
-		if !ok {
-			return output, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionRequestType, output, subscription.Result)
-		}
+	output, ok := subscription.Result.(*O)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected %T, got %T", ErrInvalidSubscriptionResultType, output, subscription.Result)
 	}
 
 	return output, nil

--- a/providers/connectwise/internal/subscriber/create.go
+++ b/providers/connectwise/internal/subscriber/create.go
@@ -31,7 +31,7 @@ func (s Strategy) Subscribe(
 }
 
 func (s Strategy) createSubscription(ctx context.Context,
-	request Request,
+	request *Request,
 	subscriptionEvents datautils.Map[common.ObjectName, common.ObjectEvents],
 ) (*common.SubscriptionResult, error) {
 	url, err := s.getSubscriptionURL()
@@ -62,7 +62,7 @@ func (s Strategy) createSubscription(ctx context.Context,
 	}
 
 	return &common.SubscriptionResult{
-		Result: Result{
+		Result: &Result{
 			ObjectWebhooks: createResult.Records,
 		},
 		ObjectEvents: state,
@@ -125,7 +125,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 		}
 
 		return &common.SubscriptionResult{
-			Result: Result{
+			Result: &Result{
 				ObjectWebhooks: make(map[common.ObjectName]SubscriptionResource),
 			},
 			ObjectEvents: events,
@@ -155,7 +155,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 	}
 
 	return &common.SubscriptionResult{
-		Result: Result{
+		Result: &Result{
 			ObjectWebhooks: remainingWebhooks,
 		},
 		ObjectEvents: state,
@@ -165,7 +165,7 @@ func (s Strategy) rollbackSubscriptionCreation(
 
 func (s Strategy) newTaskCreateSubscription(objectName common.ObjectName,
 	url string,
-	request Request,
+	request *Request,
 ) (parallelfetch.Task[common.ObjectName, SubscriptionResource], error) {
 	objectType, found := webhook.ObjectNameToObjectType[objectName]
 	if !found {

--- a/providers/connectwise/internal/subscriber/create_test.go
+++ b/providers/connectwise/internal/subscriber/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					"contacts":        {Events: eventTypesCUD},
 					"project/tickets": {Events: eventTypesCUD},
 				},
-				Request: Request{
+				Request: &Request{
 					WebhookURL: "https://test.com/webhook",
 				},
 			},
@@ -65,7 +65,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"project/tickets": {
 							ID:         26552,
@@ -104,7 +104,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					"contacts":        {Events: eventTypesCUD},
 					"project/tickets": {Events: eventTypesCUD},
 				},
-				Request: Request{
+				Request: &Request{
 					WebhookURL: "https://test.com/webhook",
 				},
 			},
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						// Contacts webhook still exists.
 						"contacts": {
@@ -164,7 +164,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					"contacts":        {Events: eventTypesCUD},
 					"project/tickets": {Events: eventTypesCUD},
 				},
-				Request: Request{
+				Request: &Request{
 					WebhookURL: "https://test.com/webhook",
 				},
 			},
@@ -194,7 +194,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{},
+				Result: &Result{},
 				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
 					"contacts":        {}, // Contacts removed successfully.
 					"project/tickets": {},
@@ -220,12 +220,12 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 func compareResult(expectedResult, actualResult any) *testutils.CompareResult {
 	result := testutils.NewCompareResult()
 
-	expectedOutput, ok := expectedResult.(Result)
+	expectedOutput, ok := expectedResult.(*Result)
 	if !ok {
 		result.AddDiff("expectedResult is not of type Result")
 	}
 
-	actualOutput, ok := actualResult.(Result)
+	actualOutput, ok := actualResult.(*Result)
 	if !ok {
 		result.AddDiff("actualResult is not of type Result")
 	}

--- a/providers/connectwise/internal/subscriber/delete_test.go
+++ b/providers/connectwise/internal/subscriber/delete_test.go
@@ -17,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name: "Failer to delete any callback",
 			Input: common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts":        {ID: 0},
 						"project/tickets": {ID: 0},
@@ -35,7 +35,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		{
 			Name: "Successfully remove subscriptions to contacts and tickets.",
 			Input: common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts":        {ID: 26571},
 						"project/tickets": {ID: 26572},

--- a/providers/connectwise/internal/subscriber/update.go
+++ b/providers/connectwise/internal/subscriber/update.go
@@ -64,9 +64,9 @@ func (s Strategy) UpdateSubscription( // nolint:cyclop,funlen
 		return nil, err
 	}
 
-	result, ok := createSubsResult.Result.(Result)
+	result, ok := createSubsResult.Result.(*Result)
 	if !ok {
-		return nil, fmt.Errorf("%w: common.SubscriptionResult.Result cannot be cast to connectwise.Result",
+		return nil, fmt.Errorf("%w: common.SubscriptionResult.Result cannot be cast to *connectwise.Result",
 			common.ErrInvalidImplementation)
 	}
 
@@ -110,7 +110,7 @@ func (s Strategy) UpdateSubscription( // nolint:cyclop,funlen
 	combinedStatus := createSubsResult.Status.Resolve(removeStatus)
 
 	return &common.SubscriptionResult{
-		Result:       Result{ObjectWebhooks: combinedWebhooks},
+		Result:       &Result{ObjectWebhooks: combinedWebhooks},
 		ObjectEvents: combinedEvents,
 		Status:       combinedStatus,
 	}, nil

--- a/providers/connectwise/internal/subscriber/update_test.go
+++ b/providers/connectwise/internal/subscriber/update_test.go
@@ -32,13 +32,13 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusSuccess: Successfully update by creating one and removing one",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Request{WebhookURL: "https://test.com/webhook"},
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"project/tickets": {Events: eventTypesCUD},
 					},
 				},
 				PreviousResult: &common.SubscriptionResult{
-					Result: Result{
+					Result: &Result{
 						ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 							"contacts": {
 								ID:         26559,
@@ -72,7 +72,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"project/tickets": {
 							ID:         26552,
@@ -91,14 +91,14 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusFailed: Create fails (with rollback) and delete succeeds",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Request{WebhookURL: "https://test.com/webhook"},
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"contacts":        {Events: eventTypesCUD},
 						"project/tickets": {Events: eventTypesCUD},
 					},
 				},
 				PreviousResult: &common.SubscriptionResult{
-					Result: Result{
+					Result: &Result{
 						ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 							"contacts": {
 								ID:         26559,
@@ -126,7 +126,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts": {
 							ID:         26559,
@@ -146,7 +146,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			Name: "SubscriptionStatusFailedToRollback: Create fails and rollback fails",
 			Input: testroutines.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
-					Request: Request{WebhookURL: "https://test.com/webhook"},
+					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"contacts":        {Events: eventTypesCUD},
 						"project/tickets": {Events: eventTypesCUD},
@@ -154,7 +154,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 					},
 				},
 				PreviousResult: &common.SubscriptionResult{
-					Result:       Result{},
+					Result:       &Result{},
 					ObjectEvents: map[common.ObjectName]common.ObjectEvents{},
 					Status:       common.SubscriptionStatusSuccess,
 				},
@@ -184,7 +184,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 			}.Server(),
 			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
-				Result: Result{
+				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
 						"contacts": { // couldn't rollback creation.
 							ID:         26559,

--- a/test/connectwise/subscription/contacts/main.go
+++ b/test/connectwise/subscription/contacts/main.go
@@ -28,7 +28,7 @@ func main() {
 		testscenario.SubscribeReceiveEventsSuite{
 			SubscribeParamBuilder: func(webhookURL string) *common.SubscribeParams {
 				return &common.SubscribeParams{
-					Request: connectwise.SubscribeRequest{
+					Request: &connectwise.SubscribeRequest{
 						WebhookURL: webhookURL,
 					},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{

--- a/test/connectwise/subscription/tickets/main.go
+++ b/test/connectwise/subscription/tickets/main.go
@@ -30,7 +30,7 @@ func main() {
 		testscenario.SubscribeReceiveEventsSuite{
 			SubscribeParamBuilder: func(webhookURL string) *common.SubscribeParams {
 				return &common.SubscribeParams{
-					Request: connectwise.SubscribeRequest{
+					Request: &connectwise.SubscribeRequest{
 						WebhookURL: webhookURL,
 					},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{

--- a/test/connectwise/subscription/update/main.go
+++ b/test/connectwise/subscription/update/main.go
@@ -21,7 +21,7 @@ func main() {
 	testscenario.SubscriptionCreateUpdateDelete(ctx, conn,
 		func(webhookURL string) *common.SubscribeParams {
 			return &common.SubscribeParams{
-				Request: connectwise.SubscribeRequest{
+				Request: &connectwise.SubscribeRequest{
 					WebhookURL: webhookURL,
 				},
 				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
@@ -32,7 +32,7 @@ func main() {
 		},
 		func(webhookURL string) *common.SubscribeParams {
 			return &common.SubscribeParams{
-				Request: connectwise.SubscribeRequest{
+				Request: &connectwise.SubscribeRequest{
 					WebhookURL: webhookURL,
 				},
 				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{

--- a/test/utils/testroutines/comparator.go
+++ b/test/utils/testroutines/comparator.go
@@ -251,10 +251,23 @@ func ComparatorSubscriptionWithResult(
 	return func(_ string, actual, expected *common.SubscriptionResult) *testutils.CompareResult {
 		result := testutils.NewCompareResult()
 		result.Merge(mockutils.SubscriptionResultComparator.CompareWithoutResultArg(actual, expected))
-		result.Merge(resultComparator(expected.Result, actual.Result))
+
+		// Connector must return `Result` as a pointer.
+		// If that is the case we proceed with comparing these results.
+		if result.Assert("expected.Result must be pointer", true, isPointer(expected.Result)) &&
+			result.Assert("actual.Result must be pointer", true, isPointer(actual.Result)) {
+			result.Merge(resultComparator(expected.Result, actual.Result))
+		}
 
 		return result
 	}
+}
+
+func isPointer(v any) bool {
+	if v == nil {
+		return false
+	}
+	return reflect.ValueOf(v).Kind() == reflect.Ptr
 }
 
 func ComparatorSubscriptionWithoutResult(


### PR DESCRIPTION
# Description

Changed all tests, scripts to use exclusively pointers for:
* `common.SubscriptionResult.Result`
* `common.SubscribeParams.Request`

The `SubscriptionInputOutput` offers useful TypedSubscriptionRequest and TypedSubscriptionResult which will ensure that any developer follows the pointer pattern.

Also in the unit tests, the expected and actual are also asserted to have the proper type:
<img width="771" height="132" alt="image" src="https://github.com/user-attachments/assets/a4402f1f-5879-4a5f-83e6-db0a510b8847" />


# Live Tests
All scripts that were modified are working as expected.

### (1)
<img width="733" height="796" alt="image" src="https://github.com/user-attachments/assets/52f6dd81-5143-4dd3-bcb6-3f6990b2a735" />
<img width="641" height="911" alt="image" src="https://github.com/user-attachments/assets/2a25c168-285c-4d33-9e79-6ff9f77a8f15" />
<img width="526" height="57" alt="image" src="https://github.com/user-attachments/assets/76480bda-1a8f-4ff9-bd89-5e400f07ef11" />

### (2)
<img width="633" height="1141" alt="image" src="https://github.com/user-attachments/assets/c6af8376-3034-4fbf-99f0-97ca6127ee3f" />
