### PR TITLE
[CON-2843] fix(supersend): Fixed campaigns and identities endpoint URL

### DIFF
--- a/providers/supersend/delete_test.go
+++ b/providers/supersend/delete_test.go
@@ -64,7 +64,7 @@ func TestDelete(t *testing.T) {
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.MethodDELETE(),
-					mockcond.Path("/v1/auto/campaign/campaign-001"),
+					mockcond.Path("/v1/campaign/campaign-001"),
 				},
 				Then: mockserver.Response(http.StatusOK),
 			}.Server(),

--- a/providers/supersend/handlers.go
+++ b/providers/supersend/handlers.go
@@ -66,9 +66,9 @@ var objectWritePaths = map[string]writePathConfig{
 		deletePath: "", // No delete endpoint documented
 	},
 	"campaigns": {
-		createPath: "/v1/auto/campaign",
+		createPath: "/v1/campaign",
 		updatePath: "/v1/campaign",
-		deletePath: "/v1/auto/campaign",
+		deletePath: "/v1/campaign",
 	},
 	"contacts": {
 		createPath: "/v2/contacts",

--- a/providers/supersend/metadata/schemas.json
+++ b/providers/supersend/metadata/schemas.json
@@ -697,10 +697,10 @@
             }
           }
         },
-        "auto/identitys": {
+        "identities": {
           "displayName": "Identities",
-          "path": "/auto/identitys",
-          "responseKey": "identities",
+          "path": "/identities",
+          "responseKey": "data",
           "fields": {
             "id": {
               "displayName": "id",

--- a/providers/supersend/metadata_test.go
+++ b/providers/supersend/metadata_test.go
@@ -36,7 +36,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Input: []string{
 				"teams", "senders", "contact/all", "sender-profiles",
 				"labels", "campaigns/overview", "managed-domains", "managed-mailboxes",
-				"placement-tests", "auto/identitys", "conversation/latest-by-profile",
+				"placement-tests", "identities", "conversation/latest-by-profile",
 			},
 			Server:     mockserver.Dummy(),
 			Comparator: testroutines.ComparatorSubsetMetadata,
@@ -262,7 +262,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							},
 						},
 					},
-					"auto/identitys": {
+					"identities": {
 						DisplayName: "Identities",
 						Fields: map[string]common.FieldMetadata{
 							"id": {

--- a/providers/supersend/write_test.go
+++ b/providers/supersend/write_test.go
@@ -216,7 +216,7 @@ func TestWrite(t *testing.T) {
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.MethodPOST(),
-					mockcond.Path("/v1/auto/campaign"),
+					mockcond.Path("/v1/campaign"),
 				},
 				Then: mockserver.Response(http.StatusOK, createCampaignResponse),
 			}.Server(),

--- a/test/supersend/metadata/main.go
+++ b/test/supersend/metadata/main.go
@@ -24,7 +24,7 @@ func main() {
 		"managed-domains",
 		"managed-mailboxes",
 		"placement-tests",
-		"auto/identitys",
+		"identities",
 		"conversation/latest-by-profile",
 	})
 	if err != nil {

--- a/test/supersend/read/main.go
+++ b/test/supersend/read/main.go
@@ -50,8 +50,8 @@ func main() {
 	// 10. placement-tests
 	readObject(ctx, conn, "placement-tests", connectors.Fields("id", "name", "status", "score"))
 
-	// 11. auto/identitys
-	readObject(ctx, conn, "auto/identitys", connectors.Fields("id", "username", "type", "status"))
+	// 11. identities
+	readObject(ctx, conn, "identities", connectors.Fields("id", "username", "type", "status"))
 
 	// 12. conversation/latest-by-profile (nested responseKey: data.conversations)
 	readObject(ctx, conn, "conversation/latest-by-profile", connectors.Fields("id", "title", "is_unread", "platform_type"))


### PR DESCRIPTION
Corrects the `Campaigns` write (/v1/auto/campaign → /v1/campaign) and `Identities` read (/auto/identitys → /identities, responseKey data) endpoint paths, which previously returned 404.