### PR TITLE
ci: auto-approve go.mod/go.sum-only PRs (for amp-common auto-updates)

### DIFF
--- a/.github/workflows/auto-approve-go-mod.yml
+++ b/.github/workflows/auto-approve-go-mod.yml
@@ -1,0 +1,33 @@
+name: Automatically approve go.mod and go.sum changes
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            allowed:
+              - modified: 'go.mod'
+              - modified: 'go.sum'
+      - uses: dorny/paths-filter@v4
+        id: changes_inverted
+        with:
+          predicate-quantifier: every
+          filters: |
+            not_allowed:
+              - '!go.mod'
+              - '!go.sum'
+      - name: Approve PR
+        if: steps.changes.outputs.allowed == 'true' && steps.changes_inverted.outputs.not_allowed == 'false'
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/reviews" \
+            -d '{"event":"APPROVE"}'


### PR DESCRIPTION
## Why
We're adding automation so that when **amp-common** updates, an `[auto] Update amp-common dependency` PR is opened in connectors (keeping the generated OpenAPI struct types in sync down the chain: openapi → amp-common → connectors → server).

connectors' branch ruleset **requires 1 approving review**, but those PRs are opened by the `ampersand-ops` bot with no human reviewer — so they'd enable auto-merge and then hang forever. This adds the missing approver.

## What
Auto-approve any PR whose diff is limited to `go.mod`/`go.sum`, using `GITHUB_TOKEN`. This is a verbatim copy of the same workflow already running in **server** and **amp-common**.

## ⚠️ Prerequisite
Requires **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** to be enabled on connectors (server/amp-common already have it). Without it, the approve step 403s.

## Companion
amp-common PR that opens the bump PRs: _(linked separately)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)