### PR TITLE
[CON-3344] [CON-3345] Jump: read support and metadata via record sampling

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -84,6 +84,7 @@ import (
 	"github.com/amp-labs/connectors/providers/intercom"
 	"github.com/amp-labs/connectors/providers/iterable"
 	"github.com/amp-labs/connectors/providers/jobber"
+	"github.com/amp-labs/connectors/providers/jump"
 	"github.com/amp-labs/connectors/providers/justcall"
 	"github.com/amp-labs/connectors/providers/kaseyavsax"
 	"github.com/amp-labs/connectors/providers/keap"
@@ -238,6 +239,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Intercom:                   wrapper(newIntercomConnector),
 	providers.Iterable:                   wrapper(newIterableConnector),
 	providers.Jobber:                     wrapper(newJobberConnector),
+	providers.Jump:                       wrapper(newJumpConnector),
 	providers.JustCall:                   wrapper(newJustCallConnector),
 	providers.KaseyaVSAX:                 wrapper(newKaseyaVSAXConnector),
 	providers.Keap:                       wrapper(newKeapConnector),
@@ -1091,6 +1093,12 @@ func newJobberConnector(
 	params common.ConnectorParams,
 ) (*jobber.Connector, error) {
 	return jobber.NewConnector(params)
+}
+
+func newJumpConnector(
+	params common.ConnectorParams,
+) (*jump.Connector, error) {
+	return jump.NewConnector(params)
 }
 
 func newJustCallConnector(

--- a/providers/jump/connector.go
+++ b/providers/jump/connector.go
@@ -1,0 +1,57 @@
+package jump
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+)
+
+type Connector struct {
+	*components.Connector
+
+	// Require authenticated client
+	common.RequireAuthenticatedClient
+	components.Reader
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Init(providers.Jump, params, constructor)
+}
+
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	registry := components.NewEmptyEndpointRegistry()
+
+	connector.SchemaProvider = schema.NewObjectSchemaProvider(
+		connector.HTTPClient().Client,
+		schema.FetchModeParallel,
+		operations.SingleObjectMetadataHandlers{
+			BuildRequest:  connector.buildSingleObjectMetadataRequest,
+			ParseResponse: connector.parseSingleObjectMetadataResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler: interpreter.ErrorHandler{
+				JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+			}.Handle,
+		},
+	)
+
+	return connector, nil
+}

--- a/providers/jump/errors.go
+++ b/providers/jump/errors.go
@@ -1,0 +1,61 @@
+package jump
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( //nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+type ResponseError struct {
+	Errors []ErrorDetails `json:"errors"`
+}
+
+type ErrorDetails struct {
+	Message string `json:"message,omitempty"`
+}
+
+func (r ResponseError) CombineErr(base error) error {
+	if len(r.Errors) == 0 {
+		return base
+	}
+
+	messages := make([]string, len(r.Errors))
+	for i, obj := range r.Errors {
+		messages[i] = obj.Message
+	}
+
+	return fmt.Errorf("%w: %v", base, strings.Join(messages, ", "))
+}
+
+//	{
+//		"errors": [{
+//		  "message": "Meeting not found",
+//		  "extensions": {
+//			"code": "MEETING_NOT_FOUND",
+//			"details": {
+//			  "id": "mtg_123"
+//			}
+//		  }
+//		}]
+//	  }
+//
+// Jump returns HTTP 200 even when the operation fails, so errors must be detected here rather
+// than by the status-code based error handler.
+func checkErrorInResponse(errorResp *ResponseError) error {
+	if errorResp == nil || len(errorResp.Errors) == 0 {
+		return nil
+	}
+
+	return errorResp.CombineErr(common.ErrBadRequest)
+}

--- a/providers/jump/graphql/query_contacts.graphql
+++ b/providers/jump/graphql/query_contacts.graphql
@@ -1,0 +1,42 @@
+query Contacts {
+  contacts(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      {{- if index .Fields "contactInfo"}}
+      contactInfo {
+        kind
+        source
+        value
+      }
+      {{- end}}
+      email
+      id
+      insertedAt
+      {{- if index .Fields "integrationReferences"}}
+      integrationReferences {
+        crmUrl
+        recordId
+        recordType
+        service
+      }
+      {{- end}}
+      name
+      status
+      type
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_documents.graphql
+++ b/providers/jump/graphql/query_documents.graphql
@@ -1,0 +1,32 @@
+query Documents {
+  documents(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      contactId
+      id
+      insertedAt
+      name
+      {{- if index .Fields "parsedResult"}}
+      parsedResult
+      {{- end}}
+      parsedText
+      processingState
+      updatedAt
+      userId
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_integrations.graphql
+++ b/providers/jump/graphql/query_integrations.graphql
@@ -1,0 +1,26 @@
+query Integrations {
+  integrations(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      accountEmail
+      id
+      insertedAt
+      kind
+      service
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_meetingPreps.graphql
+++ b/providers/jump/graphql/query_meetingPreps.graphql
@@ -1,0 +1,40 @@
+query MeetingPreps {
+  meetingPreps(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      {{- if index .Fields "answers"}}
+      answers {
+        answer
+        question
+      }
+      {{- end}}
+      contactId
+      id
+      insertedAt
+      {{- if index .Fields "prepContents"}}
+      prepContents {
+        content
+        insertedAt
+        name
+        updatedAt
+      }
+      {{- end}}
+      updatedAt
+      userId
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_meetings.graphql
+++ b/providers/jump/graphql/query_meetings.graphql
@@ -1,0 +1,187 @@
+query Meetings {
+  meetings(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      duration
+      endedAt
+      {{- if index .Fields "host"}}
+      host {
+        contactId
+        email
+        external
+        id
+        joinTime
+        leaveTime
+        name
+        role
+      }
+      {{- end}}
+      id
+      {{- if index .Fields "meetingEvents"}}
+      meetingEvents {
+        id
+        insertedAt
+        meta
+        status
+        type
+      }
+      {{- end}}
+      meetingType
+      meetingUrl
+      {{- if index .Fields "notes"}}
+      notes {
+        id
+        insertedAt
+        meetingId
+        note
+        subject
+      }
+      {{- end}}
+      {{- if index .Fields "owner"}}
+      owner {
+        deactivatedAt
+        email
+        firstName
+        fullName
+        id
+        lastName
+        owner
+      }
+      {{- end}}
+      {{- if index .Fields "participants"}}
+      participants {
+        contactId
+        email
+        external
+        id
+        joinTime
+        leaveTime
+        name
+        role
+      }
+      {{- end}}
+      platformMeetingId
+      {{- if index .Fields "pulseResults"}}
+      pulseResults {
+        evaluatedAt
+        id
+        meetingId
+        pulseId
+        resultJson
+        resultType
+        resultValue
+      }
+      {{- end}}
+      rawTranscript
+      {{- if index .Fields "recordSuggestions"}}
+      recordSuggestions {
+        actionId
+        fields {
+          name
+          recordType
+          value
+        }
+        id
+        integrationReferenceId
+        integrationReferenceIds
+        kind
+        parentRecordType
+        recordType
+        service
+        state
+        taskId
+        taskTitle
+      }
+      {{- end}}
+      {{- if index .Fields "scorecardResults"}}
+      scorecardResults {
+        calcType
+        calcValue
+        criteriaResults {
+          criteriaScores {
+            explanation
+            value
+          }
+          criteriaValue
+          gradingMethod
+          id
+          name
+          numericUpperScore
+          order
+        }
+        evaluatedAt
+        format
+        id
+        meetingId
+        name
+        scorecardId
+        showCumulative
+        viewable
+      }
+      {{- end}}
+      {{- if index .Fields "signalResults"}}
+      signalResults {
+        confidence
+        description
+        evaluatedAt
+        id
+        meetingId
+        priority
+        rawData
+        signalCategory
+        signalDefinitionId
+        signalType
+        title
+        urgency
+      }
+      {{- end}}
+      source
+      startedAt
+      status
+      summaryCreated
+      {{- if index .Fields "tasks"}}
+      tasks {
+        description
+        due
+        id
+        meetingId
+        status
+        title
+        assignee {
+          email
+          name
+          source
+        }
+      }
+      {{- end}}
+      topic
+      {{- if index .Fields "transcript"}}
+      transcript {
+        endAtSeconds
+        speaker
+        speakerId
+        startAtSeconds
+        text
+        timestamp
+      }
+      {{- end}}
+      transcriptCreatedAt
+      transcriptId
+      transcriptLanguage
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_notes.graphql
+++ b/providers/jump/graphql/query_notes.graphql
@@ -1,0 +1,26 @@
+query Notes {
+  notes(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      id
+      insertedAt
+      meetingId
+      note
+      subject
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_pulses.graphql
+++ b/providers/jump/graphql/query_pulses.graphql
@@ -1,0 +1,26 @@
+query Pulses {
+  pulses(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      description
+      id
+      insertedAt
+      meetingTypes
+      name
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_scorecards.graphql
+++ b/providers/jump/graphql/query_scorecards.graphql
@@ -1,0 +1,42 @@
+query Scorecards {
+  scorecards(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      calcType
+      calcValue
+      {{- if index .Fields "criteria"}}
+      criteria {
+        description
+        gradingFactors
+        gradingMethod
+        id
+        name
+        numericUpperScore
+        order
+      }
+      {{- end}}
+      description
+      format
+      id
+      insertedAt
+      meetingTypes
+      name
+      showCumulative
+      viewable
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_signalDefinitions.graphql
+++ b/providers/jump/graphql/query_signalDefinitions.graphql
@@ -1,0 +1,28 @@
+query SignalDefinitions {
+  signalDefinitions(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      createdById
+      id
+      insertedAt
+      key
+      modelVersion
+      name
+      prompt
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_tasks.graphql
+++ b/providers/jump/graphql/query_tasks.graphql
@@ -1,0 +1,34 @@
+query Tasks {
+  tasks(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      {{- if index .Fields "assignee"}}
+      assignee {
+        email
+        name
+        source
+      }
+      {{- end}}
+      description
+      due
+      id
+      meetingId
+      status
+      title
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/graphql/query_users.graphql
+++ b/providers/jump/graphql/query_users.graphql
@@ -1,0 +1,28 @@
+query Users {
+  users(
+    first: {{.First}}
+    {{if .After}}
+    after: "{{.After}}"
+    {{end}}
+    {{if .UpdatedAfter}}
+    updatedAfter: "{{.UpdatedAfter}}"
+    {{end}}
+    {{if .UpdatedBefore}}
+    updatedBefore: "{{.UpdatedBefore}}"
+    {{end}}
+  ) {
+    items {
+      deactivatedAt
+      email
+      firstName
+      fullName
+      id
+      lastName
+      owner
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/providers/jump/metadata.go
+++ b/providers/jump/metadata.go
@@ -1,0 +1,85 @@
+package jump
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+// optionalMetadataFields lists nested relations that read queries only include when requested.
+var optionalMetadataFields = map[string][]string{ //nolint:gochecknoglobals
+	"contacts":     {"contactInfo", "integrationReferences"},
+	"documents":    {"parsedResult"},
+	"meetingPreps": {"answers", "prepContents"},
+	"meetings": {
+		"host", "meetingEvents", "notes",
+		"owner", "participants", "pulseResults",
+		"recordSuggestions", "scorecardResults", "signalResults",
+		"tasks", "transcript",
+	},
+	"scorecards": {"criteria"},
+	"tasks":      {"assignee"},
+}
+
+var objectDisplayNames = map[string]string{ //nolint:gochecknoglobals
+	"contacts":          "Contacts",
+	"documents":         "Documents",
+	"integrations":      "Integrations",
+	"meetingPreps":      "Meeting Preps",
+	"meetings":          "Meetings",
+	"notes":             "Notes",
+	"pulses":            "Pulses",
+	"scorecards":        "Scorecards",
+	"signalDefinitions": "Signal Definitions",
+	"tasks":             "Tasks",
+	"users":             "Users",
+}
+
+func metadataReadParams(objectName string) common.ReadParams {
+	return common.ReadParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields(optionalMetadataFields[objectName]...),
+		PageSize:   1,
+	}
+}
+
+// GraphQL introspection is not available on the Jump API, so object metadata is
+// inferred by sampling the first record returned by a read query.
+func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
+	return c.buildReadRequest(ctx, metadataReadParams(objectName))
+}
+
+func (c *Connector) parseSingleObjectMetadataResponse(
+	ctx context.Context,
+	objectName string,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ObjectMetadata, error) {
+	result, err := c.parseReadResponse(ctx, metadataReadParams(objectName), request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Data) == 0 {
+		return nil, common.ErrMissingExpectedValues
+	}
+
+	objectMetadata := common.ObjectMetadata{
+		Fields:      make(map[string]common.FieldMetadata),
+		FieldsMap:   make(map[string]string),
+		DisplayName: objectDisplayNames[objectName],
+	}
+
+	for field, value := range result.Data[0].Raw {
+		objectMetadata.AddFieldMetadata(field, common.FieldMetadata{
+			DisplayName:  field,
+			ValueType:    common.InferValueTypeFromData(value),
+			ProviderType: "",
+			Values:       nil,
+		})
+	}
+
+	return &objectMetadata, nil
+}

--- a/providers/jump/metadata_test.go
+++ b/providers/jump/metadata_test.go
@@ -4,12 +4,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) {
 	requestContacts := testutils.DataFromFile(t, "metadata/request/contacts.json")
 	emptyContactsResponse := testutils.DataFromFile(t, "metadata-empty-contacts.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, contactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -92,7 +91,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, emptyContactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{},
 				Errors: map[string]error{
@@ -106,7 +105,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/jump/metadata_test.go
+++ b/providers/jump/metadata_test.go
@@ -1,0 +1,127 @@
+package jump
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestListObjectMetadata(t *testing.T) {
+	t.Parallel()
+
+	contactsResponse := testutils.DataFromFile(t, "metadata-contacts.json")
+	requestContacts := testutils.DataFromFile(t, "metadata/request/contacts.json")
+	emptyContactsResponse := testutils.DataFromFile(t, "metadata-empty-contacts.json")
+
+	tests := []testroutines.Metadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:  "Sample contacts metadata from first list record",
+			Input: []string{"contacts"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestContacts)),
+				},
+				Then: mockserver.Response(http.StatusOK, contactsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"contacts": {
+						DisplayName: "Contacts",
+						Fields: map[string]common.FieldMetadata{
+							"contactInfo": {
+								DisplayName: "contactInfo",
+								ValueType:   common.ValueTypeOther,
+							},
+							"email": {
+								DisplayName: "email",
+								ValueType:   common.ValueTypeString,
+							},
+							"id": {
+								DisplayName: "id",
+								ValueType:   common.ValueTypeString,
+							},
+							"insertedAt": {
+								DisplayName: "insertedAt",
+								ValueType:   common.ValueTypeString,
+							},
+							"integrationReferences": {
+								DisplayName: "integrationReferences",
+								ValueType:   common.ValueTypeOther,
+							},
+							"name": {
+								DisplayName: "name",
+								ValueType:   common.ValueTypeString,
+							},
+							"status": {
+								DisplayName: "status",
+								ValueType:   common.ValueTypeString,
+							},
+							"type": {
+								DisplayName: "type",
+								ValueType:   common.ValueTypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:  "Returns error when contacts list is empty",
+			Input: []string{"contacts"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestContacts)),
+				},
+				Then: mockserver.Response(http.StatusOK, emptyContactsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{},
+				Errors: map[string]error{
+					"contacts": common.ErrMissingExpectedValues,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		AuthenticatedClient: mockutils.NewClient(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetBaseURL(mockutils.ReplaceURLOrigin(connector.HTTPClient().Base, serverURL))
+
+	return connector, nil
+}

--- a/providers/jump/read.go
+++ b/providers/jump/read.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
@@ -30,20 +31,35 @@ type QueryParameters struct {
 	Fields        map[string]bool
 }
 
-func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
-	pageSize := maxPageSize
-	if params.PageSize > 0 {
-		pageSize = params.PageSize
-	}
-
-	fields := make(map[string]bool, len(params.Fields))
-	for field := range params.Fields {
+// nested relations are matched case-insensitively so templates can use exact schema names.
+func queryTemplateFields(objectName string, requested datautils.StringSet) map[string]bool {
+	fields := make(map[string]bool, len(requested))
+	for field := range requested {
 		fields[field] = true
 	}
 
+	for _, canonical := range optionalMetadataFields[objectName] {
+		for field := range requested {
+			if strings.EqualFold(field, canonical) {
+				fields[canonical] = true
+
+				break
+			}
+		}
+	}
+
+	return fields
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	first := maxPageSize
+	if params.PageSize > 0 && params.PageSize <= maxPageSize {
+		first = params.PageSize
+	}
+
 	queryParams := QueryParameters{
-		First:  pageSize,
-		Fields: fields,
+		First:  first,
+		Fields: queryTemplateFields(params.ObjectName, params.Fields),
 	}
 
 	if params.NextPage != "" {

--- a/providers/jump/read.go
+++ b/providers/jump/read.go
@@ -1,0 +1,159 @@
+package jump
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/graphql"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+const (
+	maxPageSize = 100
+)
+
+//go:embed graphql/*.graphql
+var queryFiles embed.FS
+
+type QueryParameters struct {
+	First         int
+	After         string
+	UpdatedAfter  string
+	UpdatedBefore string
+	Fields        map[string]bool
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	pageSize := maxPageSize
+	if params.PageSize > 0 {
+		pageSize = params.PageSize
+	}
+
+	fields := make(map[string]bool, len(params.Fields))
+	for field := range params.Fields {
+		fields[field] = true
+	}
+
+	queryParams := QueryParameters{
+		First:  pageSize,
+		Fields: fields,
+	}
+
+	if params.NextPage != "" {
+		queryParams.After = params.NextPage.String()
+	}
+
+	if !params.Since.IsZero() {
+		queryParams.UpdatedAfter = datautils.Time.FormatRFC3339inUTC(params.Since)
+	}
+
+	if !params.Until.IsZero() {
+		queryParams.UpdatedBefore = datautils.Time.FormatRFC3339inUTC(params.Until)
+	}
+
+	return c.buildGraphQLRequest(ctx, params.ObjectName, queryParams)
+}
+
+func (c *Connector) buildGraphQLRequest(
+	ctx context.Context,
+	objectName string,
+	queryParams QueryParameters,
+) (*http.Request, error) {
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	query, err := graphql.Operation(queryFiles, "query", objectName, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	requestBody := map[string]string{
+		"query": query,
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	if _, ok := resp.Body(); ok {
+		errorResp, err := common.UnmarshalJSON[ResponseError](resp)
+		if err == nil && errorResp != nil {
+			if checkErr := checkErrorInResponse(errorResp); checkErr != nil {
+				return nil, checkErr
+			}
+		}
+	}
+
+	return common.ParseResult(
+		resp,
+		common.ExtractOptionalRecordsFromPath("items", "data", params.ObjectName),
+		makeNextRecordsURL(params.ObjectName),
+		common.GetMarshaledData,
+		params.Fields,
+	)
+}
+
+//	{
+//		"data": {
+//		  "meetings": {
+//			"items": [
+//			  ................
+//			],
+//			"pageInfo": {
+//			  "hasNextPage": true,
+//			  "hasPreviousPage": false,
+//			  "startCursor": "g3QAAAABZAAGb2Zmc2V0YQA=",
+//			  "endCursor": "g3QAAAABZAAGb2Zmc2V0YQk="
+//			}
+//		  }
+//		}
+//	  }
+func makeNextRecordsURL(objectName string) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		pageInfo, err := jsonquery.New(node, "data", objectName).ObjectOptional("pageInfo")
+		if err != nil {
+			return "", err
+		}
+
+		if pageInfo == nil {
+			return "", nil
+		}
+
+		hasNextPage, err := jsonquery.New(pageInfo).BoolOptional("hasNextPage")
+		if err != nil {
+			return "", err
+		}
+
+		if hasNextPage == nil || !*hasNextPage {
+			return "", nil
+		}
+
+		return jsonquery.New(pageInfo).StrWithDefault("endCursor", "")
+	}
+}

--- a/providers/jump/read_test.go
+++ b/providers/jump/read_test.go
@@ -1,0 +1,208 @@
+package jump
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) {
+	t.Parallel()
+
+	tasksResponse := testutils.DataFromFile(t, "read-tasks.json")
+	requestTasks := testutils.DataFromFile(t, "read/request/tasks.json")
+	tasksPage2Response := testutils.DataFromFile(t, "read-tasks-page2.json")
+	requestTasksPage2 := testutils.DataFromFile(t, "read/request/tasks-page2.json")
+	meetingsResponse := testutils.DataFromFile(t, "read-meetings.json")
+	requestMeetings := testutils.DataFromFile(t, "read/request/meetings.json")
+	readErrorResponse := testutils.DataFromFile(t, "read-error.json")
+
+	tests := []testroutines.Read{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "tasks"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name: "Successfully read tasks with assignee",
+			Input: common.ReadParams{
+				ObjectName: "tasks",
+				Fields:     connectors.Fields("id", "title", "assignee"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestTasks)),
+				},
+				Then: mockserver.Response(http.StatusOK, tasksResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":    "tsk_9e17843922b94782832",
+							"title": "TEST",
+						},
+						Raw: map[string]any{
+							"id":          "tsk_9e17843922b94782832",
+							"title":       "TEST",
+							"status":      "Todo",
+							"meetingId":   "mtg_fbff3264957a48b4888",
+							"description": "TEST",
+							"assignee": map[string]any{
+								"email":  "ada@example.com",
+								"name":   "Amperasnd Developer",
+								"source": "USER",
+							},
+						},
+					},
+					{
+						Fields: map[string]any{
+							"id":    "tsk_bde1c8b314e8459893e",
+							"title": "Send follow-up email",
+						},
+						Raw: map[string]any{
+							"id":        "tsk_bde1c8b314e8459893e",
+							"title":     "Send follow-up email",
+							"status":    "Todo",
+							"meetingId": "mtg_fbff3264957a48b4888",
+						},
+					},
+				},
+				NextPage: "g3QAAAACdwJpZG0AAAAXdHNrX2JkZTFjOGIzMTRlODQ1OTg5M2V3C2luc2VydGVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJiAAJEgWEGdwZzZWNvbmRhCXcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQZ3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3BHllYXJiAAAH6ncEaG91cmEXdwNkYXlhF3cJem9uZV9hYmJybQAAAANVVEN3Bm1pbnV0ZWESdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEM=",
+				Done:     false,
+			},
+		},
+		{
+			Name: "Read tasks second page using NextPage cursor",
+			Input: common.ReadParams{
+				ObjectName: "tasks",
+				Fields:     connectors.Fields("id", "title"),
+				PageSize:   2,
+				NextPage:   common.NextPageToken("g3QAAAACdwJpZG0AAAAXdHNrX2JkZTFjOGIzMTRlODQ1OTg5M2V3C2luc2VydGVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJiAAJEgWEGdwZzZWNvbmRhCXcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQZ3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3BHllYXJiAAAH6ncEaG91cmEXdwNkYXlhF3cJem9uZV9hYmJybQAAAANVVEN3Bm1pbnV0ZWESdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEM="),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestTasksPage2)),
+				},
+				Then: mockserver.Response(http.StatusOK, tasksPage2Response),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":    "tsk_page2_example001",
+							"title": "Review notes",
+						},
+						Raw: map[string]any{
+							"id":        "tsk_page2_example001",
+							"title":     "Review notes",
+							"status":    "Done",
+							"meetingId": "mtg_fbff3264957a48b4888",
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "GraphQL errors in response return error",
+			Input: common.ReadParams{
+				ObjectName: "tasks",
+				Fields:     connectors.Fields("id"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+				},
+				Then: mockserver.Response(http.StatusOK, readErrorResponse),
+			}.Server(),
+			ExpectedErrs: []error{
+				testutils.StringError("VALIDATION_FAILED: invalid cursor"),
+			},
+		},
+		{
+			Name: "Successfully read meetings",
+			Input: common.ReadParams{
+				ObjectName: "meetings",
+				Fields:     connectors.Fields("id", "status", "source", "startedAt"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestMeetings)),
+				},
+				Then: mockserver.Response(http.StatusOK, meetingsResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":        "mtg_2df34b22211d4f248f8",
+							"status":    "FAILED",
+							"source":    "WEB_RECORDER",
+							"startedat": "2026-06-27T23:06:44.246638Z",
+						},
+						Raw: map[string]any{
+							"id":        "mtg_2df34b22211d4f248f8",
+							"status":    "FAILED",
+							"source":    "WEB_RECORDER",
+							"startedAt": "2026-06-27T23:06:44.246638Z",
+						},
+					},
+					{
+						Fields: map[string]any{
+							"id":        "mtg_fbff3264957a48b4888",
+							"status":    "COMPLETED",
+							"source":    nil,
+							"startedat": "2026-06-23T23:18:09.022872Z",
+						},
+						Raw: map[string]any{
+							"id":        "mtg_fbff3264957a48b4888",
+							"status":    "COMPLETED",
+							"source":    nil,
+							"startedAt": "2026-06-23T23:18:09.022872Z",
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (connectors.ReadConnector, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/jump/read_test.go
+++ b/providers/jump/read_test.go
@@ -144,6 +144,60 @@ func TestRead(t *testing.T) {
 			},
 		},
 		{
+			Name: "Read tasks with case-insensitive nested field includes assignee in query",
+			Input: common.ReadParams{
+				ObjectName: "tasks",
+				Fields:     connectors.Fields("id", "title", "Assignee"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Method(http.MethodPost),
+					mockcond.Body(string(requestTasks)),
+				},
+				Then: mockserver.Response(http.StatusOK, tasksResponse),
+			}.Server(),
+			Comparator: testroutines.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":    "tsk_9e17843922b94782832",
+							"title": "TEST",
+						},
+						Raw: map[string]any{
+							"id":          "tsk_9e17843922b94782832",
+							"title":       "TEST",
+							"status":      "Todo",
+							"meetingId":   "mtg_fbff3264957a48b4888",
+							"description": "TEST",
+							"assignee": map[string]any{
+								"email":  "ada@example.com",
+								"name":   "Amperasnd Developer",
+								"source": "USER",
+							},
+						},
+					},
+					{
+						Fields: map[string]any{
+							"id":    "tsk_bde1c8b314e8459893e",
+							"title": "Send follow-up email",
+						},
+						Raw: map[string]any{
+							"id":        "tsk_bde1c8b314e8459893e",
+							"title":     "Send follow-up email",
+							"status":    "Todo",
+							"meetingId": "mtg_fbff3264957a48b4888",
+						},
+					},
+				},
+				NextPage: "g3QAAAACdwJpZG0AAAAXdHNrX2JkZTFjOGIzMTRlODQ1OTg5M2V3C2luc2VydGVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJiAAJEgWEGdwZzZWNvbmRhCXcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQZ3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3BHllYXJiAAAH6ncEaG91cmEXdwNkYXlhF3cJem9uZV9hYmJybQAAAANVVEN3Bm1pbnV0ZWESdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEM=",
+				Done:     false,
+			},
+		},
+		{
 			Name: "Successfully read meetings",
 			Input: common.ReadParams{
 				ObjectName: "meetings",
@@ -204,5 +258,19 @@ func TestRead(t *testing.T) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
+	}
+}
+
+func TestQueryTemplateFields(t *testing.T) {
+	t.Parallel()
+
+	fields := queryTemplateFields("tasks", connectors.Fields("id", "Assignee"))
+
+	if !fields["assignee"] {
+		t.Fatal("expected canonical assignee key for case-insensitive request")
+	}
+
+	if !fields["Assignee"] {
+		t.Fatal("expected original requested field key to be preserved")
 	}
 }

--- a/providers/jump/read_test.go
+++ b/providers/jump/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	requestMeetings := testutils.DataFromFile(t, "read/request/meetings.json")
 	readErrorResponse := testutils.DataFromFile(t, "read-error.json")
 
-	tests := []testroutines.Read{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, tasksResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -105,7 +105,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, tasksPage2Response),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, tasksResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -212,7 +212,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, meetingsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -254,7 +254,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/jump/test/metadata-contacts.json
+++ b/providers/jump/test/metadata-contacts.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "contacts": {
+      "items": [
+        {
+          "contactInfo": [
+            {
+              "kind": "EMAIL",
+              "source": "JUMP_NATIVE",
+              "value": {
+                "address": "ada@example.com",
+                "kind": null,
+                "principal": true
+              }
+            },
+            {
+              "kind": "NAME",
+              "source": "JUMP_NATIVE",
+              "value": {
+                "family": "ada",
+                "prefix": null,
+                "suffix": null,
+                "middle": null,
+                "given": "ada",
+                "nickname": null,
+                "maiden_name": null
+              }
+            }
+          ],
+          "email": "ada@example.com",
+          "id": "con_db16c04d87d44df18c4",
+          "insertedAt": "2026-06-27T23:02:18.773614Z",
+          "integrationReferences": [],
+          "name": "ada ada",
+          "status": "CONFIRMED",
+          "type": "INDIVIDUAL"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "g2gCdAAAAA1",
+        "hasNextPage": false
+      }
+    }
+  }
+}

--- a/providers/jump/test/metadata-empty-contacts.json
+++ b/providers/jump/test/metadata-empty-contacts.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "contacts": {
+      "items": [],
+      "pageInfo": {
+        "endCursor": null,
+        "hasNextPage": false
+      }
+    }
+  }
+}

--- a/providers/jump/test/metadata/request/contacts.json
+++ b/providers/jump/test/metadata/request/contacts.json
@@ -1,0 +1,3 @@
+{
+  "query": "query Contacts {\n  contacts(\n    first: 1\n    \n    \n    \n  ) {\n    items {\n      contactInfo {\n        kind\n        source\n        value\n      }\n      email\n      id\n      insertedAt\n      integrationReferences {\n        crmUrl\n        recordId\n        recordType\n        service\n      }\n      name\n      status\n      type\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+}

--- a/providers/jump/test/read-error.json
+++ b/providers/jump/test/read-error.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "message": "VALIDATION_FAILED: invalid cursor"
+    }
+  ],
+  "data": null
+}

--- a/providers/jump/test/read-meetings.json
+++ b/providers/jump/test/read-meetings.json
@@ -1,0 +1,46 @@
+{
+    "data": {
+        "meetings": {
+            "items": [
+                {
+                    "duration": null,
+                    "endedAt": null,
+                    "id": "mtg_2df34b22211d4f248f8",
+                    "meetingType": null,
+                    "meetingUrl": null,
+                    "platformMeetingId": null,
+                    "rawTranscript": "",
+                    "source": "WEB_RECORDER",
+                    "startedAt": "2026-06-27T23:06:44.246638Z",
+                    "status": "FAILED",
+                    "summaryCreated": false,
+                    "topic": null,
+                    "transcriptCreatedAt": null,
+                    "transcriptId": null,
+                    "transcriptLanguage": null
+                },
+                {
+                    "duration": null,
+                    "endedAt": null,
+                    "id": "mtg_fbff3264957a48b4888",
+                    "meetingType": null,
+                    "meetingUrl": null,
+                    "platformMeetingId": null,
+                    "rawTranscript": "John Smith: Jane, Good to see you. How was the weekend? Did Leah's recital go well?\n\nJane Doe: It did. She was fantastic.",
+                    "source": null,
+                    "startedAt": "2026-06-23T23:18:09.022872Z",
+                    "status": "COMPLETED",
+                    "summaryCreated": true,
+                    "topic": "Example meeting",
+                    "transcriptCreatedAt": null,
+                    "transcriptId": null,
+                    "transcriptLanguage": null
+                }
+            ],
+            "pageInfo": {
+                "endCursor": "g3QAAAACdwJpZG0AAAAXbXRnX2ZiZmYzMjY0OTU3YTQ4YjQ4ODh3CnN0YXJ0ZWRfYXR0AAAADXcLbWljcm9zZWNvbmRoAmIAAFlYYQZ3BnNlY29uZGEJdwhjYWxlbmRhcncTRWxpeGlyLkNhbGVuZGFyLklTT3cFbW9udGhhBncKX19zdHJ1Y3RfX3cPRWxpeGlyLkRhdGVUaW1ldwp1dGNfb2Zmc2V0YQB3CnN0ZF9vZmZzZXRhAHcEeWVhcmIAAAfqdwRob3VyYRd3A2RheWEXdwl6b25lX2FiYnJtAAAAA1VUQ3cGbWludXRlYRJ3CXRpbWVfem9uZW0AAAAHRXRjL1VUQw==",
+                "hasNextPage": false
+            }
+        }
+    }
+}

--- a/providers/jump/test/read-tasks-page2.json
+++ b/providers/jump/test/read-tasks-page2.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "tasks": {
+      "items": [
+        {
+          "description": "Review notes from last meeting",
+          "due": null,
+          "id": "tsk_page2_example001",
+          "meetingId": "mtg_fbff3264957a48b4888",
+          "status": "Done",
+          "title": "Review notes"
+        }
+      ],
+      "pageInfo": {
+        "endCursor": null,
+        "hasNextPage": false
+      }
+    }
+  }
+}

--- a/providers/jump/test/read-tasks.json
+++ b/providers/jump/test/read-tasks.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+        "tasks": {
+            "items": [
+                {
+                    "assignee": {
+                        "email": "ada@example.com",
+                        "name": "Amperasnd Developer",
+                        "source": "USER"
+                    },
+                    "description": "TEST",
+                    "due": null,
+                    "id": "tsk_9e17843922b94782832",
+                    "meetingId": "mtg_fbff3264957a48b4888",
+                    "status": "Todo",
+                    "title": "TEST"
+                },
+                {
+                    "assignee": {
+                        "email": "ada@example.com",
+                        "name": "Amperasnd Developer",
+                        "source": "USER"
+                    },
+                    "description": "Send follow-up based on \"Comprehensive Financial Planning Session\" with Jane Doe.",
+                    "due": null,
+                    "id": "tsk_bde1c8b314e8459893e",
+                    "meetingId": "mtg_fbff3264957a48b4888",
+                    "status": "Todo",
+                    "title": "Send follow-up email"
+                }
+            ],
+            "pageInfo": {
+                "endCursor": "g3QAAAACdwJpZG0AAAAXdHNrX2JkZTFjOGIzMTRlODQ1OTg5M2V3C2luc2VydGVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJiAAJEgWEGdwZzZWNvbmRhCXcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQZ3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3BHllYXJiAAAH6ncEaG91cmEXdwNkYXlhF3cJem9uZV9hYmJybQAAAANVVEN3Bm1pbnV0ZWESdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEM=",
+                "hasNextPage": true
+            }
+        }
+    }
+}

--- a/providers/jump/test/read/request/meetings.json
+++ b/providers/jump/test/read/request/meetings.json
@@ -1,0 +1,3 @@
+{
+  "query": "query Meetings {\n  meetings(\n    first: 2\n    \n    \n    \n  ) {\n    items {\n      duration\n      endedAt\n      id\n      meetingType\n      meetingUrl\n      platformMeetingId\n      rawTranscript\n      source\n      startedAt\n      status\n      summaryCreated\n      topic\n      transcriptCreatedAt\n      transcriptId\n      transcriptLanguage\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+}

--- a/providers/jump/test/read/request/tasks-page2.json
+++ b/providers/jump/test/read/request/tasks-page2.json
@@ -1,0 +1,3 @@
+{
+  "query": "query Tasks {\n  tasks(\n    first: 2\n    \n    after: \"g3QAAAACdwJpZG0AAAAXdHNrX2JkZTFjOGIzMTRlODQ1OTg5M2V3C2luc2VydGVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJiAAJEgWEGdwZzZWNvbmRhCXcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQZ3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3BHllYXJiAAAH6ncEaG91cmEXdwNkYXlhF3cJem9uZV9hYmJybQAAAANVVEN3Bm1pbnV0ZWESdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEM=\"\n    \n    \n    \n  ) {\n    items {\n      description\n      due\n      id\n      meetingId\n      status\n      title\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+}

--- a/providers/jump/test/read/request/tasks.json
+++ b/providers/jump/test/read/request/tasks.json
@@ -1,0 +1,3 @@
+{
+  "query": "query Tasks {\n  tasks(\n    first: 2\n    \n    \n    \n  ) {\n    items {\n      assignee {\n        email\n        name\n        source\n      }\n      description\n      due\n      id\n      meetingId\n      status\n      title\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+}

--- a/test/jump/connector.go
+++ b/test/jump/connector.go
@@ -1,0 +1,27 @@
+package jump
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/jump"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetConnector(ctx context.Context) *jump.Connector {
+	filePath := credscanning.LoadPath(providers.Jump)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
+
+	client := utils.NewAPIKeyClient(ctx, reader, providers.Jump)
+
+	conn, err := jump.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating Jump connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/jump/metadata/main.go
+++ b/test/jump/metadata/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	connTest "github.com/amp-labs/connectors/test/jump"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetConnector(ctx)
+
+	res, err := conn.ListObjectMetadata(ctx, []string{
+		"contacts",
+		"meetings",
+		"notes",
+		"tasks",
+		"users",
+	})
+	if err != nil {
+		utils.Fail("error listing metadata from Jump", "error", err)
+	}
+
+	slog.Info("Listing metadata..")
+	utils.DumpJSON(res, os.Stdout)
+}

--- a/test/jump/read/main.go
+++ b/test/jump/read/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/jump"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetConnector(ctx)
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "meetings",
+		Fields:     connectors.Fields("id", "status", "source", "startedAt"),
+		PageSize:   2,
+	})
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "scorecards",
+		Fields:     connectors.Fields("id", "name", "criteria"),
+		PageSize:   2,
+	})
+
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "tasks",
+		Fields:     connectors.Fields("id", "name", "assignee"),
+		PageSize:   2,
+	})
+}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
## Sample Tests
### metadata

<img width="1507" height="1299" alt="Screenshot from 2026-07-03 21-17-59" src="https://github.com/user-attachments/assets/a74d1055-e25e-428d-8613-e454c352620b" />

<img width="1507" height="1299" alt="Screenshot from 2026-07-03 21-18-07" src="https://github.com/user-attachments/assets/24ea35e5-1280-4609-a189-7a2dcf05863c" />


<img width="1507" height="1299" alt="Screenshot from 2026-07-03 21-18-20" src="https://github.com/user-attachments/assets/7b2c6686-7e4f-4d0f-a5e1-ca6f2be0bf12" />


<img width="1507" height="1299" alt="Screenshot from 2026-07-03 21-18-27" src="https://github.com/user-attachments/assets/24001ac0-925b-4a51-91c8-888e88e46db0" />

### read

<img width="2456" height="1126" alt="Screenshot from 2026-07-03 21-28-39" src="https://github.com/user-attachments/assets/094eff0e-791e-4029-97cf-b09568dbc199" />
<img width="2552" height="1332" alt="Screenshot from 2026-07-03 21-28-51" src="https://github.com/user-attachments/assets/3ea9e7f4-f375-4013-ac19-54ddf90ac35d" />
<img width="1552" height="809" alt="Screenshot from 2026-07-03 21-32-34" src="https://github.com/user-attachments/assets/a24e9788-d9fa-41f7-a7f0-ce646312e360" />


<img width="1552" height="809" alt="Screenshot from 2026-07-03 21-32-41" src="https://github.com/user-attachments/assets/b57f1c31-5e19-4458-a7b7-079bf12ffac9" />



<img width="1552" height="809" alt="Screenshot from 2026-07-03 21-32-52" src="https://github.com/user-attachments/assets/6bccb097-49ac-4cc8-89be-e94e05567feb" />
