### PR TITLE
fix(common): treat provider 404 as non-retryable (ENG-4099)

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -32,8 +32,9 @@ func InterpretError(res *http.Response, body []byte) error {
 		// Forbidden, not retryable
 		return NewHTTPError(res.StatusCode, body, headers, createError(ErrForbidden))
 	case http.StatusNotFound:
-		// Semantics are debatable (temporarily missing vs. permanently gone), but for now treat this as a retryable error
-		return NewHTTPError(res.StatusCode, body, headers, createError(ErrRetryable))
+		// Resource missing or access revoked — non-retryable (matches interpreter.DefaultStatusCodeMappingToErr).
+		return NewHTTPError(res.StatusCode, body, headers,
+			createError(fmt.Errorf("%w: %w", ErrBadRequest, ErrNotFound)))
 	case http.StatusTooManyRequests:
 		// Too many requests, retryable
 		return NewHTTPError(res.StatusCode, body, headers, createError(ErrRetryable))


### PR DESCRIPTION
## What
`common.InterpretError` mapped HTTP 404 → `ErrRetryable`. For connectors whose read `ErrorHandler` is `InterpretError` (e.g. GitHub `/issues`, superSend), a permanent 404 (resource deleted / access revoked) was retried until the Temporal retry budget was exhausted, then the read schedule **paused** — and a manual unpause just re-paused it.

## Change
404 now maps to `ErrBadRequest` + `ErrNotFound` (non-retryable), matching `interpreter.DefaultStatusCodeMappingToErr`, which already treats 404 that way. The two status mappers now agree.

## Impact
All connectors using `InterpretError`: a 404 fails fast (non-retryable) instead of retry-then-pause. Sibling of the Google DWD `FAILED_PRECONDITION` classification issue (ENG-4109).

Sentry: BACKEND-WP, WN (GitHub), Y3 (superSend). Fixes ENG-4099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)