### PR TITLE
[ENG-4095] feat(stripe): Read for specific accounts

### DIFF
--- a/providers/stripe/read.go
+++ b/providers/stripe/read.go
@@ -34,6 +34,9 @@ const (
 
 // ReadParamsOpts defines optional parameters for the Read operation.
 type ReadParamsOpts struct {
+	// ReadForConnectedAccounts enables reading data for specified connected accounts.
+	// This takes precedence over ReadForAllConnectedAccounts.
+	ReadForConnectedAccounts []string
 	// ReadForAllConnectedAccounts enables reading data from all connected accounts
 	// instead of only the main account. When true, the connector parallelizes reads
 	// across all connected accounts and adds the connected account ID to each result row.
@@ -83,17 +86,32 @@ func (c *Connector) readFirstPage(ctx context.Context, params common.ReadParams)
 		return nil, err
 	}
 
-	if !isReadForConnectedAccounts(params) {
+	target := inferReadTarget(params)
+	switch target.Scope {
+	case ReadScopeMainAccount:
 		// Standard read for the current account.
 		return c.readRecords(ctx, params.ObjectName, params.Fields, url)
-	}
+	case ReadScopeSelectedConnectedAccounts:
+		return c.readForConnectedAccounts(ctx, params, url, target.AccountIDs)
+	case ReadScopeAllConnectedAccounts:
+		accountIDs, err := c.listAllAccounts(ctx)
+		if err != nil {
+			return nil, err
+		}
 
+		return c.readForConnectedAccounts(ctx, params, url, accountIDs)
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrReadTargetUnknown, target.Scope)
+	}
+}
+
+func (c *Connector) readForConnectedAccounts(
+	ctx context.Context,
+	params common.ReadParams,
+	url *urlbuilder.URL,
+	accountIDs []string,
+) (*common.ReadResult, error) {
 	// Parallelized read across all connected accounts.
-	accountIDs, err := c.listAccounts(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	tasks := make([]parallelfetch.Task[string, common.ReadResult], len(accountIDs))
 	for index, accountID := range accountIDs {
 		// Each task reads records for a specific connected account
@@ -267,11 +285,11 @@ type accountsListResponse struct {
 	} `json:"data"`
 }
 
-// listAccounts retrieves all connected account IDs for the main account.
+// listAllAccounts retrieves all connected account IDs for the main account.
 // It handles pagination internally to collect all accounts.
 //
 // See [Stripe accounts list documentation](https://docs.stripe.com/api/accounts/list).
-func (c *Connector) listAccounts(ctx context.Context) ([]string, error) {
+func (c *Connector) listAllAccounts(ctx context.Context) ([]string, error) {
 	url, err := c.getURL("accounts")
 	if err != nil {
 		return nil, err
@@ -306,15 +324,39 @@ func (c *Connector) listAccounts(ctx context.Context) ([]string, error) {
 	}
 }
 
-// isReadForConnectedAccounts checks if ReadParams opts specify reading from
-// all connected accounts instead of the main account.
-func isReadForConnectedAccounts(params common.ReadParams) bool {
+type ReadScope int
+
+var ErrReadTargetUnknown = errors.New("unsupported read target")
+
+const (
+	ReadScopeMainAccount ReadScope = iota
+	ReadScopeSelectedConnectedAccounts
+	ReadScopeAllConnectedAccounts
+)
+
+type readTarget struct {
+	Scope      ReadScope
+	AccountIDs []string
+}
+
+func inferReadTarget(params common.ReadParams) readTarget {
 	opts, ok := params.Opts.(ReadParamsOpts)
 	if !ok {
-		return false
+		return readTarget{Scope: ReadScopeMainAccount}
 	}
 
-	return opts.ReadForAllConnectedAccounts
+	if len(opts.ReadForConnectedAccounts) > 0 {
+		return readTarget{
+			Scope:      ReadScopeSelectedConnectedAccounts,
+			AccountIDs: opts.ReadForConnectedAccounts,
+		}
+	}
+
+	if opts.ReadForAllConnectedAccounts {
+		return readTarget{Scope: ReadScopeAllConnectedAccounts}
+	}
+
+	return readTarget{Scope: ReadScopeMainAccount}
 }
 
 // incrementalObjects contains object names that support incremental reading

--- a/providers/stripe/read_test.go
+++ b/providers/stripe/read_test.go
@@ -369,6 +369,44 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "Read customers for specific connected accounts",
+			Input: common.ReadParams{
+				ObjectName: "customers",
+				Fields:     connectors.Fields("id"),
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts:    []string{"acct_2c81631b20648a90"},
+					ReadForAllConnectedAccounts: true, // ignored
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.Path("/v1/customers"),
+						mockcond.Header(map[string][]string{
+							"Stripe-Account": {"acct_2c81631b20648a90"},
+						}),
+					},
+					Then: mockserver.Response(http.StatusOK, responseCustomersLastPage),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetReadSorted,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_2c81631b20648a90",
+						"id":                           "cus_Rd3NKXxTV0Hzpp",
+					},
+					Raw: map[string]any{"email": "sean.foster@example.com"},
+					Id:  "cus_Rd3NKXxTV0Hzpp",
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "Aggregate next page token correctly navigates to the next page",
 			Input: common.ReadParams{
 				ObjectName: "customers",


### PR DESCRIPTION
# Description

- Added `ReadParamsOpts.ReadForConnectedAccounts` to support reads from selected connected accounts.
- The main read flow is now split into three explicit paths using a switch and enum-style read scope values, making the execution intent clear and explicit.
- Reads can now run against:
  - the main account,
  - all connected accounts, or
  - a specific list of connected accounts.
- When both `ReadForAllConnectedAccounts` and a specific list of account IDs are provided, the explicit account list takes precedence.

# Unit Test
- Added a test to verify that reading specific connected accounts does not trigger a list-all-accounts call.
- The test also confirms that records are read with the selected account ID set in the request header.