### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	cloud.google.com/go/bigquery v1.75.0
 	github.com/PuerkitoBio/goquery v1.11.0
-	github.com/amp-labs/amp-common v0.0.0-20260702174851-6e9e70f095ee
+	github.com/amp-labs/amp-common v0.0.0-20260702182809-46a0766d9c3b
 	github.com/antchfx/xmlquery v1.5.0
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
-github.com/amp-labs/amp-common v0.0.0-20260702174851-6e9e70f095ee h1:Zh8RiC2rqS6zqFY5Q1GjNiENw2RO+vJDi6JLdo5lJH4=
-github.com/amp-labs/amp-common v0.0.0-20260702174851-6e9e70f095ee/go.mod h1:brlGiqGV+b3kBszGhXkm6lPQzd+qy+7piuxRV/31nVY=
+github.com/amp-labs/amp-common v0.0.0-20260702182809-46a0766d9c3b h1:/D7GtafCEi2Jf4zUwu2gNy9rjsuP5Xmydi7KBmqc7YE=
+github.com/amp-labs/amp-common v0.0.0-20260702182809-46a0766d9c3b/go.mod h1:brlGiqGV+b3kBszGhXkm6lPQzd+qy+7piuxRV/31nVY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.0 h1:uAi+mO40ZWfyU6mlUBxRVvL6uBNZ6LMU4M3+mQIBV4c=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [46a0766d9c3b71d18530ddf19802d54137cc14cb](https://github.com/amp-labs/amp-common/commit/46a0766d9c3b71d18530ddf19802d54137cc14cb) from [main](https://github.com/amp-labs/amp-common/tree/main)