### PR TITLE
[CON-3310] feat(stripe): Nested expanding of fields

### DIFF
--- a/providers/stripe/custom.go
+++ b/providers/stripe/custom.go
@@ -1,17 +1,14 @@
 package stripe
 
 import (
-	"maps"
-
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
 )
 
-// flattenCustomFields converts a Stripe record node into a flat map and promotes keys
-// from the nested "metadata" object to the root level. This is used so that
-// user-defined custom fields keys can be queried directly as top-level fields in
-// ReadResult.Fields, while leaving ReadResult.Raw untouched.
-func flattenCustomFields(node *ajson.Node) (map[string]any, error) {
+// getCustomFields converts a Stripe record node into a flat map and returns custom fields
+// from the nested "metadata" object. This is used so that user-defined
+// custom fields keys can be queried directly as top-level fields ReadResult.Fields.
+func getCustomFields(node *ajson.Node) (map[string]any, error) {
 	root, err := jsonquery.Convertor.ObjectToMap(node)
 	if err != nil {
 		return nil, err
@@ -20,18 +17,15 @@ func flattenCustomFields(node *ajson.Node) (map[string]any, error) {
 	// custom fields are stored in the metadata object
 	customFieldsValue, ok := root["metadata"]
 	if !ok {
-		// No metadata field, return as is
-		return root, nil
+		// No metadata field, return nothing.
+		return make(map[string]any), nil
 	}
 
 	customFieldsMap, ok := customFieldsValue.(map[string]any)
 	if !ok || len(customFieldsMap) == 0 {
-		// custom fields is not a map or is empty, return as is
-		return root, nil
+		// Custom fields is not a map or is empty, return nothing
+		return make(map[string]any), nil
 	}
 
-	// flatten metadata keys to root level
-	maps.Copy(root, customFieldsMap)
-
-	return root, nil
+	return customFieldsMap, nil
 }

--- a/providers/stripe/custom_test.go
+++ b/providers/stripe/custom_test.go
@@ -19,7 +19,7 @@ func TestFlattenCustomFields(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "Object with custom fields should flatten custom fields to root level",
+			name: "Object with custom fields should return them",
 			input: map[string]any{
 				"id":    "cus_test123",
 				"email": "test@example.com",
@@ -31,14 +31,6 @@ func TestFlattenCustomFields(t *testing.T) {
 				},
 			},
 			expected: map[string]any{
-				"id":    "cus_test123",
-				"email": "test@example.com",
-				"name":  "Test Customer",
-				"metadata": map[string]any{
-					"order_id":     "6735",
-					"user_id":      "456",
-					"internal_ref": "REF-2024-001",
-				},
 				"order_id":     "6735",
 				"user_id":      "456",
 				"internal_ref": "REF-2024-001",
@@ -46,32 +38,24 @@ func TestFlattenCustomFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Object without custom fields should return as is",
+			name: "Object without custom fields should return nothing",
 			input: map[string]any{
 				"id":    "cus_test123",
 				"email": "test@example.com",
 				"name":  "Test Customer",
 			},
-			expected: map[string]any{
-				"id":    "cus_test123",
-				"email": "test@example.com",
-				"name":  "Test Customer",
-			},
-			wantErr: false,
+			expected: make(map[string]any),
+			wantErr:  false,
 		},
 		{
-			name: "Object with empty custom fields should return as is",
+			name: "Object with empty custom fields should return nothing",
 			input: map[string]any{
 				"id":       "cus_test123",
 				"email":    "test@example.com",
 				"metadata": map[string]any{},
 			},
-			expected: map[string]any{
-				"id":       "cus_test123",
-				"email":    "test@example.com",
-				"metadata": map[string]any{},
-			},
-			wantErr: false,
+			expected: make(map[string]any),
+			wantErr:  false,
 		},
 	}
 
@@ -86,7 +70,7 @@ func TestFlattenCustomFields(t *testing.T) {
 			node, err := ajson.Unmarshal(jsonBytes)
 			require.NoError(t, err)
 
-			result, err := flattenCustomFields(node)
+			result, err := getCustomFields(node)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/providers/stripe/metadata/metadata.go
+++ b/providers/stripe/metadata/metadata.go
@@ -23,10 +23,12 @@ var (
 	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
 
 	//go:embed expandableFields.json
-	expandableFields []byte
-
-	ExpandableFields = fileregistry.MustParseJSON[ExpandableFieldsDef](expandableFields) // nolint:gochecknoglobals
+	expandableFieldsFile []byte
+	expandableFields     = fileregistry.MustParseJSON[ExpandableFieldsDef](expandableFieldsFile) // nolint:gochecknoglobals
 )
 
-// ExpandableFieldsDef is a registry of object names to expandable query params for a field.
+// ExpandableFieldsDef stores expandable Stripe fields by resource name.
+//
+// The map keys represent Stripe resource names, and each value contains the set
+// of queryable expand paths for that resource.
 type ExpandableFieldsDef map[string]datautils.Set[string]

--- a/providers/stripe/metadata/query-params.go
+++ b/providers/stripe/metadata/query-params.go
@@ -1,0 +1,178 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/common/readhelper"
+)
+
+/*
+MakeExpandableQueryParam builds a Stripe `expand[]` query parameter for a field in JSON path format.
+Regular fields can be passed and result in empty query parameter.
+
+The connector only has partial knowledge of the nested object graph, so it can
+only infer the deepest valid expansion path from the registry of known expandable
+fields. When the requested path includes unsupported segments, the function trims
+the query at the last resolvable expandable object.
+
+Example:
+(balance_transactions, $['source']['payment_intent']['customer']['id'])
+
+	(balance_transactions, source) -> can expand
+	(source, payment_intent)       -> unknown
+	(payment_intent, customer)     -> can expand
+	(customer, id)                 -> unknown
+
+Therefore, the expand query must include everything up to customer:
+
+	data.source.payment_intent.customer
+
+Stripe expansion has a maximum nesting depth of 4 levels, so this helper stops
+as soon as the path would exceed that limit. If the requested field path cannot
+be matched to at least one expandable field, the function returns an empty string.
+
+Docs:
+https://docs.stripe.com/expand#multiple-levels
+
+Example error returned by Stripe when the limit is exceeded:
+
+	{
+	    "error": {
+	        "code": "property_expansion_max_depth",
+	        "message": "You cannot expand more than 4 levels of a property.
+						Property: data.source.payment_intent.customer.discount",
+	        "request_log_url": "",
+	        "type": "invalid_request_error"
+	    }
+	}
+*/
+func MakeExpandableQueryParam(objectName, field string) string {
+	keys := readhelper.ParseJSONPath(field)
+	if len(keys) == 0 {
+		return ""
+	}
+
+	// We only have partial knowledge of the nested object graph, so we infer the
+	// longest valid expansion path we can safely build from the registry.
+	type pair struct {
+		// resource is the Stripe object currently used to resolve the next field.
+		// A resource may be known by more than one name, for example singular and plural.
+		resource string
+
+		// field is the next segment in the requested JSON path.
+		// It may refer to either a primitive field or another nested Stripe object.
+		field string
+
+		// expandable reports whether the field can be expanded on the current resource.
+		// This is resolved against the expandable-fields registry.
+		expandable bool
+	}
+
+	// Partition the requested path into resource/field pairs.
+	// The first segment is resolved relative to the root object.
+	currentResource := objectName
+	lastExpandablePair := 0
+	pairs := make([]pair, len(keys))
+
+	for index, key := range keys {
+		expandable := expandableFields.Exists(currentResource, key)
+		if !expandable && index == 0 {
+			// If the root field is not expandable, the path cannot be turned into a
+			// valid Stripe expand parameter.
+			return ""
+		}
+
+		pairs[index] = pair{
+			resource:   currentResource,
+			field:      key,
+			expandable: expandable,
+		}
+
+		currentResource = key
+
+		if expandable {
+			lastExpandablePair = index
+		}
+	}
+
+	// If the final object itself is expandable, keep the path at that object.
+	// This lets the caller expand the full object instead of stopping at a parent.
+	if expandableFields.Has(currentResource) {
+		lastExpandablePair = len(pairs) - 1
+	}
+
+	// Stripe list responses require the `data.` prefix in expand paths.
+	// We construct the query from the root and stop before exceeding the 4-level limit.
+	const maxPropertyLevel = 4
+
+	var queryParamBuilder strings.Builder
+	queryParamBuilder.WriteString("data")
+
+	for i := 0; i <= lastExpandablePair; i++ {
+		if i+1 == maxPropertyLevel {
+			// Stripe enforces a maximum expansion depth of 4 levels.
+			// If the requested path exceeds that limit, return an empty query parameter
+			// value instead of generating a truncated query that would not yield the desired field.
+			// The connector will skip this field.
+			return ""
+		}
+
+		queryParamBuilder.WriteString(".")
+		queryParamBuilder.WriteString(pairs[i].field)
+	}
+
+	return queryParamBuilder.String()
+}
+
+func (f ExpandableFieldsDef) Has(resourceName string) bool {
+	possibleObjectNames := createPossibleObjectNames(resourceName)
+
+	for _, objectName := range possibleObjectNames {
+		if _, ok := f[objectName]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f ExpandableFieldsDef) Exists(resourceName, fieldName string) bool {
+	possibleObjectNames := createPossibleObjectNames(resourceName)
+	queryParam := fmt.Sprintf("data.%v", fieldName)
+
+	for _, objectName := range possibleObjectNames {
+		if f.queryParamExists(objectName, queryParam) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f ExpandableFieldsDef) queryParamExists(objectName, queryParam string) bool {
+	queryParams, ok := f[objectName]
+	if !ok {
+		return false
+	}
+
+	return queryParams.Has(queryParam)
+}
+
+// createPossibleObjectNames returns the resource name as provided and a pluralized
+// variant.
+//
+// Stripe resource names and our internal naming do not always match exactly.
+// In the common case, the API may refer to a singular object while the connector
+// works with a plural form, so we try both.
+//
+// NOTE: If we later need special-case mappings for irregular names, this is the place to add them.
+func createPossibleObjectNames(resourceName string) []string {
+	return []string{
+		// Try the resource name as provided.
+		resourceName,
+		// Some Stripe resources may be referenced in singular form, while we index by plural.
+		naming.NewPluralString(resourceName).String(),
+	}
+}

--- a/providers/stripe/metadata/query-params_test.go
+++ b/providers/stripe/metadata/query-params_test.go
@@ -1,0 +1,76 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestMakeExpandableQueryParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		objectName string
+		field      string
+		expected   string
+	}{
+		{
+			name:       "empty field",
+			objectName: "checkout/sessions",
+			field:      "",
+			expected:   "",
+		},
+		{
+			name:       "primitive field",
+			objectName: "checkout/sessions",
+			field:      "id",
+			expected:   "",
+		},
+		{
+			name:       "nested checkout session line items",
+			objectName: "checkout/sessions",
+			field:      "$['line_items']['currency']",
+			expected:   "data.line_items",
+		},
+		{
+			name:       "balance transactions top-level source",
+			objectName: "balance_transactions",
+			field:      "$['source']",
+			expected:   "data.source",
+		},
+		{
+			name:       "balance transactions source payment intent",
+			objectName: "balance_transactions",
+			field:      "$['source']['payment_intent']",
+			expected:   "data.source.payment_intent",
+		},
+		{
+			name:       "balance transactions nested path ending in primitive",
+			objectName: "balance_transactions",
+			field:      "$['source']['payment_intent']['customer']['id']",
+			expected:   "data.source.payment_intent.customer",
+		},
+		{
+			name:       "balance transactions nested path ending in expandable object",
+			objectName: "balance_transactions",
+			field:      "$['source']['payment_intent']['customer']",
+			expected:   "data.source.payment_intent.customer",
+		},
+		{
+			name:       "balance transactions depth limit exceeded",
+			objectName: "balance_transactions",
+			field:      "$['source']['payment_intent']['customer']['discount']",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MakeExpandableQueryParam(tt.objectName, tt.field)
+			res := testutils.NewCompareResult()
+			res.Assert("expandable query param", tt.expected, got)
+			res.Validate(t, tt.name)
+		})
+	}
+}

--- a/providers/stripe/read.go
+++ b/providers/stripe/read.go
@@ -3,7 +3,7 @@ package stripe
 import (
 	"context"
 	"errors"
-	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/amp-labs/connectors/common"
@@ -27,9 +27,6 @@ const (
 	// in ReadResult.Data[*].Fields.
 	// This field is populated when ReadParamsOpts.ReadForAllConnectedAccounts is set to true.
 	fieldConnectedAccountID = "AMPERSAND-connectedAccountId"
-
-	// CheckoutSession is an object that supports expanding nested list of line items.
-	objectNameCheckoutSession = "checkout/sessions"
 )
 
 // ReadParamsOpts defines optional parameters for the Read operation.
@@ -112,10 +109,12 @@ func (c *Connector) readFirstPage(ctx context.Context, params common.ReadParams)
 // It applies:
 //   - Pagination: adds "limit" query parameter
 //   - Incremental reading: adds "created[gte]" for objects supporting incremental reads
-//   - Object expansion: adds "expand[]" for LineItems fields of format:
+//   - Object expansion: adds "expand[]" for fields of format:
 //     => "$['line_items']['currency']"
 //     => "$['line_items']['description']"
 //     => "$['line_items']['...']"
+//     => "$['source']['payment_intent']['customer']['id']"
+//     => "$['source']['payment_intent']['id']"
 //
 // See [Stripe expand documentation](https://docs.stripe.com/expand#how-it-works).
 func (c *Connector) buildFirstPageReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
@@ -133,16 +132,12 @@ func (c *Connector) buildFirstPageReadURL(params common.ReadParams) (*urlbuilder
 
 	expandTargets := make(datautils.Set[string])
 
-	if expandableFields, ok := metadata.ExpandableFields[params.ObjectName]; ok {
-		for field := range params.Fields {
-			rawFieldName := getRawFieldName(field)
-
-			// If the requested field supports expansion, add it to the expand list
-			// so the provider can return the nested object in the response.
-			queryParam := fmt.Sprintf("data.%v", rawFieldName)
-			if expandableFields.Has(queryParam) {
-				expandTargets.AddOne(queryParam)
-			}
+	for field := range params.Fields {
+		// If the requested field supports expansion, add it to the expand list
+		// so the provider can return the nested object in the response.
+		queryParam := metadata.MakeExpandableQueryParam(params.ObjectName, field)
+		if queryParam != "" {
+			expandTargets.AddOne(queryParam)
 		}
 	}
 
@@ -152,15 +147,6 @@ func (c *Connector) buildFirstPageReadURL(params common.ReadParams) (*urlbuilder
 	}
 
 	return url, nil
-}
-
-func getRawFieldName(field string) string {
-	keys := readhelper.ParseJSONPath(field)
-	if len(keys) > 0 {
-		return keys[0]
-	}
-
-	return field
 }
 
 // executeReadTasks runs multiple read tasks in parallel and aggregates their results.
@@ -236,18 +222,13 @@ func (c *Connector) readRecords(ctx context.Context,
 
 	responseFieldName := metadata.Schemas.LookupArrayFieldName(c.Module.ID, objectName)
 
-	marshaller := readhelper.MakeMarshaledDataFuncWithId(flattenCustomFields, readhelper.IdFieldQuery{Field: "id"})
-	if objectName == objectNameCheckoutSession {
-		marshaller = readhelper.MakeMarshaledSelectedDataFunc(
-			checkoutSessionsEmbedLineItems,
-			jsonquery.Convertor.ObjectToMap, // raw already has line-items
-		)
-	}
-
 	return common.ParseResult(res,
 		makeGetRecords(responseFieldName),
 		makeNextRecordsURL(url),
-		marshaller,
+		readhelper.MakeMarshaledSelectedDataFunc(
+			fieldsSelector,
+			jsonquery.Convertor.ObjectToMap,
+		),
 		selectedFields,
 	)
 }
@@ -364,7 +345,7 @@ var incrementalObjects = datautils.NewSet( // nolint:gochecknoglobals
 	"treasury/financial_accounts",
 )
 
-func checkoutSessionsEmbedLineItems(node *ajson.Node, fields []string) (map[string]any, string, error) {
+func fieldsSelector(node *ajson.Node, fields []string) (map[string]any, string, error) {
 	root, err := jsonquery.Convertor.ObjectToMap(node)
 	if err != nil {
 		return nil, "", err
@@ -375,7 +356,13 @@ func checkoutSessionsEmbedLineItems(node *ajson.Node, fields []string) (map[stri
 		return nil, "", err
 	}
 
+	customFields, err := getCustomFields(node)
+	if err != nil {
+		return nil, "", err
+	}
+
 	selected := readhelper.SelectFields(root, datautils.NewSetFromList(fields))
+	maps.Copy(selected, customFields)
 
 	return selected, identifier, nil
 }

--- a/providers/stripe/read_test.go
+++ b/providers/stripe/read_test.go
@@ -26,6 +26,8 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCustomersWithMetadata := testutils.DataFromFile(t, "read/customers/with-metadata.json")
 	responseCheckoutSessionsWithItems := testutils.DataFromFile(t, "read/checkout-sessions/with-line-items.json")
 	responseInvoices := testutils.DataFromFile(t, "read/invoices/incremental.json")
+	responseBalanceWithSource := testutils.DataFromFile(t, "read/balance_transactions/nested-source.json")
+	responseBalanceWithPaymentIntents := testutils.DataFromFile(t, "read/balance_transactions/nested-source-nested-payment-intent.json")
 
 	tests := []testconn.TestCaseRead{
 		{
@@ -401,6 +403,72 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 					Raw: map[string]any{"email": "sean.foster@example.com"},
 					Id:  "cus_Rd3NKXxTV0Hzpp",
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Balance transactions requested with nested source",
+			Input: common.ReadParams{
+				ObjectName: "balance_transactions",
+				Fields:     connectors.Fields("$['source']['amount']"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/v1/balance_transactions"),
+					mockcond.QueryParam("expand[]", "data.source"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseBalanceWithSource),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"source": map[string]any{
+							"amount": float64(1100),
+						},
+					},
+					Raw: map[string]any{"currency": "usd"},
+					Id:  "txn_3TonX5ES6gLOjP911H3BpXoI",
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Balance transactions requested with nested payment intents",
+			Input: common.ReadParams{
+				ObjectName: "balance_transactions",
+				Fields:     connectors.Fields("$['source']['payment_intent']['customer']['email']"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/v1/balance_transactions"),
+					mockcond.QueryParam("expand[]", "data.source.payment_intent.customer"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseBalanceWithPaymentIntents),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"source": map[string]any{
+							"payment_intent": map[string]any{
+								"customer": map[string]any{
+									"email": "andrew.ross@example.com",
+								},
+							},
+						},
+					},
+					Raw: map[string]any{"available_on": float64(1783010097)},
+					Id:  "txn_3TonX5ES6gLOjP911H3BpXoI",
 				}},
 				NextPage: "",
 				Done:     true,

--- a/providers/stripe/test/read/balance_transactions/nested-source-nested-payment-intent.json
+++ b/providers/stripe/test/read/balance_transactions/nested-source-nested-payment-intent.json
@@ -1,0 +1,177 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "txn_3TonX5ES6gLOjP911H3BpXoI",
+      "object": "balance_transaction",
+      "amount": 1100,
+      "available_on": 1783010097,
+      "balance_type": "payments",
+      "created": 1783010092,
+      "currency": "usd",
+      "description": null,
+      "exchange_rate": null,
+      "fee": 9,
+      "fee_details": [
+        {
+          "amount": 9,
+          "application": null,
+          "currency": "usd",
+          "description": "Stripe processing fees",
+          "type": "stripe_fee"
+        }
+      ],
+      "net": 1091,
+      "reporting_category": "charge",
+      "source": {
+        "id": "py_3TonX5ES6gLOjP9113RJaMNS",
+        "object": "charge",
+        "amount": 1100,
+        "amount_captured": 1100,
+        "amount_refunded": 0,
+        "application": null,
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": "txn_3TonX5ES6gLOjP911H3BpXoI",
+        "billing_details": {
+          "address": {
+            "city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null
+          },
+          "email": null,
+          "name": "User 002",
+          "phone": null,
+          "tax_id": null
+        },
+        "calculated_statement_descriptor": null,
+        "captured": true,
+        "created": 1783010085,
+        "currency": "usd",
+        "customer": "cus_Rd3kcMGRvsoY8j",
+        "description": null,
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_balance_transaction": null,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {},
+        "invoice": null,
+        "livemode": false,
+        "metadata": {},
+        "on_behalf_of": null,
+        "order": null,
+        "outcome": {
+          "advice_code": null,
+          "network_advice_code": null,
+          "network_decline_code": null,
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "risk_score": 13,
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": {
+          "id": "pi_3TonX5ES6gLOjP9110pnynic",
+          "object": "payment_intent",
+          "amount": 1100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 1100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3TonX5ES6gLOjP9110pnynic_secret_yufAmnvbkgcO1FzisLLzdfVIB",
+          "confirmation_method": "automatic",
+          "created": 1783009931,
+          "currency": "usd",
+          "customer": {
+            "id": "cus_Rd3kcMGRvsoY8j",
+            "email": "andrew.ross@example.com"
+          },
+          "customer_account": null,
+          "description": null,
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "py_3TonX5ES6gLOjP9113RJaMNS",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {},
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1TonIuES6gLOjP91uyNbV5xz",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "us_bank_account": {
+              "mandate_options": {},
+              "transaction_purpose": "unspecified",
+              "verification_method": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "us_bank_account"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        },
+        "payment_method": "pm_1TonIuES6gLOjP91uyNbV5xz",
+        "payment_method_details": {
+          "type": "us_bank_account",
+          "us_bank_account": {
+            "account_holder_type": "individual",
+            "account_type": "checking",
+            "bank_name": "STRIPE TEST BANK",
+            "expected_debit_date": "2026-07-02",
+            "fingerprint": "8uWn0GTh9ts6fjyh",
+            "last4": "6789",
+            "mandate": "mandate_1TonJFES6gLOjP910IFf3y3N",
+            "payment_reference": "fHCKkEd0+RBS6nC39y2NJCxd2/c9HjgYTDCTOLE1ad0=",
+            "routing_number": "110000000"
+          }
+        },
+        "radar_options": {},
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3lIeEhFUzZnTE9qUDkxKL35mtIGMgaZaYuOezU6LBbLzzU-R87tuBi_p4A3o8DQq_NGwsYpc72uPiZkyJ_im32EIQkyvXWynY4H",
+        "refunded": false,
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+      },
+      "status": "available",
+      "type": "payment"
+    }
+  ],
+  "has_more": false,
+  "url": "/v1/balance_transactions"
+}

--- a/providers/stripe/test/read/balance_transactions/nested-source.json
+++ b/providers/stripe/test/read/balance_transactions/nested-source.json
@@ -1,0 +1,117 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "txn_3TonX5ES6gLOjP911H3BpXoI",
+      "object": "balance_transaction",
+      "amount": 1100,
+      "available_on": 1783010097,
+      "balance_type": "payments",
+      "created": 1783010092,
+      "currency": "usd",
+      "description": null,
+      "exchange_rate": null,
+      "fee": 9,
+      "fee_details": [
+        {
+          "amount": 9,
+          "application": null,
+          "currency": "usd",
+          "description": "Stripe processing fees",
+          "type": "stripe_fee"
+        }
+      ],
+      "net": 1091,
+      "reporting_category": "charge",
+      "source": {
+        "id": "py_3TonX5ES6gLOjP9113RJaMNS",
+        "object": "charge",
+        "amount": 1100,
+        "amount_captured": 1100,
+        "amount_refunded": 0,
+        "application": null,
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": "txn_3TonX5ES6gLOjP911H3BpXoI",
+        "billing_details": {
+          "address": {
+            "city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null
+          },
+          "email": null,
+          "name": "User 002",
+          "phone": null,
+          "tax_id": null
+        },
+        "calculated_statement_descriptor": null,
+        "captured": true,
+        "created": 1783010085,
+        "currency": "usd",
+        "customer": "cus_Rd3kcMGRvsoY8j",
+        "description": null,
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_balance_transaction": null,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {},
+        "invoice": null,
+        "livemode": false,
+        "metadata": {},
+        "on_behalf_of": null,
+        "order": null,
+        "outcome": {
+          "advice_code": null,
+          "network_advice_code": null,
+          "network_decline_code": null,
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "risk_score": 13,
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_3TonX5ES6gLOjP9110pnynic",
+        "payment_method": "pm_1TonIuES6gLOjP91uyNbV5xz",
+        "payment_method_details": {
+          "type": "us_bank_account",
+          "us_bank_account": {
+            "account_holder_type": "individual",
+            "account_type": "checking",
+            "bank_name": "STRIPE TEST BANK",
+            "expected_debit_date": "2026-07-02",
+            "fingerprint": "8uWn0GTh9ts6fjyh",
+            "last4": "6789",
+            "mandate": "mandate_1TonJFES6gLOjP910IFf3y3N",
+            "payment_reference": "fHCKkEd0+RBS6nC39y2NJCxd2/c9HjgYTDCTOLE1ad0=",
+            "routing_number": "110000000"
+          }
+        },
+        "radar_options": {},
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT3lIeEhFUzZnTE9qUDkxKPWmmtIGMgYZcpjYMTs6LBah0Ejid0EWrutpzx45L5fiGfwb-4e1OpwOwMZINaHPbbZkDsf2yyWU_8-c",
+        "refunded": false,
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+      },
+      "status": "available",
+      "type": "payment"
+    }
+  ],
+  "has_more": false,
+  "url": "/v1/balance_transactions"
+}

--- a/test/stripe/read/balance-transactions/main.go
+++ b/test/stripe/read/balance-transactions/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/stripe"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetStripeConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "balance_transactions",
+		Fields: connectors.Fields(
+			"$['source']['amount']",
+			"$['source']['payment_intent']['currency']",
+			"$['source']['payment_intent']['customer']['name']",
+		),
+		PageSize: 1,
+	})
+	if err != nil {
+		utils.Fail("error reading from provider", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Description

* `readhelper.SelectFields` now applies to all objects without exceptions. (allows selecting deeply nested objects/arrays/primitives)
* `customFields` are also attached to all applicable objects. This behavior is unchanged, and the unit test for custom fields still pass.
* `MakeExpandableQueryParam` can now construct complex, deeply nested `expand[]` query parameters. See the detailed docs for the algorithm.
  * `query-param_test.go` contains unit tests that show which query params are generated from a JSON path.

# Live Tests

## Checkout Sessions

Checkout Sessions behaves as before.
This does top root level expanding.
<img width="705" height="1112" alt="image" src="https://github.com/user-attachments/assets/a98340eb-db05-4a61-a91f-37a45c8db34f" />

## Balance Transactions

Deeply nested fields are now supported:
<img width="664" height="747" alt="image" src="https://github.com/user-attachments/assets/22509c20-3199-4635-b956-2de8403dd428" />

Usually, when the `payment_intent` is not expanded, the raw payload looks like this, with `payment_intent` set to an ID instead of an object:
<img width="669" height="657" alt="image" src="https://github.com/user-attachments/assets/8bf4e0fd-b6bf-44d7-87e1-2b00810ab7ca" />