### PR TITLE
tidy(testroutines): TestCase as name prefix

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -203,9 +203,10 @@ type BatchRecordReaderConnector interface {
 	GetRecordsByIds(
 		ctx context.Context,
 		objectName string,
-		recordIds []string, //nolint:revive
+		recordIds []string,
 		fields []string,
-		associations []string) ([]common.ReadResultRow, error)
+		associations []string,
+	) ([]common.ReadResultRow, error)
 }
 
 // WebhookVerifierConnector defines the interface for connectors that can

--- a/internal/components/deleter/deleter_test.go
+++ b/internal/components/deleter/deleter_test.go
@@ -3,7 +3,6 @@ package deleter
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
@@ -15,7 +14,7 @@ import (
 func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -43,7 +42,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/internal/components/reader/reader_test.go
+++ b/internal/components/reader/reader_test.go
@@ -15,7 +15,7 @@ import (
 func TestRead(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -44,7 +44,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/internal/components/schema/openapi_test.go
+++ b/internal/components/schema/openapi_test.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
@@ -15,7 +14,7 @@ import (
 func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -62,7 +61,7 @@ func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL), nil
 			})
 		})

--- a/internal/components/writer/writer_test.go
+++ b/internal/components/writer/writer_test.go
@@ -3,7 +3,6 @@ package writer
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/internal/components/mocked"
@@ -15,7 +14,7 @@ import (
 func TestWrite(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -43,7 +42,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/delete_test.go
+++ b/providers/acculynx/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -75,7 +74,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/metadata_test.go
+++ b/providers/acculynx/metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -16,7 +15,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -190,7 +189,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -67,7 +67,7 @@ var jobHistoryResponse []byte
 func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -467,7 +467,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/write_test.go
+++ b/providers/acculynx/write_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -22,7 +21,7 @@ var jobCreateResponse []byte
 func TestWrite(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -487,7 +486,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestWriteConnector(tt.Server)
 			})
 		})

--- a/providers/acuityscheduling/metadata_test.go
+++ b/providers/acuityscheduling/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	clientsResponse := testutils.DataFromFile(t, "clients-read.json")
 	blocksResponse := testutils.DataFromFile(t, "blocks-read.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -158,7 +157,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acuityscheduling/read_test.go
+++ b/providers/acuityscheduling/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	clientsResponse := testutils.DataFromFile(t, "clients-read.json")
 	blocksResponse := testutils.DataFromFile(t, "blocks-read.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -152,7 +152,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acuityscheduling/write_test.go
+++ b/providers/acuityscheduling/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createClientsResponse := testutils.DataFromFile(t, "create-clients.json")
 	createAppointmentsResponse := testutils.DataFromFile(t, "create-appointments.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -109,7 +108,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aircall/delete_test.go
+++ b/providers/aircall/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		// --- Contacts ---
 		{
 			Name: "Delete contact successfully",
@@ -134,7 +133,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/metadata_test.go
+++ b/providers/aircall/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for Users and Calls",
 			Input:      []string{"users", "calls"},
@@ -83,7 +82,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/read_test.go
+++ b/providers/aircall/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseUsersPaginated := testutils.DataFromFile(t, "read/users/paginated-response.json")
 	responseCallsEmpty := testutils.DataFromFile(t, "read/calls/empty-response.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -460,7 +460,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/write_test.go
+++ b/providers/aircall/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -15,7 +14,7 @@ import (
 func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		// --- Contacts (POST/POST) ---
 		{
 			Name: "Create contact successfully",
@@ -440,7 +439,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/apollo/metadata_test.go
+++ b/providers/apollo/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	opportunityResponse := testutils.DataFromFile(t, "opportunities.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -78,7 +77,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/apollo/read_test.go
+++ b/providers/apollo/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 	sequencesResponse := testutils.DataFromFile(t, "sequences.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -82,7 +82,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/apollo/write_test.go
+++ b/providers/apollo/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	updateDealsResponse := testutils.DataFromFile(t, "update-deals.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -110,7 +109,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/metadata_test.go
+++ b/providers/asana/metadata_test.go
@@ -3,7 +3,6 @@ package asana
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -22,7 +21,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 	responseSingleTag := testutils.DataFromFile(t, "single-tag.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -149,7 +148,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/read_test.go
+++ b/providers/asana/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseUsers := testutils.DataFromFile(t, "read-users.json")
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/write_test.go
+++ b/providers/asana/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	responsePortfolios := testutils.DataFromFile(t, "write-projects.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -102,7 +101,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseErrorFormat := testutils.DataFromFile(t, "delete-issue-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -16,7 +15,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseIssueSchema := testutils.DataFromFile(t, "issue-metadata.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Server response must include array",
 			Input: []string{"butterflies"},
@@ -98,7 +97,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseIssuesFirstPage := testutils.DataFromFile(t, "read-issues.json")
 	responsePathNotFoundError := testutils.DataFromFile(t, "path-not-found.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -213,7 +213,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInvalidTypeError := testutils.DataFromFile(t, "create-issue-invalid-type.json")
 	createIssueResponse := testutils.DataFromFile(t, "create-issue.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -101,7 +100,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -28,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	optionsResponse := testutils.DataFromFile(t, "options.json")
 	usersObjectResponse := []byte(`{"data": {"plural_noun": "Users"}}`)
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -293,7 +292,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseTasks := testutils.DataFromFile(t, "tasks.json")
 	responseCompanies := testutils.DataFromFile(t, "companies_read.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -217,7 +217,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/write_test.go
+++ b/providers/attio/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tasksResponse := testutils.DataFromFile(t, "write_tasks.json")
 	companiesRecordResponse := testutils.DataFromFile(t, "write_companies_record.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -220,7 +219,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/metadata_test.go
+++ b/providers/avoma/metadata_test.go
@@ -3,7 +3,6 @@ package avoma
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -111,7 +110,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/read_test.go
+++ b/providers/avoma/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseMeetings := testutils.DataFromFile(t, "meetings.json")
 	responseUsers := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/write_test.go
+++ b/providers/avoma/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	updateSmartCategoriesResponse := testutils.DataFromFile(t, "update_smart_categories.json")
 	callsResponse := testutils.DataFromFile(t, "create_calls.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -132,7 +131,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/delete_test.go
+++ b/providers/aws/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -15,7 +14,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -66,7 +65,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/metadata_test.go
+++ b/providers/aws/metadata_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -15,7 +14,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -89,7 +88,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/read_test.go
+++ b/providers/aws/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseGroups := testutils.DataFromFile(t, "read/groups.json")
 	responseInstances := testutils.DataFromFile(t, "read/instances.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/write_test.go
+++ b/providers/aws/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTrustedTokenIssuersCreate := testutils.DataFromFile(t, "write/issuer/new.json")
 	responseUserCreate := testutils.DataFromFile(t, "write/user/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -144,7 +143,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/metadata_test.go
+++ b/providers/bentley/metadata_test.go
@@ -3,7 +3,6 @@ package bentley
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object returns not-supported error",
 			Input:      []string{"nonexistent_object"},
@@ -86,7 +85,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/read_test.go
+++ b/providers/bentley/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseWebhooks := testutils.DataFromFile(t, "read-webhooks.json")
 	responseContextCaptureJobs := testutils.DataFromFile(t, "read-contextcapture-jobs.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -239,7 +239,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/write_test.go
+++ b/providers/bentley/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCreateWebhook := testutils.DataFromFile(t, "write-create-webhook.json")
 	responseUpdateManufacturer := testutils.DataFromFile(t, "write-update-manufacturer.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -181,7 +180,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/delete_test.go
+++ b/providers/blackbaud/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -54,7 +53,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/metadata_test.go
+++ b/providers/blackbaud/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	volunteersResponse := testutils.DataFromFile(t, "volunteers.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -136,7 +135,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/read_test.go
+++ b/providers/blackbaud/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	volunteersResponse := testutils.DataFromFile(t, "volunteers.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/write_test.go
+++ b/providers/blackbaud/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -92,7 +91,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/metadata_test.go
+++ b/providers/braintree/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	customersMetadataResponse := testutils.DataFromFile(t, "metadata-customers.json")
 	metadataErrorResponse := testutils.DataFromFile(t, "metadata-error.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -100,7 +99,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/read_test.go
+++ b/providers/braintree/read_test.go
@@ -38,7 +38,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	merchantAccountsResponse := testutils.DataFromFile(t, "read-merchantAccounts.json")
 	errorValidationResponse := testutils.DataFromFile(t, "read-error-validation.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -354,7 +354,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/write_test.go
+++ b/providers/braintree/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -25,7 +24,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	createCustomerRequestBody := testutils.DataFromFile(t, "request-create-customer.json")
 	updateCustomerRequestBody := testutils.DataFromFile(t, "request-update-customer.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -193,7 +192,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breakcold/delete_test.go
+++ b/providers/breakcold/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-lead.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/metadata_test.go
+++ b/providers/breakcold/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	statusResponse := testutils.DataFromFile(t, "status.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -84,7 +83,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/read_test.go
+++ b/providers/breakcold/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	statusResponse := testutils.DataFromFile(t, "status.json")
 	remindersResponse := testutils.DataFromFile(t, "reminders.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/write_test.go
+++ b/providers/breakcold/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	leadResponse := testutils.DataFromFile(t, "write_lead.json")
 	remindersResponse := testutils.DataFromFile(t, "write_reminders.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -176,7 +175,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breezy/delete_test.go
+++ b/providers/breezy/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -55,7 +54,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/metadata_test.go
+++ b/providers/breezy/metadata_test.go
@@ -3,7 +3,6 @@ package breezy
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name: "Successful metadata for recruiting objects",
 			Input: []string{
@@ -176,7 +175,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/read_test.go
+++ b/providers/breezy/read_test.go
@@ -28,7 +28,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	responseQuestionnaires := testutils.DataFromFile(t, "read/questionnaires.json")
 	responseTemplates := testutils.DataFromFile(t, "read/templates.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -353,7 +353,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/write_test.go
+++ b/providers/breezy/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createResp := testutils.DataFromFile(t, "write/position-create.json")
 	updateResp := testutils.DataFromFile(t, "write/position-update.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -117,7 +116,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/campaignmonitor/delete_test.go
+++ b/providers/campaignmonitor/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-client_id.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/metadata_test.go
+++ b/providers/campaignmonitor/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	clientsResponse := testutils.DataFromFile(t, "clients.json")
 	adminsResponse := testutils.DataFromFile(t, "admins.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"clients", "admins", "campaigns"},
@@ -64,7 +63,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/read_test.go
+++ b/providers/campaignmonitor/read_test.go
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	clientsResponse := testutils.DataFromFile(t, "clients.json")
 	adminsResponse := testutils.DataFromFile(t, "admins.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -74,7 +74,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/write_test.go
+++ b/providers/campaignmonitor/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 
 	clientsResponse := testutils.DataFromFile(t, "write_clients.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +46,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/capsule/delete_test.go
+++ b/providers/capsule/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -55,7 +54,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/metadata_test.go
+++ b/providers/capsule/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responsePartiesCustomFields := testutils.DataFromFile(t, "read/parties/custom-fields.json")
 	responseProjectsCustomFields := testutils.DataFromFile(t, "read/projects/custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for multiple objects",
 			Input: []string{"activitytypes", "parties"},
@@ -138,7 +137,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/read_test.go
+++ b/providers/capsule/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responsePartiesLastPage := testutils.DataFromFile(t, "read/parties/last-page.json")
 	responseProjects := testutils.DataFromFile(t, "read/projects/first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "categories", Fields: connectors.Fields("colour")},
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/write_test.go
+++ b/providers/capsule/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseTask := testutils.DataFromFile(t, "write/task/new.json")
 	responseProject := testutils.DataFromFile(t, "write/project/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -174,7 +173,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/metadata_test.go
+++ b/providers/chargebee/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseCustomers := testutils.DataFromFile(t, "customers.json")
 	responseSubscriptions := testutils.DataFromFile(t, "subscriptions.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -299,7 +298,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/read_test.go
+++ b/providers/chargebee/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCustomers := testutils.DataFromFile(t, "customers.json")
 	responseSubscriptions := testutils.DataFromFile(t, "subscriptions.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -274,7 +274,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/write_test.go
+++ b/providers/chargebee/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCustomerCreate := testutils.DataFromFile(t, "customer-create.json")
 	responseCustomerUpdate := testutils.DataFromFile(t, "customer-update.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -133,7 +132,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargeover/handlers_test.go
+++ b/providers/chargeover/handlers_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	okResponse := testutils.DataFromFile(t, "customers.json")
 	unsupportedObjects := testutils.DataFromFile(t, "404.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -294,7 +293,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/metadata_test.go
+++ b/providers/chilipiper/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	workspace := testutils.DataFromFile(t, "workspace.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -66,7 +65,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/read_test.go
+++ b/providers/chilipiper/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 	team := testutils.DataFromFile(t, "team.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -101,7 +101,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/write_test.go
+++ b/providers/chilipiper/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	addUsers := testutils.DataFromFile(t, "add_user_team.json")
 	distribution := testutils.DataFromFile(t, "distribution.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -88,7 +87,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/metadata_test.go
+++ b/providers/claricopilot/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	usersResponse := testutils.DataFromFile(t, "users.json")
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -86,7 +85,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/read_test.go
+++ b/providers/claricopilot/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCallLast := testutils.DataFromFile(t, "calls-second-page.json")
 	responseScorecardTemplates := testutils.DataFromFile(t, "scorecardtemplates.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/write_test.go
+++ b/providers/claricopilot/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createCallsResponse := testutils.DataFromFile(t, "create_calls.json")
 	updateContactsResponse := testutils.DataFromFile(t, "update_contact.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -100,7 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/metadata_test.go
+++ b/providers/closecrm/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -80,7 +79,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/read_test.go
+++ b/providers/closecrm/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 	activityResponse := testutils.DataFromFile(t, "activities.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/write_test.go
+++ b/providers/closecrm/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	leadCreationResponse := testutils.DataFromFile(t, "create-lead.json")
 	updateLeadResponse := testutils.DataFromFile(t, "update-lead.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -136,7 +135,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/cloudtalk/delete_test.go
+++ b/providers/cloudtalk/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name: "Delete Contact",
 			Input: common.DeleteParams{
@@ -57,7 +56,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/metadata_test.go
+++ b/providers/cloudtalk/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for Calls",
 			Input:      []string{"calls"},
@@ -48,7 +47,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/read_test.go
+++ b/providers/cloudtalk/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsPaginated := testutils.DataFromFile(t, "read/contacts/paginated-response.json")
 	responseCallsEmpty := testutils.DataFromFile(t, "read/calls/empty-response.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -221,7 +221,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/write_test.go
+++ b/providers/cloudtalk/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestWrite(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name: "Create contact successfully",
 			Input: common.WriteParams{
@@ -184,7 +183,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/delete_test.go
+++ b/providers/connectwise/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete/contact-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -68,7 +67,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/internal/subscriber/create_test.go
+++ b/providers/connectwise/internal/subscriber/create_test.go
@@ -33,7 +33,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 		common.SubscriptionEventTypeDelete,
 	}
 
-	tests := []testroutines.TestCaseCreateSubscription{
+	tests := []testroutines.TestCaseSubscribe{
 		{
 			Name: "Creating subscription to contacts and tickets successfully",
 			Input: common.SubscribeParams{

--- a/providers/connectwise/internal/webhook/message_test.go
+++ b/providers/connectwise/internal/webhook/message_test.go
@@ -13,7 +13,7 @@ func TestEvent(t *testing.T) {
 	responseContactUpdated := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "contact-update.json")
 	responseContactDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "contact-delete.json")
 
-	for _, tt := range []testroutines.SubscriptionEventTestCase{
+	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseContactCreated,

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -85,7 +84,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/read-by-ids_test.go
+++ b/providers/connectwise/read-by-ids_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 
 	responseContacts := testutils.DataFromFile(t, "read/contacts-batch-by-ids.json")
 
-	tests := []testroutines.ReadByIds{
+	tests := []testroutines.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -67,7 +66,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchRecordReaderConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/read_test.go
+++ b/providers/connectwise/read_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	linkHeaderRaw := "<" + nextPageRaw.String() + ">; rel=\"next\""
 	nextPageRelative := common.NextPageToken(testroutines.URLTestServer + "/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/write_test.go
+++ b/providers/connectwise/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	errorNotFound := testutils.DataFromFile(t, "write/contacts/not-found.json")
 	responseContact := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -153,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/constantcontact/delete_test.go
+++ b/providers/constantcontact/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +45,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/metadata_test.go
+++ b/providers/constantcontact/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseContactsCustomFields := testutils.DataFromFile(t, "read/contacts/custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -101,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/read_test.go
+++ b/providers/constantcontact/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts/1-first-page.json")
 	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts/2-second-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/write_test.go
+++ b/providers/constantcontact/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateContact := testutils.DataFromFile(t, "write-contact.json")
 	responseCreateEmailCampaign := testutils.DataFromFile(t, "write-email-campaign.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -147,7 +146,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/delete_test.go
+++ b/providers/copper/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -65,7 +64,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/metadata_test.go
+++ b/providers/copper/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseCustomFields := testutils.DataFromFile(t, "custom/fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for Projects and Leads",
 			Input: []string{"projects", "leads", "companies"},
@@ -178,7 +177,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/read_test.go
+++ b/providers/copper/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCompanies := testutils.DataFromFile(t, "read/companies/with-custom-fields.json")
 	responseCustomFields := testutils.DataFromFile(t, "custom/fields.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -191,7 +191,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/write_test.go
+++ b/providers/copper/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseCompanies := testutils.DataFromFile(t, "write/companies/new.json")
 	responseProjects := testutils.DataFromFile(t, "write/projects/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -145,7 +144,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/delete_test.go
+++ b/providers/customerapp/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -3,7 +3,6 @@ package customerapp
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -72,7 +71,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/read_test.go
+++ b/providers/customerapp/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNewslettersFirstPage := testutils.DataFromFile(t, "read-newsletters-1-first-page.json")
 	responseNewslettersEmptyPage := testutils.DataFromFile(t, "read-newsletters-2-empty-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/write_test.go
+++ b/providers/customerapp/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorSegmentBadRequest := testutils.DataFromFile(t, "write-segment-bad-request.json")
 	responseSegment := testutils.DataFromFile(t, "write-segment.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -90,7 +89,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/delete_test.go
+++ b/providers/devrev/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestDelete(t *testing.T) {
 	// DevRev accounts-delete-response from schema: empty object {}
 	responseAccountsDelete := testutils.DataFromFile(t, "write-accounts-delete-response.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name: "Delete account successfully",
 			Input: common.DeleteParams{
@@ -65,7 +64,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/metadata_test.go
+++ b/providers/devrev/metadata_test.go
@@ -3,7 +3,6 @@ package devrev
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successfully describe articles and commands",
 			Input:      []string{"articles", "commands"},
@@ -98,7 +97,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/read_test.go
+++ b/providers/devrev/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	responseArticles := testutils.DataFromFile(t, "read-articles.json")
 	responseVistasGroups := testutils.DataFromFile(t, "read-vistas-groups.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Read accounts empty",
 			Input: common.ReadParams{
@@ -364,7 +364,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/write_test.go
+++ b/providers/devrev/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -43,7 +42,7 @@ func TestWrite(t *testing.T) {
 	responseRevUserCreate := testutils.DataFromFile(t, "write-rev-user-response.json")
 	responseAuthTokensCreate := testutils.DataFromFile(t, "write-auth-tokens-create-response.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name: "Create article successfully",
 			Input: common.WriteParams{
@@ -175,7 +174,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/metadata_test.go
+++ b/providers/dropboxsign/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	bulkJobsResponse := testutils.DataFromFile(t, "read-bulk_send_job.json")
 	faxResponse := testutils.DataFromFile(t, "read-fax.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -149,7 +148,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/read_test.go
+++ b/providers/dropboxsign/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	bulkJobsFirstPage := testutils.DataFromFile(t, "read-bulk_send_job-first-page.json")
 	bulkJobsLastPage := testutils.DataFromFile(t, "read-bulk_send_job-last-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -174,7 +174,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/write_test.go
+++ b/providers/dropboxsign/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createTeamResponse := testutils.DataFromFile(t, "create-team.json")
 	updateTeamResponse := testutils.DataFromFile(t, "update-team.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -125,7 +124,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicsbusiness/delete_test.go
+++ b/providers/dynamicsbusiness/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -48,7 +47,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/metadata_test.go
+++ b/providers/dynamicsbusiness/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 
 	responseCustomers := testutils.DataFromFile(t, "metadata/customers.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -73,7 +72,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/read_test.go
+++ b/providers/dynamicsbusiness/read_test.go
@@ -26,7 +26,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	date := time.Date(2024, 9, 19, 4, 30, 45, 621*millisecondInNano,
 		time.FixedZone("UTC-8", -8*60*60))
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -211,7 +211,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/write_test.go
+++ b/providers/dynamicsbusiness/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseErrorFormat := testutils.DataFromFile(t, "write/contacts/not-found.json")
 	responseContacts := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -104,7 +103,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -15,7 +14,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -23,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseContactsOptionsStates := testutils.DataFromFile(t, "metadata/contacts/options-states.json")
 	responseContactsOptionsStatuses := testutils.DataFromFile(t, "metadata/contacts/options-statuses.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -297,7 +296,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/read_test.go
+++ b/providers/dynamicscrm/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseContactsGet := testutils.DataFromFile(t, "contacts-read.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -15,7 +14,7 @@ import (
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -77,7 +76,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/delete_test.go
+++ b/providers/fastspring/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -72,7 +71,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/metadata_test.go
+++ b/providers/fastspring/metadata_test.go
@@ -3,7 +3,6 @@ package fastspring
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for commerce objects",
 			Input:      []string{"accounts", "orders", "products", "subscriptions", "events-processed", "events-unprocessed"},
@@ -148,7 +147,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/read_test.go
+++ b/providers/fastspring/read_test.go
@@ -35,7 +35,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 			"nextPage": 0
 	}`)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -155,7 +155,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/write_test.go
+++ b/providers/fastspring/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	orderResp := []byte(`{"orders":[{"order":"ord_1","action":"order.update","result":"success"}]}`)
 	subscriptionResp := []byte(`{"subscription":"sub_1","action":"subscription.update","result":"success"}`)
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -251,7 +250,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/metadata_test.go
+++ b/providers/fathom/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	meetingsResponse := testutils.DataFromFile(t, "meetings-first-page.json")
 	teamsResponse := testutils.DataFromFile(t, "teams.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -152,7 +151,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/read_test.go
+++ b/providers/fathom/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseMeetingsFirst := testutils.DataFromFile(t, "meetings-first-page.json")
 	responseMeetingsSecond := testutils.DataFromFile(t, "meetings-second-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -94,7 +94,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/write_test.go
+++ b/providers/fathom/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	createWebhooksResponse := testutils.DataFromFile(t, "create-webhooks.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -64,7 +63,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/metadata_test.go
+++ b/providers/flatfile/metadata_test.go
@@ -3,7 +3,6 @@ package flatfile
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -82,7 +81,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/read_test.go
+++ b/providers/flatfile/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseEventsFirst := testutils.DataFromFile(t, "events-first-page.json")
 	responseEventsSecond := testutils.DataFromFile(t, "events-second-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/write_test.go
+++ b/providers/flatfile/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createEventsResponse := testutils.DataFromFile(t, "create-events.json")
 	updateEnvironmentsResponse := testutils.DataFromFile(t, "update-environments.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -105,7 +104,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fourfour/metadata_test.go
+++ b/providers/fourfour/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -99,7 +98,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/fourfour/read_test.go
+++ b/providers/fourfour/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 	contactsFirstPageResponse := testutils.DataFromFile(t, "contacts-first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/freshdesk/metadata_test.go
+++ b/providers/freshdesk/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tickets := testutils.DataFromFile(t, "tickets.json")
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -80,7 +79,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/freshdesk/read_test.go
+++ b/providers/freshdesk/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 	mailboxes := testutils.DataFromFile(t, "mailboxes.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -95,7 +95,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/freshdesk/write_test.go
+++ b/providers/freshdesk/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	contact := testutils.DataFromFile(t, "create-contacts.json")
 	ticket := testutils.DataFromFile(t, "update-ticket.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -123,7 +122,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/delete_test.go
+++ b/providers/getresponse/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -34,7 +33,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		]
 	}`
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -131,7 +130,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/metadata_test.go
+++ b/providers/getresponse/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -16,7 +15,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -90,7 +89,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/read_test.go
+++ b/providers/getresponse/read_test.go
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		}
 	]`
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -376,7 +376,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/write_test.go
+++ b/providers/getresponse/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -62,7 +61,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		]
 	}`
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -241,7 +240,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -3,7 +3,6 @@ package gong
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -93,7 +92,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	fakeServerResp2 := testutils.DataFromFile(t, "read_cursor.json")
 	responseTranscripts := testutils.DataFromFile(t, "read_transcripts.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -516,7 +516,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInvalidRequest := testutils.DataFromFile(t, "write-invalid-request.json")
 	responseCreateCall := testutils.DataFromFile(t, "write-call.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -73,7 +72,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/delete_test.go
+++ b/providers/google/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "calendar/delete/calendarList/not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -69,7 +68,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -79,7 +78,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 func TestMailDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -114,7 +113,7 @@ func TestMailDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/metadata_test.go
+++ b/providers/google/metadata_test.go
@@ -3,7 +3,6 @@ package google
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -14,7 +13,7 @@ import (
 func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"calendarList", "settings", "events"},
@@ -81,7 +80,7 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -91,7 +90,7 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"myConnections", "peopleDirectory"},
@@ -146,7 +145,7 @@ func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -156,7 +155,7 @@ func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 func TestMailListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for messages and drafts",
 			Input:      []string{"messages", "drafts"},
@@ -204,7 +203,7 @@ func TestMailListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/read_test.go
+++ b/providers/google/read_test.go
@@ -25,7 +25,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseEventsFirstPage := testutils.DataFromFile(t, "calendar/read/events/1-first-page.json")
 	responseEventsLastPage := testutils.DataFromFile(t, "calendar/read/events/2-last-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -292,7 +292,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -307,7 +307,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 	responseEventsTeam := testutils.DataFromFile(t, "calendar/read/all-calendars/events-team.json")
 	responseEventsLastPage := testutils.DataFromFile(t, "calendar/read/events/2-last-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Opts present but flag disabled reads only the primary calendar",
 			Input: common.ReadParams{
@@ -378,7 +378,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -395,7 +395,7 @@ func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
 	timeMin := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	timeMax := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "singleEvents opts set events.list params, dedupe by id, and fetch series masters",
 			Input: common.ReadParams{
@@ -463,7 +463,7 @@ func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -481,7 +481,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMyConnectionsLastPage := testutils.DataFromFile(t, "contacts/read/myConnections/2-last-page.json")
 	responseOtherContacts := testutils.DataFromFile(t, "contacts/read/otherContacts/one-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -685,7 +685,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -704,7 +704,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseDraftMessageItem1 := testutils.DataFromFile(t, "mail/read/drafts/message-item-1.json")
 	responseDraftMessageItem2 := testutils.DataFromFile(t, "mail/read/drafts/message-item-2.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -959,7 +959,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/write_test.go
+++ b/providers/google/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInsertCalendar := testutils.DataFromFile(t, "calendar/write/calendarList/new.json")
 	responseEvent := testutils.DataFromFile(t, "calendar/write/events/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -127,7 +126,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -140,7 +139,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseContactGroups := testutils.DataFromFile(t, "contacts/write/contactGroups/new.json")
 	responseMyConnections := testutils.DataFromFile(t, "contacts/write/myConnections/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -273,7 +272,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -285,7 +284,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	responseDrafts := testutils.DataFromFile(t, "mail/write/drafts/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -359,7 +358,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/metadata_test.go
+++ b/providers/goto/metadata_test.go
@@ -3,7 +3,6 @@ package gotoconn
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -21,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	webinarsResponse := testutils.DataFromFile(t, "webinars.json")
 	sessionsResponse := testutils.DataFromFile(t, "sessions.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -92,7 +91,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/read_test.go
+++ b/providers/goto/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	groupsResponse := testutils.DataFromFile(t, "groups.json")
 	licensesResponse := testutils.DataFromFile(t, "licenses.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -172,7 +172,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/write_test.go
+++ b/providers/goto/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createTemplatesResponse := testutils.DataFromFile(t, "create-templates.json")
 	createWebhookResponse := testutils.DataFromFile(t, "create-webhook.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -187,7 +186,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/granola/metadata_test.go
+++ b/providers/granola/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -17,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 	noteResponse := testutils.DataFromFile(t, "note_not_1d3tmYTlCICgjy.json")
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -201,7 +200,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/granola/read_test.go
+++ b/providers/granola/read_test.go
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) {
 		"not_4f7kQhLpMNBvxy": testutils.DataFromFile(t, "note_not_4f7kQhLpMNBvxy.json"),
 		"not_9b2xRwNsTLCfop": testutils.DataFromFile(t, "note_not_9b2xRwNsTLCfop.json"),
 	}
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Read empty items",
 			Input: common.ReadParams{
@@ -478,7 +478,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gusto/delete_test.go
+++ b/providers/gusto/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -101,7 +100,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				if tt.Name == "DELETE earning_types without companyID returns ErrMissingCompanyID" {
 					return constructTestWriteConnector(tt.Server.URL, "")
 				}

--- a/providers/gusto/metadata_test.go
+++ b/providers/gusto/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -121,7 +120,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/gusto/read_test.go
+++ b/providers/gusto/read_test.go
@@ -33,7 +33,7 @@ const testCompanyID = "test-company-uuid"
 func TestRead(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -309,7 +309,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				noCompanyIDCases := map[string]bool{
 					"Company-scoped reads require companyId metadata":  true,
 					"Employee-scoped reads require companyId metadata": true,

--- a/providers/gusto/write_test.go
+++ b/providers/gusto/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -34,7 +33,7 @@ var earningTypeUpdateResponse []byte
 func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -307,7 +306,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				// Cases that test ErrMissingCompanyID explicitly omit the metadata.
 				switch tt.Name {
 				case "Create employee without companyID returns ErrMissingCompanyID",

--- a/providers/helpscoutmailbox/connector_test.go
+++ b/providers/helpscoutmailbox/connector_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	zerorecords := testutils.DataFromFile(t, "mailboxes.json")
 	conversations := testutils.DataFromFile(t, "conversations.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -128,7 +128,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/helpscoutmailbox/connector_test.go
+++ b/providers/helpscoutmailbox/connector_test.go
@@ -229,7 +229,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -300,7 +300,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/helpscoutmailbox/connector_test.go
+++ b/providers/helpscoutmailbox/connector_test.go
@@ -141,7 +141,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	conversations := testutils.DataFromFile(t, "conversations.json")
 	users := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"conversations", "users"},
@@ -216,7 +216,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/metadata_test.go
+++ b/providers/heyreach/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	listResponse := testutils.DataFromFile(t, "list.json")
 	liAccountResponse := testutils.DataFromFile(t, "li_account.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -162,7 +161,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/read_test.go
+++ b/providers/heyreach/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	listResponse := testutils.DataFromFile(t, "list.json")
 	liAccountResponse := testutils.DataFromFile(t, "li_account.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/write_test.go
+++ b/providers/heyreach/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	listResponse := testutils.DataFromFile(t, "create_list.json")
 	addLeadToCampaignAndListResponse := testutils.DataFromFile(t, "add_lead_list_campaign.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -109,7 +108,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/delete_test.go
+++ b/providers/highlevelstandard/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-business-id.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/metadata_test.go
+++ b/providers/highlevelstandard/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	businessesResponse := testutils.DataFromFile(t, "businesses.json")
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -127,7 +126,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/read_test.go
+++ b/providers/highlevelstandard/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/write_test.go
+++ b/providers/highlevelstandard/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	calendarsGroupsResponse := testutils.DataFromFile(t, "write_calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "write_products_collections.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -153,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/delete_test.go
+++ b/providers/highlevelwhitelabel/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-business-id.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/metadata_test.go
+++ b/providers/highlevelwhitelabel/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	businessesResponse := testutils.DataFromFile(t, "businesses.json")
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -127,7 +126,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/read_test.go
+++ b/providers/highlevelwhitelabel/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/write_test.go
+++ b/providers/highlevelwhitelabel/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	calendarsGroupsResponse := testutils.DataFromFile(t, "write_calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "write_products_collections.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -153,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/delete_test.go
+++ b/providers/housecallPro/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name: "Delete price book material successfully",
 			Input: common.DeleteParams{
@@ -78,7 +77,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/metadata_test.go
+++ b/providers/housecallPro/metadata_test.go
@@ -3,7 +3,6 @@ package housecallpro
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successfully describe material categories, job types, and invoices",
 			Input:      []string{"price_book/material_categories", "job_fields/job_types", "invoices"},
@@ -197,7 +196,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) {
 	responseRoutes := testutils.DataFromFile(t, "read-routes.json")
 	responseJobs := testutils.DataFromFile(t, "read-jobs.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Read customers empty",
 			Input: common.ReadParams{
@@ -509,7 +509,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/write_test.go
+++ b/providers/housecallPro/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -22,7 +21,7 @@ func TestWrite(t *testing.T) {
 	responseMaterialCreate := testutils.DataFromFile(t, "write-material-create.json")
 	responseMaterialUpdate := testutils.DataFromFile(t, "write-material-update.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name: "Create customer successfully",
 			Input: common.WriteParams{
@@ -203,7 +202,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/authinfo_test.go
+++ b/providers/hubspot/authinfo_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestGetPostAuthInfo(t *testing.T) {
 
 	accountInfo := testutils.DataFromFile(t, "post-auth/account-info.json")
 
-	tests := []testroutines.PostAuthInfo{
+	tests := []testroutines.TestCaseGetPostAuthInfo{
 		{
 			Name: "Get post auth info",
 			Server: mockserver.Conditional{
@@ -39,7 +38,7 @@ func TestGetPostAuthInfo(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.AuthMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestablePostAuthMetadata, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/batch-write_test.go
+++ b/providers/hubspot/batch-write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -35,7 +34,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.BatchWrite{
+	tests := []testroutines.TestCaseBatchWrite{
 		{
 			Name: "At least one object name must be queried",
 			Input: &common.BatchWriteParam{
@@ -240,7 +239,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchWriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -271,7 +270,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.BatchWrite{
+	tests := []testroutines.TestCaseBatchWrite{
 		{
 			Name: "General high level error not tied to any record",
 			Input: &common.BatchWriteParam{
@@ -448,7 +447,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchWriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/delete_test.go
+++ b/providers/hubspot/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +49,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -25,7 +25,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseLists := testutils.DataFromFile(t, "read-lists-1-first-page.json")
 	responseEventDealClosed := testutils.DataFromFile(t, "read/events/e_deal_closed.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -698,7 +698,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -1033,7 +1032,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (connectors.UpsertMetadataConnector, error) {
+			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -38,7 +38,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMeetingLinks := testutils.DataFromFile(t, "read/meeting-links.json")
 	responseEventVisitedPage := testutils.DataFromFile(t, "read/events/e_visited_page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -880,7 +880,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/search_test.go
+++ b/providers/hubspot/search_test.go
@@ -22,7 +22,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 	responseContactsLastPage := testutils.DataFromFile(t, "search/contacts/2-second-page.json")
 	responseContactsToCompanies := testutils.DataFromFile(t, "search/contacts/contacts-to-companies.json")
 
-	tests := []testroutines.Search{
+	tests := []testroutines.TestCaseSearch{
 		{
 			Name:         "Object name must be included",
 			Server:       mockserver.Dummy(),
@@ -199,7 +199,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.SearchConnector, error) {
+			tt.Run(t, func() (testroutines.TestableSearcher, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/subscriptionEvent_test.go
+++ b/providers/hubspot/subscriptionEvent_test.go
@@ -10,7 +10,7 @@ import (
 func TestSubscriptionEvent(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []testroutines.SubscriptionEventTestCase{
+	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
 		{
 			Name: "Unsupported event",
 			Input: SubscriptionEvent{

--- a/providers/insightly/delete_test.go
+++ b/providers/insightly/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +45,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/metadata_test.go
+++ b/providers/insightly/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseFruitObject := testutils.DataFromFile(t, "read/custom-objects/fruit.json")
 	responseFruitFields := testutils.DataFromFile(t, "read/fruits-custom-object/custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -248,7 +247,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/read_test.go
+++ b/providers/insightly/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContacts := testutils.DataFromFile(t, "read/contacts/list.json")
 	responseFruits := testutils.DataFromFile(t, "read/fruits-custom-object/list.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -304,7 +304,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/write_test.go
+++ b/providers/insightly/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	writeContactsResponse := testutils.DataFromFile(t, "write/contacts.json")
 	writeLeadsResponse := testutils.DataFromFile(t, "write/leads.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -131,7 +130,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/delete_test.go
+++ b/providers/instantly/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseNotFoundErr := testutils.DataFromFile(t, "delete-tag-missing.json")
 	responseTag := testutils.DataFromFile(t, "delete-tag.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -3,7 +3,6 @@ package instantly
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -67,7 +66,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCampaigns := testutils.DataFromFile(t, "read-campaigns.json")
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -205,7 +205,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -25,7 +24,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTagErr := testutils.DataFromFile(t, "write-tag-bad-request.json")
 	responseTag := testutils.DataFromFile(t, "write-tag.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -158,7 +157,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/delete_test.go
+++ b/providers/instantlyai/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-custom-tags.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/metadata_test.go
+++ b/providers/instantlyai/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	customTagsResponse := testutils.DataFromFile(t, "custom-tags.json")
 	leadListsResponse := testutils.DataFromFile(t, "lead-lists.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -232,7 +231,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/read_test.go
+++ b/providers/instantlyai/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	customTagsResponse := testutils.DataFromFile(t, "custom-tags.json")
 	leadListsResponse := testutils.DataFromFile(t, "lead-lists.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -120,7 +120,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/write_test.go
+++ b/providers/instantlyai/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	customTagsResponse := testutils.DataFromFile(t, "write_custom_tags.json")
 	accountsResponse := testutils.DataFromFile(t, "write_accounts.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -111,7 +110,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFound := testutils.DataFromFile(t, "resource-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/metadata_test.go
+++ b/providers/intercom/metadata_test.go
@@ -3,7 +3,6 @@ package intercom
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -93,7 +92,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -34,7 +34,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNotesFirstPage := testutils.DataFromFile(t, "read-notes-1-first-page.json")
 	responseNotesSecondPage := testutils.DataFromFile(t, "read-notes-2-last-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -277,7 +277,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	messageForInvalidSyntax := "There was a problem in the JSON you submitted [ddf8bfe97056e23f5d2b1ed92627ad07]: " +
 		"logged with error code"
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -102,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/delete_test.go
+++ b/providers/iterable/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseMissingListErr := testutils.DataFromFile(t, "delete-missing-list-bad-request.json")
 	responseList := testutils.DataFromFile(t, "delete-list.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +69,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/metadata_test.go
+++ b/providers/iterable/metadata_test.go
@@ -3,7 +3,6 @@ package iterable
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -83,7 +82,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/read_test.go
+++ b/providers/iterable/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	errorTemplatesInvalidSince := testutils.DataFromFile(t, "read-templates-invalid-since.html")
 	errorInvalidRestMethod := testutils.DataFromFile(t, "error-wrong-method.html")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/write_test.go
+++ b/providers/iterable/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -23,7 +22,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTemplateInvalidRequestJSON := testutils.DataFromFile(t, "write-template-invalid-request.json")
 	responseWebhookTEXT := testutils.DataFromFile(t, "write-webhook-bad-request.txt")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -186,7 +185,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/justcall/delete_test.go
+++ b/providers/justcall/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 
 	deleteSuccessResponse := testutils.DataFromFile(t, "delete/success.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -98,7 +97,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/metadata_test.go
+++ b/providers/justcall/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) {
 
 	responseCustomFields := testutils.DataFromFile(t, "read/sales_dialer_contacts/custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for sales_dialer/contacts with custom fields",
 			Input: []string{"sales_dialer/contacts"},
@@ -56,7 +55,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/read_test.go
+++ b/providers/justcall/read_test.go
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	responseWebhooks := testutils.DataFromFile(t, "read/webhooks/list.json")
 	responseSalesDialerContacts := testutils.DataFromFile(t, "read/sales_dialer_contacts/first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -416,7 +416,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/write_test.go
+++ b/providers/justcall/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -22,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 	successResponse := testutils.DataFromFile(t, "write/success.json")
 	errorResponse := testutils.DataFromFile(t, "write/error.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -219,7 +218,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/keap/delete_test.go
+++ b/providers/keap/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-contact.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseContactsModel := testutils.DataFromFile(t, "custom-fields/contacts-v2.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -151,7 +150,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -31,7 +31,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	// Tags
 	responseTags := testutils.DataFromFile(t, "read/tags/v2.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -247,7 +247,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/write_test.go
+++ b/providers/keap/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorContactBadRequest := testutils.DataFromFile(t, "write-contacts-missing-fields.json")
 	responseContacts := testutils.DataFromFile(t, "write-contacts.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -108,7 +107,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/kit/metadata_test.go
+++ b/providers/kit/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -28,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tagsresponse := testutils.DataFromFile(t, "tags.json")
 	webhooksresponse := testutils.DataFromFile(t, "webhooks.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -200,7 +199,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -212,7 +211,7 @@ func TestListObjectMetadataWithCustomFields(t *testing.T) {
 
 	customfieldsresponse := testutils.DataFromFile(t, "custom_fields.json")
 
-	test := testroutines.Metadata{
+	test := testroutines.TestCaseListObjectMetadata{
 		Name:  "Successful metadata for subscribers with custom fields",
 		Input: []string{"subscribers"},
 		Server: mockserver.Conditional{
@@ -242,7 +241,7 @@ func TestListObjectMetadataWithCustomFields(t *testing.T) {
 		ExpectedErrs: nil,
 	}
 
-	test.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+	test.Run(t, func() (testroutines.TestableMetadataReader, error) {
 		return constructTestConnector(test.Server.URL)
 	})
 }

--- a/providers/kit/read_test.go
+++ b/providers/kit/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseEmptyPageTags := testutils.DataFromFile(t, "emptypage_tags.json")
 	responseEmailTemplates := testutils.DataFromFile(t, "email_templates.json")
 	responseSubscribers := testutils.DataFromFile(t, "subscribers.json")
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -220,7 +220,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/kit/write_test.go
+++ b/providers/kit/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tagsResponse := testutils.DataFromFile(t, "write_tags.json")
 	tagsIssue := testutils.DataFromFile(t, "tag_issue.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -190,7 +189,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/delete_test.go
+++ b/providers/klaviyo/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -74,7 +73,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -3,7 +3,6 @@ package klaviyo
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -82,7 +81,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/write_test.go
+++ b/providers/klaviyo/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -23,7 +22,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -154,7 +153,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/delete_test.go
+++ b/providers/lever/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-requisition-fields.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/metadata_test.go
+++ b/providers/lever/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	opportunitiesResponse := testutils.DataFromFile(t, "opportunities.json")
 	requisitionFieldsResponse := testutils.DataFromFile(t, "requisition_fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"opportunities", "requisition_fields"},
@@ -91,7 +90,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/read_test.go
+++ b/providers/lever/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	requisitionFieldsResponse := testutils.DataFromFile(t, "requisition_fields.json")
 	usersResponse := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -177,7 +177,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/write_test.go
+++ b/providers/lever/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	requisitionFieldResponse := testutils.DataFromFile(t, "write_requisition_field.json")
 	requisitionsResponse := testutils.DataFromFile(t, "write_requisitions.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -231,7 +230,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/linkedin/delete_test.go
+++ b/providers/linkedin/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-adAccounts.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -66,7 +65,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})
@@ -76,7 +75,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 func TestPlatformDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "posts", RecordId: "urn:li:share:7393604235420078080"},
@@ -100,7 +99,7 @@ func TestPlatformDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestPlatformConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/metadata_test.go
+++ b/providers/linkedin/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	adTargetingFacetsResponse := testutils.DataFromFile(t, "adTargetingFacets.json")
 	dmpEngagementSourceTypesResponse := testutils.DataFromFile(t, "dmpEngagementSourceTypes.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple object with metadata",
 			Input: []string{"adTargetingFacets", "dmpEngagementSourceTypes"},
@@ -114,7 +113,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/read_test.go
+++ b/providers/linkedin/read_test.go
@@ -19,7 +19,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	dmpEngagementSourceTypesResponse := testutils.DataFromFile(t, "dmpEngagementSourceTypes.json")
 	adAccountsResponse := testutils.DataFromFile(t, "adAccounts.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -196,7 +196,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/write_test.go
+++ b/providers/linkedin/write_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -18,7 +17,7 @@ import (
 func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -79,7 +78,7 @@ func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})
@@ -89,7 +88,7 @@ func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 func TestPlatformWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -150,7 +149,7 @@ func TestPlatformWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestPlatformConnector(tt.Server)
 			})
 		})

--- a/providers/livestorm/delete_test.go
+++ b/providers/livestorm/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -56,7 +55,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/metadata_test.go
+++ b/providers/livestorm/metadata_test.go
@@ -3,7 +3,6 @@ package livestorm
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for events and people",
 			Input:      []string{"events", "people", "people_attributes", "users"},
@@ -124,7 +123,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -29,7 +29,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	peopleAttributesBody := testutils.DataFromFile(t, "read-people-attributes.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -277,7 +277,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/write_test.go
+++ b/providers/livestorm/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	eventUpdateResp := []byte(`{"data":{"id":"evt_1","type":"events","attributes":{"title":"Updated"}}}`)
 	userCreateResp := []byte(`{"data":{"id":"usr_1","type":"users","attributes":{"email":"new@example.com"}}}`)
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -135,7 +134,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/delete_test.go
+++ b/providers/loxo/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -15,7 +14,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -67,7 +66,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/metadata_test.go
+++ b/providers/loxo/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	companiesResponse := testutils.DataFromFile(t, "companies.json")
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"companies", "currencies"},
@@ -111,7 +110,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/read_test.go
+++ b/providers/loxo/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	countriesResponse := testutils.DataFromFile(t, "countries.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/write_test.go
+++ b/providers/loxo/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	companiesFieldResponse := testutils.DataFromFile(t, "write_companies.json")
 	peopleResponse := testutils.DataFromFile(t, "write_people.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -136,7 +135,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/metadata_test.go
+++ b/providers/marketo/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	channelsResponse := testutils.DataFromFile(t, "channels.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -85,7 +84,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/read_test.go
+++ b/providers/marketo/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	campaignsResponse := testutils.DataFromFile(t, "campaigns.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -134,7 +134,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/write_test.go
+++ b/providers/marketo/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "not-found.json")
 	leadCreationResponse := testutils.DataFromFile(t, "write-leads.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -79,7 +78,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/meta/internal/whatsapp/write_test.go
+++ b/providers/meta/internal/whatsapp/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -26,7 +25,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	messageTemplateCreateResponse := testutils.DataFromFile(t, "message-template-create.json")
 	phoneNumberCreateResponse := testutils.DataFromFile(t, "phone-number-create.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -160,7 +159,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestAdapter(tt.Server)
 			})
 		})

--- a/providers/microsoft/delete_test.go
+++ b/providers/microsoft/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/internal/subscriber/create_test.go
+++ b/providers/microsoft/internal/subscriber/create_test.go
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 	  "headers": {"Content-Type": "application/json"}
 	}`)
 
-	tests := []testroutines.TestCaseCreateSubscription{
+	tests := []testroutines.TestCaseSubscribe{
 		{
 			Name: "Missing object for subscription",
 			Input: common.SubscribeParams{

--- a/providers/microsoft/internal/webhook/message_test.go
+++ b/providers/microsoft/internal/webhook/message_test.go
@@ -12,7 +12,7 @@ func TestEvent(t *testing.T) {
 	responseMessageUpdated := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "event-message-updated.json")
 	responseMessageDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "event-message-deleted.json")
 
-	for _, tt := range []testroutines.SubscriptionEventTestCase{
+	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseMessageCreated,

--- a/providers/microsoft/metadata_test.go
+++ b/providers/microsoft/metadata_test.go
@@ -3,7 +3,6 @@ package microsoft
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for multiple objects",
 			Input:      []string{"users", "groups", "me/events", "me/messages"},
@@ -96,7 +95,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/read-by-ids_test.go
+++ b/providers/microsoft/read-by-ids_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 
 	responseMessages := testutils.DataFromFile(t, "read/messages/batch-by-ids.json")
 
-	tests := []testroutines.ReadByIds{
+	tests := []testroutines.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -107,7 +106,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchRecordReaderConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/read_test.go
+++ b/providers/microsoft/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCalendarEvents := testutils.DataFromFile(t, "read/events/list.json")
 	responseMessagesEvents := testutils.DataFromFile(t, "read/messages/list.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -184,7 +184,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/write_test.go
+++ b/providers/microsoft/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseUser := testutils.DataFromFile(t, "write/users/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -191,7 +190,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/monday/read_test.go
+++ b/providers/monday/read_test.go
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	errorBadRequest := testutils.DataFromFile(t, "boards/err-unknown-property.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:  "Error requesting unknown field for the object",
 			Input: common.ReadParams{ObjectName: "boards", Fields: connectors.Fields("id", "random_field")},
@@ -37,7 +37,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/delete_test.go
+++ b/providers/nutshell/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +46,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/metadata_test.go
+++ b/providers/nutshell/metadata_test.go
@@ -3,7 +3,6 @@ package nutshell
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"competitormaps", "contacts", "products"},
@@ -86,7 +85,7 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/read_test.go
+++ b/providers/nutshell/read_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseAccountsEmptyPage := testutils.DataFromFile(t, "read/accounts/2-empty-page.json")
 	responseEvents := testutils.DataFromFile(t, "read/events/1-first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -230,7 +230,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/write_test.go
+++ b/providers/nutshell/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	errorMediaType := testutils.DataFromFile(t, "write/err-media-type.txt")
 	responseAccounts := testutils.DataFromFile(t, "write/accounts/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -141,7 +140,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/delete_test.go
+++ b/providers/odoo/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) {
 
 	respUnlink := testutils.DataFromFile(t, "delete-crm-lead-unlink.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name: "Unlink crm.lead successfully",
 			Input: common.DeleteParams{
@@ -44,7 +43,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/metadata_test.go
+++ b/providers/odoo/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -21,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	calendarModel := testutils.DataFromFile(t, "calendar-model.json")
 	calendarFields := testutils.DataFromFile(t, "calendar-model-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -527,7 +526,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/read_test.go
+++ b/providers/odoo/read_test.go
@@ -30,7 +30,7 @@ func TestRead(t *testing.T) {
 	responseRoleLast := testutils.DataFromFile(t, "read-role-last-page.json")
 	responseRoleUntilWindow := []byte(`[{"id":99,"name":"Filtered"}]`)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Read crm.iap.lead.role empty",
 			Input: common.ReadParams{
@@ -303,7 +303,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/write_test.go
+++ b/providers/odoo/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) {
 	respCreate := testutils.DataFromFile(t, "write-crm-lead-create.json")
 	respUpdate := testutils.DataFromFile(t, "write-crm-lead-update.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name: "Create crm.lead successfully",
 			Input: common.WriteParams{
@@ -103,7 +102,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/okta/delete_test.go
+++ b/providers/okta/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -98,7 +97,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/metadata_test.go
+++ b/providers/okta/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -293,7 +292,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/read_test.go
+++ b/providers/okta/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	responseGroupsWithCustomFields := testutils.DataFromFile(t, "read-groups-with-custom-fields.json")
 	errorResponse := testutils.DataFromFile(t, "error.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -348,7 +348,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/write_test.go
+++ b/providers/okta/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) {
 	updateGroupResponse := testutils.DataFromFile(t, "write-group-update.json")
 	errorResponse := testutils.DataFromFile(t, "error.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -152,7 +151,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/outplay/metadata_test.go
+++ b/providers/outplay/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	prospectAccountResponse := testutils.DataFromFile(t, "prospectaccount-read.json")
 	callAnalysisResponse := testutils.DataFromFile(t, "callanalysis-read.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -313,7 +312,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outplay/read_test.go
+++ b/providers/outplay/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) {
 	prospectAccountResponse := testutils.DataFromFile(t, "prospectaccount-read.json")
 	callAnalysisResponse := testutils.DataFromFile(t, "callanalysis-read.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read objects must be implemented",
 			Input:        common.ReadParams{},
@@ -147,7 +147,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnectorForRead(tt.Server.URL)
 			})
 		})

--- a/providers/outplay/write_test.go
+++ b/providers/outplay/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createNoteResponse := testutils.DataFromFile(t, "create-note.json")
 	updateNoteResponse := testutils.DataFromFile(t, "update-note.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -172,7 +171,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/metadata_test.go
+++ b/providers/outreach/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	schemaResponse := testutils.DataFromFile(t, "schema.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -145,7 +144,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/read_test.go
+++ b/providers/outreach/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 	mailingsResponse := testutils.DataFromFile(t, "mailings.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -126,7 +126,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/write_test.go
+++ b/providers/outreach/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 	updateDealsResponse := testutils.DataFromFile(t, "emailaddress.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -182,7 +181,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/metadata_test.go
+++ b/providers/paddle/metadata_test.go
@@ -3,7 +3,6 @@ package paddle
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
@@ -123,7 +122,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/read_test.go
+++ b/providers/paddle/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCustomersSecond := testutils.DataFromFile(t, "customers-second-page.json")
 	responseProducts := testutils.DataFromFile(t, "products.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -130,7 +130,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/write_test.go
+++ b/providers/paddle/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createCustomerResponse := testutils.DataFromFile(t, "create-customer.json")
 	createDiscountResponse := testutils.DataFromFile(t, "create-discount.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -203,7 +202,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/delete_test.go
+++ b/providers/phoneburner/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,cyclop
 
 	respUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -98,7 +97,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	isCustomField := true
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for contacts, folders, members, voicemails, and dialsession",
 			Input:      []string{"contacts", "folders", "members", "voicemails", "dialsession", "tags"},
@@ -197,7 +196,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseVoicemails := testutils.DataFromFile(t, "read/voicemails.json")
 	responseUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -373,7 +373,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/write_test.go
+++ b/providers/phoneburner/write_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -22,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	respDialsession := testutils.DataFromFile(t, "write/dialsession.json")
 	respUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -188,7 +187,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/delete_test.go
+++ b/providers/pinterest/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-boards.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/metadata_test.go
+++ b/providers/pinterest/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	boardsResponse := testutils.DataFromFile(t, "boards.json")
 	mediaResponse := testutils.DataFromFile(t, "media.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"pins", "boards", "media"},
@@ -101,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/read_test.go
+++ b/providers/pinterest/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	boardsResponse := testutils.DataFromFile(t, "boards.json")
 	mediaResponse := testutils.DataFromFile(t, "media.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/write_test.go
+++ b/providers/pinterest/write_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	boardsResponse := testutils.DataFromFile(t, "boards_write.json")
 	mediaResponse := testutils.DataFromFile(t, "media_write.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -276,7 +275,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipedrive/metadata_test.go
+++ b/providers/pipedrive/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -21,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	success := testutils.DataFromFile(t, "currencies.json")
 	activityFields := testutils.DataFromFile(t, "activityFields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -154,7 +153,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})
@@ -166,7 +165,7 @@ func TestListObjectMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	dealsFields := testutils.DataFromFile(t, "dealsFields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "A success API Response for Deals",
 			Input: []string{"deals"},
@@ -230,7 +229,7 @@ func TestListObjectMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveCRM)
 			})
 		})

--- a/providers/pipedrive/read_test.go
+++ b/providers/pipedrive/read_test.go
@@ -19,7 +19,7 @@ func TestReadCRM(t *testing.T) {
 	dealsResponse := testutils.DataFromFile(t, "deals.json")
 	dealProductsResponse := testutils.DataFromFile(t, "deal-products.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Deals include products when products field is requested",
 			Input: common.ReadParams{
@@ -116,7 +116,7 @@ func TestReadCRM(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveCRM)
 			})
 		})
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		Always: mockserver.Response(http.StatusOK, nextPageTest),
 	}.Server()
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name Required",
 			Server:       mockserver.Dummy(),
@@ -251,7 +251,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})

--- a/providers/pipedrive/write_test.go
+++ b/providers/pipedrive/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "not-found.json")
 	createActivityResponse := testutils.DataFromFile(t, "create-activity.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -137,7 +136,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})

--- a/providers/pipeliner/delete_test.go
+++ b/providers/pipeliner/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseRemoveNote := testutils.DataFromFile(t, "delete-note.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +46,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/metadata_test.go
+++ b/providers/pipeliner/metadata_test.go
@@ -3,7 +3,6 @@ package pipeliner
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -96,7 +95,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseProfilesSecondPage := testutils.DataFromFile(t, "read-profiles-2-second-page.json")
 	responseProfilesLastPage := testutils.DataFromFile(t, "read-profiles-3-last-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateNote := testutils.DataFromFile(t, "create-note.json")
 	responseUpdateNote := testutils.DataFromFile(t, "update-note.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -145,7 +144,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/metadata_test.go
+++ b/providers/procore/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -23,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	projectsResponse := testutils.DataFromFile(t, "projects.json")
 	operationsResponse := testutils.DataFromFile(t, "operations.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -94,7 +93,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/read_test.go
+++ b/providers/procore/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	since := time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC)
 	until := time.Date(2024, 10, 1, 23, 59, 59, 0, time.UTC)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -204,7 +204,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/write_test.go
+++ b/providers/procore/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createProjectResponse := testutils.DataFromFile(t, "create_project.json")
 	updateProjectResponse := testutils.DataFromFile(t, "update_project.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -139,7 +138,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/metadata_test.go
+++ b/providers/pylon/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	contactsResponse := testutils.DataFromFile(t, "contacts-read.json")
 	tagsResponse := testutils.DataFromFile(t, "tags-read.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -138,7 +137,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/read_test.go
+++ b/providers/pylon/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseAccountsSecond := testutils.DataFromFile(t, "accounts-second-page.json")
 	responseIssuesEmpty := testutils.DataFromFile(t, "issues-empty-response.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/write_test.go
+++ b/providers/pylon/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	createTasksResponse := testutils.DataFromFile(t, "create-tasks.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/metadata_test.go
+++ b/providers/quickbooks/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -25,7 +24,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	graphQLEmptyResponse := testutils.DataFromFile(t, "custom-fields/graphql-empty.json")
 	graphQLErrorResponse := testutils.DataFromFile(t, "custom-fields/graphql-error.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -423,7 +422,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/read_test.go
+++ b/providers/quickbooks/read_test.go
@@ -29,7 +29,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseItem := testutils.DataFromFile(t, "item-read.json")
 	responseError := testutils.DataFromFile(t, "error-bad-request.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -371,7 +371,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/write_test.go
+++ b/providers/quickbooks/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createAccountResponse := testutils.DataFromFile(t, "create-account.json")
 	writeErrorResponse := testutils.DataFromFile(t, "write-error.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -209,7 +208,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/metadata_test.go
+++ b/providers/recurly/metadata_test.go
@@ -3,7 +3,6 @@ package recurly
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
@@ -806,7 +805,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/read_test.go
+++ b/providers/recurly/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseInvoicesFirst := testutils.DataFromFile(t, "read-invoices.json")
 	responseInvoicesLast := testutils.DataFromFile(t, "read-invoices-last.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -184,7 +184,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/write_test.go
+++ b/providers/recurly/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCreateSubscription := testutils.DataFromFile(t, "create-subscription.json")
 	responseUpdateSubscription := testutils.DataFromFile(t, "update-subscription.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -295,7 +294,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/revenuecat/delete_test.go
+++ b/providers/revenuecat/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -115,7 +114,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/revenuecat/metadata_test.go
+++ b/providers/revenuecat/metadata_test.go
@@ -3,7 +3,6 @@ package revenuecat
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"nonexistent_object"},
@@ -121,7 +120,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/revenuecat/read_test.go
+++ b/providers/revenuecat/read_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
@@ -41,7 +40,7 @@ func TestRead(t *testing.T) {
 	  "url":"/v2/projects/proj_123/products"
 	}`)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -230,7 +229,7 @@ func TestRead(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/revenuecat/write_test.go
+++ b/providers/revenuecat/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -22,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	respOffering := testutils.DataFromFile(t, "write/offering.json")
 	respProduct := testutils.DataFromFile(t, "write/product.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -262,7 +261,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/ringcentral/handlers_test.go
+++ b/providers/ringcentral/handlers_test.go
@@ -177,7 +177,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	statesResponse := testutils.DataFromFile(t, "read-comm-handling-states.json")
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -323,7 +323,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/ringcentral/handlers_test.go
+++ b/providers/ringcentral/handlers_test.go
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	okResponse := testutils.DataFromFile(t, "meetings.json")
 	unsupportedObjects := testutils.DataFromFile(t, "404.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -150,7 +150,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/metadata_test.go
+++ b/providers/sageintacct/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseUserSchema := testutils.DataFromFile(t, "user-metadata.json")
 	responseUnsupportedObject := testutils.DataFromFile(t, "unsupported-object-metadata.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -182,7 +181,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/read_test.go
+++ b/providers/sageintacct/read_test.go
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseBudget := testutils.DataFromFile(t, "read-budget.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -80,7 +80,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/write_test.go
+++ b/providers/sageintacct/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createPaymentResponse := testutils.DataFromFile(t, "create-payment.json")
 	updatePaymentSummaryResponse := testutils.DataFromFile(t, "update-payment-summary.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -89,7 +88,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/delete_test.go
+++ b/providers/salesfinity/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name: "Delete successfully",
 			Input: common.DeleteParams{
@@ -40,7 +39,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/metadata_test.go
+++ b/providers/salesfinity/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	analyticsSdrPerformanceResponse := testutils.DataFromFile(t, "analytics-sdr-performance.json")
 	contactListsCsvResponse := testutils.DataFromFile(t, "contact-lists-csv.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -400,7 +399,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/read_test.go
+++ b/providers/salesfinity/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) {
 	responseCallLogFirstPage := testutils.DataFromFile(t, "call-log.json")
 	responseCallLogLastPage := testutils.DataFromFile(t, "read-call-log-last-page.json")
 	responseContactListsCsv := testutils.DataFromFile(t, "contact-lists-csv.json")
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 
 		{
 			Name: "Read empty items",
@@ -341,7 +341,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/write_test.go
+++ b/providers/salesfinity/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestWrite(t *testing.T) {
 
 	responseContactListsWrite := testutils.DataFromFile(t, "contact-lists-write-response.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name: "Create contact list successfully",
 			Input: common.WriteParams{
@@ -85,7 +84,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/delete_test.go
+++ b/providers/salesflare/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +45,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/metadata_test.go
+++ b/providers/salesflare/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseOpportunities := testutils.DataFromFile(t, "read/opportunities.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for multiple objects",
 			Input:      []string{"me/contacts", "workflows"},
@@ -101,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/read_test.go
+++ b/providers/salesflare/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts/1-first-page.json")
 	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts/2-empty-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("firstname")},
@@ -99,7 +99,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/write_test.go
+++ b/providers/salesflare/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorBadRequest := testutils.DataFromFile(t, "write/bad-request.json")
 	responseContact := testutils.DataFromFile(t, "write/contacts-new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -88,7 +87,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/batch-write_test.go
+++ b/providers/salesforce/batch-write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -35,7 +34,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.BatchWrite{
+	tests := []testroutines.TestCaseBatchWrite{
 		{
 			Name: "At least one object name must be queried",
 			Input: &common.BatchWriteParam{
@@ -195,7 +194,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchWriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -226,7 +225,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.BatchWrite{
+	tests := []testroutines.TestCaseBatchWrite{
 		{
 			Name: "General high level error not tied to any record",
 			Input: &common.BatchWriteParam{
@@ -356,7 +355,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchWriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/delete_test.go
+++ b/providers/salesforce/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseErrorFormat := testutils.DataFromFile(t, "crm/delete/not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -87,7 +86,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -103,7 +102,7 @@ func TestDeletePardot(t *testing.T) { // nolint:funlen,cyclop
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -175,7 +174,7 @@ func TestDeletePardot(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -668,7 +667,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (connectors.UpsertMetadataConnector, error) {
+			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -701,7 +700,7 @@ func TestUpsertMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocogni
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.UpsertMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseAccountsMeta := testutils.DataFromFile(t, "metadata/read/accounts-sampled.json")
 	responseCustomObjMeta := testutils.DataFromFile(t, "metadata/read/custom-object-with-custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -269,7 +269,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -285,7 +285,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -420,7 +420,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -715,7 +715,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseDeleteFields := testutils.DataFromFile(t, "metadata/delete/delete-fields-response.xml")
 	responseFieldNotFound := testutils.DataFromFile(t, "metadata/delete/delete-field-not-found.xml")
 
-	tests := []testroutines.DeleteMetadata{
+	tests := []testroutines.TestCaseDeleteMetadata{
 		{
 			Name:         "At least one field must be provided",
 			Input:        nil,
@@ -777,7 +777,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (connectors.DeleteMetadataConnector, error) {
+			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -787,7 +787,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 func TestDeleteMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.DeleteMetadata{
+	tests := []testroutines.TestCaseDeleteMetadata{
 		{
 			Name: "Access token must be injected into the context",
 			Input: &common.DeleteMetadataParams{
@@ -805,7 +805,7 @@ func TestDeleteMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocogni
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseOpportunityWithAccount := testutils.DataFromFile(t, "read-opportunity-with-account.json")
 	responseOpportunityWithContacts := testutils.DataFromFile(t, "read-opportunity-with-contacts.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -301,7 +301,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -321,7 +321,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -530,7 +530,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/search_test.go
+++ b/providers/salesforce/search_test.go
@@ -21,7 +21,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseOpportunityWithAccount := testutils.DataFromFile(t, "read-opportunity-with-account.json")
 	responseOpportunityWithContacts := testutils.DataFromFile(t, "read-opportunity-with-contacts.json")
 
-	tests := []testroutines.Search{
+	tests := []testroutines.TestCaseSearch{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -288,7 +288,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.SearchConnector, error) {
+			tt.Run(t, func() (testroutines.TestableSearcher, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateOK := testutils.DataFromFile(t, "create-ok.json")
 	responseOKWithErrors := testutils.DataFromFile(t, "success-with-errors.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -118,7 +117,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -134,7 +133,7 @@ func TestWritePardot(t *testing.T) { // nolint:funlen,cyclop
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -203,7 +202,7 @@ func TestWritePardot(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	listSchema := testutils.DataFromFile(t, "write-signals-error.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -63,7 +62,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/metadata_test.go
+++ b/providers/salesloft/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseCustomFieldsFirstPage := testutils.DataFromFile(t, "read/custom-fields/first-page.json")
 	responseCustomFieldsSecondPage := testutils.DataFromFile(t, "read/custom-fields/last-page.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -176,7 +175,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -26,7 +26,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	accountsSince, err := time.Parse(time.RFC3339Nano, "2024-06-07T10:51:20.851224-04:00")
 	mockutils.NoErrors(t, err)
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -245,7 +245,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	createAccountRes := testutils.DataFromFile(t, "write-create-account.json")
 	createTaskRes := testutils.DataFromFile(t, "write-create-task.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -150,7 +149,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/delete_test.go
+++ b/providers/sellsy/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFound := testutils.DataFromFile(t, "delete/err-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -59,7 +58,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/metadata_test.go
+++ b/providers/sellsy/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseCustomFields := testutils.DataFromFile(t, "read/custom-fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for Tasks and Favourite Filters",
 			Input: []string{"tasks", "companies/favourite-filters"},
@@ -135,7 +134,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/read_test.go
+++ b/providers/sellsy/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsEmptyPage := testutils.DataFromFile(t, "read/contacts/empty.json")
 	responseTasksLabelsFirstPage := testutils.DataFromFile(t, "read/tasks-labels/1-first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -261,7 +261,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/write_test.go
+++ b/providers/sellsy/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseBadRequest := testutils.DataFromFile(t, "write/contacts/err-bad-request.json")
 	responseContacts := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -92,7 +91,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/delete_test.go
+++ b/providers/shopify/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -21,7 +20,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 	requestCustomerDelete := testutils.DataFromFile(t, "delete/request-customer-delete.json")
 	requestProductDelete := testutils.DataFromFile(t, "delete/request-product-delete.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object name must be included",
 			Server:       mockserver.Dummy(),
@@ -79,7 +78,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/metadata_test.go
+++ b/providers/shopify/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -16,7 +15,7 @@ import (
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully fetch metadata for Product object",
 			Input: []string{"products"},
@@ -132,7 +131,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/read_test.go
+++ b/providers/shopify/read_test.go
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) {
 	requestCustomers := testutils.DataFromFile(t, "read/request/customers.json")
 	requestOrders := testutils.DataFromFile(t, "read/request/orders.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -198,7 +198,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/write_test.go
+++ b/providers/shopify/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -26,7 +25,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	requestProductCreate := testutils.DataFromFile(t, "write/request-product-create.json")
 	requestProductUpdate := testutils.DataFromFile(t, "write/request-product-update.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -175,7 +174,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/slack/internal/webhook/message_test.go
+++ b/providers/slack/internal/webhook/message_test.go
@@ -12,7 +12,7 @@ func TestEvent(t *testing.T) {
 	responseConversationDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "channel-deleted.json")
 	responseConversationArchived := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "channel-archived.json")
 
-	for _, tt := range []testroutines.SubscriptionEventTestCase{
+	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseConversationCreated,

--- a/providers/slack/internal/webhook/verifier_test.go
+++ b/providers/slack/internal/webhook/verifier_test.go
@@ -33,7 +33,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 	validSlackSignature := computeSlackSignature(testSigningKey, validTimestamp, string(eventMessage))
 	invalidSlackSignature := "mismatching-signature-from-provider"
 
-	tests := []testroutines.TestCaseWebhookMessageVerification{
+	tests := []testroutines.TestCaseVerifyWebhookMessage{
 		{
 			Name: "Missing signature header in input",
 			Input: testroutines.WebhookMessageVerificationParams{

--- a/providers/slack/metadata_test.go
+++ b/providers/slack/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 	conversationsResponse := testutils.DataFromFile(t, "conversations-list.json")
 	usersResponse := testutils.DataFromFile(t, "users-list.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -135,7 +134,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/read-by-ids_test.go
+++ b/providers/slack/read-by-ids_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 	responseConversation1 := testutils.DataFromFile(t, "read/conversation-1.json")
 	responseConversation2 := testutils.DataFromFile(t, "read/conversation-2.json")
 
-	tests := []testroutines.ReadByIds{
+	tests := []testroutines.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -69,7 +68,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.BatchRecordReaderConnector, error) {
+			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/read_test.go
+++ b/providers/slack/read_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	listConnectInvitesResponse := testutils.DataFromFile(t, "conversations-list-connect-invites.json")
 	requestSharedInviteResponse := testutils.DataFromFile(t, "conversations-request-shared-invite.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -346,7 +346,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/write_test.go
+++ b/providers/slack/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -294,7 +293,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseNotFoundErr := testutils.DataFromFile(t, "delete-not-found-resource.json")
 	responseCampaign := testutils.DataFromFile(t, "delete-campaign.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -68,7 +67,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -3,7 +3,6 @@ package smartlead
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -70,7 +69,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCampaignsEmpty := testutils.DataFromFile(t, "read-campaign-empty.json")
 	responseInvalidPath := testutils.DataFromFile(t, "read-invalid-path.html")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -113,7 +113,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -21,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseClient := testutils.DataFromFile(t, "write-client-new.json")
 	responseAccount := testutils.DataFromFile(t, "write-account-new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -121,7 +120,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/delete_test.go
+++ b/providers/snapchatads/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-members.json")
 	membersResponse := testutils.DataFromFile(t, "delete_members.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConn(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/metadata_test.go
+++ b/providers/snapchatads/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -21,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	membersResponse := testutils.DataFromFile(t, "members.json")
 	rolesResponse := testutils.DataFromFile(t, "roles.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"members", "roles"},
@@ -110,7 +109,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/read_test.go
+++ b/providers/snapchatads/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	membersResponse := testutils.DataFromFile(t, "members.json")
 	rolesResponse := testutils.DataFromFile(t, "roles.json")
 	billingcentersResponse := testutils.DataFromFile(t, "billingcenters.json")
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:  "Read list of members",
 			Input: common.ReadParams{ObjectName: "members", Fields: connectors.Fields("")},
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/write_test.go
+++ b/providers/snapchatads/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	billingcentersResponse := testutils.DataFromFile(t, "write_billingcenters.json")
 	rolesResponse := testutils.DataFromFile(t, "write_roles.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:  "Create a billingcenters as POST",
 			Input: common.WriteParams{ObjectName: "billingcenters", RecordData: "dummy"},
@@ -198,7 +197,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/delete_test.go
+++ b/providers/stripe/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete/err-not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -67,7 +66,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/metadata_test.go
+++ b/providers/stripe/metadata_test.go
@@ -3,7 +3,6 @@ package stripe
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testroutines"
@@ -12,7 +11,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -95,7 +94,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/read_test.go
+++ b/providers/stripe/read_test.go
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCheckoutSessionsWithItems := testutils.DataFromFile(t, "read/checkout-sessions/with-line-items.json")
 	responseInvoices := testutils.DataFromFile(t, "read/invoices/incremental.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -414,7 +414,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/write_test.go
+++ b/providers/stripe/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorSetupPaymentIntent := testutils.DataFromFile(t, "general-errors/error-setup-payment-intent.json")
 	responseCreateCustomer := testutils.DataFromFile(t, "write/customers/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -112,7 +111,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/delete_test.go
+++ b/providers/supersend/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -14,7 +13,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -102,7 +101,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/metadata_test.go
+++ b/providers/supersend/metadata_test.go
@@ -3,7 +3,6 @@ package supersend
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -322,7 +321,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/read_test.go
+++ b/providers/supersend/read_test.go
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	responseSendersLastPage := testutils.DataFromFile(t, "read/senders-last-page.json")
 	responseConversations := testutils.DataFromFile(t, "read/conversations.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -262,7 +262,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/write_test.go
+++ b/providers/supersend/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -27,7 +26,7 @@ func TestWrite(t *testing.T) {
 	createSenderProfileResponse := testutils.DataFromFile(t, "write/create-sender-profile.json")
 	updateSenderProfileResponse := testutils.DataFromFile(t, "write/update-sender-profile.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -381,7 +380,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/talkdesk/handlers_test.go
+++ b/providers/talkdesk/handlers_test.go
@@ -33,7 +33,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	contacts := testutils.DataFromFile(t, "contacts.json")
 	activities := testutils.DataFromFile(t, "activities.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -152,7 +152,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamleader/read_test.go
+++ b/providers/teamleader/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseContactFirst := testutils.DataFromFile(t, "contacts-first-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +72,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamleader/write_test.go
+++ b/providers/teamleader/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createContactsResponse := testutils.DataFromFile(t, "create-contacts.json")
 	createCompaniesResponse := testutils.DataFromFile(t, "create-companies.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -81,7 +80,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/delete_test.go
+++ b/providers/teamwork/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFoundError := testutils.DataFromFile(t, "delete/not-found.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -76,7 +75,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/metadata_test.go
+++ b/providers/teamwork/metadata_test.go
@@ -3,7 +3,6 @@ package teamwork
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for projects and tasks",
 			Input:      []string{"projects", "tasks"},
@@ -68,7 +67,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/read_test.go
+++ b/providers/teamwork/read_test.go
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNotebooksFirstPage := testutils.DataFromFile(t, "read/notebooks/1-first-page.json")
 	responseNotebooksSecondPage := testutils.DataFromFile(t, "read/notebooks/2-second-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "companies", Fields: connectors.Fields("name")},
@@ -159,7 +159,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/write_test.go
+++ b/providers/teamwork/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseConflictError := testutils.DataFromFile(t, "write/conflict.json")
 	responseCompanies := testutils.DataFromFile(t, "write/companies/new.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -101,7 +100,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/delete_test.go
+++ b/providers/webex/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -15,7 +14,7 @@ import (
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +46,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/metadata_test.go
+++ b/providers/webex/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -20,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	rolesResponse := testutils.DataFromFile(t, "read-roles.json")
 	groupsResponse := testutils.DataFromFile(t, "read-groups.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -218,7 +217,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/read_test.go
+++ b/providers/webex/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	responseReadPeopleFirstPage := testutils.DataFromFile(t, "read-people-first-page.json")
 	responseReadPeopleSecondPage := testutils.DataFromFile(t, "read-people-second-page.json")
 	responseReadGroupsFiltered := testutils.DataFromFile(t, "read-groups-filtered.json")
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -356,7 +356,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/write_test.go
+++ b/providers/webex/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) {
 
 	responseCreateUpdatePerson := testutils.DataFromFile(t, "create-update-person.json")
 	responseUpdateGroup := testutils.DataFromFile(t, "write-group.json")
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -134,7 +133,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/metadata_test.go
+++ b/providers/xero/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	accountResponse := testutils.DataFromFile(t, "accounts.json")
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -222,7 +221,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/read_test.go
+++ b/providers/xero/read_test.go
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responsePaymentOrdersFirst := testutils.DataFromFile(t, "purchase-orders-first.json")
 	responsePaymentOrdersSecond := testutils.DataFromFile(t, "purchase-orders-second.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/write_test.go
+++ b/providers/xero/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -18,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createContactGroupResponse := testutils.DataFromFile(t, "create-contactGroups.json")
 	updateContactGroupResponse := testutils.DataFromFile(t, "update-contactGroups.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -102,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -17,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseServerError := testutils.DataFromFile(t, "server-error.json")
 
-	tests := []testroutines.Delete{
+	tests := []testroutines.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.DeleteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -18,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseTicketsCustomFields := testutils.DataFromFile(t, "read/custom_fields/ticket_fields.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -194,7 +193,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseTriggersLastPage := testutils.DataFromFile(t, "read/triggers-2-last-page.json")
 	responseReadPosts := testutils.DataFromFile(t, "read/help-center-posts.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -173,7 +173,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 	responseUsersLastPage := testutils.DataFromFile(t, "read/incremental/users-2-last-page.json")
 	responseOrganizations := testutils.DataFromFile(t, "read/incremental/organizations.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name: "Incremental Tickets no since with custom fields",
 			Input: common.ReadParams{
@@ -330,7 +330,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -23,7 +22,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 	responseRecordValidationError := testutils.DataFromFile(t, "record-validation.json")
 	createBrand := testutils.DataFromFile(t, "create-brand.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -164,7 +163,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -176,7 +175,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 
 	responseCreatePost := testutils.DataFromFile(t, "write-post.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:  "Creating a help center post invokes correct endpoint",
 			Input: common.WriteParams{ObjectName: "posts", RecordData: "dummy"},
@@ -208,7 +207,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/internal/mail/metadata_test.go
+++ b/providers/zoho/internal/mail/metadata_test.go
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	accountsResponse := testutils.DataFromFile(t, "accounts.json")
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,

--- a/providers/zoho/internal/mail/read_test.go
+++ b/providers/zoho/internal/mail/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 	messagesResponse := testutils.DataFromFile(t, "messages.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object name and fields are required",
 			Input:        common.ReadParams{ObjectName: "notes"},

--- a/providers/zoho/internal/mail/write_test.go
+++ b/providers/zoho/internal/mail/write_test.go
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 	taskCreateResponse := testutils.DataFromFile(t, "write_task_create.json")
 	folderCreateResponse := testutils.DataFromFile(t, "write_folder_create.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object name is required",
 			Input:        common.WriteParams{},

--- a/providers/zoho/metadata_test.go
+++ b/providers/zoho/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
@@ -19,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	dealResponse := testutils.DataFromFile(t, "deals.json")
 	unsupported := testutils.DataFromFile(t, "arsenal.json")
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -120,7 +119,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/read_test.go
+++ b/providers/zoho/read_test.go
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupportedread.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/write_test.go
+++ b/providers/zoho/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -19,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	leadsWriteResponse := testutils.DataFromFile(t, "leads-write.json")
 	updateContactsResponse := testutils.DataFromFile(t, "updatecontact.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -124,7 +123,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/metadata_test.go
+++ b/providers/zoom/metadata_test.go
@@ -3,7 +3,6 @@ package zoom
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -13,7 +12,7 @@ import (
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.Metadata{
+	tests := []testroutines.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -114,7 +113,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 		// nolint:varnamelen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.ObjectMetadataConnector, error) {
+			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/read_test.go
+++ b/providers/zoom/read_test.go
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseRecordingsFirstPage := testutils.DataFromFile(t, "recordings-first-page.json")
 	responseRecordingsSecondPage := testutils.DataFromFile(t, "recordings-second-page.json")
 
-	tests := []testroutines.Read{
+	tests := []testroutines.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -346,7 +346,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.ReadConnector, error) {
+			tt.Run(t, func() (testroutines.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/write_test.go
+++ b/providers/zoom/write_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
@@ -20,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	responseCreateUser := testutils.DataFromFile(t, "./write/create-users.json")
 	responseCreateContactsGroup := testutils.DataFromFile(t, "./write/create-contacts-groups.json")
 
-	tests := []testroutines.Write{
+	tests := []testroutines.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +136,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (connectors.WriteConnector, error) {
+			tt.Run(t, func() (testroutines.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/test/utils/testroutines/batch-write.go
+++ b/test/utils/testroutines/batch-write.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	batchWriteType = TestCase[*common.BatchWriteParam, *common.BatchWriteResult]
-	// BatchWrite is a test suite useful for testing connectors.BatchWriteConnector interface.
-	BatchWrite batchWriteType
+	// TestCaseBatchWrite is a test suite useful for testing connectors.BatchWriteConnector interface.
+	TestCaseBatchWrite batchWriteType
 )
 
 // Run provides a procedure to test connectors.BatchWriteConnector
-func (m BatchWrite) Run(t *testing.T, builder ConnectorBuilder[connectors.BatchWriteConnector]) {
+func (m TestCaseBatchWrite) Run(t *testing.T, builder ConnectorBuilder[TestableBatchWriter]) {
 	t.Helper()
 	t.Cleanup(func() {
 		batchWriteType(m).Close()

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -24,6 +24,21 @@ func (builder ConnectorBuilder[C]) Build(t *testing.T, testCaseName string) C {
 	return conn
 }
 
+// TestableMetadataDeleter is the minimal interface for a connector that can delete metadata.
+type TestableMetadataDeleter interface {
+	DeleteMetadata(ctx context.Context, params *common.DeleteMetadataParams) (*common.DeleteMetadataResult, error)
+}
+
+// TestableDeleter is the minimal interface for a connector that can delete records.
+type TestableDeleter interface {
+	Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error)
+}
+
+// TestableBatchWriter is the minimal interface for a connector that can batch write records.
+type TestableBatchWriter interface {
+	BatchWrite(ctx context.Context, params *common.BatchWriteParam) (*common.BatchWriteResult, error)
+}
+
 // TestableWebhookMessageVerifier is the minimal interface for a connector that can verify webhook messages.
 type TestableWebhookMessageVerifier interface {
 	VerifyWebhookMessage(

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -24,6 +24,11 @@ func (builder ConnectorBuilder[C]) Build(t *testing.T, testCaseName string) C {
 	return conn
 }
 
+// TestableMetadataReader is the minimal interface for a connector that can read metadata.
+type TestableMetadataReader interface {
+	ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
+}
+
 // TestableMetadataDeleter is the minimal interface for a connector that can delete metadata.
 type TestableMetadataDeleter interface {
 	DeleteMetadata(ctx context.Context, params *common.DeleteMetadataParams) (*common.DeleteMetadataResult, error)

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -34,6 +34,11 @@ type TestableMetadataReader interface {
 	ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)
 }
 
+// TestableMetadataUpdater is the minimal interface for a connector that can update metadata.
+type TestableMetadataUpdater interface {
+	UpsertMetadata(ctx context.Context, params *common.UpsertMetadataParams) (*common.UpsertMetadataResult, error)
+}
+
 // TestableMetadataDeleter is the minimal interface for a connector that can delete metadata.
 type TestableMetadataDeleter interface {
 	DeleteMetadata(ctx context.Context, params *common.DeleteMetadataParams) (*common.DeleteMetadataResult, error)

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -49,6 +49,17 @@ type TestableDeleter interface {
 	Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error)
 }
 
+// TestableBatchReader is the minimal interface for a connector that can batch read records.
+type TestableBatchReader interface {
+	GetRecordsByIds(
+		ctx context.Context,
+		objectName string,
+		recordIds []string,
+		fields []string,
+		associations []string,
+	) ([]common.ReadResultRow, error)
+}
+
 // TestableBatchWriter is the minimal interface for a connector that can batch write records.
 type TestableBatchWriter interface {
 	BatchWrite(ctx context.Context, params *common.BatchWriteParam) (*common.BatchWriteResult, error)

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -49,6 +49,11 @@ type TestableReader interface {
 	Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
 }
 
+// TestableWriter is the minimal interface for a connector that can write records.
+type TestableWriter interface {
+	Write(ctx context.Context, params common.WriteParams) (*common.WriteResult, error)
+}
+
 // TestableDeleter is the minimal interface for a connector that can delete records.
 type TestableDeleter interface {
 	Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error)

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -24,6 +24,11 @@ func (builder ConnectorBuilder[C]) Build(t *testing.T, testCaseName string) C {
 	return conn
 }
 
+// TestablePostAuthMetadata is the minimal interface for a connector that returns post auth metadata.
+type TestablePostAuthMetadata interface {
+	GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error)
+}
+
 // TestableMetadataReader is the minimal interface for a connector that can read metadata.
 type TestableMetadataReader interface {
 	ListObjectMetadata(ctx context.Context, objectNames []string) (*common.ListObjectMetadataResult, error)

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -49,6 +49,11 @@ type TestableDeleter interface {
 	Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error)
 }
 
+// TestableSearcher is the minimal interface for a connector that can search records.
+type TestableSearcher interface {
+	Search(ctx context.Context, params *common.SearchParams) (*common.SearchResult, error)
+}
+
 // TestableBatchReader is the minimal interface for a connector that can batch read records.
 type TestableBatchReader interface {
 	GetRecordsByIds(

--- a/test/utils/testroutines/connector.go
+++ b/test/utils/testroutines/connector.go
@@ -39,6 +39,11 @@ type TestableMetadataDeleter interface {
 	DeleteMetadata(ctx context.Context, params *common.DeleteMetadataParams) (*common.DeleteMetadataResult, error)
 }
 
+// TestableReader is the minimal interface for a connector that can read records.
+type TestableReader interface {
+	Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error)
+}
+
 // TestableDeleter is the minimal interface for a connector that can delete records.
 type TestableDeleter interface {
 	Delete(ctx context.Context, params common.DeleteParams) (*common.DeleteResult, error)

--- a/test/utils/testroutines/delete-metadata.go
+++ b/test/utils/testroutines/delete-metadata.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	deleteMetadataType = TestCase[*common.DeleteMetadataParams, *common.DeleteMetadataResult]
-	// DeleteMetadata is a test suite useful for testing connectors.DeleteMetadataConnector interface.
-	DeleteMetadata deleteMetadataType
+	// TestCaseDeleteMetadata is a test suite useful for testing connectors.DeleteMetadataConnector interface.
+	TestCaseDeleteMetadata deleteMetadataType
 )
 
 // Run provides a procedure to test connectors.DeleteMetadataConnector.
-func (m DeleteMetadata) Run(t *testing.T, builder ConnectorBuilder[connectors.DeleteMetadataConnector]) {
+func (m TestCaseDeleteMetadata) Run(t *testing.T, builder ConnectorBuilder[TestableMetadataDeleter]) {
 	m.RunWithContext(t, t.Context(), builder)
 }
 
 // RunWithContext provides a procedure to test connectors.DeleteMetadataConnector.
-func (m DeleteMetadata) RunWithContext(t *testing.T, ctx context.Context,
-	builder ConnectorBuilder[connectors.DeleteMetadataConnector],
+func (m TestCaseDeleteMetadata) RunWithContext(t *testing.T, ctx context.Context,
+	builder ConnectorBuilder[TestableMetadataDeleter],
 ) {
 	t.Helper()
 	t.Cleanup(func() {

--- a/test/utils/testroutines/delete.go
+++ b/test/utils/testroutines/delete.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	deleteType = TestCase[common.DeleteParams, *common.DeleteResult]
-	// Delete is a test suite useful for testing connectors.DeleteConnector interface.
-	Delete deleteType
+	// TestCaseDelete is a test suite useful for testing connectors.DeleteConnector interface.
+	TestCaseDelete deleteType
 )
 
 // Run provides a procedure to test connectors.DeleteConnector
-func (d Delete) Run(t *testing.T, builder ConnectorBuilder[connectors.DeleteConnector]) {
+func (d TestCaseDelete) Run(t *testing.T, builder ConnectorBuilder[TestableDeleter]) {
 	t.Helper()
 	t.Cleanup(func() {
 		deleteType(d).Close()

--- a/test/utils/testroutines/metadata.go
+++ b/test/utils/testroutines/metadata.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	metadataType = TestCase[[]string, *common.ListObjectMetadataResult]
-	// Metadata is a test suite useful for testing connectors.ObjectMetadataConnector interface.
-	Metadata metadataType
+	// TestCaseListObjectMetadata is a test suite useful for testing connectors.ObjectMetadataConnector interface.
+	TestCaseListObjectMetadata metadataType
 )
 
 // Run provides a procedure to test connectors.ObjectMetadataConnector
-func (m Metadata) Run(t *testing.T, builder ConnectorBuilder[connectors.ObjectMetadataConnector]) {
+func (m TestCaseListObjectMetadata) Run(t *testing.T, builder ConnectorBuilder[TestableMetadataReader]) {
 	t.Helper()
 	t.Cleanup(func() {
 		metadataType(m).Close()

--- a/test/utils/testroutines/post-auth-info.go
+++ b/test/utils/testroutines/post-auth-info.go
@@ -3,19 +3,18 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 type (
 	postAuthInfoType = TestCase[any, *common.PostAuthInfo]
-	// PostAuthInfo is a test suite useful for testing connectors.AuthMetadataConnector interface.
-	PostAuthInfo postAuthInfoType
+	// TestCaseGetPostAuthInfo is a test suite useful for testing connectors.AuthMetadataConnector interface.
+	TestCaseGetPostAuthInfo postAuthInfoType
 )
 
 // Run provides a procedure to test connectors.AuthMetadataConnector
-func (r PostAuthInfo) Run(t *testing.T, builder ConnectorBuilder[connectors.AuthMetadataConnector]) {
+func (r TestCaseGetPostAuthInfo) Run(t *testing.T, builder ConnectorBuilder[TestablePostAuthMetadata]) {
 	t.Helper()
 	t.Cleanup(func() {
 		postAuthInfoType(r).Close()

--- a/test/utils/testroutines/read-by-ids.go
+++ b/test/utils/testroutines/read-by-ids.go
@@ -3,14 +3,13 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	readByIdsType = TestCase[ReadByIdsParams, []common.ReadResultRow]
-	// ReadByIds is a test suite useful for testing connectors.BatchRecordReaderConnector interface.
-	ReadByIds readByIdsType
+	// TestCaseGetRecordsByIds is a test suite useful for testing connectors.BatchRecordReaderConnector interface.
+	TestCaseGetRecordsByIds readByIdsType
 )
 
 type ReadByIdsParams struct {
@@ -21,7 +20,7 @@ type ReadByIdsParams struct {
 }
 
 // Run provides a procedure to test connectors.BatchRecordReaderConnector
-func (r ReadByIds) Run(t *testing.T, builder ConnectorBuilder[connectors.BatchRecordReaderConnector]) {
+func (r TestCaseGetRecordsByIds) Run(t *testing.T, builder ConnectorBuilder[TestableBatchReader]) {
 	t.Helper()
 	t.Cleanup(func() {
 		readByIdsType(r).Close()

--- a/test/utils/testroutines/read.go
+++ b/test/utils/testroutines/read.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	readType = TestCase[common.ReadParams, *common.ReadResult]
-	// Read is a test suite useful for testing connectors.ReadConnector interface.
-	Read readType
+	// TestCaseRead is a test suite useful for testing connectors.ReadConnector interface.
+	TestCaseRead readType
 )
 
 // Run provides a procedure to test connectors.ReadConnector
-func (r Read) Run(t *testing.T, builder ConnectorBuilder[connectors.ReadConnector]) {
+func (r TestCaseRead) Run(t *testing.T, builder ConnectorBuilder[TestableReader]) {
 	t.Helper()
 	t.Cleanup(func() {
 		readType(r).Close()

--- a/test/utils/testroutines/search.go
+++ b/test/utils/testroutines/search.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	searchType = TestCase[common.SearchParams, *common.SearchResult]
-	// Search is a test suite useful for testing connectors.SearchConnector interface.
-	Search searchType
+	// TestCaseSearch is a test suite useful for testing connectors.SearchConnector interface.
+	TestCaseSearch searchType
 )
 
 // Run provides a procedure to test connectors.SearchConnector
-func (s Search) Run(t *testing.T, builder ConnectorBuilder[connectors.SearchConnector]) {
+func (s TestCaseSearch) Run(t *testing.T, builder ConnectorBuilder[TestableSearcher]) {
 	t.Helper()
 	t.Cleanup(func() {
 		searchType(s).Close()

--- a/test/utils/testroutines/subscription-event.go
+++ b/test/utils/testroutines/subscription-event.go
@@ -33,14 +33,14 @@ type SubscriptionEventExpectedErr struct {
 	UpdatedFields      error
 }
 
-type SubscriptionEventTestCase struct {
+type TestCaseSubscriptionEvent struct {
 	Name                     string
 	Input                    common.Event
 	Expected                 []SubscriptionEventExpected
 	SubscriptionEventListErr error
 }
 
-func (c SubscriptionEventTestCase) Run(t *testing.T) {
+func (c TestCaseSubscriptionEvent) Run(t *testing.T) {
 	t.Helper()
 
 	result := testutils.NewCompareResult()

--- a/test/utils/testroutines/subscriptions-create.go
+++ b/test/utils/testroutines/subscriptions-create.go
@@ -8,12 +8,12 @@ import (
 
 type (
 	createSubscriptionType = TestCase[common.SubscribeParams, *common.SubscriptionResult]
-	// TestCaseCreateSubscription is a test suite useful for testing part of connectors.SubscribeConnector interface.
-	TestCaseCreateSubscription createSubscriptionType
+	// TestCaseSubscribe is a test suite useful for testing part of connectors.SubscribeConnector interface.
+	TestCaseSubscribe createSubscriptionType
 )
 
 // Run provides a procedure to test connectors.SubscribeConnector
-func (s TestCaseCreateSubscription) Run(t *testing.T, builder ConnectorBuilder[TestableSubscriptionCreator]) {
+func (s TestCaseSubscribe) Run(t *testing.T, builder ConnectorBuilder[TestableSubscriptionCreator]) {
 	t.Helper()
 	t.Cleanup(func() {
 		createSubscriptionType(s).Close()

--- a/test/utils/testroutines/upsert-metadata.go
+++ b/test/utils/testroutines/upsert-metadata.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
@@ -15,13 +14,13 @@ type (
 )
 
 // Run provides a procedure to test connectors.UpsertMetadataConnector.
-func (m TestCaseUpsertMetadata) Run(t *testing.T, builder ConnectorBuilder[connectors.UpsertMetadataConnector]) {
+func (m TestCaseUpsertMetadata) Run(t *testing.T, builder ConnectorBuilder[TestableMetadataUpdater]) {
 	m.RunWithContext(t, t.Context(), builder)
 }
 
 // RunWithContext provides a procedure to test connectors.UpsertMetadataConnector.
 func (m TestCaseUpsertMetadata) RunWithContext(t *testing.T, ctx context.Context,
-	builder ConnectorBuilder[connectors.UpsertMetadataConnector],
+	builder ConnectorBuilder[TestableMetadataUpdater],
 ) {
 	t.Helper()
 	t.Cleanup(func() {

--- a/test/utils/testroutines/webook-message-verifier.go
+++ b/test/utils/testroutines/webook-message-verifier.go
@@ -8,8 +8,8 @@ import (
 
 type (
 	webhookMessageVerificationType = TestCase[WebhookMessageVerificationParams, bool]
-	// TestCaseWebhookMessageVerification is a test suite useful for testing connectors.WebhookVerifierConnector interface.
-	TestCaseWebhookMessageVerification webhookMessageVerificationType
+	// TestCaseVerifyWebhookMessage is a test suite useful for testing connectors.WebhookVerifierConnector interface.
+	TestCaseVerifyWebhookMessage webhookMessageVerificationType
 )
 
 type WebhookMessageVerificationParams struct {
@@ -18,7 +18,7 @@ type WebhookMessageVerificationParams struct {
 }
 
 // Run provides a procedure to test connectors.WebhookVerifierConnector
-func (r TestCaseWebhookMessageVerification) Run(t *testing.T,
+func (r TestCaseVerifyWebhookMessage) Run(t *testing.T,
 	builder ConnectorBuilder[TestableWebhookMessageVerifier],
 ) {
 	t.Helper()

--- a/test/utils/testroutines/write.go
+++ b/test/utils/testroutines/write.go
@@ -3,18 +3,17 @@ package testroutines
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 )
 
 type (
 	writeType = TestCase[common.WriteParams, *common.WriteResult]
-	// Write is a test suite useful for testing connectors.WriteConnector interface.
-	Write writeType
+	// TestCaseWrite is a test suite useful for testing connectors.WriteConnector interface.
+	TestCaseWrite writeType
 )
 
 // Run provides a procedure to test connectors.WriteConnector
-func (w Write) Run(t *testing.T, builder ConnectorBuilder[connectors.WriteConnector]) {
+func (w TestCaseWrite) Run(t *testing.T, builder ConnectorBuilder[TestableWriter]) {
 	t.Helper()
 	t.Cleanup(func() {
 		writeType(w).Close()


### PR DESCRIPTION
# Goal

Consistent naming of connector unit test cases and using dedicated interfaces.

# Description

`testroutines` to rely on interfaces dedicated for testing:

<img width="394" height="278" alt="image" src="https://github.com/user-attachments/assets/2f1d190b-b506-48c6-97fc-1a8dd0c06861" />

These interface won't be confused with regular `connectors` interfaces. They focus on unit testing one method and start with `Testable` prefix.

The methods are easy to find because they start with `TestCase` prefix:

<img width="739" height="322" alt="image" src="https://github.com/user-attachments/assets/ccc1d118-7e95-4937-b10a-95e392c96fcd" />

# Examples
* To test `Read` capability of the connector, one would type: `testroutines.TestCaseRead`.
* To test `UpdateSubscription`, type: `testroutines.TestCaseUpdateSubscription`.

# Next

See follow up PR to rename package `testroutines` to `testconn`.