### PR TITLE
[CON-3357] feat: support wealthbox connector

### DIFF
--- a/providers/wealthbox.go
+++ b/providers/wealthbox.go
@@ -31,7 +31,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [ ] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
<img width="1468" height="768" alt="Screenshot 2026-06-30 at 16 13 20" src="https://github.com/user-attachments/assets/e9e8bb37-2a82-459f-baee-c494f2b72349" />


## POST
<img width="1460" height="747" alt="Screenshot 2026-06-30 at 16 24 55" src="https://github.com/user-attachments/assets/d126e58e-21e9-435a-9c32-9363cfcae662" />

## PUT
<img width="1460" height="666" alt="Screenshot 2026-06-30 at 16 25 54" src="https://github.com/user-attachments/assets/a01fee9b-5150-498d-92d4-a69757e44092" />


## DELETE
<img width="1458" height="465" alt="Screenshot 2026-06-30 at 16 28 05" src="https://github.com/user-attachments/assets/975175c8-8105-46a4-bfcd-ccc38ce16583" />


## Invalid requests
Wrong verb applied, 
<img width="1467" height="420" alt="Screenshot 2026-06-30 at 16 28 26" src="https://github.com/user-attachments/assets/c1c06a35-0fec-485c-a98b-3632221ad943" />

## Successful console operation (operation & events)
<img width="1467" height="420" alt="Screenshot 2026-06-30 at 16 28 26" src="https://github.com/user-attachments/assets/2d07bff5-25af-4bab-9e6d-9bd1dc2e0a63" />

## Failed console operation (operation & events)
<img width="1148" height="621" alt="Screenshot 2026-06-30 at 16 41 01" src="https://github.com/user-attachments/assets/62a648bd-2ff1-4620-8c77-f706d18aa2af" />

