### PR TITLE
[CON-3211] fix(acculynx): return empty Workspace() for consumer-URL-routed subscription

### DIFF
--- a/providers/acculynx/subscriptionEvent.go
+++ b/providers/acculynx/subscriptionEvent.go
@@ -55,7 +55,6 @@ var (
 	errUnsupportedTopicName  = errors.New("acculynx event: topicName does not map to a supported object")
 	errMissingInnerEvent     = errors.New("acculynx event: missing inner event payload")
 	errMissingObjectWrapper  = errors.New("acculynx event: missing object wrapper inside event")
-	errMissingSubscriptionID = errors.New("acculynx event: missing subscriptionId")
 	errMissingRecordID       = errors.New("acculynx event: missing record id for topic")
 	errUnparsableEventTime   = errors.New("acculynx event: unparsable eventDateTime")
 	// errParentRecordIDUnavailable is returned for topics whose payload omits
@@ -128,15 +127,16 @@ func (e SubscriptionEvent) ObjectName() (string, error) {
 	}
 }
 
-// Workspace returns the top-level subscriptionId. AccuLynx enforces one
-// subscription per installation, making it a 1:1 proxy for the installation.
+// Workspace returns an empty string because AccuLynx subscriptions are
+// consumer-URL routed: each installation registers a unique, immutable
+// consumerUrl, so the receiver matches a webhook to its installation by that URL
+// — not by a workspace key. AccuLynx implements no GetPostAuthInfo, so no
+// installation carries a providerWorkspaceRef; returning a non-empty value here
+// (e.g. the subscriptionId) leaves the receiver with nothing to match, so it
+// accepts the event (HTTP 200) but never routes it to a destination. This
+// follows the URL-routed convention used by salesforce/housecallPro/outreach.
 func (e SubscriptionEvent) Workspace() (string, error) {
-	subID, ok := e[eventFieldSubscriptionID].(string)
-	if !ok || subID == "" {
-		return "", errMissingSubscriptionID
-	}
-
-	return subID, nil
+	return "", nil
 }
 
 // RecordId returns the affected contact/job id from event.<object>.id.

--- a/providers/acculynx/subscriptionEvent_test.go
+++ b/providers/acculynx/subscriptionEvent_test.go
@@ -78,9 +78,13 @@ func TestSubscriptionEvent_EventType(t *testing.T) {
 	}
 }
 
-func TestSubscriptionEvent_Workspace_ReturnsSubscriptionId(t *testing.T) {
+func TestSubscriptionEvent_Workspace_ReturnsEmpty(t *testing.T) {
 	t.Parallel()
 
+	// AccuLynx is consumer-URL routed, so Workspace must be empty even though the
+	// payload always carries a subscriptionId. A non-empty Workspace has no
+	// matching installation providerWorkspaceRef, which causes the receiver to
+	// accept the event but never route it to a destination.
 	evt := SubscriptionEvent{
 		eventFieldTopicName:      "job_created",
 		eventFieldSubscriptionID: "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8",
@@ -93,16 +97,7 @@ func TestSubscriptionEvent_Workspace_ReturnsSubscriptionId(t *testing.T) {
 
 	got, err := evt.Workspace()
 	assert.NilError(t, err)
-	assert.Equal(t, got, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
-}
-
-func TestSubscriptionEvent_Workspace_MissingSubscriptionIdReturnsError(t *testing.T) {
-	t.Parallel()
-
-	evt := SubscriptionEvent{eventFieldTopicName: "job_created"}
-
-	_, err := evt.Workspace()
-	assert.Assert(t, errors.Is(err, errMissingSubscriptionID))
+	assert.Equal(t, got, "")
 }
 
 func TestSubscriptionEvent_RecordId_RoutesByObjectType(t *testing.T) {
@@ -308,7 +303,7 @@ func TestSubscriptionEvent_RealPayload_ContactAdded(t *testing.T) {
 
 	ws, err := evt.Workspace()
 	assert.NilError(t, err)
-	assert.Equal(t, ws, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
+	assert.Equal(t, ws, "")
 
 	rid, err := evt.RecordId()
 	assert.NilError(t, err)
@@ -359,7 +354,7 @@ func TestSubscriptionEvent_RealPayload_JobMilestoneChanged(t *testing.T) {
 
 	ws, err := evt.Workspace()
 	assert.NilError(t, err)
-	assert.Equal(t, ws, "6541d9e1-12c1-45b8-b5bd-5ffa8849a4b8")
+	assert.Equal(t, ws, "")
 
 	rid, err := evt.RecordId()
 	assert.NilError(t, err)
@@ -437,9 +432,11 @@ func TestSubscriptionEvent_RecordId_CustomFieldStatusChanged_NoParentID(t *testi
 			assert.NilError(t, err)
 			assert.Assert(t, obj == objectContacts || obj == objectJobs)
 
+			// Workspace is always empty (consumer-URL routed), even though the
+			// payload carries a subscriptionId.
 			ws, err := evt.Workspace()
 			assert.NilError(t, err)
-			assert.Equal(t, ws, "sub-xyz")
+			assert.Equal(t, ws, "")
 
 			// But RecordId fails with the dedicated sentinel so consumers can skip enrichment.
 			_, err = evt.RecordId()


### PR DESCRIPTION
Issue: AccuLynx subscribe events were accepted by the subscribe-receiver (HTTP 200) but never delivered to the destination. Workspace() returned the subscriptionId, but AccuLynx sets no providerWorkspaceRef (it implements no GetPostAuthInfo), so the receiver had nothing to match the event to an installation and silently dropped it.

Fix: Return "" from Workspace() so events route by the unique per-installation consumerUrl (AccuLynx is URL-routed), matching the convention used by salesforce, housecallPro, and outreach. Unit tests updated.