### PR TITLE
[CON-3389] feat(housecallPro): populate job customer association

### DIFF
--- a/providers/housecallPro/associations.go
+++ b/providers/housecallPro/associations.go
@@ -5,7 +5,13 @@ import (
 	"github.com/amp-labs/connectors/common/readhelper"
 )
 
-const customerAssociation = "customer"
+const customerObject = "customers"
+
+var embeddedAssociationFields = map[string]map[string]string{ //nolint:gochecknoglobals
+	"jobs": {
+		customerObject: "customer",
+	},
+}
 
 func readMarshaller(params common.ReadParams) common.MarshalFromNodeFunc {
 	base := readhelper.MakeMarshaledDataFuncWithId(nil, readIDFieldByObject.Get(params.ObjectName))
@@ -22,23 +28,31 @@ func readMarshaller(params common.ReadParams) common.MarshalFromNodeFunc {
 
 // extractAssociations attaches related objects to rows for each requested association.
 func extractAssociations(objectName string, associatedObjects []string, rows []common.ReadResultRow) {
-	for _, assocObj := range associatedObjects {
-		if objectName == "jobs" && assocObj == customerAssociation {
-			attachJobCustomer(rows)
-		}
+	fieldByAssociation, ok := embeddedAssociationFields[objectName]
+	if !ok {
+		return
 	}
-}
 
-// attachJobCustomer attaches the customer object embedded on each job to its
-// Associations. Housecall Pro returns job.customer inline on GET /jobs.
-func attachJobCustomer(rows []common.ReadResultRow) {
-	for idx := range rows {
-		customer, ok := rows[idx].Raw[customerAssociation].(map[string]any)
-		if !ok || len(customer) == 0 {
+	for _, assocObj := range associatedObjects {
+		field, ok := fieldByAssociation[assocObj]
+		if !ok {
 			continue
 		}
 
-		id, _ := customer["id"].(string)
+		attachEmbeddedAssociation(rows, assocObj, field)
+	}
+}
+
+// attachEmbeddedAssociation attaches the object embedded under field on each row
+// to its Associations, keyed by the requested association name.
+func attachEmbeddedAssociation(rows []common.ReadResultRow, associationName, field string) {
+	for idx := range rows {
+		embedded, ok := rows[idx].Raw[field].(map[string]any)
+		if !ok || len(embedded) == 0 {
+			continue
+		}
+
+		id, _ := embedded["id"].(string)
 		if id == "" {
 			continue
 		}
@@ -47,9 +61,9 @@ func attachJobCustomer(rows []common.ReadResultRow) {
 			rows[idx].Associations = make(map[string][]common.Association)
 		}
 
-		rows[idx].Associations[customerAssociation] = []common.Association{{
+		rows[idx].Associations[associationName] = []common.Association{{
 			ObjectId: id,
-			Raw:      customer,
+			Raw:      embedded,
 		}}
 	}
 }

--- a/providers/housecallPro/associations.go
+++ b/providers/housecallPro/associations.go
@@ -1,0 +1,46 @@
+package housecallpro
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+)
+
+const customerAssociation = "customer"
+
+func readMarshaller(params common.ReadParams) common.MarshalFromNodeFunc {
+	base := readhelper.MakeMarshaledDataFuncWithId(nil, readIDFieldByObject.Get(params.ObjectName))
+	if params.ObjectName != "jobs" {
+		return base
+	}
+
+	return readhelper.ChainedMarshaller(base, func(rows []common.ReadResultRow) error {
+		attachJobCustomer(rows)
+
+		return nil
+	})
+}
+
+// attachJobCustomer attaches the customer object embedded on each job to its
+// Associations. Housecall Pro returns job.customer inline on GET /jobs.
+func attachJobCustomer(rows []common.ReadResultRow) {
+	for idx := range rows {
+		customer, ok := rows[idx].Raw[customerAssociation].(map[string]any)
+		if !ok || len(customer) == 0 {
+			continue
+		}
+
+		id, _ := customer["id"].(string)
+		if id == "" {
+			continue
+		}
+
+		if rows[idx].Associations == nil {
+			rows[idx].Associations = make(map[string][]common.Association)
+		}
+
+		rows[idx].Associations[customerAssociation] = []common.Association{{
+			ObjectId: id,
+			Raw:      customer,
+		}}
+	}
+}

--- a/providers/housecallPro/associations.go
+++ b/providers/housecallPro/associations.go
@@ -9,15 +9,24 @@ const customerAssociation = "customer"
 
 func readMarshaller(params common.ReadParams) common.MarshalFromNodeFunc {
 	base := readhelper.MakeMarshaledDataFuncWithId(nil, readIDFieldByObject.Get(params.ObjectName))
-	if params.ObjectName != "jobs" {
+	if len(params.AssociatedObjects) == 0 {
 		return base
 	}
 
 	return readhelper.ChainedMarshaller(base, func(rows []common.ReadResultRow) error {
-		attachJobCustomer(rows)
+		extractAssociations(params.ObjectName, params.AssociatedObjects, rows)
 
 		return nil
 	})
+}
+
+// extractAssociations attaches related objects to rows for each requested association.
+func extractAssociations(objectName string, associatedObjects []string, rows []common.ReadResultRow) {
+	for _, assocObj := range associatedObjects {
+		if objectName == "jobs" && assocObj == customerAssociation {
+			attachJobCustomer(rows)
+		}
+	}
 }
 
 // attachJobCustomer attaches the customer object embedded on each job to its

--- a/providers/housecallPro/associations_test.go
+++ b/providers/housecallPro/associations_test.go
@@ -8,6 +8,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractAssociationsSkipsWhenNotRequested(t *testing.T) {
+	t.Parallel()
+
+	customer := map[string]any{
+		"id":         "cus_b0f661aa89324111b575da039c45e19f",
+		"first_name": "Walter",
+	}
+
+	rows := []common.ReadResultRow{{
+		Id:  "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4",
+		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
+	}}
+
+	extractAssociations("jobs", nil, rows)
+	assert.Nil(t, rows[0].Associations)
+
+	extractAssociations("customers", []string{"customer"}, rows)
+	assert.Nil(t, rows[0].Associations)
+}
+
+func TestExtractAssociationsAttachesJobCustomer(t *testing.T) {
+	t.Parallel()
+
+	customer := map[string]any{
+		"id":         "cus_b0f661aa89324111b575da039c45e19f",
+		"first_name": "Walter",
+	}
+
+	rows := []common.ReadResultRow{{
+		Id:  "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4",
+		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
+	}}
+
+	extractAssociations("jobs", []string{"customer"}, rows)
+
+	require.Len(t, rows[0].Associations[customerAssociation], 1)
+	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerAssociation][0].ObjectId)
+}
+
 func TestAttachJobCustomer(t *testing.T) {
 	t.Parallel()
 

--- a/providers/housecallPro/associations_test.go
+++ b/providers/housecallPro/associations_test.go
@@ -21,10 +21,16 @@ func TestExtractAssociationsSkipsWhenNotRequested(t *testing.T) {
 		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
 	}}
 
+	// No associations requested.
 	extractAssociations("jobs", nil, rows)
 	assert.Nil(t, rows[0].Associations)
 
-	extractAssociations("customers", []string{"customer"}, rows)
+	// Unknown association for jobs.
+	extractAssociations("jobs", []string{"unknown"}, rows)
+	assert.Nil(t, rows[0].Associations)
+
+	// Object that has no association mappings.
+	extractAssociations("customers", []string{customerObject}, rows)
 	assert.Nil(t, rows[0].Associations)
 }
 
@@ -41,13 +47,13 @@ func TestExtractAssociationsAttachesJobCustomer(t *testing.T) {
 		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
 	}}
 
-	extractAssociations("jobs", []string{"customer"}, rows)
+	extractAssociations("jobs", []string{customerObject}, rows)
 
-	require.Len(t, rows[0].Associations[customerAssociation], 1)
-	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerAssociation][0].ObjectId)
+	require.Len(t, rows[0].Associations[customerObject], 1)
+	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerObject][0].ObjectId)
 }
 
-func TestAttachJobCustomer(t *testing.T) {
+func TestAttachEmbeddedAssociation(t *testing.T) {
 	t.Parallel()
 
 	customer := map[string]any{
@@ -61,14 +67,14 @@ func TestAttachJobCustomer(t *testing.T) {
 		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
 	}}
 
-	attachJobCustomer(rows)
+	attachEmbeddedAssociation(rows, customerObject, "customer")
 
-	require.Len(t, rows[0].Associations[customerAssociation], 1)
-	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerAssociation][0].ObjectId)
-	assert.Equal(t, customer, rows[0].Associations[customerAssociation][0].Raw)
+	require.Len(t, rows[0].Associations[customerObject], 1)
+	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerObject][0].ObjectId)
+	assert.Equal(t, customer, rows[0].Associations[customerObject][0].Raw)
 }
 
-func TestAttachJobCustomerSkipsMissingOrEmpty(t *testing.T) {
+func TestAttachEmbeddedAssociationSkipsMissingOrEmpty(t *testing.T) {
 	t.Parallel()
 
 	rows := []common.ReadResultRow{
@@ -80,7 +86,7 @@ func TestAttachJobCustomerSkipsMissingOrEmpty(t *testing.T) {
 		}}},
 	}
 
-	attachJobCustomer(rows)
+	attachEmbeddedAssociation(rows, customerObject, "customer")
 
 	for i := range rows {
 		assert.Nil(t, rows[i].Associations, "row %d should have no associations", i)

--- a/providers/housecallPro/associations_test.go
+++ b/providers/housecallPro/associations_test.go
@@ -1,0 +1,49 @@
+package housecallpro
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachJobCustomer(t *testing.T) {
+	t.Parallel()
+
+	customer := map[string]any{
+		"id":         "cus_b0f661aa89324111b575da039c45e19f",
+		"first_name": "Walter",
+		"last_name":  "Whitman",
+	}
+
+	rows := []common.ReadResultRow{{
+		Id:  "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4",
+		Raw: map[string]any{"id": "job_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
+	}}
+
+	attachJobCustomer(rows)
+
+	require.Len(t, rows[0].Associations[customerAssociation], 1)
+	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerAssociation][0].ObjectId)
+	assert.Equal(t, customer, rows[0].Associations[customerAssociation][0].Raw)
+}
+
+func TestAttachJobCustomerSkipsMissingOrEmpty(t *testing.T) {
+	t.Parallel()
+
+	rows := []common.ReadResultRow{
+		{Raw: map[string]any{}},                             // no customer
+		{Raw: map[string]any{"customer": nil}},              // null customer
+		{Raw: map[string]any{"customer": map[string]any{}}}, // empty customer
+		{Raw: map[string]any{"customer": map[string]any{ // customer without id
+			"first_name": "Whitman",
+		}}},
+	}
+
+	attachJobCustomer(rows)
+
+	for i := range rows {
+		assert.Nil(t, rows[i].Associations, "row %d should have no associations", i)
+	}
+}

--- a/providers/housecallPro/read.go
+++ b/providers/housecallPro/read.go
@@ -108,7 +108,7 @@ func (c *Connector) parseReadResponse(
 		resp,
 		common.MakeRecordsFunc(responseKey),
 		makeFilterFunc(params, reqURL),
-		readhelper.MakeMarshaledDataFuncWithId(nil, readIDFieldByObject.Get(params.ObjectName)),
+		readMarshaller(params),
 		params.Fields,
 	)
 }

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -403,7 +403,7 @@ func TestRead(t *testing.T) {
 				ObjectName:        "jobs",
 				Fields:            connectors.Fields("id", "work_status", "updated_at"),
 				PageSize:          1,
-				AssociatedObjects: []string{"customer"},
+				AssociatedObjects: []string{"customers"},
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -430,7 +430,7 @@ func TestRead(t *testing.T) {
 							"work_status": "scheduled",
 						},
 						Associations: map[string][]common.Association{
-							"customer": {
+							"customers": {
 								{
 									ObjectId: "cus_00000000000000000000000000000001",
 									Raw: map[string]any{

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -25,6 +25,7 @@ func TestRead(t *testing.T) {
 	responseInvoices := testutils.DataFromFile(t, "invoice.json")
 	responseEmployees := testutils.DataFromFile(t, "read-employees.json")
 	responseRoutes := testutils.DataFromFile(t, "read-routes.json")
+	responseJobs := testutils.DataFromFile(t, "read-jobs.json")
 
 	tests := []testroutines.Read{
 		{
@@ -358,6 +359,58 @@ func TestRead(t *testing.T) {
 			},
 			ExpectedErrs: nil,
 		},
+		{
+			Name: "Read jobs attaches embedded customer as association",
+			Input: common.ReadParams{
+				ObjectName: "jobs",
+				Fields:     connectors.Fields("id", "work_status", "updated_at"),
+				PageSize:   1,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/jobs"),
+					mockcond.QueryParam("page_size", "1"),
+					mockcond.QueryParam("sort_by", "updated_at"),
+					mockcond.QueryParam("sort_direction", "desc"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseJobs),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":          "job_00000000000000000000000000000001",
+							"work_status": "scheduled",
+							"updated_at":  "2026-01-02T00:00:00Z",
+						},
+						Raw: map[string]any{
+							"id":          "job_00000000000000000000000000000001",
+							"work_status": "scheduled",
+						},
+						Associations: map[string][]common.Association{
+							"customer": {
+								{
+									ObjectId: "cus_00000000000000000000000000000001",
+									Raw: map[string]any{
+										"id":         "cus_00000000000000000000000000000001",
+										"first_name": "Jane",
+										"last_name":  "Sample",
+										"email":      "jane.sample@example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+
 		{
 			Name: "Read invoices",
 			Input: common.ReadParams{

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -360,11 +360,50 @@ func TestRead(t *testing.T) {
 			ExpectedErrs: nil,
 		},
 		{
-			Name: "Read jobs attaches embedded customer as association",
+			Name: "Read jobs without customer association request",
 			Input: common.ReadParams{
 				ObjectName: "jobs",
 				Fields:     connectors.Fields("id", "work_status", "updated_at"),
 				PageSize:   1,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/jobs"),
+					mockcond.QueryParam("page_size", "1"),
+					mockcond.QueryParam("sort_by", "updated_at"),
+					mockcond.QueryParam("sort_direction", "desc"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseJobs),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":          "job_00000000000000000000000000000001",
+							"work_status": "scheduled",
+							"updated_at":  "2026-01-02T00:00:00Z",
+						},
+						Raw: map[string]any{
+							"id":          "job_00000000000000000000000000000001",
+							"work_status": "scheduled",
+						},
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read jobs attaches embedded customer as association",
+			Input: common.ReadParams{
+				ObjectName:        "jobs",
+				Fields:            connectors.Fields("id", "work_status", "updated_at"),
+				PageSize:          1,
+				AssociatedObjects: []string{"customer"},
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),

--- a/providers/housecallPro/record.go
+++ b/providers/housecallPro/record.go
@@ -66,5 +66,9 @@ func (c *Connector) GetRecordsByIds( //nolint:revive
 		out = append(out, rows...)
 	}
 
+	if objectName == "jobs" {
+		attachJobCustomer(out)
+	}
+
 	return out, nil
 }

--- a/providers/housecallPro/record.go
+++ b/providers/housecallPro/record.go
@@ -66,9 +66,7 @@ func (c *Connector) GetRecordsByIds( //nolint:revive
 		out = append(out, rows...)
 	}
 
-	if objectName == "jobs" {
-		attachJobCustomer(out)
-	}
+	extractAssociations(objectName, associations, out)
 
 	return out, nil
 }

--- a/providers/housecallPro/record_test.go
+++ b/providers/housecallPro/record_test.go
@@ -10,6 +10,54 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 )
 
+func TestGetRecordsByIds_job_withCustomerAssociation(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{
+  "id": "job_ac6f3efd11c14a5aa93e9fc0ab5354ab",
+  "work_status": "needs scheduling",
+  "updated_at": "2026-04-02T15:20:38Z",
+  "customer": {
+    "id": "cus_b0f661aa89324111b575da039c45e19f",
+    "first_name": "Walter",
+    "last_name": "Whitman"
+  }
+}`)
+
+	server := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.Method(http.MethodGet),
+			mockcond.Path("/jobs/job_ac6f3efd11c14a5aa93e9fc0ab5354ab"),
+		},
+		Then: mockserver.Response(http.StatusOK, payload),
+	}.Server()
+	t.Cleanup(server.Close)
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := conn.GetRecordsByIds(t.Context(), "jobs",
+		[]string{"job_ac6f3efd11c14a5aa93e9fc0ab5354ab"},
+		[]string{"id", "work_status"},
+		[]string{"customer"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	assocs := rows[0].Associations["customer"]
+	if len(assocs) != 1 || assocs[0].ObjectId != "cus_b0f661aa89324111b575da039c45e19f" {
+		t.Fatalf("unexpected customer association: %+v", rows[0].Associations)
+	}
+}
+
 func TestGetRecordsByIds_job(t *testing.T) {
 	t.Parallel()
 

--- a/providers/housecallPro/record_test.go
+++ b/providers/housecallPro/record_test.go
@@ -42,7 +42,7 @@ func TestGetRecordsByIds_job_withCustomerAssociation(t *testing.T) {
 	rows, err := conn.GetRecordsByIds(t.Context(), "jobs",
 		[]string{"job_ac6f3efd11c14a5aa93e9fc0ab5354ab"},
 		[]string{"id", "work_status"},
-		[]string{"customer"},
+		[]string{"customers"},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func TestGetRecordsByIds_job_withCustomerAssociation(t *testing.T) {
 		t.Fatalf("expected 1 row, got %d", len(rows))
 	}
 
-	assocs := rows[0].Associations["customer"]
+	assocs := rows[0].Associations["customers"]
 	if len(assocs) != 1 || assocs[0].ObjectId != "cus_b0f661aa89324111b575da039c45e19f" {
 		t.Fatalf("unexpected customer association: %+v", rows[0].Associations)
 	}

--- a/providers/housecallPro/test/read-jobs.json
+++ b/providers/housecallPro/test/read-jobs.json
@@ -1,0 +1,45 @@
+{
+    "page": 1,
+    "page_size": 1,
+    "total_pages": 1,
+    "total_items": 1,
+    "jobs": [
+        {
+            "id": "job_00000000000000000000000000000001",
+            "invoice_number": "0",
+            "description": "",
+            "customer": {
+                "id": "cus_00000000000000000000000000000001",
+                "first_name": "Jane",
+                "last_name": "Sample",
+                "email": "jane.sample@example.com",
+                "mobile_number": "5550000000",
+                "home_number": "5550000000",
+                "work_number": "5550000000",
+                "company": "Sample Co",
+                "company_name": "Acme",
+                "company_id": "00000000-0000-0000-0000-000000000000",
+                "kind": "homeowner",
+                "lead_source": null,
+                "notes": "Sample customer for tests.",
+                "notifications_enabled": true,
+                "tags": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z"
+            },
+            "address": {
+                "id": "adr_00000000000000000000000000000001",
+                "type": "service",
+                "street": "1 Example St",
+                "street_line_2": null,
+                "city": "Sampleville",
+                "state": "CA",
+                "zip": "00000",
+                "country": "USA"
+            },
+            "work_status": "scheduled",
+            "created_at": "2026-01-02T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z"
+        }
+    ]
+}


### PR DESCRIPTION
On Read jobs (and GetRecordsByIds for jobs), attach the embedded customer object to Associations["customer"] with ObjectId and Raw.

### TEST
<img width="821" height="1068" alt="Screenshot from 2026-06-27 03-53-29" src="https://github.com/user-attachments/assets/0e3199e6-7561-48b6-ac1a-f63ecbcc64f4" />

<img width="367" height="634" alt="Screenshot from 2026-06-27 03-53-40" src="https://github.com/user-attachments/assets/42d59e15-e2a6-4741-b069-df27f64e98d1" />
