### PR TITLE
tidy(testconn): Rename from testroutines

### DIFF
--- a/internal/components/deleter/deleter_test.go
+++ b/internal/components/deleter/deleter_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -42,7 +42,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/internal/components/reader/reader_test.go
+++ b/internal/components/reader/reader_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestRead(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -44,7 +44,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/internal/components/schema/openapi_test.go
+++ b/internal/components/schema/openapi_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/staticschema"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -25,7 +25,7 @@ func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name:       "Unknown object requested",
 			Input:      []string{"someUnknownObject"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"someUnknownObject": common.ErrObjectNotSupported,
@@ -36,7 +36,7 @@ func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"orders"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"orders": {
@@ -61,7 +61,7 @@ func TestOpenAPI(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL), nil
 			})
 		})

--- a/internal/components/writer/writer_test.go
+++ b/internal/components/writer/writer_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/amp-labs/connectors/internal/components/mocked"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -42,7 +42,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/delete_test.go
+++ b/providers/acculynx/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -74,7 +74,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/metadata_test.go
+++ b/providers/acculynx/metadata_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -26,7 +26,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 			Name:       "Unknown object returns ErrObjectNotSupported",
 			Input:      []string{"nonexistent"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"nonexistent": common.ErrObjectNotSupported,
@@ -49,7 +49,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 		},
 		{
 			Name:   "Successfully describe top-level contacts object",
@@ -67,7 +67,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 		},
 		{
 			Name:   "Slash-named nested object resolves correctly",
@@ -83,7 +83,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 		},
 		{
 			Name:  "Contacts metadata enriched with custom field definitions",
@@ -101,7 +101,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -136,7 +136,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"jobs": {
@@ -181,7 +181,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 		},
 	}
 
@@ -189,7 +189,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 //go:embed test/read/users-first-page.json
@@ -67,7 +67,7 @@ var jobHistoryResponse []byte
 func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -126,7 +126,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						"status":      "Active",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/api/v2/users?pageSize=2&recordStartIndex=2",
+				NextPage: testconn.URLTestServer + "/api/v2/users?pageSize=2&recordStartIndex=2",
 				Done:     false,
 			},
 		},
@@ -136,7 +136,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				ObjectName: "users",
 				Fields:     connectors.Fields("id"),
 				PageSize:   2,
-				NextPage:   testroutines.URLTestServer + "/api/v2/users?pageSize=2&recordStartIndex=4",
+				NextPage:   testconn.URLTestServer + "/api/v2/users?pageSize=2&recordStartIndex=4",
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -151,7 +151,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -189,7 +189,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Done: true,
@@ -238,7 +238,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -319,7 +319,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Done: true,
@@ -361,7 +361,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Done: true,
@@ -397,7 +397,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Done: true,
@@ -430,7 +430,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Done: true,
@@ -455,7 +455,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Done: true,
@@ -467,7 +467,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acculynx/write_test.go
+++ b/providers/acculynx/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 //go:embed test/write/contact-create.json
@@ -21,7 +21,7 @@ var jobCreateResponse []byte
 func TestWrite(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -78,7 +78,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "ctc_001",
@@ -112,7 +112,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "job_001",
@@ -146,7 +146,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cf_001",
@@ -175,7 +175,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -200,7 +200,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -225,7 +225,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -250,7 +250,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -275,7 +275,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -302,7 +302,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -326,7 +326,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -351,7 +351,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -376,7 +376,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -402,7 +402,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -427,7 +427,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -452,7 +452,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 		{
@@ -477,7 +477,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected:   &common.WriteResult{Success: true},
 		},
 	}
@@ -486,7 +486,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestWriteConnector(tt.Server)
 			})
 		})

--- a/providers/acuityscheduling/metadata_test.go
+++ b/providers/acuityscheduling/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	clientsResponse := testutils.DataFromFile(t, "clients-read.json")
 	blocksResponse := testutils.DataFromFile(t, "blocks-read.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, blocksResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"clients": {
@@ -157,7 +157,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acuityscheduling/read_test.go
+++ b/providers/acuityscheduling/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	clientsResponse := testutils.DataFromFile(t, "clients-read.json")
 	blocksResponse := testutils.DataFromFile(t, "blocks-read.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -38,7 +38,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v1/clients"),
 				Then:  mockserver.Response(http.StatusOK, clientsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -84,7 +84,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v1/blocks"),
 				Then:  mockserver.Response(http.StatusOK, blocksResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -152,7 +152,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/acuityscheduling/write_test.go
+++ b/providers/acuityscheduling/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createClientsResponse := testutils.DataFromFile(t, "create-clients.json")
 	createAppointmentsResponse := testutils.DataFromFile(t, "create-appointments.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -108,7 +108,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aircall/delete_test.go
+++ b/providers/aircall/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		// --- Contacts ---
 		{
 			Name: "Delete contact successfully",
@@ -133,7 +133,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/metadata_test.go
+++ b/providers/aircall/metadata_test.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for Users and Calls",
 			Input:      []string{"users", "calls"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"users": {
@@ -82,7 +82,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/read_test.go
+++ b/providers/aircall/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseUsersPaginated := testutils.DataFromFile(t, "read/users/paginated-response.json")
 	responseCallsEmpty := testutils.DataFromFile(t, "read/calls/empty-response.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -90,7 +90,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersPaginated),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -131,7 +131,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read/teams/response.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -163,7 +163,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read/tags/response.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -195,7 +195,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read/contacts/response.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -229,7 +229,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read/numbers/response.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -371,7 +371,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -404,7 +404,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -437,7 +437,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read/teams/response.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -460,7 +460,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/aircall/write_test.go
+++ b/providers/aircall/write_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		// --- Contacts (POST/POST) ---
 		{
 			Name: "Create contact successfully",
@@ -439,7 +439,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/apollo/metadata_test.go
+++ b/providers/apollo/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	opportunityResponse := testutils.DataFromFile(t, "opportunities.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -59,7 +59,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusBadRequest, unsupportedResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"arsenal": mockutils.ExpectedSubsetErrors{
@@ -77,7 +77,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/apollo/read_test.go
+++ b/providers/apollo/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 	sequencesResponse := testutils.DataFromFile(t, "sequences.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -82,7 +82,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/apollo/write_test.go
+++ b/providers/apollo/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	updateDealsResponse := testutils.DataFromFile(t, "update-deals.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -109,7 +109,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/metadata_test.go
+++ b/providers/asana/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 	responseSingleTag := testutils.DataFromFile(t, "single-tag.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -60,7 +60,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"projects": {
@@ -148,7 +148,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/read_test.go
+++ b/providers/asana/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseUsers := testutils.DataFromFile(t, "read-users.json")
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/asana/write_test.go
+++ b/providers/asana/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	responsePortfolios := testutils.DataFromFile(t, "write-projects.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -45,7 +45,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responsePortfolios),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "15",
@@ -77,7 +77,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.MethodPUT(),
 				Then:  mockserver.Response(http.StatusOK, responsePortfolios),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "15",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/delete_test.go
+++ b/providers/atlassian/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseErrorFormat := testutils.DataFromFile(t, "delete-issue-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/metadata_test.go
+++ b/providers/atlassian/metadata_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -15,7 +15,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseIssueSchema := testutils.DataFromFile(t, "issue-metadata.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Server response must include array",
 			Input: []string{"butterflies"},
@@ -62,7 +62,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseIssueSchema),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"issue": {
@@ -97,7 +97,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/read_test.go
+++ b/providers/atlassian/read_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseIssuesFirstPage := testutils.DataFromFile(t, "read-issues.json")
 	responsePathNotFoundError := testutils.DataFromFile(t, "path-not-found.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				  "issues": []
 				}`),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					{"fields":{}, "id": "1"}
 				]}`),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					  "issues": [{"fields":{}, "id": "0"}]
 					}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -179,7 +179,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseIssuesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -213,7 +213,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/atlassian/write_test.go
+++ b/providers/atlassian/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInvalidTypeError := testutils.DataFromFile(t, "create-issue-invalid-type.json")
 	createIssueResponse := testutils.DataFromFile(t, "create-issue.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -84,7 +84,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createIssueResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "10004",
@@ -100,7 +100,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/metadata_test.go
+++ b/providers/attio/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	optionsResponse := testutils.DataFromFile(t, "options.json")
 	usersObjectResponse := []byte(`{"data": {"plural_noun": "Users"}}`)
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +72,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"lists": {
@@ -292,7 +292,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseTasks := testutils.DataFromFile(t, "tasks.json")
 	responseCompanies := testutils.DataFromFile(t, "companies_read.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -217,7 +217,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/attio/write_test.go
+++ b/providers/attio/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tasksResponse := testutils.DataFromFile(t, "write_tasks.json")
 	companiesRecordResponse := testutils.DataFromFile(t, "write_companies_record.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -219,7 +219,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/metadata_test.go
+++ b/providers/avoma/metadata_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -23,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"templates"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"templates": common.ErrObjectNotSupported,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"notes", "template"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"notes": {
@@ -110,7 +110,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/read_test.go
+++ b/providers/avoma/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseMeetings := testutils.DataFromFile(t, "meetings.json")
 	responseUsers := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/avoma/write_test.go
+++ b/providers/avoma/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	updateSmartCategoriesResponse := testutils.DataFromFile(t, "update_smart_categories.json")
 	callsResponse := testutils.DataFromFile(t, "create_calls.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -131,7 +131,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/delete_test.go
+++ b/providers/aws/delete_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -65,7 +65,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/metadata_test.go
+++ b/providers/aws/metadata_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -25,7 +25,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -36,7 +36,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Metadata for objects across AWS Services",
 			Input:      []string{"Users", "Applications", "Helicopters"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Users": {
@@ -88,7 +88,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/read_test.go
+++ b/providers/aws/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseGroups := testutils.DataFromFile(t, "read/groups.json")
 	responseInstances := testutils.DataFromFile(t, "read/instances.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -60,7 +60,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseGroups),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -94,7 +94,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseInstances),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/aws/write_test.go
+++ b/providers/aws/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/providers/aws/internal/core"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTrustedTokenIssuersCreate := testutils.DataFromFile(t, "write/issuer/new.json")
 	responseUserCreate := testutils.DataFromFile(t, "write/user/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -143,7 +143,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/metadata_test.go
+++ b/providers/bentley/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object returns not-supported error",
 			Input:      []string{"nonexistent_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"nonexistent_object": common.ErrObjectNotSupported,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Successfully describe contextcapture/jobs with metadata",
 			Input:      []string{"contextcapture/jobs"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contextcapture/jobs": {
@@ -53,7 +53,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Successfully describe objects from multiple OpenAPI files",
 			Input:      []string{"contextcapture/jobs", "webhooks"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contextcapture/jobs": {
@@ -85,7 +85,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/read_test.go
+++ b/providers/bentley/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseWebhooks := testutils.DataFromFile(t, "read-webhooks.json")
 	responseContextCaptureJobs := testutils.DataFromFile(t, "read-contextcapture-jobs.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/itwins"),
 				Then:  mockserver.Response(http.StatusOK, responseITwinsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -83,7 +83,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/itwins"),
 				Then:  mockserver.Response(http.StatusOK, responseITwinsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -112,7 +112,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/webhooks"),
 				Then:  mockserver.Response(http.StatusOK, responseWebhooks),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -149,7 +149,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContextCaptureJobs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -186,7 +186,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContextCaptureJobs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -216,7 +216,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/itwins"),
 				Then:  mockserver.Response(http.StatusOK, responseITwinsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -239,7 +239,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/bentley/write_test.go
+++ b/providers/bentley/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCreateWebhook := testutils.DataFromFile(t, "write-create-webhook.json")
 	responseUpdateManufacturer := testutils.DataFromFile(t, "write-update-manufacturer.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -59,7 +59,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusCreated, responseCreateITwin),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "itwin-new-001",
@@ -94,7 +94,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateITwin),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "itwin-existing-001",
@@ -130,7 +130,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusCreated, responseCreateWebhook),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "wh-new-001",
@@ -163,7 +163,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateManufacturer),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "mfr-001",
@@ -180,7 +180,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/delete_test.go
+++ b/providers/blackbaud/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -53,7 +53,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/metadata_test.go
+++ b/providers/blackbaud/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	volunteersResponse := testutils.DataFromFile(t, "volunteers.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, volunteersResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"crm-adnmg/currencies": {
@@ -135,7 +135,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/read_test.go
+++ b/providers/blackbaud/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	volunteersResponse := testutils.DataFromFile(t, "volunteers.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/blackbaud/write_test.go
+++ b/providers/blackbaud/write_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -91,7 +91,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/metadata_test.go
+++ b/providers/braintree/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	customersMetadataResponse := testutils.DataFromFile(t, "metadata-customers.json")
 	metadataErrorResponse := testutils.DataFromFile(t, "metadata-error.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -60,7 +60,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, customersMetadataResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -99,7 +99,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/read_test.go
+++ b/providers/braintree/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -38,7 +38,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	merchantAccountsResponse := testutils.DataFromFile(t, "read-merchantAccounts.json")
 	errorValidationResponse := testutils.DataFromFile(t, "read-error-validation.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -117,7 +117,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Done: true,
 			},
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 		},
 		{
@@ -176,7 +176,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Done: true,
 			},
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 		},
 		{
@@ -237,7 +237,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Done: true,
 			},
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 		},
 		{
@@ -294,7 +294,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Done: true,
 			},
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 		},
 		{
@@ -345,7 +345,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Done: true,
 			},
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 		},
 	}
@@ -354,7 +354,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/braintree/write_test.go
+++ b/providers/braintree/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	createCustomerRequestBody := testutils.DataFromFile(t, "request-create-customer.json")
 	updateCustomerRequestBody := testutils.DataFromFile(t, "request-update-customer.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -59,7 +59,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"id": "customer_123",
 				},
 			},
-			Comparator:   testroutines.ComparatorSubsetWrite,
+			Comparator:   testconn.ComparatorSubsetWrite,
 			ExpectedErrs: nil,
 		},
 		{
@@ -91,7 +91,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"id": "customer_123",
 				},
 			},
-			Comparator:   testroutines.ComparatorSubsetWrite,
+			Comparator:   testconn.ComparatorSubsetWrite,
 			ExpectedErrs: nil,
 		},
 		{
@@ -120,7 +120,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"id": "txn_456",
 				},
 			},
-			Comparator:   testroutines.ComparatorSubsetWrite,
+			Comparator:   testconn.ComparatorSubsetWrite,
 			ExpectedErrs: nil,
 		},
 		{
@@ -149,7 +149,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"id": "pm_123",
 				},
 			},
-			Comparator:   testroutines.ComparatorSubsetWrite,
+			Comparator:   testconn.ComparatorSubsetWrite,
 			ExpectedErrs: nil,
 		},
 		{
@@ -183,7 +183,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"id": "pm_123",
 				},
 			},
-			Comparator:   testroutines.ComparatorSubsetWrite,
+			Comparator:   testconn.ComparatorSubsetWrite,
 			ExpectedErrs: nil,
 		},
 	}
@@ -192,7 +192,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breakcold/delete_test.go
+++ b/providers/breakcold/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-lead.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/metadata_test.go
+++ b/providers/breakcold/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	statusResponse := testutils.DataFromFile(t, "status.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -39,7 +39,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, leadsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"status": {
@@ -83,7 +83,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/read_test.go
+++ b/providers/breakcold/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	statusResponse := testutils.DataFromFile(t, "status.json")
 	remindersResponse := testutils.DataFromFile(t, "reminders.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -32,7 +32,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/status"),
 				Then:  mockserver.Response(http.StatusOK, statusResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -61,7 +61,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/reminders/list"),
 				Then:  mockserver.Response(http.StatusOK, remindersResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breakcold/write_test.go
+++ b/providers/breakcold/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	leadResponse := testutils.DataFromFile(t, "write_lead.json")
 	remindersResponse := testutils.DataFromFile(t, "write_reminders.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -175,7 +175,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/breezy/delete_test.go
+++ b/providers/breezy/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -54,7 +54,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/metadata_test.go
+++ b/providers/breezy/metadata_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name: "Successful metadata for recruiting objects",
 			Input: []string{
@@ -25,7 +25,7 @@ func TestListObjectMetadata(t *testing.T) {
 				"templates",
 			},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"companies": {
@@ -149,7 +149,7 @@ func TestListObjectMetadata(t *testing.T) {
 			Name:       "Unsupported object returns object not supported error",
 			Input:      []string{"companies", "unknown_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"companies": {
@@ -175,7 +175,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/read_test.go
+++ b/providers/breezy/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -28,7 +28,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	responseQuestionnaires := testutils.DataFromFile(t, "read/questionnaires.json")
 	responseTemplates := testutils.DataFromFile(t, "read/templates.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -89,7 +89,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompanies),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -120,7 +120,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responsePositions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -169,7 +169,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responsePositions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -198,7 +198,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responsePipelines),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -228,7 +228,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseCategories),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -265,7 +265,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseDepartments),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -293,7 +293,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseQuestionnaires),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -329,7 +329,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseTemplates),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -353,7 +353,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/breezy/write_test.go
+++ b/providers/breezy/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createResp := testutils.DataFromFile(t, "write/position-create.json")
 	updateResp := testutils.DataFromFile(t, "write/position-update.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, createResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "pos_new",
@@ -96,7 +96,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, updateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "pos001",
@@ -116,7 +116,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/campaignmonitor/delete_test.go
+++ b/providers/campaignmonitor/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-client_id.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/metadata_test.go
+++ b/providers/campaignmonitor/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	clientsResponse := testutils.DataFromFile(t, "clients.json")
 	adminsResponse := testutils.DataFromFile(t, "admins.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"clients", "admins", "campaigns"},
@@ -32,7 +32,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, adminsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"clients": {
@@ -63,7 +63,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/read_test.go
+++ b/providers/campaignmonitor/read_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	clientsResponse := testutils.DataFromFile(t, "clients.json")
 	adminsResponse := testutils.DataFromFile(t, "admins.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -74,7 +74,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/campaignmonitor/write_test.go
+++ b/providers/campaignmonitor/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 
 	clientsResponse := testutils.DataFromFile(t, "write_clients.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/capsule/delete_test.go
+++ b/providers/capsule/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -54,7 +54,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/metadata_test.go
+++ b/providers/capsule/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responsePartiesCustomFields := testutils.DataFromFile(t, "read/parties/custom-fields.json")
 	responseProjectsCustomFields := testutils.DataFromFile(t, "read/projects/custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for multiple objects",
 			Input: []string{"activitytypes", "parties"},
@@ -27,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/parties/fields/definitions"),
 				Then:  mockserver.Response(http.StatusOK, responsePartiesCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"activitytypes": {
@@ -83,7 +83,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:   mockcond.Path("/api/v2/kases/fields/definitions"),
 				Then: mockserver.Response(http.StatusOK, responseProjectsCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"projects": {
@@ -137,7 +137,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/read_test.go
+++ b/providers/capsule/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responsePartiesLastPage := testutils.DataFromFile(t, "read/parties/last-page.json")
 	responseProjects := testutils.DataFromFile(t, "read/projects/first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "categories", Fields: connectors.Fields("colour")},
@@ -56,7 +56,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					mockserver.Response(http.StatusOK, responsePartiesFirstPage),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/v2/parties"),
 				Then:  mockserver.Response(http.StatusOK, responsePartiesLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -123,7 +123,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseProjects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/capsule/write_test.go
+++ b/providers/capsule/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseTask := testutils.DataFromFile(t, "write/task/new.json")
 	responseProject := testutils.DataFromFile(t, "write/project/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -66,7 +66,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseTask),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "147248893",
@@ -97,7 +97,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseTask),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "147248893",
@@ -125,7 +125,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseProject),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "5271516",
@@ -155,7 +155,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseProject),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "5271516",
@@ -173,7 +173,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/metadata_test.go
+++ b/providers/chargebee/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseCustomers := testutils.DataFromFile(t, "customers.json")
 	responseSubscriptions := testutils.DataFromFile(t, "subscriptions.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -265,7 +265,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -298,7 +298,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/read_test.go
+++ b/providers/chargebee/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCustomers := testutils.DataFromFile(t, "customers.json")
 	responseSubscriptions := testutils.DataFromFile(t, "subscriptions.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -42,7 +42,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSubscriptions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{ //nolint:dupl
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -159,7 +159,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -215,7 +215,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSubscriptions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{ //nolint:dupl
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -274,7 +274,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargebee/write_test.go
+++ b/providers/chargebee/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCustomerCreate := testutils.DataFromFile(t, "customer-create.json")
 	responseCustomerUpdate := testutils.DataFromFile(t, "customer-update.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -132,7 +132,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chargeover/handlers_test.go
+++ b/providers/chargeover/handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	okResponse := testutils.DataFromFile(t, "customers.json")
 	unsupportedObjects := testutils.DataFromFile(t, "404.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -32,7 +32,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusNotFound, unsupportedObjects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrRetryable,
@@ -47,7 +47,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, okResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -293,7 +293,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/metadata_test.go
+++ b/providers/chilipiper/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	workspace := testutils.DataFromFile(t, "workspace.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusNotFound, unsupportedResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"workspace": {
@@ -65,7 +65,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/read_test.go
+++ b/providers/chilipiper/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 	team := testutils.DataFromFile(t, "team.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -101,7 +101,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/chilipiper/write_test.go
+++ b/providers/chilipiper/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	addUsers := testutils.DataFromFile(t, "add_user_team.json")
 	distribution := testutils.DataFromFile(t, "distribution.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -87,7 +87,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/metadata_test.go
+++ b/providers/claricopilot/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	usersResponse := testutils.DataFromFile(t, "users.json")
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, callsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"calls": {
@@ -85,7 +85,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/read_test.go
+++ b/providers/claricopilot/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCallLast := testutils.DataFromFile(t, "calls-second-page.json")
 	responseScorecardTemplates := testutils.DataFromFile(t, "scorecardtemplates.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/calls"),
 				Then:  mockserver.Response(http.StatusOK, responseCallFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -61,7 +61,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"call_review_page_url": "https://copilot.clari.com/call/7549847e-4e97-4650-a20d-87791520e529",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/calls?limit=25&skip=1", // nolint:lll
+				NextPage: testconn.URLTestServer + "/calls?limit=25&skip=1", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -77,7 +77,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/calls"),
 				Then:  mockserver.Response(http.StatusOK, responseCallLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
 				NextPage: "",
@@ -93,7 +93,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/scorecard-template"),
 				Then:  mockserver.Response(http.StatusOK, responseScorecardTemplates),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/claricopilot/write_test.go
+++ b/providers/claricopilot/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createCallsResponse := testutils.DataFromFile(t, "create_calls.json")
 	updateContactsResponse := testutils.DataFromFile(t, "update_contact.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -99,7 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/metadata_test.go
+++ b/providers/closecrm/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, leadsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"lead": {
@@ -79,7 +79,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/read_test.go
+++ b/providers/closecrm/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 	activityResponse := testutils.DataFromFile(t, "activities.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -65,7 +65,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v1/activity"),
 				Then:  mockserver.Response(http.StatusOK, activityResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/closecrm/write_test.go
+++ b/providers/closecrm/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	leadCreationResponse := testutils.DataFromFile(t, "create-lead.json")
 	updateLeadResponse := testutils.DataFromFile(t, "update-lead.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, leadCreationResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "lead_q6XxGP7gFqn1UZ2F8lrmm0JuIOQzEsUGoVY0Yz9fLWx",
@@ -99,7 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPUT(),
 				Then:  mockserver.Response(http.StatusOK, updateLeadResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "lead_hVUTYHtMmG2p7DNRJGy3IQuB3GfBLwCu46qsw1gbm6c",
@@ -135,7 +135,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/cloudtalk/delete_test.go
+++ b/providers/cloudtalk/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name: "Delete Contact",
 			Input: common.DeleteParams{
@@ -56,7 +56,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/metadata_test.go
+++ b/providers/cloudtalk/metadata_test.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for Calls",
 			Input:      []string{"calls"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"calls": {
@@ -47,7 +47,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/read_test.go
+++ b/providers/cloudtalk/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsPaginated := testutils.DataFromFile(t, "read/contacts/paginated-response.json")
 	responseCallsEmpty := testutils.DataFromFile(t, "read/calls/empty-response.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -81,7 +81,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactsPaginated),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -115,7 +115,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -221,7 +221,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/cloudtalk/write_test.go
+++ b/providers/cloudtalk/write_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name: "Create contact successfully",
 			Input: common.WriteParams{
@@ -183,7 +183,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/delete_test.go
+++ b/providers/connectwise/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete/contact-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -67,7 +67,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/internal/subscriber/create_test.go
+++ b/providers/connectwise/internal/subscriber/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -33,7 +33,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 		common.SubscriptionEventTypeDelete,
 	}
 
-	tests := []testroutines.TestCaseSubscribe{
+	tests := []testconn.TestCaseSubscribe{
 		{
 			Name: "Creating subscription to contacts and tickets successfully",
 			Input: common.SubscribeParams{
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusOK, responseWebhookForTickets),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
@@ -132,7 +132,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusBadRequest, deleteWebhookFailed),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
@@ -192,7 +192,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusNoContent),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{},
 				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
@@ -210,7 +210,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSubscriptionCreator, error) {
+			tt.Run(t, func() (testconn.TestableSubscriptionCreator, error) {
 				return constructTestStrategy(tt.Server)
 			})
 		})

--- a/providers/connectwise/internal/subscriber/delete_test.go
+++ b/providers/connectwise/internal/subscriber/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDeleteSubscription{
+	tests := []testconn.TestCaseDeleteSubscription{
 		{
 			Name: "Failer to delete any callback",
 			Input: common.SubscriptionResult{
@@ -29,7 +29,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodDELETE(),
 				Then:  mockserver.Response(http.StatusInternalServerError),
 			}.Server(),
-			Expected:     testroutines.None{},
+			Expected:     testconn.None{},
 			ExpectedErrs: []error{common.ErrServer},
 		},
 		{
@@ -60,7 +60,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusNoContent),
 				}},
 			}.Server(),
-			Expected:     testroutines.None{},
+			Expected:     testconn.None{},
 			ExpectedErrs: nil,
 		},
 	}
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSubscriptionRemover, error) {
+			tt.Run(t, func() (testconn.TestableSubscriptionRemover, error) {
 				return constructTestStrategy(tt.Server)
 			})
 		})

--- a/providers/connectwise/internal/subscriber/update_test.go
+++ b/providers/connectwise/internal/subscriber/update_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,10 +27,10 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 		common.SubscriptionEventTypeDelete,
 	}
 
-	tests := []testroutines.TestCaseUpdateSubscription{
+	tests := []testconn.TestCaseUpdateSubscription{
 		{
 			Name: "SubscriptionStatusSuccess: Successfully update by creating one and removing one",
-			Input: testroutines.UpdateSubscriptionParams{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
@@ -70,7 +70,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusNoContent),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
@@ -89,7 +89,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 		},
 		{
 			Name: "SubscriptionStatusFailed: Create fails (with rollback) and delete succeeds",
-			Input: testroutines.UpdateSubscriptionParams{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
@@ -124,7 +124,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errorCreateBadRequest1),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
@@ -144,7 +144,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 		},
 		{
 			Name: "SubscriptionStatusFailedToRollback: Create fails and rollback fails",
-			Input: testroutines.UpdateSubscriptionParams{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					Request: &Request{WebhookURL: "https://test.com/webhook"},
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
@@ -182,7 +182,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusBadRequest, deleteWebhookFailed),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(compareResult),
+			Comparator: testconn.ComparatorSubscriptionWithResult(compareResult),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					ObjectWebhooks: map[common.ObjectName]SubscriptionResource{
@@ -208,7 +208,7 @@ func TestUpdateSubscription(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSubscriptionUpdater, error) {
+			tt.Run(t, func() (testconn.TestableSubscriptionUpdater, error) {
 				return constructTestStrategy(tt.Server)
 			})
 		})

--- a/providers/connectwise/internal/webhook/message_test.go
+++ b/providers/connectwise/internal/webhook/message_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -13,12 +13,12 @@ func TestEvent(t *testing.T) {
 	responseContactUpdated := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "contact-update.json")
 	responseContactDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "contact-delete.json")
 
-	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
+	for _, tt := range []testconn.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseContactCreated,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "create",
 					RawEventName: "added",
 					ObjectName:   "contacts",
@@ -29,8 +29,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Updated event",
 			Input: responseContactUpdated,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "update",
 					RawEventName: "updated",
 					ObjectName:   "contacts",
@@ -41,8 +41,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Deleted event",
 			Input: responseContactDeleted,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "delete",
 					RawEventName: "deleted",
 					ObjectName:   "contacts",

--- a/providers/connectwise/internal/webhook/verifier_test.go
+++ b/providers/connectwise/internal/webhook/verifier_test.go
@@ -6,10 +6,10 @@ package webhook
 //	const signingKey = "test-signing-key"
 //	eventMessage := testutils.DataFromFile(t, "contact-create.json")
 //
-//	tests := []testroutines.TestCaseWebhookMessageVerification{
+//	tests := []testconn.TestCaseWebhookMessageVerification{
 //		{
 //			Name: "Valid signature",
-//			Input: testroutines.WebhookMessageVerificationParams{
+//			Input: testconn.WebhookMessageVerificationParams{
 //				Request: &common.WebhookRequest{Body: eventMessage},
 //			},
 //			InputMutator: withSignatureHeader(signingKey),
@@ -30,7 +30,7 @@ package webhook
 //		},
 //		{
 //			Name: "Invalid signature",
-//			Input: testroutines.WebhookMessageVerificationParams{
+//			Input: testconn.WebhookMessageVerificationParams{
 //				Request: &common.WebhookRequest{
 //					Headers: http.Header{"x-content-signature": []string{"mismatching-signature-from-provider"}},
 //					Body:    eventMessage,
@@ -54,7 +54,7 @@ package webhook
 //		},
 //		{
 //			Name: "Missing signature header in input",
-//			Input: testroutines.WebhookMessageVerificationParams{
+//			Input: testconn.WebhookMessageVerificationParams{
 //				Request: &common.WebhookRequest{Body: eventMessage},
 //			},
 //			InputMutator: replaceServerURLInBody,
@@ -68,7 +68,7 @@ package webhook
 //		},
 //		{
 //			Name: "Fetch signing key fails",
-//			Input: testroutines.WebhookMessageVerificationParams{
+//			Input: testconn.WebhookMessageVerificationParams{
 //				Request: &common.WebhookRequest{Body: eventMessage},
 //			},
 //			InputMutator: withSignatureHeader(signingKey),
@@ -85,7 +85,7 @@ package webhook
 //		t.Run(tt.Name, func(t *testing.T) {
 //			t.Parallel()
 //
-//			tt.Run(t, func() (testroutines.TestableWebhookMessageVerifier, error) {
+//			tt.Run(t, func() (testconn.TestableWebhookMessageVerifier, error) {
 //				return constructTestVerifier(tt.Server)
 //			})
 //		})
@@ -108,19 +108,19 @@ package webhook
 //}
 //
 //func replaceServerURLInBody(
-//	server *httptest.Server, input testroutines.WebhookMessageVerificationParams,
-//) testroutines.WebhookMessageVerificationParams {
+//	server *httptest.Server, input testconn.WebhookMessageVerificationParams,
+//) testconn.WebhookMessageVerificationParams {
 //	// Body has the URL which should be stubbed so connector will make a call to the mock server.
 //	input.Request.Body = []byte(
-//		testroutines.ResolveTestServerURL(string(input.Request.Body), server.URL),
+//		testconn.ResolveTestServerURL(string(input.Request.Body), server.URL),
 //	)
 //	return input
 //}
 //
-//func withSignatureHeader(secretKey string) testroutines.InputMutator[testroutines.WebhookMessageVerificationParams] {
+//func withSignatureHeader(secretKey string) testconn.InputMutator[testconn.WebhookMessageVerificationParams] {
 //	return func(
-//		server *httptest.Server, input testroutines.WebhookMessageVerificationParams,
-//	) testroutines.WebhookMessageVerificationParams {
+//		server *httptest.Server, input testconn.WebhookMessageVerificationParams,
+//	) testconn.WebhookMessageVerificationParams {
 //		input = replaceServerURLInBody(server, input)
 //
 //		// The body changes between test runs so we must compute the signature ourselves.

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -23,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"contacts", "companies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -84,7 +84,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/read-by-ids_test.go
+++ b/providers/connectwise/read-by-ids_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 
 	responseContacts := testutils.DataFromFile(t, "read/contacts-batch-by-ids.json")
 
-	tests := []testroutines.TestCaseGetRecordsByIds{
+	tests := []testconn.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -26,7 +26,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		},
 		{
 			Name: "Read contacts by identifiers",
-			Input: testroutines.ReadByIdsParams{
+			Input: testconn.ReadByIdsParams{
 				ObjectName: "contacts",
 				RecordIds:  []string{"57920", "57921", "57922"},
 				Fields:     []string{"firstName"},
@@ -43,7 +43,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSortedSubsetReadByIds,
+			Comparator: testconn.ComparatorSortedSubsetReadByIds,
 			Expected: []common.ReadResultRow{{
 				Id:     "57920",
 				Fields: map[string]any{"firstname": "Maxime Schaefer [1]"},
@@ -66,7 +66,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
+			tt.Run(t, func() (testconn.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/read_test.go
+++ b/providers/connectwise/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,9 +22,9 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	nextPageRaw := common.NextPageToken("https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
 	linkHeaderRaw := "<" + nextPageRaw.String() + ">; rel=\"next\""
-	nextPageRelative := common.NextPageToken(testroutines.URLTestServer + "/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
+	nextPageRelative := common.NextPageToken(testconn.URLTestServer + "/v4_6_release/apis/3.0/company/contacts/?conditions=LastUpdated+%3e%3d+%5b2025-04-01T20%3a02%3a28Z%5d&pageSize=2&page=2")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -62,7 +62,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					mockserver.Response(http.StatusOK, responseCampaignsFirstPage),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					mockserver.Response(http.StatusOK, responseContacts),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/connectwise/write_test.go
+++ b/providers/connectwise/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	errorNotFound := testutils.DataFromFile(t, "write/contacts/not-found.json")
 	responseContact := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -68,7 +68,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "57919",
@@ -98,7 +98,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "57919",
@@ -134,7 +134,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "57919",
@@ -152,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/constantcontact/delete_test.go
+++ b/providers/constantcontact/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -45,7 +45,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/metadata_test.go
+++ b/providers/constantcontact/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseContactsCustomFields := testutils.DataFromFile(t, "read/contacts/custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -27,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -76,7 +76,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v3/contact_custom_fields"),
 				Then:  mockserver.Response(http.StatusOK, responseContactsCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -100,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/read_test.go
+++ b/providers/constantcontact/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts/1-first-page.json")
 	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts/2-second-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -71,7 +71,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseContactsCustomFields),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -89,7 +89,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						}},
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=",
+				NextPage: testconn.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -110,7 +110,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusNoContent),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/constantcontact/write_test.go
+++ b/providers/constantcontact/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateContact := testutils.DataFromFile(t, "write-contact.json")
 	responseCreateEmailCampaign := testutils.DataFromFile(t, "write-email-campaign.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "af73e650-96f0-11ef-b2a0-fa163eafb85e",
@@ -74,7 +74,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "af73e650-96f0-11ef-b2a0-fa163eafb85e",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateEmailCampaign),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "987cb9ab-ad0c-4087-bd46-2e2ad241221f",
@@ -128,7 +128,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateEmailCampaign),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "987cb9ab-ad0c-4087-bd46-2e2ad241221f",
@@ -146,7 +146,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/delete_test.go
+++ b/providers/copper/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -64,7 +64,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/metadata_test.go
+++ b/providers/copper/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseCustomFields := testutils.DataFromFile(t, "custom/fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for Projects and Leads",
 			Input: []string{"projects", "leads", "companies"},
@@ -31,7 +31,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"projects": {
@@ -177,7 +177,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/read_test.go
+++ b/providers/copper/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCompanies := testutils.DataFromFile(t, "read/companies/with-custom-fields.json")
 	responseCustomFields := testutils.DataFromFile(t, "custom/fields.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -84,7 +84,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Then: mockserver.Response(http.StatusOK, responseProjectsFirstPage),
 				Else: mockserver.Response(http.StatusOK, responseCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -165,7 +165,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseCustomFields),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -191,7 +191,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/copper/write_test.go
+++ b/providers/copper/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseCompanies := testutils.DataFromFile(t, "write/companies/new.json")
 	responseProjects := testutils.DataFromFile(t, "write/projects/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -49,7 +49,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompanies),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "73615382",
@@ -75,7 +75,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompanies),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "73615382",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseProjects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1621193",
@@ -126,7 +126,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseProjects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1621193",
@@ -144,7 +144,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/delete_test.go
+++ b/providers/customerapp/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/metadata_test.go
+++ b/providers/customerapp/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -71,7 +71,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/read_test.go
+++ b/providers/customerapp/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNewslettersFirstPage := testutils.DataFromFile(t, "read-newsletters-1-first-page.json")
 	responseNewslettersEmptyPage := testutils.DataFromFile(t, "read-newsletters-2-empty-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -64,7 +64,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/newsletters"),
 				Then:  mockserver.Response(http.StatusOK, responseNewslettersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -78,7 +78,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"created":        float64(1724072465),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/newsletters?limit=50&start=MQ==",
+				NextPage: testconn.URLTestServer + "/v1/newsletters?limit=50&start=MQ==",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/customerapp/write_test.go
+++ b/providers/customerapp/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorSegmentBadRequest := testutils.DataFromFile(t, "write-segment-bad-request.json")
 	responseSegment := testutils.DataFromFile(t, "write-segment.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -89,7 +89,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/delete_test.go
+++ b/providers/devrev/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestDelete(t *testing.T) {
 	// DevRev accounts-delete-response from schema: empty object {}
 	responseAccountsDelete := testutils.DataFromFile(t, "write-accounts-delete-response.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name: "Delete account successfully",
 			Input: common.DeleteParams{
@@ -64,7 +64,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/metadata_test.go
+++ b/providers/devrev/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successfully describe articles and commands",
 			Input:      []string{"articles", "commands"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"articles": {
@@ -97,7 +97,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/read_test.go
+++ b/providers/devrev/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	responseArticles := testutils.DataFromFile(t, "read-articles.json")
 	responseVistasGroups := testutils.DataFromFile(t, "read-vistas-groups.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Read accounts empty",
 			Input: common.ReadParams{
@@ -61,7 +61,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -76,7 +76,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
+				NextPage: testconn.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -86,7 +86,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "accounts",
 				Fields:     connectors.Fields("id", "display_name", "modified_date"),
-				NextPage:   testroutines.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
+				NextPage:   testconn.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -134,7 +134,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -149,7 +149,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/accounts.list?limit=50&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
+				NextPage: testconn.URLTestServer + "/accounts.list?limit=50&cursor=cursor_page_2&sort_by=modified_date%3Adesc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -186,7 +186,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&modified_date.after=2026-02-20T17:00:00Z&sort_by=modified_date%3Adesc",
+				NextPage: testconn.URLTestServer + "/accounts.list?limit=99&cursor=cursor_page_2&modified_date.after=2026-02-20T17:00:00Z&sort_by=modified_date%3Adesc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -228,7 +228,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseArticles),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -267,7 +267,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseArticles),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -302,7 +302,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseArticles),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 0,
 				Data: []common.ReadResultRow{},
@@ -327,7 +327,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseVistasGroups),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{},
@@ -364,7 +364,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/devrev/write_test.go
+++ b/providers/devrev/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -42,7 +42,7 @@ func TestWrite(t *testing.T) {
 	responseRevUserCreate := testutils.DataFromFile(t, "write-rev-user-response.json")
 	responseAuthTokensCreate := testutils.DataFromFile(t, "write-auth-tokens-create-response.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name: "Create article successfully",
 			Input: common.WriteParams{
@@ -59,7 +59,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusCreated, responseArticlesCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "don:core:devrev:article/1",
@@ -88,7 +88,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseArticlesUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "don:core:devrev:article/1",
@@ -117,7 +117,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusCreated, responseRevUserCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1b5d9e8e-6e12-4a0a-bf67-2a8e34c8e2aa",
@@ -153,7 +153,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusCreated, responseAuthTokensCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "",
@@ -174,7 +174,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/metadata_test.go
+++ b/providers/dropboxsign/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	bulkJobsResponse := testutils.DataFromFile(t, "read-bulk_send_job.json")
 	faxResponse := testutils.DataFromFile(t, "read-fax.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, faxResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"bulk_send_job": {
@@ -148,7 +148,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/read_test.go
+++ b/providers/dropboxsign/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	bulkJobsFirstPage := testutils.DataFromFile(t, "read-bulk_send_job-first-page.json")
 	bulkJobsLastPage := testutils.DataFromFile(t, "read-bulk_send_job-last-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v3/bulk_send_job/list"),
 				Then:  mockserver.Response(http.StatusOK, bulkJobsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -134,7 +134,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v3/bulk_send_job/list"),
 				Then:  mockserver.Response(http.StatusOK, bulkJobsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
 				NextPage: "2",
@@ -159,7 +159,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, bulkJobsLastPage),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -174,7 +174,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dropboxsign/write_test.go
+++ b/providers/dropboxsign/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createTeamResponse := testutils.DataFromFile(t, "create-team.json")
 	updateTeamResponse := testutils.DataFromFile(t, "update-team.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -124,7 +124,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicsbusiness/delete_test.go
+++ b/providers/dynamicsbusiness/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +47,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/metadata_test.go
+++ b/providers/dynamicsbusiness/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 
 	responseCustomers := testutils.DataFromFile(t, "metadata/customers.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -44,7 +44,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusNotFound, "{}"),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -72,7 +72,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/read_test.go
+++ b/providers/dynamicsbusiness/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -26,7 +26,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	date := time.Date(2024, 9, 19, 4, 30, 45, 621*millisecondInNano,
 		time.FixedZone("UTC-8", -8*60*60))
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseCustomersFirstPage),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					"/v2.0/test-workspace/test-environment/api/v2.0/companies(test-company-id)/Customers"),
 				Then: mockserver.Response(http.StatusOK, responseCustomersLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseBalanceSheets),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -211,7 +211,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicsbusiness/write_test.go
+++ b/providers/dynamicsbusiness/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseErrorFormat := testutils.DataFromFile(t, "write/contacts/not-found.json")
 	responseContacts := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -53,7 +53,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9dc64b0b-4630-f011-9a4a-7ced8d1df4b8",
@@ -83,7 +83,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9dc64b0b-4630-f011-9a4a-7ced8d1df4b8",
@@ -103,7 +103,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/dynamicscrm/delete_test.go
+++ b/providers/dynamicscrm/delete_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/metadata_test.go
+++ b/providers/dynamicscrm/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseContactsOptionsStates := testutils.DataFromFile(t, "metadata/contacts/options-states.json")
 	responseContactsOptionsStatuses := testutils.DataFromFile(t, "metadata/contacts/options-statuses.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			Name:       "Failure to return attributes for an object",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": mockutils.ExpectedSubsetErrors{
@@ -57,7 +57,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				}},
 				Default: mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"contacts": mockutils.ExpectedSubsetErrors{
@@ -80,7 +80,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				}},
 				Default: mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"contacts": mockutils.ExpectedSubsetErrors{
@@ -115,7 +115,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				}},
 				Default: mockserver.Response(http.StatusOK, []byte{}),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -296,7 +296,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/read_test.go
+++ b/providers/dynamicscrm/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseContactsGet := testutils.DataFromFile(t, "contacts-read.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/dynamicscrm/write_test.go
+++ b/providers/dynamicscrm/write_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -76,7 +76,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/delete_test.go
+++ b/providers/fastspring/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/metadata_test.go
+++ b/providers/fastspring/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for commerce objects",
 			Input:      []string{"accounts", "orders", "products", "subscriptions", "events-processed", "events-unprocessed"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"accounts": {
@@ -121,7 +121,7 @@ func TestListObjectMetadata(t *testing.T) {
 			Name:       "Unsupported object returns object not supported error",
 			Input:      []string{"accounts", "unknown_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"accounts": {
@@ -147,7 +147,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/read_test.go
+++ b/providers/fastspring/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 // TestRead duplicates default limit ("1000") and event "days" ("30") as string literals instead of
@@ -35,7 +35,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 			"nextPage": 0
 	}`)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,10 +71,10 @@ func TestRead(t *testing.T) { // nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
-				NextPage: testroutines.URLTestServer + "/accounts?limit=1000&page=2",
+				NextPage: testconn.URLTestServer + "/accounts?limit=1000&page=2",
 				Done:     false,
 			},
 		},
@@ -83,7 +83,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 			Input: common.ReadParams{
 				ObjectName: "accounts",
 				Fields:     datautils.NewStringSet("id"),
-				NextPage:   testroutines.URLTestServer + "/accounts?limit=1000&page=2",
+				NextPage:   testconn.URLTestServer + "/accounts?limit=1000&page=2",
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -140,7 +140,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -155,7 +155,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fastspring/write_test.go
+++ b/providers/fastspring/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) { //nolint:funlen
@@ -20,7 +20,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	orderResp := []byte(`{"orders":[{"order":"ord_1","action":"order.update","result":"success"}]}`)
 	subscriptionResp := []byte(`{"subscription":"sub_1","action":"subscription.update","result":"success"}`)
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, accountCreateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "acc_new",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, accountUpdateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "acc_1",
@@ -131,7 +131,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, productResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "my-product",
@@ -164,7 +164,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, productBulkResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "",
@@ -200,7 +200,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, orderResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "ord_1",
@@ -231,7 +231,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, subscriptionResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sub_1",
@@ -250,7 +250,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/metadata_test.go
+++ b/providers/fathom/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	meetingsResponse := testutils.DataFromFile(t, "meetings-first-page.json")
 	teamsResponse := testutils.DataFromFile(t, "teams.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, teamsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"meetings": {
@@ -151,7 +151,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/read_test.go
+++ b/providers/fathom/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseMeetingsFirst := testutils.DataFromFile(t, "meetings-first-page.json")
 	responseMeetingsSecond := testutils.DataFromFile(t, "meetings-second-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/external/v1/meetings"),
 				Then:  mockserver.Response(http.StatusOK, responseMeetingsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -79,7 +79,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/external/v1/meetings"),
 				Then:  mockserver.Response(http.StatusOK, responseMeetingsSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -94,7 +94,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fathom/write_test.go
+++ b/providers/fathom/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	createWebhooksResponse := testutils.DataFromFile(t, "create-webhooks.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -63,7 +63,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/metadata_test.go
+++ b/providers/flatfile/metadata_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -23,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			Name:       "Unknown object requested",
 			Input:      []string{"godzilla"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"godzilla": common.ErrObjectNotSupported,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"users", "prompts"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"users": {
@@ -81,7 +81,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/read_test.go
+++ b/providers/flatfile/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseEventsFirst := testutils.DataFromFile(t, "events-first-page.json")
 	responseEventsSecond := testutils.DataFromFile(t, "events-second-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v1/events"),
 				Then:  mockserver.Response(http.StatusOK, responseEventsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -56,7 +56,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"dataUrl":   "",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/events?pageNumber=2&pageSize=100", // nolint:lll
+				NextPage: testconn.URLTestServer + "/v1/events?pageNumber=2&pageSize=100", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -64,13 +64,13 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 		{
 			Name:  "Successful read second page with chosen fields",
-			Input: common.ReadParams{ObjectName: "events", Fields: connectors.Fields("id", "domain", "topic"), NextPage: testroutines.URLTestServer + "/v1/events?pageNumber=2&pageSize=100"}, // nolint:lll
+			Input: common.ReadParams{ObjectName: "events", Fields: connectors.Fields("id", "domain", "topic"), NextPage: testconn.URLTestServer + "/v1/events?pageNumber=2&pageSize=100"}, // nolint:lll
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If:    mockcond.Path("/v1/events"),
 				Then:  mockserver.Response(http.StatusOK, responseEventsSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -86,7 +86,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"createdAt": "2025-07-03T11:52:08.818Z",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/events?pageNumber=3&pageSize=100", // nolint:lll
+				NextPage: testconn.URLTestServer + "/v1/events?pageNumber=3&pageSize=100", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/flatfile/write_test.go
+++ b/providers/flatfile/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createEventsResponse := testutils.DataFromFile(t, "create-events.json")
 	updateEnvironmentsResponse := testutils.DataFromFile(t, "update-environments.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -104,7 +104,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/fourfour/metadata_test.go
+++ b/providers/fourfour/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, leadsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -98,7 +98,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/fourfour/read_test.go
+++ b/providers/fourfour/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 	contactsFirstPageResponse := testutils.DataFromFile(t, "contacts-first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -34,7 +34,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/odata/Contacts"),
 				Then:  mockserver.Response(http.StatusOK, contactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -73,7 +73,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, leadsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -108,7 +108,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, contactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Done: true,
@@ -123,7 +123,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/odata/Contacts"),
 				Then:  mockserver.Response(http.StatusOK, contactsFirstPageResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "http://fourfour.example.com/odata/Contacts?$skip=1&$top=1",
@@ -136,14 +136,14 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "Contacts",
 				Fields:     connectors.Fields("id", "first_name"),
-				NextPage:   testroutines.URLTestServer + "/odata/Contacts?$skip=1&$top=1",
+				NextPage:   testconn.URLTestServer + "/odata/Contacts?$skip=1&$top=1",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If:    mockcond.Path("/odata/Contacts"),
 				Then:  mockserver.Response(http.StatusOK, contactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/freshdesk/metadata_test.go
+++ b/providers/freshdesk/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tickets := testutils.DataFromFile(t, "tickets.json")
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -40,7 +40,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"tickets": {
@@ -79,7 +79,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/freshdesk/read_test.go
+++ b/providers/freshdesk/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	zeroRecords := testutils.DataFromFile(t, "empty.json")
 	mailboxes := testutils.DataFromFile(t, "mailboxes.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -95,7 +95,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/freshdesk/write_test.go
+++ b/providers/freshdesk/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	contact := testutils.DataFromFile(t, "create-contacts.json")
 	ticket := testutils.DataFromFile(t, "update-ticket.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, contact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "501002381517",
@@ -85,7 +85,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, ticket),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "3",
@@ -122,7 +122,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/delete_test.go
+++ b/providers/getresponse/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -33,7 +33,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		]
 	}`
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -130,7 +130,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/metadata_test.go
+++ b/providers/getresponse/metadata_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -26,7 +26,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"nonexistent_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"nonexistent_object": common.ErrObjectNotSupported,
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe contacts object with metadata",
 			Input:      []string{"contacts"},
 			Server:     testServerCustomFieldsListJSON(`[]`),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -57,7 +57,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Describe contacts merges custom field definitions",
 			Input:      []string{"contacts"},
 			Server:     testServerCustomFieldsListJSON(`[{"customFieldId":"fld1","name":"Tier","fieldType":"text","valueType":"single_select","values":["gold","silver"]}]`),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -89,7 +89,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/read_test.go
+++ b/providers/getresponse/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		}
 	]`
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -376,7 +376,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/getresponse/write_test.go
+++ b/providers/getresponse/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -61,7 +61,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		]
 	}`
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -90,7 +90,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusAccepted, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "",
@@ -118,7 +118,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusAccepted, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "",
@@ -138,7 +138,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, []byte(contactUpdateResponse)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "pV3r",
@@ -174,7 +174,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusAccepted, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "",
@@ -194,7 +194,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, []byte(campaignUpdateResponse)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "f4PSi",
@@ -240,7 +240,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/metadata_test.go
+++ b/providers/gong/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"calls"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"calls": {
@@ -59,7 +59,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"workspaces", "users"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"workspaces": {
@@ -92,7 +92,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/read_test.go
+++ b/providers/gong/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	fakeServerResp2 := testutils.DataFromFile(t, "read_cursor.json")
 	responseTranscripts := testutils.DataFromFile(t, "read_transcripts.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:   mockcond.Body(`{"filter":{"fromDateTime":"2024-09-19T12:30:45Z"},"contentSelector":{"context":"Extended","exposedFields":{"parties":true, "media": true}}}`),
 				Then: mockserver.Response(http.StatusOK, fakeServerResp),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				}`),
 				Then: mockserver.Response(http.StatusOK, fakeServerResp),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -304,7 +304,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -405,7 +405,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_flows_bob.json")),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -466,7 +466,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read_users_alice_only.json")),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -492,7 +492,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v2/calls/transcript"),
 				Then:  mockserver.Response(http.StatusOK, responseTranscripts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -516,7 +516,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gong/record_test.go
+++ b/providers/gong/record_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestGetRecordsByIds(t *testing.T) {
 	callsResp := testutils.DataFromFile(t, "read.json")
 	usersResp := testutils.DataFromFile(t, "get-records-users.json")
 
-	tests := []testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
+	tests := []testconn.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
 		{
 			Name: "Calls by IDs POST to /v2/calls/extensive with callIds filter and contentSelector",
 			Input: GetRecordsByIdsInput{

--- a/providers/gong/write_test.go
+++ b/providers/gong/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInvalidRequest := testutils.DataFromFile(t, "write-invalid-request.json")
 	responseCreateCall := testutils.DataFromFile(t, "write-call.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +72,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/delete_test.go
+++ b/providers/google/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "calendar/delete/calendarList/not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -68,7 +68,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -78,7 +78,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 func TestMailDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -113,7 +113,7 @@ func TestMailDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/metadata_test.go
+++ b/providers/google/metadata_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"calendarList", "settings", "events"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"calendarList": {
@@ -80,7 +80,7 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -90,12 +90,12 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"myConnections", "peopleDirectory"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"myConnections": {
@@ -145,7 +145,7 @@ func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -155,12 +155,12 @@ func TestContactsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 func TestMailListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for messages and drafts",
 			Input:      []string{"messages", "drafts"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"messages": {
@@ -203,7 +203,7 @@ func TestMailListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/proxy_test.go
+++ b/providers/google/proxy_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestProxy(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Proxy{
+	tests := []testconn.Proxy{
 		{
 			Name: "Google Calendar Proxy",
 			Builder: func() (connectors.ProxyConnector, error) {

--- a/providers/google/read_test.go
+++ b/providers/google/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseEventsFirstPage := testutils.DataFromFile(t, "calendar/read/events/1-first-page.json")
 	responseEventsLastPage := testutils.DataFromFile(t, "calendar/read/events/2-last-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -74,7 +74,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/calendar/v3/users/me/calendarList"),
 				Then:  mockserver.Response(http.StatusOK, responseCalendarListFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 4,
 				Data: []common.ReadResultRow{{
@@ -110,7 +110,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"id": "en.indian#holiday@group.v.calendar.google.com",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/calendar/v3/users/me/calendarList?maxResults=3000" +
+				NextPage: testconn.URLTestServer + "/calendar/v3/users/me/calendarList?maxResults=3000" +
 					"&pageToken=EjAKDAjR0u-8BhCAjJaYAxIgdTpnY2FsK2dyb3VwOi8vaG9saWRheS9lbi5pbmRpYW4aHhIJBwYs8u00rJIAqsmIjAQNEgsIk9TvvAYQgM7SWQ==", // nolint:lll
 				Done: false,
 			},
@@ -130,7 +130,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCalendarListLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -157,7 +157,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/calendar/v3/users/me/settings"),
 				Then:  mockserver.Response(http.StatusOK, responseSettingsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 10,
 				Data: []common.ReadResultRow{{
@@ -168,7 +168,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"value": "false",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/calendar/v3/users/me/settings?maxResults=3000" +
+				NextPage: testconn.URLTestServer + "/calendar/v3/users/me/settings?maxResults=3000" +
 					"&pageToken=CiEKCwoJL2NhbHVzZXIvEgQIAhIAGgxzaG93RGVjbGluZWQQoJLNg62eiwM=", // nolint:lll
 				Done: false,
 			},
@@ -185,7 +185,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/calendar/v3/users/me/settings"),
 				Then:  mockserver.Response(http.StatusOK, responseSettingsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -217,7 +217,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseEventsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -248,7 +248,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"summary": "Meeting with Integration",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/calendar/v3/calendars/primary/events?maxResults=3000" +
+				NextPage: testconn.URLTestServer + "/calendar/v3/calendars/primary/events?maxResults=3000" +
 					"&updatedMin=2024-09-19T12:30:45.000Z" +
 					"&pageToken=CkAKMAouCgwIwcaswgYQmOig1QESHgocChptZDE1a3E3a3Y0cDF2aXV0YTNqaXAyaW5uZxoMCNfVwMMGENC33MkBwD4B", // nolint:lll
 				Done: false,
@@ -266,7 +266,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/calendar/v3/calendars/primary/events"),
 				Then:  mockserver.Response(http.StatusOK, responseEventsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -292,7 +292,7 @@ func TestCalendarRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -307,7 +307,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 	responseEventsTeam := testutils.DataFromFile(t, "calendar/read/all-calendars/events-team.json")
 	responseEventsLastPage := testutils.DataFromFile(t, "calendar/read/events/2-last-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Opts present but flag disabled reads only the primary calendar",
 			Input: common.ReadParams{
@@ -320,7 +320,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 				If:    mockcond.Path("/calendar/v3/calendars/primary/events"),
 				Then:  mockserver.Response(http.StatusOK, responseEventsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -352,7 +352,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 					Then: mockserver.Response(http.StatusOK, responseEventsTeam),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				// event-shared appears on both calendars (same iCalUID) and is deduped.
 				Rows: 3,
@@ -378,7 +378,7 @@ func TestCalendarReadEventsForAllCalendars(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -395,7 +395,7 @@ func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
 	timeMin := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	timeMax := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "singleEvents opts set events.list params, dedupe by id, and fetch series masters",
 			Input: common.ReadParams{
@@ -433,7 +433,7 @@ func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
 					Then: mockserver.Response(http.StatusOK, responseEvents),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				// Two instances share one iCalUID but have distinct ids, so dedupe-by-id keeps both;
 				// the standalone event and the separately fetched master are also kept (4 rows).
@@ -463,7 +463,7 @@ func TestCalendarReadEventsDatabookOpts(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -481,7 +481,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMyConnectionsLastPage := testutils.DataFromFile(t, "contacts/read/myConnections/2-last-page.json")
 	responseOtherContacts := testutils.DataFromFile(t, "contacts/read/otherContacts/one-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -530,7 +530,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/contactGroups"),
 				Then:  mockserver.Response(http.StatusOK, responseContactGroupsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -554,7 +554,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"formattedName": "Friends",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/contactGroups?groupFields=name&pageSize=1000" +
+				NextPage: testconn.URLTestServer + "/v1/contactGroups?groupFields=name&pageSize=1000" +
 					"&pageToken=CAISDAjEt9vDBhDoq6i8Ag",
 				Done: false,
 			},
@@ -574,7 +574,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactGroupsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -604,7 +604,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/people/me/connections"),
 				Then:  mockserver.Response(http.StatusOK, responseMyConnectionsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -616,7 +616,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"etag": "%EgUBAi43PRoEAQIFByIMZHUyb2I4ZWlGdVk9",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/people/me/connections?pageSize=1000" +
+				NextPage: testconn.URLTestServer + "/v1/people/me/connections?pageSize=1000" +
 					"&pageToken=GiAKHAgBagsIvd7bwwYQiLuICXILCLTe28MGEOChvEYQAg",
 				Done: false,
 			},
@@ -633,7 +633,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/people/me/connections"),
 				Then:  mockserver.Response(http.StatusOK, responseMyConnectionsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -661,7 +661,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/otherContacts"),
 				Then:  mockserver.Response(http.StatusOK, responseOtherContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -685,7 +685,7 @@ func TestContactsRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -704,7 +704,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseDraftMessageItem1 := testutils.DataFromFile(t, "mail/read/drafts/message-item-1.json")
 	responseDraftMessageItem2 := testutils.DataFromFile(t, "mail/read/drafts/message-item-2.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -759,7 +759,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseMessagesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -809,7 +809,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseMessageItem),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -863,7 +863,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseDraftMessageItem2),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -959,7 +959,7 @@ func TestMailRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/google/write_test.go
+++ b/providers/google/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseInsertCalendar := testutils.DataFromFile(t, "calendar/write/calendarList/new.json")
 	responseEvent := testutils.DataFromFile(t, "calendar/write/events/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +62,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseInsertCalendar),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "en.italian#holiday@group.v.calendar.google.com",
@@ -107,7 +107,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseEvent),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "std4ien2l4fovmbup80ov20tp8",
@@ -126,7 +126,7 @@ func TestCalendarWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestCalendarConnector(tt.Server.URL)
 			})
 		})
@@ -139,7 +139,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseContactGroups := testutils.DataFromFile(t, "contacts/write/contactGroups/new.json")
 	responseMyConnections := testutils.DataFromFile(t, "contacts/write/myConnections/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -166,7 +166,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactGroups),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "50ea5f3188536092",
@@ -195,7 +195,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactGroups),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "50ea5f3188536092",
@@ -224,7 +224,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMyConnections),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "c2600607527630254940",
@@ -253,7 +253,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMyConnections),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "c2600607527630254940",
@@ -272,7 +272,7 @@ func TestContactsWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestContactsConnector(tt.Server.URL)
 			})
 		})
@@ -284,7 +284,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	responseDrafts := testutils.DataFromFile(t, "mail/write/drafts/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -307,7 +307,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseDrafts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "r5151461288000502025",
@@ -340,7 +340,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseDrafts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "r5151461288000502025",
@@ -358,7 +358,7 @@ func TestMailWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestMailConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/metadata_test.go
+++ b/providers/goto/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	webinarsResponse := testutils.DataFromFile(t, "webinars.json")
 	sessionsResponse := testutils.DataFromFile(t, "sessions.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(200, webinarsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"webinars": {
@@ -67,7 +67,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(200, sessionsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"sessions": {
@@ -91,7 +91,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/read_test.go
+++ b/providers/goto/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	groupsResponse := testutils.DataFromFile(t, "groups.json")
 	licensesResponse := testutils.DataFromFile(t, "licenses.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, webinarsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -79,7 +79,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, sessionsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -112,7 +112,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, groupsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, licensesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -172,7 +172,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/goto/write_test.go
+++ b/providers/goto/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createTemplatesResponse := testutils.DataFromFile(t, "create-templates.json")
 	createWebhookResponse := testutils.DataFromFile(t, "create-webhook.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -49,7 +49,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, []byte(`{"id":"user-123","displayName":"Alice"}`)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "user-123",
@@ -79,7 +79,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, createGroupsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "dfoahofadso",
@@ -109,7 +109,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, createTeamsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -137,7 +137,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, createTemplatesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "kdhoasdofaso",
@@ -168,7 +168,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, createWebhookResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cdb516e0-85f8-4e30-bf19-ddb0ea9d40c2",
@@ -186,7 +186,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/granola/metadata_test.go
+++ b/providers/granola/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 	noteResponse := testutils.DataFromFile(t, "note_not_1d3tmYTlCICgjy.json")
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -45,7 +45,7 @@ func TestListObjectMetadata(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"notes": {
@@ -142,7 +142,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusInternalServerError),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"notes": mockutils.ExpectedSubsetErrors{
@@ -163,7 +163,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, []byte("{}")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"notes": mockutils.ExpectedSubsetErrors{
@@ -184,7 +184,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, []byte(`{"notes": []}`)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"notes": mockutils.ExpectedSubsetErrors{
@@ -200,7 +200,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/granola/read_test.go
+++ b/providers/granola/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) {
 		"not_4f7kQhLpMNBvxy": testutils.DataFromFile(t, "note_not_4f7kQhLpMNBvxy.json"),
 		"not_9b2xRwNsTLCfop": testutils.DataFromFile(t, "note_not_9b2xRwNsTLCfop.json"),
 	}
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Read empty items",
 			Input: common.ReadParams{
@@ -64,7 +64,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseNotes),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -159,7 +159,7 @@ func TestRead(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -243,7 +243,7 @@ func TestRead(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -276,7 +276,7 @@ func TestRead(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -311,7 +311,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseNotes),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -348,7 +348,7 @@ func TestRead(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -402,7 +402,7 @@ func TestRead(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -478,7 +478,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/gusto/delete_test.go
+++ b/providers/gusto/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -100,7 +100,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				if tt.Name == "DELETE earning_types without companyID returns ErrMissingCompanyID" {
 					return constructTestWriteConnector(tt.Server.URL, "")
 				}

--- a/providers/gusto/metadata_test.go
+++ b/providers/gusto/metadata_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -57,7 +57,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -78,7 +78,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -111,7 +111,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 	}
@@ -120,7 +120,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/gusto/read_test.go
+++ b/providers/gusto/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 //go:embed test/read/employees-first-page.json
@@ -33,7 +33,7 @@ const testCompanyID = "test-company-uuid"
 func TestRead(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -88,7 +88,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 						"email":      "bob@example.com",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
+				NextPage: testconn.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
 				Done:     false,
 			},
 		},
@@ -128,7 +128,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				ObjectName: "employees",
 				Fields:     connectors.Fields("uuid"),
 				PageSize:   2,
-				NextPage:   testroutines.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
+				NextPage:   testconn.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -205,7 +205,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -248,7 +248,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				// 2 jobs from emp_001 + 1 job from emp_002 = 3 total
 				Rows: 3,
@@ -271,7 +271,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					},
 				}},
 				// Employee list had exactly 2 rows (== per=2), so there may be more employees.
-				NextPage: testroutines.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
+				NextPage: testconn.URLTestServer + "/v1/companies/" + testCompanyID + "/employees?page=2&per=2",
 				Done:     false,
 			},
 		},
@@ -294,7 +294,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -309,7 +309,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				noCompanyIDCases := map[string]bool{
 					"Company-scoped reads require companyId metadata":  true,
 					"Employee-scoped reads require companyId metadata": true,

--- a/providers/gusto/write_test.go
+++ b/providers/gusto/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 //go:embed test/write/employee-create.json
@@ -33,7 +33,7 @@ var earningTypeUpdateResponse []byte
 func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -92,7 +92,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "emp_001",
@@ -126,7 +126,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "emp_001",
@@ -160,7 +160,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "loc_001",
@@ -196,7 +196,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "et_001",
@@ -241,7 +241,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "job_001",
@@ -282,7 +282,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "comp_001",
@@ -306,7 +306,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				// Cases that test ErrMissingCompanyID explicitly omit the metadata.
 				switch tt.Name {
 				case "Create employee without companyID returns ErrMissingCompanyID",

--- a/providers/helpscoutmailbox/connector_test.go
+++ b/providers/helpscoutmailbox/connector_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	zerorecords := testutils.DataFromFile(t, "mailboxes.json")
 	conversations := testutils.DataFromFile(t, "conversations.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -65,7 +65,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/conversations"),
 				Then:  mockserver.Response(http.StatusOK, conversations),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -128,7 +128,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -141,7 +141,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	conversations := testutils.DataFromFile(t, "conversations.json")
 	users := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"conversations", "users"},
@@ -158,7 +158,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"conversations": {
@@ -216,7 +216,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -229,7 +229,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.txt")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -300,7 +300,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/metadata_test.go
+++ b/providers/heyreach/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	listResponse := testutils.DataFromFile(t, "list.json")
 	liAccountResponse := testutils.DataFromFile(t, "li_account.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -42,7 +42,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, liAccountResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaign/GetAll": {
@@ -161,7 +161,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/read_test.go
+++ b/providers/heyreach/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	listResponse := testutils.DataFromFile(t, "list.json")
 	liAccountResponse := testutils.DataFromFile(t, "li_account.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/heyreach/write_test.go
+++ b/providers/heyreach/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	listResponse := testutils.DataFromFile(t, "create_list.json")
 	addLeadToCampaignAndListResponse := testutils.DataFromFile(t, "add_lead_list_campaign.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -108,7 +108,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/delete_test.go
+++ b/providers/highlevelstandard/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-business-id.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/metadata_test.go
+++ b/providers/highlevelstandard/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	businessesResponse := testutils.DataFromFile(t, "businesses.json")
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -44,7 +44,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, calendarsGroupsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"businesses": {
@@ -126,7 +126,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/read_test.go
+++ b/providers/highlevelstandard/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelstandard/write_test.go
+++ b/providers/highlevelstandard/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	calendarsGroupsResponse := testutils.DataFromFile(t, "write_calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "write_products_collections.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -152,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/delete_test.go
+++ b/providers/highlevelwhitelabel/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-business-id.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/metadata_test.go
+++ b/providers/highlevelwhitelabel/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	businessesResponse := testutils.DataFromFile(t, "businesses.json")
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -44,7 +44,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, calendarsGroupsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"businesses": {
@@ -126,7 +126,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/read_test.go
+++ b/providers/highlevelwhitelabel/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	calendarsGroupsResponse := testutils.DataFromFile(t, "calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "products_collections.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/highlevelwhitelabel/write_test.go
+++ b/providers/highlevelwhitelabel/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	calendarsGroupsResponse := testutils.DataFromFile(t, "write_calendars_groups.json")
 	productsCollectionsResponse := testutils.DataFromFile(t, "write_products_collections.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -152,7 +152,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/delete_test.go
+++ b/providers/housecallPro/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name: "Delete price book material successfully",
 			Input: common.DeleteParams{
@@ -77,7 +77,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/metadata_test.go
+++ b/providers/housecallPro/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successfully describe material categories, job types, and invoices",
 			Input:      []string{"price_book/material_categories", "job_fields/job_types", "invoices"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"price_book/material_categories": {
@@ -196,7 +196,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) {
 	responseRoutes := testutils.DataFromFile(t, "read-routes.json")
 	responseJobs := testutils.DataFromFile(t, "read-jobs.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Read customers empty",
 			Input: common.ReadParams{
@@ -69,7 +69,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -88,7 +88,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
+				NextPage: testconn.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "customers",
 				Fields:     connectors.Fields("id", "first_name", "email", "updated_at"),
-				NextPage:   testroutines.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
+				NextPage:   testconn.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -150,7 +150,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 0,
 				Data: []common.ReadResultRow{},
@@ -174,11 +174,11 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				Data:     []common.ReadResultRow{},
-				NextPage: testroutines.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
+				NextPage: testconn.URLTestServer + "/customers?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -199,7 +199,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseEmployees),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -239,7 +239,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoutes),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -274,7 +274,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseMaterialCategoryFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -303,7 +303,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/api/price_book/material_categories?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
+				NextPage: testconn.URLTestServer + "/api/price_book/material_categories?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -314,7 +314,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "price_book/material_categories",
 				Fields:     connectors.Fields("uuid", "name", "updated_at"),
-				NextPage:   testroutines.URLTestServer + "/api/price_book/material_categories?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
+				NextPage:   testconn.URLTestServer + "/api/price_book/material_categories?page=2&page_size=1&sort_by=updated_at&sort_direction=desc",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -325,7 +325,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseMaterialCategoryLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -376,7 +376,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseJobs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -415,7 +415,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseJobs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -465,7 +465,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseInvoices),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -509,7 +509,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/housecallPro/write_test.go
+++ b/providers/housecallPro/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestWrite(t *testing.T) {
 	responseMaterialCreate := testutils.DataFromFile(t, "write-material-create.json")
 	responseMaterialUpdate := testutils.DataFromFile(t, "write-material-update.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name: "Create customer successfully",
 			Input: common.WriteParams{
@@ -40,7 +40,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomerCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cust_9f3a7c2b1d",
@@ -71,7 +71,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomerUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cust_9f3a7c2b1d",
@@ -97,7 +97,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseJobTypeCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "job_type_123",
@@ -126,7 +126,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseJobTypeUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "job_type_123",
@@ -157,7 +157,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseMaterialCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "mat_8c92ab4f1e",
@@ -186,7 +186,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseMaterialUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "mat_8c92ab4f1e",
@@ -202,7 +202,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/authinfo_test.go
+++ b/providers/hubspot/authinfo_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestGetPostAuthInfo(t *testing.T) {
 
 	accountInfo := testutils.DataFromFile(t, "post-auth/account-info.json")
 
-	tests := []testroutines.TestCaseGetPostAuthInfo{
+	tests := []testconn.TestCaseGetPostAuthInfo{
 		{
 			Name: "Get post auth info",
 			Server: mockserver.Conditional{
@@ -38,7 +38,7 @@ func TestGetPostAuthInfo(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestablePostAuthMetadata, error) {
+			tt.Run(t, func() (testconn.TestablePostAuthMetadata, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/batch-write_test.go
+++ b/providers/hubspot/batch-write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -34,7 +34,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.TestCaseBatchWrite{
+	tests := []testconn.TestCaseBatchWrite{
 		{
 			Name: "At least one object name must be queried",
 			Input: &common.BatchWriteParam{
@@ -66,7 +66,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusConflict, errConflictExisting),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status:       common.BatchStatusFailure,
 				Errors:       []any{"Contact already exists"},
@@ -91,7 +91,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status:       common.BatchStatusFailure,
 				Errors:       []any{},
@@ -116,7 +116,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errManyInvalidFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: []any{
@@ -157,7 +157,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusMultiStatus, errPartialSuccess),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusPartial,
 				// objectWriteTraceId is removed from all errors (internal field)
@@ -206,7 +206,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusSuccess,
 				Errors: []any{},
@@ -239,7 +239,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
+			tt.Run(t, func() (testconn.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -270,7 +270,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.TestCaseBatchWrite{
+	tests := []testconn.TestCaseBatchWrite{
 		{
 			Name: "General high level error not tied to any record",
 			Input: &common.BatchWriteParam{
@@ -286,7 +286,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errDuplicateIDs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status:       common.BatchStatusFailure,
 				Errors:       []any{"Duplicate IDs found in batch input: [123456]. IDs must be unique"},
@@ -311,7 +311,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errManyInvalidFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: []any{
@@ -366,7 +366,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusMultiStatus, errUpdatePartial),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusPartial,
 				// Top-level errors are sanitized (ids removed from context)
@@ -414,7 +414,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusSuccess,
 				Errors: []any{},
@@ -447,7 +447,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
+			tt.Run(t, func() (testconn.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/delete_test.go
+++ b/providers/hubspot/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -49,7 +49,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/internal/associations/create_test.go
+++ b/providers/hubspot/internal/associations/create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -200,11 +200,11 @@ func constructTestStrategy(serverURL string) (*Strategy, error) {
 }
 
 type (
-	testCaseTypeBatchCreate = testroutines.TestCase[*BatchCreateParams, *BatchCreateResult]
+	testCaseTypeBatchCreate = testconn.TestCase[*BatchCreateParams, *BatchCreateResult]
 	batchCreateTestCase     testCaseTypeBatchCreate
 )
 
-func (c batchCreateTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Strategy]) {
+func (c batchCreateTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Strategy]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.BatchCreate(t.Context(), c.Input)

--- a/providers/hubspot/metadata_test.go
+++ b/providers/hubspot/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseLists := testutils.DataFromFile(t, "read-lists-1-first-page.json")
 	responseEventDealClosed := testutils.DataFromFile(t, "read/events/e_deal_closed.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -51,7 +51,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusOK, `{"requiredProperties": ["mobilephone"]}`),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -237,7 +237,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusForbidden, metadataErrSchemaScopes),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -279,7 +279,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusOK, `{}`),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"deals": {
@@ -343,7 +343,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				If:    mockcond.Path("/crm/v3/lists/search"),
 				Then:  mockserver.Response(http.StatusOK, responseLists),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"lists": {
@@ -381,7 +381,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				"marketing-events", "meeting-links",
 			},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"marketing-campaigns": {
@@ -488,7 +488,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, responseEventDealClosed),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"AMPERSAND-event-occurrences-e_deal_closed": {
@@ -553,7 +553,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusOK, "{}"),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -614,7 +614,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusOK, "{}"),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -667,7 +667,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.ResponseString(http.StatusOK, "{}"),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -697,7 +697,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -778,7 +778,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	payloadUpdateInterests := testutils.DataFromFile(t, "custom/update/6-payload-update-property-interests.json")
 	responseUpdateInterests := testutils.DataFromFile(t, "custom/update/7-response-update-property-interests.json")
 
-	tests := []testroutines.TestCaseUpsertMetadata{
+	tests := []testconn.TestCaseUpsertMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -837,7 +837,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusCreated, responseBatchCreateProperties1),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetUpsertMetadata,
+			Comparator: testconn.ComparatorSubsetUpsertMetadata,
 			Expected: &common.UpsertMetadataResult{
 				Success: true,
 				Fields: map[string]map[string]common.FieldUpsertResult{
@@ -975,7 +975,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, responseUpdateInterests),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetUpsertMetadata,
+			Comparator: testconn.ComparatorSubsetUpsertMetadata,
 			Expected: &common.UpsertMetadataResult{
 				Success: true,
 				Fields: map[string]map[string]common.FieldUpsertResult{
@@ -1032,7 +1032,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataUpdater, error) {
+			tt.RunWithContext(t, ctx, func() (testconn.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -38,7 +38,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseMeetingLinks := testutils.DataFromFile(t, "read/meeting-links.json")
 	responseEventVisitedPage := testutils.DataFromFile(t, "read/events/e_visited_page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -62,7 +62,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/crm/v3/objects/contacts"),
 				Then:  mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     3,
 				NextPage: "394",
@@ -160,7 +160,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     3,
 				NextPage: "394",
@@ -185,7 +185,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     3,
 				NextPage: "394",
@@ -206,7 +206,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -249,7 +249,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Data:     []common.ReadResultRow{},
@@ -278,7 +278,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCampaignsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -336,7 +336,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCampaignsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -359,7 +359,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "marketing-campaigns",
 				Fields:     connectors.Fields("hs_name"),
-				NextPage:   testroutines.URLTestServer + "/marketing/campaigns/2026-03?limit=2&sort=-updatedAt&properties=hs_name%2Chs_notes%2Chs_budget_items_sum_amount&after=Mg%3D%3D",
+				NextPage:   testconn.URLTestServer + "/marketing/campaigns/2026-03?limit=2&sort=-updatedAt&properties=hs_name%2Chs_notes%2Chs_budget_items_sum_amount&after=Mg%3D%3D",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -370,7 +370,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCampaignsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -427,7 +427,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseMarketingEmailAssets),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -541,7 +541,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseCampaignsBatchMulti),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected:   nil,
 			ExpectedErrs: []error{
 				testutils.StringError("Invalid request: 'Invalid campaign GUID format: 430318c4-abb7-4bf7-a75ee-9c5fa8f475a6'"),
@@ -597,7 +597,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseContactsBatched),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -669,7 +669,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseMarketingEmailFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -702,7 +702,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "marketing-emails",
 				Fields:     connectors.Fields("subject"),
-				NextPage:   testroutines.URLTestServer + "/marketing/emails/2026-03?limit=3&sort=-updatedAt&after=Mw%3D%3D",
+				NextPage:   testconn.URLTestServer + "/marketing/emails/2026-03?limit=3&sort=-updatedAt&after=Mw%3D%3D",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -715,7 +715,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseMarketingEmailLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -747,7 +747,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/marketing/forms/2026-09-beta"),
 				Then:  mockserver.Response(http.StatusOK, responseMarketingForms),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -778,7 +778,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/marketing/marketing-events/2026-03"),
 				Then:  mockserver.Response(http.StatusOK, responseMarketingEvents),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -811,7 +811,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/scheduler/2026-03/meetings/meeting-links"),
 				Then:  mockserver.Response(http.StatusOK, responseMeetingLinks),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -847,7 +847,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseEventVisitedPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -880,7 +880,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/hubspot/search_test.go
+++ b/providers/hubspot/search_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 	responseContactsLastPage := testutils.DataFromFile(t, "search/contacts/2-second-page.json")
 	responseContactsToCompanies := testutils.DataFromFile(t, "search/contacts/contacts-to-companies.json")
 
-	tests := []testroutines.TestCaseSearch{
+	tests := []testconn.TestCaseSearch{
 		{
 			Name:         "Object name must be included",
 			Server:       mockserver.Dummy(),
@@ -93,7 +93,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusOK, responseContactsToCompanies),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -162,7 +162,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusOK, responseContactsToCompanies),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -199,7 +199,7 @@ func TestSearch(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSearcher, error) {
+			tt.Run(t, func() (testconn.TestableSearcher, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -445,11 +445,11 @@ func TestReadUsingSearchAPI(t *testing.T) {
 }
 
 type (
-	SearchViaReadType = testroutines.TestCase[SearchParams, *common.ReadResult]
+	SearchViaReadType = testconn.TestCase[SearchParams, *common.ReadResult]
 	SearchViaRead     SearchViaReadType
 )
 
-func (r SearchViaRead) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (r SearchViaRead) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 
 	t.Cleanup(func() {

--- a/providers/hubspot/subscriptionEvent_test.go
+++ b/providers/hubspot/subscriptionEvent_test.go
@@ -3,25 +3,25 @@ package hubspot
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestSubscriptionEvent(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
+	for _, tt := range []testconn.TestCaseSubscriptionEvent{
 		{
 			Name: "Unsupported event",
 			Input: SubscriptionEvent{
 				"subscriptionType": "someObject.creation",
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					RawEventName: "someObject.creation",
 					EventType:    "create",
 				},
-				Err: testroutines.SubscriptionEventExpectedErr{
+				Err: testconn.SubscriptionEventExpectedErr{
 					EventType:          nil,
 					RawEventName:       nil,
 					ObjectName:         testutils.StringError("subscription is not supported for the object 'someObject'"),
@@ -36,11 +36,11 @@ func TestSubscriptionEvent(t *testing.T) {
 			Input: SubscriptionEvent{
 				"subscriptionType": "",
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType: "other",
 				},
-				Err: testroutines.SubscriptionEventExpectedErr{
+				Err: testconn.SubscriptionEventExpectedErr{
 					EventType:          testutils.StringError("unexpected subscription event type: ''"),
 					RawEventName:       nil,
 					ObjectName:         testutils.StringError("subscription is not supported for the object ''"),
@@ -56,13 +56,13 @@ func TestSubscriptionEvent(t *testing.T) {
 				"objectTypeId":     "0-1",
 				"subscriptionType": "importantContacts.creation",
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "create",
 					RawEventName: "importantContacts.creation",
 					ObjectName:   "contact",
 				},
-				Err: testroutines.SubscriptionEventExpectedErr{
+				Err: testconn.SubscriptionEventExpectedErr{
 					EventType:          nil,
 					RawEventName:       nil,
 					ObjectName:         nil,
@@ -80,8 +80,8 @@ func TestSubscriptionEvent(t *testing.T) {
 				"occurredAt":       1625097600000,
 				"portalId":         101,
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "create",
 					RawEventName:       "contact.creation",
 					ObjectName:         "contact",
@@ -100,8 +100,8 @@ func TestSubscriptionEvent(t *testing.T) {
 				"portalId":         101,
 				"occurredAt":       1625097600000,
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "update",
 					RawEventName:       "contact.propertyChange",
 					ObjectName:         "contact",
@@ -120,8 +120,8 @@ func TestSubscriptionEvent(t *testing.T) {
 				"portalId":         101,
 				"occurredAt":       1625097600000,
 			},
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "delete",
 					RawEventName:       "contact.deletion",
 					ObjectName:         "contact",

--- a/providers/insightly/delete_test.go
+++ b/providers/insightly/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -45,7 +45,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/metadata_test.go
+++ b/providers/insightly/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseFruitObject := testutils.DataFromFile(t, "read/custom-objects/fruit.json")
 	responseFruitFields := testutils.DataFromFile(t, "read/fruits-custom-object/custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -30,7 +30,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -45,7 +45,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				If:    mockcond.Path("/v3.1/CustomFields/Teams"),
 				Then:  mockserver.ResponseString(http.StatusOK, `[]`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Teams": {
@@ -80,7 +80,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				If:    mockcond.Path("/v3.1/CustomFields/Contacts"),
 				Then:  mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Contacts": {
@@ -204,7 +204,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, responseFruitFields),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Fruit__c": {
@@ -247,7 +247,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/read_test.go
+++ b/providers/insightly/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContacts := testutils.DataFromFile(t, "read/contacts/list.json")
 	responseFruits := testutils.DataFromFile(t, "read/fruits-custom-object/list.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -63,7 +63,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -89,7 +89,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						}},
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v3.1/Leads/Search?skip=500&top=500",
+				NextPage: testconn.URLTestServer + "/v3.1/Leads/Search?skip=500&top=500",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -99,7 +99,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "Leads",
 				Fields:     connectors.Fields("FIRST_NAME", "LAST_NAME"),
-				NextPage:   testroutines.URLTestServer + "/v3.1/Leads/Search?skip=500&top=500",
+				NextPage:   testconn.URLTestServer + "/v3.1/Leads/Search?skip=500&top=500",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -110,7 +110,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						}},
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v3.1/Leads/Search?top=500&skip=1000",
+				NextPage: testconn.URLTestServer + "/v3.1/Leads/Search?top=500&skip=1000",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "Leads",
 				Fields:     connectors.Fields("FIRST_NAME", "LAST_NAME"),
-				NextPage:   testroutines.URLTestServer + "/v3.1/Leads/Search?top=500&skip=1000",
+				NextPage:   testconn.URLTestServer + "/v3.1/Leads/Search?top=500&skip=1000",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -146,7 +146,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				Data:     []common.ReadResultRow{},
@@ -172,10 +172,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/v3.1/Leads/Search?skip=500&top=500&updated_after_utc=2024-03-04T08:22:56Z",
 				Done: false,
 			},
@@ -192,7 +192,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v3.1/Contacts/Search"),
 				Then:  mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -228,7 +228,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						},
 					},
 				}},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/v3.1/Contacts/Search?skip=500&top=500",
 				Done: false,
 			},
@@ -245,7 +245,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v3.1/Fruit__c/Search"),
 				Then:  mockserver.Response(http.StatusOK, responseFruits),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -291,7 +291,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						},
 					},
 				}},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/v3.1/Fruit__c/Search?skip=500&top=500",
 				Done: false,
 			},
@@ -304,7 +304,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/insightly/write_test.go
+++ b/providers/insightly/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	writeContactsResponse := testutils.DataFromFile(t, "write/contacts.json")
 	writeLeadsResponse := testutils.DataFromFile(t, "write/leads.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -43,7 +43,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, writeContactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "366638973",
@@ -77,7 +77,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, writeContactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "366638973",
@@ -111,7 +111,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, writeLeadsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "78572651",
@@ -130,7 +130,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/delete_test.go
+++ b/providers/instantly/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseNotFoundErr := testutils.DataFromFile(t, "delete-tag-missing.json")
 	responseTag := testutils.DataFromFile(t, "delete-tag.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/metadata_test.go
+++ b/providers/instantly/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"campaigns", "emails"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"emails": {
@@ -66,7 +66,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/read_test.go
+++ b/providers/instantly/read_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCampaigns := testutils.DataFromFile(t, "read-campaigns.json")
 	responseTags := testutils.DataFromFile(t, "read-tags.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				data := fmt.Sprintf("[%v]", strings.Join(manyCampaigns, ","))
 				_, _ = writer.Write([]byte(data)) // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
 			}),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     DefaultPageSize,
 				NextPage: "test-placeholder?limit=100&skip=800",
@@ -118,7 +118,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.ResponseString(http.StatusOK, "[]"),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -133,7 +133,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/v1/campaign/list"),
 				Then:  mockserver.Response(http.StatusOK, responseCampaigns),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -153,7 +153,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"name": "My Campaign",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/api/v1/campaign/list?limit=100&skip=100",
+				NextPage: testconn.URLTestServer + "/api/v1/campaign/list?limit=100&skip=100",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -169,7 +169,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/v1/custom-tag"),
 				Then:  mockserver.Response(http.StatusOK, responseTags),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -193,7 +193,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"description":     "High Delivery Accounts 2",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/api/v1/custom-tag?limit=100&skip=100",
+				NextPage: testconn.URLTestServer + "/api/v1/custom-tag?limit=100&skip=100",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -205,7 +205,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantly/write_test.go
+++ b/providers/instantly/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTagErr := testutils.DataFromFile(t, "write-tag-bad-request.json")
 	responseTag := testutils.DataFromFile(t, "write-tag.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -157,7 +157,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/delete_test.go
+++ b/providers/instantlyai/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-custom-tags.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/metadata_test.go
+++ b/providers/instantlyai/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	customTagsResponse := testutils.DataFromFile(t, "custom-tags.json")
 	leadListsResponse := testutils.DataFromFile(t, "lead-lists.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -42,7 +42,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, leadListsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"background-jobs": {
@@ -231,7 +231,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/read_test.go
+++ b/providers/instantlyai/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	customTagsResponse := testutils.DataFromFile(t, "custom-tags.json")
 	leadListsResponse := testutils.DataFromFile(t, "lead-lists.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -33,7 +33,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/campaigns"),
 				Then:  mockserver.Response(http.StatusOK, campaignsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -48,7 +48,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/api/v2/campaigns?limit=100&starting_after=0196d267-98dd-7720-b740-f132c2c547d9",
 				Done: false,
 			},
@@ -62,7 +62,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/custom-tags"),
 				Then:  mockserver.Response(http.StatusOK, customTagsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -78,7 +78,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/api/v2/custom-tags?limit=100&starting_after=01966b52-881d-76de-acb0-8b12432533f6",
 				Done: false,
 			},
@@ -92,7 +92,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/lead-lists"),
 				Then:  mockserver.Response(http.StatusOK, leadListsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -108,7 +108,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/api/v2/lead-lists?limit=100&starting_after=01966b52-883f-760d-b7dc-cdd0fc3f7841",
 				Done: false,
 			},
@@ -120,7 +120,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/instantlyai/write_test.go
+++ b/providers/instantlyai/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	customTagsResponse := testutils.DataFromFile(t, "write_custom_tags.json")
 	accountsResponse := testutils.DataFromFile(t, "write_accounts.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -110,7 +110,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/delete_test.go
+++ b/providers/intercom/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFound := testutils.DataFromFile(t, "resource-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/metadata_test.go
+++ b/providers/intercom/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -92,7 +92,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/read_test.go
+++ b/providers/intercom/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -34,7 +34,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNotesFirstPage := testutils.DataFromFile(t, "read-notes-1-first-page.json")
 	responseNotesSecondPage := testutils.DataFromFile(t, "read-notes-2-last-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -108,7 +108,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Header(testApiVersionHeader),
 				Then:  mockserver.Response(http.StatusOK, responseNotesSecondPage),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -120,7 +120,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNotesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
 				NextPage: "https://api.intercom.io/contacts/6643703ffae7834d1792fd30/notes?per_page=2&page=2",
@@ -135,10 +135,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
-				NextPage: testroutines.URLTestServer + "/contacts?per_page=60&starting_after=" +
+				NextPage: testconn.URLTestServer + "/contacts?per_page=60&starting_after=" +
 					"WzE3MTU2OTU2NzkwMDAsIjY2NDM3MDNmZmFlNzgzNGQxNzkyZmQzMCIsMl0=",
 				Done: false,
 			},
@@ -152,7 +152,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseNotesSecondPage),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -163,7 +163,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseContactsThirdPage),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -178,7 +178,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/contacts"),
 				Then:  mockserver.Response(http.StatusOK, responseContactsSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -197,7 +197,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"updated_at": float64(1715706939),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/contacts?per_page=60&starting_after=" +
+				NextPage: testconn.URLTestServer + "/contacts?per_page=60&starting_after=" +
 					"Wy0xLCI2NjQzOWI5NDdiYjA5NWE2ODFmN2ZkOWUiLDNd",
 				Done: false,
 			},
@@ -214,7 +214,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/conversations"),
 				Then:  mockserver.Response(http.StatusOK, responseReadConversations),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -250,7 +250,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.BodyBytes(requestSearchConversations),
 				Then:  mockserver.Response(http.StatusOK, responseSearchConversations),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -265,7 +265,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"updated_at":            float64(1726752145),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
+				NextPage: testconn.URLTestServer + "/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -277,7 +277,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/intercom/write_test.go
+++ b/providers/intercom/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	messageForInvalidSyntax := "There was a problem in the JSON you submitted [ddf8bfe97056e23f5d2b1ed92627ad07]: " +
 		"logged with error code"
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -78,7 +78,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createArticle),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9333081",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/delete_test.go
+++ b/providers/iterable/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseMissingListErr := testutils.DataFromFile(t, "delete-missing-list-bad-request.json")
 	responseList := testutils.DataFromFile(t, "delete-list.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -69,7 +69,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/metadata_test.go
+++ b/providers/iterable/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -82,7 +82,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/read_test.go
+++ b/providers/iterable/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	errorTemplatesInvalidSince := testutils.DataFromFile(t, "read-templates-invalid-since.html")
 	errorInvalidRestMethod := testutils.DataFromFile(t, "error-wrong-method.html")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -67,11 +67,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/catalogs"),
 				Then:  mockserver.Response(http.StatusOK, responseCatalogsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Data:     []common.ReadResultRow{},
-				NextPage: testroutines.URLTestServer + "/api/catalogs?pageSize=1&page=2", // nolint:lll
+				NextPage: testconn.URLTestServer + "/api/catalogs?pageSize=1&page=2", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -87,7 +87,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/catalogs"),
 				Then:  mockserver.Response(http.StatusOK, responseCatalogsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Data:     []common.ReadResultRow{},
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/iterable/write_test.go
+++ b/providers/iterable/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseTemplateInvalidRequestJSON := testutils.DataFromFile(t, "write-template-invalid-request.json")
 	responseWebhookTEXT := testutils.DataFromFile(t, "write-webhook-bad-request.txt")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -185,7 +185,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/justcall/delete_test.go
+++ b/providers/justcall/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 
 	deleteSuccessResponse := testutils.DataFromFile(t, "delete/success.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -97,7 +97,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/metadata_test.go
+++ b/providers/justcall/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestListObjectMetadata(t *testing.T) {
 
 	responseCustomFields := testutils.DataFromFile(t, "read/sales_dialer_contacts/custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for sales_dialer/contacts with custom fields",
 			Input: []string{"sales_dialer/contacts"},
@@ -25,7 +25,7 @@ func TestListObjectMetadata(t *testing.T) {
 				If:    mockcond.Path("/v2.1/sales_dialer/contacts/custom-fields"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"sales_dialer/contacts": {
@@ -55,7 +55,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/read_test.go
+++ b/providers/justcall/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	responseWebhooks := testutils.DataFromFile(t, "read/webhooks/list.json")
 	responseSalesDialerContacts := testutils.DataFromFile(t, "read/sales_dialer_contacts/first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -52,7 +52,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -133,7 +133,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Input: common.ReadParams{
 				ObjectName: "calls",
 				Fields:     connectors.Fields("id", "contact_name"),
-				NextPage:   testroutines.URLTestServer + "/v2.1/calls?page=3&per_page=2",
+				NextPage:   testconn.URLTestServer + "/v2.1/calls?page=3&per_page=2",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -144,7 +144,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -177,7 +177,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -225,7 +225,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseTexts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -273,7 +273,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseWebhooks),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -322,7 +322,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -354,7 +354,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSalesDialerContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -416,7 +416,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/justcall/write_test.go
+++ b/providers/justcall/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 	successResponse := testutils.DataFromFile(t, "write/success.json")
 	errorResponse := testutils.DataFromFile(t, "write/error.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -47,7 +47,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, createContactResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "12345",
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, updateContactResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "12345",
@@ -95,7 +95,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, sendSMSResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "98765",
@@ -121,7 +121,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, updateCallResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "328951212",
@@ -143,7 +143,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, successResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -163,7 +163,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, successResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -183,7 +183,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, successResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -203,7 +203,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, successResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -218,7 +218,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/keap/delete_test.go
+++ b/providers/keap/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-contact.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/metadata_test.go
+++ b/providers/keap/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseContactsModel := testutils.DataFromFile(t, "custom-fields/contacts-v2.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -46,7 +46,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/crm/rest/v2/contacts/model"),
 				Then:  mockserver.Response(http.StatusOK, responseContactsModel),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {
@@ -132,7 +132,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/crm/rest/v2/contacts/model"),
 				Then:  mockserver.Response(http.StatusInternalServerError),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"contacts": mockutils.ExpectedSubsetErrors{
@@ -150,7 +150,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/read_test.go
+++ b/providers/keap/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -31,7 +31,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	// Tags
 	responseTags := testutils.DataFromFile(t, "read/tags/v2.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -95,7 +95,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		//			Then: mockserver.Response(http.StatusOK, responseOpportunitiesModel),
 		//		}},
 		//	}.Server(),
-		//	Comparator: testroutines.ComparatorSubsetRead,
+		//	Comparator: testconn.ComparatorSubsetRead,
 		//	Expected: &common.ReadResult{
 		//		Rows: 1,
 		//		Data: []common.ReadResultRow{{
@@ -138,7 +138,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseContactsModel),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -247,7 +247,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/keap/write_test.go
+++ b/providers/keap/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorContactBadRequest := testutils.DataFromFile(t, "write-contacts-missing-fields.json")
 	responseContacts := testutils.DataFromFile(t, "write-contacts.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -84,7 +84,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "30",
@@ -107,7 +107,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/kit/metadata_test.go
+++ b/providers/kit/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tagsresponse := testutils.DataFromFile(t, "tags.json")
 	webhooksresponse := testutils.DataFromFile(t, "webhooks.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "Object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, webhooksresponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"broadcasts": {
@@ -199,7 +199,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -211,7 +211,7 @@ func TestListObjectMetadataWithCustomFields(t *testing.T) {
 
 	customfieldsresponse := testutils.DataFromFile(t, "custom_fields.json")
 
-	test := testroutines.TestCaseListObjectMetadata{
+	test := testconn.TestCaseListObjectMetadata{
 		Name:  "Successful metadata for subscribers with custom fields",
 		Input: []string{"subscribers"},
 		Server: mockserver.Conditional{
@@ -219,7 +219,7 @@ func TestListObjectMetadataWithCustomFields(t *testing.T) {
 			If:    mockcond.Path("/v4/custom_fields"),
 			Then:  mockserver.Response(http.StatusOK, customfieldsresponse),
 		}.Server(),
-		Comparator: testroutines.ComparatorSubsetMetadata,
+		Comparator: testconn.ComparatorSubsetMetadata,
 		Expected: &common.ListObjectMetadataResult{
 			Result: map[string]common.ObjectMetadata{
 				"subscribers": {
@@ -241,7 +241,7 @@ func TestListObjectMetadataWithCustomFields(t *testing.T) {
 		ExpectedErrs: nil,
 	}
 
-	test.Run(t, func() (testroutines.TestableMetadataReader, error) {
+	test.Run(t, func() (testconn.TestableMetadataReader, error) {
 		return constructTestConnector(test.Server.URL)
 	})
 }

--- a/providers/kit/read_test.go
+++ b/providers/kit/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseEmptyPageTags := testutils.DataFromFile(t, "emptypage_tags.json")
 	responseEmailTemplates := testutils.DataFromFile(t, "email_templates.json")
 	responseSubscribers := testutils.DataFromFile(t, "subscribers.json")
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -86,7 +86,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v4/custom_fields"),
 				Then:  mockserver.Response(http.StatusOK, responseNextPageCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v4/custom_fields?after=WzFd&per_page=500",
+				NextPage: testconn.URLTestServer + "/v4/custom_fields?after=WzFd&per_page=500",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -184,7 +184,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseSubscribers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -220,7 +220,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/kit/write_test.go
+++ b/providers/kit/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	tagsResponse := testutils.DataFromFile(t, "write_tags.json")
 	tagsIssue := testutils.DataFromFile(t, "tag_issue.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -189,7 +189,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/delete_test.go
+++ b/providers/klaviyo/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -73,7 +73,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/metadata_test.go
+++ b/providers/klaviyo/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"campaigns", "lists"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {
@@ -81,7 +81,7 @@ func TestListObjectMetadataV1(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/read_test.go
+++ b/providers/klaviyo/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -72,7 +72,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseProfilesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -113,7 +113,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Since:      time.Date(2024, 3, 4, 8, 22, 56, 0, time.UTC),
 				Filter:     "equals(messages.channel,'email')",
 			},
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentMIME("application/vnd.api+json"),
 				If: mockcond.And{
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/klaviyo/write_test.go
+++ b/providers/klaviyo/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 
 	header := http.Header{"revision": []string{"2024-10-15"}}
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -132,7 +132,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateTag),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9891d452-56fe-4397-b431-a92e79cdc980",
@@ -153,7 +153,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/delete_test.go
+++ b/providers/lever/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-requisition-fields.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/metadata_test.go
+++ b/providers/lever/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	opportunitiesResponse := testutils.DataFromFile(t, "opportunities.json")
 	requisitionFieldsResponse := testutils.DataFromFile(t, "requisition_fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"opportunities", "requisition_fields"},
@@ -32,7 +32,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, requisitionFieldsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"opportunities": {
@@ -90,7 +90,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/read_test.go
+++ b/providers/lever/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	requisitionFieldsResponse := testutils.DataFromFile(t, "requisition_fields.json")
 	usersResponse := testutils.DataFromFile(t, "users.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v1/opportunities"),
 				Then:  mockserver.Response(http.StatusOK, opportunitiesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -100,7 +100,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v1/opportunities?limit=100" +
+				NextPage: testconn.URLTestServer + "/v1/opportunities?limit=100" +
 					"&updated_at_start=1748822400000&updated_at_end=1751241600000" +
 					"&offset=%255B1%252C1750233409740%252C%252248dd4e94-fea0-4f9a-be5f-95b1853cbbbe%2522%255D",
 				Done: false,
@@ -143,7 +143,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v1/users"),
 				Then:  mockserver.Response(http.StatusOK, usersResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -165,7 +165,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/v1/users?limit=100&offset=%255B1733206956064%252C%2522c21d911f-8292-49b7-b135-f7cc233b43fd%2522%255D",
 				Done: false,
 			},
@@ -177,7 +177,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/lever/write_test.go
+++ b/providers/lever/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	requisitionFieldResponse := testutils.DataFromFile(t, "write_requisition_field.json")
 	requisitionsResponse := testutils.DataFromFile(t, "write_requisitions.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -230,7 +230,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/linkedin/delete_test.go
+++ b/providers/linkedin/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-adAccounts.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -65,7 +65,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})
@@ -75,7 +75,7 @@ func TestAdsDelete(t *testing.T) { // nolint:funlen,cyclop
 func TestPlatformDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:  "Successful delete",
 			Input: common.DeleteParams{ObjectName: "posts", RecordId: "urn:li:share:7393604235420078080"},
@@ -99,7 +99,7 @@ func TestPlatformDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestPlatformConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/metadata_test.go
+++ b/providers/linkedin/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	adTargetingFacetsResponse := testutils.DataFromFile(t, "adTargetingFacets.json")
 	dmpEngagementSourceTypesResponse := testutils.DataFromFile(t, "dmpEngagementSourceTypes.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple object with metadata",
 			Input: []string{"adTargetingFacets", "dmpEngagementSourceTypes"},
@@ -43,7 +43,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, dmpEngagementSourceTypesResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"adTargetingFacets": {
@@ -113,7 +113,7 @@ func TestAdsListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/read_test.go
+++ b/providers/linkedin/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	dmpEngagementSourceTypesResponse := testutils.DataFromFile(t, "dmpEngagementSourceTypes.json")
 	adAccountsResponse := testutils.DataFromFile(t, "adAccounts.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -147,7 +147,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, adAccountsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -196,7 +196,7 @@ func TestAdsRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})

--- a/providers/linkedin/write_test.go
+++ b/providers/linkedin/write_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -78,7 +78,7 @@ func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestAdsConnector(tt.Server)
 			})
 		})
@@ -88,7 +88,7 @@ func TestAdsWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 func TestPlatformWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -149,7 +149,7 @@ func TestPlatformWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestPlatformConnector(tt.Server)
 			})
 		})

--- a/providers/livestorm/delete_test.go
+++ b/providers/livestorm/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Object name is required",
 			Server:       mockserver.Dummy(),
@@ -55,7 +55,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/metadata_test.go
+++ b/providers/livestorm/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for events and people",
 			Input:      []string{"events", "people", "people_attributes", "users"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"events": {
@@ -96,7 +96,7 @@ func TestListObjectMetadata(t *testing.T) {
 			Name:       "Unsupported object returns object not supported error",
 			Input:      []string{"events", "unknown_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"events": {
@@ -123,7 +123,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/read_test.go
+++ b/providers/livestorm/read_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/go-test/deep"
 )
@@ -29,7 +29,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	peopleAttributesBody := testutils.DataFromFile(t, "read-people-attributes.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -68,11 +68,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, eventsBody),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Done:     false,
-				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100&filter[updated_since]=1735689600&filter[updated_until]=1735776000",
+				NextPage: testconn.URLTestServer + "/v1/events?page[number]=1&page[size]=100&filter[updated_since]=1735689600&filter[updated_until]=1735776000",
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
@@ -107,11 +107,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, eventsMultipageBody),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Done:     false,
-				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
+				NextPage: testconn.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, peopleFirstPageBody),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Done: true,
@@ -172,7 +172,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name: "Read people offset pagination via meta.next_page absolute URL",
 			Input: common.ReadParams{
 				ObjectName: "people",
-				NextPage:   testroutines.URLTestServer + "/v1/people?page[number]=2&page[size]=100",
+				NextPage:   testconn.URLTestServer + "/v1/people?page[number]=2&page[size]=100",
 				Fields:     connectors.Fields("email"),
 			},
 			Server: mockserver.NewServer(func(w http.ResponseWriter, r *http.Request) {
@@ -189,11 +189,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 				_, _ = w.Write([]byte(body)) // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
 			}),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Done:     false,
-				NextPage: testroutines.URLTestServer + "/v1/people?page[number]=3&page[size]=100",
+				NextPage: testconn.URLTestServer + "/v1/people?page[number]=3&page[size]=100",
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
@@ -226,7 +226,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, peopleAttributesBody),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Done: true,
@@ -250,7 +250,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name: "Read events from NextPage token uses provided URL as-is",
 			Input: common.ReadParams{
 				ObjectName: objectEvents,
-				NextPage:   testroutines.URLTestServer + "/v1/events?page[number]=5&page[size]=100",
+				NextPage:   testconn.URLTestServer + "/v1/events?page[number]=5&page[size]=100",
 				Fields:     connectors.Fields("title"),
 			},
 			Server: mockserver.Conditional{
@@ -263,11 +263,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, eventsBody),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Done:     false,
-				NextPage: testroutines.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
+				NextPage: testconn.URLTestServer + "/v1/events?page[number]=1&page[size]=100",
 			},
 		},
 	}
@@ -277,7 +277,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/livestorm/write_test.go
+++ b/providers/livestorm/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) { //nolint:funlen
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	eventUpdateResp := []byte(`{"data":{"id":"evt_1","type":"events","attributes":{"title":"Updated"}}}`)
 	userCreateResp := []byte(`{"data":{"id":"usr_1","type":"users","attributes":{"email":"new@example.com"}}}`)
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, eventCreateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "evt_new",
@@ -85,7 +85,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, eventUpdateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "evt_1",
@@ -113,7 +113,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, userCreateResp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "usr_1",
@@ -134,7 +134,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/delete_test.go
+++ b/providers/loxo/delete_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -66,7 +66,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/metadata_test.go
+++ b/providers/loxo/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	companiesResponse := testutils.DataFromFile(t, "companies.json")
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"companies", "currencies"},
@@ -32,7 +32,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, currenciesResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"companies": {
@@ -110,7 +110,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/read_test.go
+++ b/providers/loxo/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	currenciesResponse := testutils.DataFromFile(t, "currencies.json")
 	countriesResponse := testutils.DataFromFile(t, "countries.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -33,7 +33,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/integration-user-loxo-withampersand-com/people"),
 				Then:  mockserver.Response(http.StatusOK, peopleResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -65,7 +65,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer +
+				NextPage: testconn.URLTestServer +
 					"/integration-user-loxo-withampersand-com/people?" +
 					"per_page=100&scroll_id=5B313735363231393831313237352C302E302C313338383639335D",
 				Done: false,
@@ -111,7 +111,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/integration-user-loxo-withampersand-com/countries"),
 				Then:  mockserver.Response(http.StatusOK, countriesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/integration-user-loxo-withampersand-com/countries?" +
+				NextPage: testconn.URLTestServer + "/integration-user-loxo-withampersand-com/countries?" +
 					"per_page=100&page=101",
 				Done: false,
 			},
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/loxo/write_test.go
+++ b/providers/loxo/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	companiesFieldResponse := testutils.DataFromFile(t, "write_companies.json")
 	peopleResponse := testutils.DataFromFile(t, "write_people.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -135,7 +135,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/metadata_test.go
+++ b/providers/marketo/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	channelsResponse := testutils.DataFromFile(t, "channels.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -84,7 +84,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/read_test.go
+++ b/providers/marketo/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	campaignsResponse := testutils.DataFromFile(t, "campaigns.json")
 	leadsResponse := testutils.DataFromFile(t, "leads.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -134,7 +134,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/marketo/write_test.go
+++ b/providers/marketo/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "not-found.json")
 	leadCreationResponse := testutils.DataFromFile(t, "write-leads.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, leadCreationResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "550",
@@ -78,7 +78,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/meta/internal/whatsapp/write_test.go
+++ b/providers/meta/internal/whatsapp/write_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	messageTemplateCreateResponse := testutils.DataFromFile(t, "message-template-create.json")
 	phoneNumberCreateResponse := testutils.DataFromFile(t, "phone-number-create.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -69,7 +69,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "wamid.HBgLMTY0NjcwNDM1OTUVAgARGBI4MjZGRDA0OUE2OTQ3RkEyMzcA",
@@ -105,7 +105,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2450146205448663",
@@ -139,7 +139,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1906385232743451",
@@ -159,7 +159,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestAdapter(tt.Server)
 			})
 		})

--- a/providers/microsoft/delete_test.go
+++ b/providers/microsoft/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/internal/batch/operation_test.go
+++ b/providers/microsoft/internal/batch/operation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -104,11 +104,11 @@ func constructTestStrategy(serverURL string) (*Strategy, error) {
 	return NewStrategy(transport.JSONHTTPClient(), transport.ProviderInfo()), nil
 }
 
-type testType[B any] = testroutines.TestCase[*Params, *Result[B]]
+type testType[B any] = testconn.TestCase[*Params, *Result[B]]
 type testSuite[B any] testType[B]
 
 // Run provides a procedure to test connectors.ObjectMetadataConnector
-func (s testSuite[B]) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Strategy]) {
+func (s testSuite[B]) Run(t *testing.T, builder testconn.ConnectorBuilder[*Strategy]) {
 	t.Helper()
 	t.Cleanup(func() {
 		testType[B](s).Close()

--- a/providers/microsoft/internal/subscriber/create_test.go
+++ b/providers/microsoft/internal/subscriber/create_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/amp-labs/connectors/providers/microsoft/internal/batch"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 	  "headers": {"Content-Type": "application/json"}
 	}`)
 
-	tests := []testroutines.TestCaseSubscribe{
+	tests := []testconn.TestCaseSubscribe{
 		{
 			Name: "Missing object for subscription",
 			Input: common.SubscribeParams{
@@ -113,7 +113,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusNoContent, responseRollbackDelete),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(resultComparator),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{},
 				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
@@ -154,7 +154,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusOK, errorRollbackDelete),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(resultComparator),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					Subscriptions: map[string]SubscriptionResource{
@@ -194,7 +194,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusCreated, responseSubscribeToMessages),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubscriptionWithResult(resultComparator),
+			Comparator: testconn.ComparatorSubscriptionWithResult(resultComparator),
 			Expected: &common.SubscriptionResult{
 				Result: &Result{
 					Subscriptions: map[string]SubscriptionResource{
@@ -221,7 +221,7 @@ func TestCreate(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSubscriptionCreator, error) {
+			tt.Run(t, func() (testconn.TestableSubscriptionCreator, error) {
 				return constructTestStrategy(tt.Server)
 			})
 		})

--- a/providers/microsoft/internal/webhook/message_test.go
+++ b/providers/microsoft/internal/webhook/message_test.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -12,12 +12,12 @@ func TestEvent(t *testing.T) {
 	responseMessageUpdated := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "event-message-updated.json")
 	responseMessageDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "event-message-deleted.json")
 
-	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
+	for _, tt := range []testconn.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseMessageCreated,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "create",
 					RawEventName: "created",
 					ObjectName:   "me/messages",
@@ -28,8 +28,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Updated event",
 			Input: responseMessageUpdated,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "update",
 					RawEventName: "updated",
 					ObjectName:   "me/messages",
@@ -40,8 +40,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Deleted event",
 			Input: responseMessageDeleted,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:    "delete",
 					RawEventName: "deleted",
 					ObjectName:   "me/messages",

--- a/providers/microsoft/metadata_test.go
+++ b/providers/microsoft/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for multiple objects",
 			Input:      []string{"users", "groups", "me/events", "me/messages"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"users": {
@@ -95,7 +95,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/read-by-ids_test.go
+++ b/providers/microsoft/read-by-ids_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 
 	responseMessages := testutils.DataFromFile(t, "read/messages/batch-by-ids.json")
 
-	tests := []testroutines.TestCaseGetRecordsByIds{
+	tests := []testconn.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -24,7 +24,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		},
 		{
 			Name: "Read messages by identifiers",
-			Input: testroutines.ReadByIdsParams{
+			Input: testconn.ReadByIdsParams{
 				ObjectName: "me/messages",
 				RecordIds:  []string{"msg1", "msg2", "msg3"},
 				Fields:     []string{"subject"},
@@ -65,7 +65,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMessages),
 			}.Server(),
-			Comparator: testroutines.ComparatorSortedSubsetReadByIds,
+			Comparator: testconn.ComparatorSortedSubsetReadByIds,
 			Expected: []common.ReadResultRow{{
 				Id: "msg1",
 				Fields: map[string]any{
@@ -106,7 +106,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
+			tt.Run(t, func() (testconn.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/read_test.go
+++ b/providers/microsoft/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCalendarEvents := testutils.DataFromFile(t, "read/events/list.json")
 	responseMessagesEvents := testutils.DataFromFile(t, "read/messages/list.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -53,7 +53,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v1.0/users"),
 				Then:  mockserver.Response(http.StatusOK, responseUsersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -76,14 +76,14 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Input: common.ReadParams{
 				ObjectName: "users",
 				Fields:     connectors.Fields("displayName"),
-				NextPage:   testroutines.URLTestServer + "/v1.0/users?$top=1&$skiptoken=RFNwdAIAAQAAACM6aW50ZWdyYXRpb24udXNlckB3aXRoYW1wZXJzYW5kLmNvbSlVc2VyXzEyMTUxZWE2LTZkODYtNGFmZC1hNjhkLTg4YWIzNGY1MTcwYbkAAAAAAAAAAAAA", // nolint:lll
+				NextPage:   testconn.URLTestServer + "/v1.0/users?$top=1&$skiptoken=RFNwdAIAAQAAACM6aW50ZWdyYXRpb24udXNlckB3aXRoYW1wZXJzYW5kLmNvbSlVc2VyXzEyMTUxZWE2LTZkODYtNGFmZC1hNjhkLTg4YWIzNGY1MTcwYbkAAAAAAAAAAAAA", // nolint:lll
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If:    mockcond.Path("/v1.0/users"),
 				Then:  mockserver.Response(http.StatusOK, responseUsersLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -110,7 +110,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCalendarEvents),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -148,7 +148,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMessagesEvents),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -184,7 +184,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/microsoft/write_test.go
+++ b/providers/microsoft/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseUser := testutils.DataFromFile(t, "write/users/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -33,7 +33,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseUser),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "520168be-3102-47bf-979d-7a99cb8ed8c5",
@@ -70,7 +70,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseUser),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "520168be-3102-47bf-979d-7a99cb8ed8c5",
@@ -93,7 +93,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -110,7 +110,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -127,7 +127,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -144,7 +144,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -161,7 +161,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -178,7 +178,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.ResponseString(http.StatusOK, `{"subject": "hello", "id": "753"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true, RecordId: "753", Data: map[string]any{"subject": "hello"},
 			},
@@ -190,7 +190,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/monday/read_test.go
+++ b/providers/monday/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 	errorBadRequest := testutils.DataFromFile(t, "boards/err-unknown-property.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:  "Error requesting unknown field for the object",
 			Input: common.ReadParams{ObjectName: "boards", Fields: connectors.Fields("id", "random_field")},
@@ -37,7 +37,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/delete_test.go
+++ b/providers/nutshell/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/metadata_test.go
+++ b/providers/nutshell/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for CalendarList and Settings",
 			Input:      []string{"competitormaps", "contacts", "products"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"competitormaps": {
@@ -85,7 +85,7 @@ func TestCalendarListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cy
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/read_test.go
+++ b/providers/nutshell/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseAccountsEmptyPage := testutils.DataFromFile(t, "read/accounts/2-empty-page.json")
 	responseEvents := testutils.DataFromFile(t, "read/events/1-first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"href": "https://app.nutshell.com/rest/accounts/19-accounts",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/rest/accounts?" +
+				NextPage: testconn.URLTestServer + "/rest/accounts?" +
 					"filter[createdTime]=2025-08-06T22:06:54Z 2025-08-06T22:06:56Z&" +
 					"page[limit]=10000&" +
 					"page[page]=1",
@@ -148,7 +148,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "accounts",
 				Fields:     connectors.Fields("name"),
-				NextPage: testroutines.URLTestServer + "/rest/accounts?" +
+				NextPage: testconn.URLTestServer + "/rest/accounts?" +
 					"filter[createdTime]=2025-08-06T22:06:54Z 2025-08-06T22:06:56Z&page[limit]=10000&page[page]=1",
 			},
 			Server: mockserver.Conditional{
@@ -187,7 +187,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseEvents),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -230,7 +230,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/nutshell/write_test.go
+++ b/providers/nutshell/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	errorMediaType := testutils.DataFromFile(t, "write/err-media-type.txt")
 	responseAccounts := testutils.DataFromFile(t, "write/accounts/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccounts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "23-accounts",
@@ -95,7 +95,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccounts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "23-accounts",
@@ -120,7 +120,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccounts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "23-accounts",
@@ -140,7 +140,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/delete_test.go
+++ b/providers/odoo/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) {
 
 	respUnlink := testutils.DataFromFile(t, "delete-crm-lead-unlink.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name: "Unlink crm.lead successfully",
 			Input: common.DeleteParams{
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/metadata_test.go
+++ b/providers/odoo/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	calendarModel := testutils.DataFromFile(t, "calendar-model.json")
 	calendarFields := testutils.DataFromFile(t, "calendar-model-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -49,7 +49,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"uom.uom": {
@@ -216,7 +216,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"resource.calendar": {
@@ -478,7 +478,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"uom.uom": mockutils.ExpectedSubsetErrors{
@@ -510,7 +510,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"uom.uom": mockutils.ExpectedSubsetErrors{
@@ -526,7 +526,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/read_test.go
+++ b/providers/odoo/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"github.com/spyzhov/ajson"
 )
@@ -30,7 +30,7 @@ func TestRead(t *testing.T) {
 	responseRoleLast := testutils.DataFromFile(t, "read-role-last-page.json")
 	responseRoleUntilWindow := []byte(`[{"id":99,"name":"Filtered"}]`)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Read crm.iap.lead.role empty",
 			Input: common.ReadParams{
@@ -69,7 +69,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleLimitThree),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{
@@ -133,7 +133,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleUntilWindow),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -166,7 +166,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleUntilWindow),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -196,7 +196,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 10,
 				Data: []common.ReadResultRow{
@@ -235,7 +235,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 10,
 				Data: []common.ReadResultRow{
@@ -274,7 +274,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseRoleLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -303,7 +303,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/odoo/write_test.go
+++ b/providers/odoo/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) {
 	respCreate := testutils.DataFromFile(t, "write-crm-lead-create.json")
 	respUpdate := testutils.DataFromFile(t, "write-crm-lead-update.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name: "Create crm.lead successfully",
 			Input: common.WriteParams{
@@ -38,7 +38,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, respCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "142",
@@ -64,7 +64,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, respUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "104",
@@ -89,7 +89,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, respCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "142",
@@ -102,7 +102,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/okta/delete_test.go
+++ b/providers/okta/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -97,7 +97,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/metadata_test.go
+++ b/providers/okta/metadata_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -45,7 +45,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -70,7 +70,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -96,7 +96,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -121,7 +121,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -144,7 +144,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -167,7 +167,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -190,7 +190,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -214,7 +214,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -236,7 +236,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 		{
@@ -283,7 +283,7 @@ func TestListObjectMetadata(t *testing.T) {
 				},
 				Errors: nil,
 			},
-			Comparator:   testroutines.ComparatorSubsetMetadata,
+			Comparator:   testconn.ComparatorSubsetMetadata,
 			ExpectedErrs: nil,
 		},
 	}
@@ -292,7 +292,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/read_test.go
+++ b/providers/okta/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 	responseGroupsWithCustomFields := testutils.DataFromFile(t, "read-groups-with-custom-fields.json")
 	errorResponse := testutils.DataFromFile(t, "error.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -45,7 +45,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -102,7 +102,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 					mockserver.Response(http.StatusOK, responseUsers),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -142,7 +142,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseGroups),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -176,7 +176,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseApps),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -213,7 +213,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -265,7 +265,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUsersWithCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -309,7 +309,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseGroupsWithCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -348,7 +348,7 @@ func TestRead(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/okta/write_test.go
+++ b/providers/okta/write_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) {
 	updateGroupResponse := testutils.DataFromFile(t, "write-group-update.json")
 	errorResponse := testutils.DataFromFile(t, "error.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -42,7 +42,7 @@ func TestWrite(t *testing.T) {
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, createUserResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "00u_newuser_12345",
@@ -69,7 +69,7 @@ func TestWrite(t *testing.T) {
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, updateUserResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "00u1234567890abcdef",
@@ -95,7 +95,7 @@ func TestWrite(t *testing.T) {
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, createGroupResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "00g_newgroup_12345",
@@ -122,7 +122,7 @@ func TestWrite(t *testing.T) {
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, updateGroupResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "00g1234567890abcdef",
@@ -151,7 +151,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/outplay/metadata_test.go
+++ b/providers/outplay/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	prospectAccountResponse := testutils.DataFromFile(t, "prospectaccount-read.json")
 	callAnalysisResponse := testutils.DataFromFile(t, "callanalysis-read.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -44,7 +44,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, callAnalysisResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"prospectaccount": { //nolint:dupl
@@ -217,7 +217,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, prospectAccountResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"prospectaccount": { //nolint:dupl
@@ -312,7 +312,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outplay/read_test.go
+++ b/providers/outplay/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) {
 	prospectAccountResponse := testutils.DataFromFile(t, "prospectaccount-read.json")
 	callAnalysisResponse := testutils.DataFromFile(t, "callanalysis-read.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read objects must be implemented",
 			Input:        common.ReadParams{},
@@ -43,7 +43,7 @@ func TestRead(t *testing.T) {
 					Then: mockserver.Response(http.StatusOK, prospectAccountResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -105,7 +105,7 @@ func TestRead(t *testing.T) {
 					Then: mockserver.Response(http.StatusOK, callAnalysisResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -147,7 +147,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnectorForRead(tt.Server.URL)
 			})
 		})

--- a/providers/outplay/write_test.go
+++ b/providers/outplay/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createNoteResponse := testutils.DataFromFile(t, "create-note.json")
 	updateNoteResponse := testutils.DataFromFile(t, "update-note.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -171,7 +171,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/metadata_test.go
+++ b/providers/outreach/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	schemaResponse := testutils.DataFromFile(t, "schema.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, schemaResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"opportunities": {
@@ -144,7 +144,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/read_test.go
+++ b/providers/outreach/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 	mailingsResponse := testutils.DataFromFile(t, "mailings.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -78,7 +78,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/mailings"),
 				Then:  mockserver.Response(http.StatusOK, mailingsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -126,7 +126,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/outreach/records_test.go
+++ b/providers/outreach/records_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestGetRecordsByIds(t *testing.T) {
 
 	accountsByIdsResponse := testutils.DataFromFile(t, "accounts_by_ids.json")
 
-	tests := []testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
+	tests := []testconn.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
 		{
 			Name:         "Missing object name returns error",
 			Server:       mockserver.Dummy(),

--- a/providers/outreach/write_test.go
+++ b/providers/outreach/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "unsupported.json")
 	updateDealsResponse := testutils.DataFromFile(t, "emailaddress.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -67,7 +67,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, sequencesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "18",
@@ -181,7 +181,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/metadata_test.go
+++ b/providers/paddle/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successful metadata for multiple objects",
 			Input:      []string{"client-tokens", "discount-groups"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"client-tokens": {
@@ -122,7 +122,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/read_test.go
+++ b/providers/paddle/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCustomersSecond := testutils.DataFromFile(t, "customers-second-page.json")
 	responseProducts := testutils.DataFromFile(t, "products.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/customers"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -78,7 +78,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/customers"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomersSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -94,7 +94,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/products"),
 				Then:  mockserver.Response(http.StatusOK, responseProducts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -130,7 +130,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/paddle/write_test.go
+++ b/providers/paddle/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createCustomerResponse := testutils.DataFromFile(t, "create-customer.json")
 	createDiscountResponse := testutils.DataFromFile(t, "create-discount.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -202,7 +202,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/delete_test.go
+++ b/providers/phoneburner/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,cyclop
 
 	respUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -97,7 +97,7 @@ func TestDelete(t *testing.T) { //nolint:funlen,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/metadata_test.go
+++ b/providers/phoneburner/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,12 +19,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	isCustomField := true
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for contacts, folders, members, voicemails, and dialsession",
 			Input:      []string{"contacts", "folders", "members", "voicemails", "dialsession", "tags"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -134,7 +134,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomfieldsDefinitions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -169,7 +169,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unsupported object returns object not supported error",
 			Input:      []string{"contacts", "unknown_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -196,7 +196,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/phoneburner/read_test.go
+++ b/providers/phoneburner/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseVoicemails := testutils.DataFromFile(t, "read/voicemails.json")
 	responseUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -57,7 +57,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -97,7 +97,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactsWithCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -168,7 +168,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseDialSessions),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -183,7 +183,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"call_count":     float64(0),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/rest/1/dialsession?page=2&page_size=100",
+				NextPage: testconn.URLTestServer + "/rest/1/dialsession?page=2&page_size=100",
 				Done:     false,
 			},
 		},
@@ -199,7 +199,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMembers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -231,7 +231,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseTags),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -253,7 +253,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 						"title": "Tag #2",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/rest/1/tags?page=2&page_size=100",
+				NextPage: testconn.URLTestServer + "/rest/1/tags?page=2&page_size=100",
 				Done:     false,
 			},
 		},
@@ -273,7 +273,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseMembers),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -292,7 +292,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseVoicemails),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -327,7 +327,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseVoicemails),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -373,7 +373,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -394,5 +394,5 @@ func comparatorSubsetReadOrderByFolderID(
 		return ai < aj
 	})
 
-	return testroutines.ComparatorSubsetRead(serverURL, actual, expected)
+	return testconn.ComparatorSubsetRead(serverURL, actual, expected)
 }

--- a/providers/phoneburner/write_test.go
+++ b/providers/phoneburner/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	respDialsession := testutils.DataFromFile(t, "write/dialsession.json")
 	respUnauthorized := testutils.DataFromFile(t, "read/error-unauthorized.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -58,7 +58,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, respContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "30919347",
@@ -81,7 +81,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, respContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "30919347",
@@ -102,7 +102,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, respFolder),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "11888",
@@ -125,7 +125,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, respMember),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "25381104",
@@ -151,7 +151,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, respDialsession),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success: true,
 				Data: map[string]any{
@@ -187,7 +187,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/delete_test.go
+++ b/providers/pinterest/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-boards.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/metadata_test.go
+++ b/providers/pinterest/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	boardsResponse := testutils.DataFromFile(t, "boards.json")
 	mediaResponse := testutils.DataFromFile(t, "media.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"pins", "boards", "media"},
@@ -36,7 +36,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, mediaResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"pins": {
@@ -100,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/read_test.go
+++ b/providers/pinterest/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	boardsResponse := testutils.DataFromFile(t, "boards.json")
 	mediaResponse := testutils.DataFromFile(t, "media.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -34,7 +34,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v5/pins"),
 				Then:  mockserver.Response(http.StatusOK, pinsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -101,7 +101,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v5/pins?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
+				NextPage: testconn.URLTestServer + "/v5/pins?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -114,7 +114,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v5/boards"),
 				Then:  mockserver.Response(http.StatusOK, boardsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v5/boards?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
+				NextPage: testconn.URLTestServer + "/v5/boards?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v5/media"),
 				Then:  mockserver.Response(http.StatusOK, mediaResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v5/media?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
+				NextPage: testconn.URLTestServer + "/v5/media?bookmark=P2MxMDU0MzM0OTYyNzU0OTg0NjUzLjE3MTUzMzgzMDksLTF8NHwxMjE0NzA2NjAzMTA1Mz&page_size=250", // nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pinterest/write_test.go
+++ b/providers/pinterest/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	boardsResponse := testutils.DataFromFile(t, "boards_write.json")
 	mediaResponse := testutils.DataFromFile(t, "media_write.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -275,7 +275,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipedrive/metadata_test.go
+++ b/providers/pipedrive/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	success := testutils.DataFromFile(t, "currencies.json")
 	activityFields := testutils.DataFromFile(t, "activityFields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, success),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"currencies": {
@@ -68,7 +68,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, zeroRecords),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"leadLabels": {
@@ -115,7 +115,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v1/activityFields"),
 				Then:  mockserver.Response(http.StatusOK, activityFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"activities": {
@@ -153,7 +153,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})
@@ -165,7 +165,7 @@ func TestListObjectMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	dealsFields := testutils.DataFromFile(t, "dealsFields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "A success API Response for Deals",
 			Input: []string{"deals"},
@@ -177,7 +177,7 @@ func TestListObjectMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, dealsFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"deals": {
@@ -229,7 +229,7 @@ func TestListObjectMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveCRM)
 			})
 		})

--- a/providers/pipedrive/read_test.go
+++ b/providers/pipedrive/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestReadCRM(t *testing.T) {
 	dealsResponse := testutils.DataFromFile(t, "deals.json")
 	dealProductsResponse := testutils.DataFromFile(t, "deal-products.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Deals include products when products field is requested",
 			Input: common.ReadParams{
@@ -39,7 +39,7 @@ func TestReadCRM(t *testing.T) {
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -95,7 +95,7 @@ func TestReadCRM(t *testing.T) {
 				If:    mockcond.Path("/api/v2/deals"),
 				Then:  mockserver.Response(http.StatusOK, dealsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -116,7 +116,7 @@ func TestReadCRM(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveCRM)
 			})
 		})
@@ -135,7 +135,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		Always: mockserver.Response(http.StatusOK, nextPageTest),
 	}.Server()
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name Required",
 			Server:       mockserver.Dummy(),
@@ -151,7 +151,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Name:         "NextPage URL construction",
 			Input:        common.ReadParams{ObjectName: "activities", Fields: connectors.Fields("id")},
 			Server:       server,
-			Comparator:   testroutines.ComparatorSubsetRead,
+			Comparator:   testconn.ComparatorSubsetRead,
 			ExpectedErrs: nil,
 			Expected: &common.ReadResult{
 				Rows: 1,
@@ -210,7 +210,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/leads"),
 				Then:  mockserver.Response(http.StatusOK, leads),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -251,7 +251,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})

--- a/providers/pipedrive/write_test.go
+++ b/providers/pipedrive/write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	unsupportedResponse := testutils.DataFromFile(t, "not-found.json")
 	createActivityResponse := testutils.DataFromFile(t, "create-activity.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createActivityResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "9",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPUT(),
 				Then:  mockserver.Response(http.StatusOK, updateActivityResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1",
@@ -136,7 +136,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL, providers.ModulePipedriveLegacy)
 			})
 		})

--- a/providers/pipeliner/delete_test.go
+++ b/providers/pipeliner/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseRemoveNote := testutils.DataFromFile(t, "delete-note.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/metadata_test.go
+++ b/providers/pipeliner/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"Notes"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Notes": {
@@ -60,7 +60,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"Phones", "Tags"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Phones": {
@@ -95,7 +95,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/read_test.go
+++ b/providers/pipeliner/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseProfilesSecondPage := testutils.DataFromFile(t, "read-profiles-2-second-page.json")
 	responseProfilesLastPage := testutils.DataFromFile(t, "read-profiles-3-last-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseProfilesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
 				NextPage: "WyIwMDAwMDAwMC0wMDAwLTAwMDEtMDAwMS0wMDAwMDAwMDhlOTciXQ==",
@@ -106,7 +106,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseProfilesLastPage),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/v100/rest/spaces/test-workspace/entities/Profiles"),
 				Then:  mockserver.Response(http.StatusOK, responseProfilesSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pipeliner/write_test.go
+++ b/providers/pipeliner/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateNote := testutils.DataFromFile(t, "create-note.json")
 	responseUpdateNote := testutils.DataFromFile(t, "update-note.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -99,7 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateNote),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",
@@ -124,7 +124,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				If:    mockcond.MethodPATCH(),
 				Then:  mockserver.Response(http.StatusOK, responseUpdateNote),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "0190978c-d6d1-de35-3f6d-7cf0a0e264db",
@@ -144,7 +144,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/metadata_test.go
+++ b/providers/procore/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 	projectsResponse := testutils.DataFromFile(t, "projects.json")
 	operationsResponse := testutils.DataFromFile(t, "operations.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -41,7 +41,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"company/projects": {
@@ -70,7 +70,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, operationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"operations": {
@@ -93,7 +93,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/read_test.go
+++ b/providers/procore/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	since := time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC)
 	until := time.Date(2024, 10, 1, 23, 59, 59, 0, time.UTC)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, Done: true},
 			ExpectedErrs: nil,
 		},
@@ -115,7 +115,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					mockserver.Response(http.StatusOK, projectsResponse),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
 				NextPage: "https://api.procore.com/rest/v1.0/companies/" + testCompanyID + "/projects?page=2&per_page=100",
@@ -128,7 +128,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Input: common.ReadParams{
 				ObjectName: "company/projects",
 				Fields:     connectors.Fields("id"),
-				NextPage:   common.NextPageToken(testroutines.URLTestServer + "/rest/v1.0/companies/" + testCompanyID + "/projects?page=3&per_page=100"),
+				NextPage:   common.NextPageToken(testconn.URLTestServer + "/rest/v1.0/companies/" + testCompanyID + "/projects?page=3&per_page=100"),
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -139,7 +139,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, Done: true},
 			ExpectedErrs: nil,
 		},
@@ -150,7 +150,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				Fields:     connectors.Fields("id"),
 				Since:      since,
 				Until:      until,
-				NextPage: common.NextPageToken(testroutines.URLTestServer +
+				NextPage: common.NextPageToken(testconn.URLTestServer +
 					"/rest/v1.0/companies/" + testCompanyID + "/projects" +
 					"?filters%5Bupdated_at%5D=2024-10-01T00%3A00%3A00Z...2024-10-01T23%3A59%3A59Z" +
 					"&page=2&per_page=100"),
@@ -165,7 +165,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, projectsResponse),
 			}.Server(),
-			Comparator:   testroutines.ComparatorPagination,
+			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, Done: true},
 			ExpectedErrs: nil,
 		},
@@ -180,7 +180,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				If:    mockcond.Path("/rest/v2.0/companies/" + testCompanyID + "/async_operations"),
 				Then:  mockserver.Response(http.StatusOK, operationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -204,7 +204,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/procore/write_test.go
+++ b/providers/procore/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	createProjectResponse := testutils.DataFromFile(t, "create_project.json")
 	updateProjectResponse := testutils.DataFromFile(t, "update_project.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -43,7 +43,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, createProjectResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2783407",
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, updateProjectResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2783405",
@@ -99,7 +99,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, createProjectResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2783407",
@@ -123,7 +123,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, updateProjectResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2783405",
@@ -138,7 +138,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/metadata_test.go
+++ b/providers/pylon/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	contactsResponse := testutils.DataFromFile(t, "contacts-read.json")
 	tagsResponse := testutils.DataFromFile(t, "tags-read.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, tagsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -137,7 +137,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/read_test.go
+++ b/providers/pylon/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseAccountsSecond := testutils.DataFromFile(t, "accounts-second-page.json")
 	responseIssuesEmpty := testutils.DataFromFile(t, "issues-empty-response.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/accounts"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -75,7 +75,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/issues"),
 				Then:  mockserver.Response(http.StatusOK, responseIssuesEmpty),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				NextPage: "",
@@ -94,7 +94,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/accounts"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountsSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/pylon/write_test.go
+++ b/providers/pylon/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	createTasksResponse := testutils.DataFromFile(t, "create-tasks.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/metadata_test.go
+++ b/providers/quickbooks/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	graphQLEmptyResponse := testutils.DataFromFile(t, "custom-fields/graphql-empty.json")
 	graphQLErrorResponse := testutils.DataFromFile(t, "custom-fields/graphql-error.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -44,7 +44,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, customerResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"account": {
@@ -86,7 +86,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				If:    mockcond.QueryParam("query", "SELECT * FROM Item STARTPOSITION 0 MAXRESULTS 1"),
 				Then:  mockserver.Response(http.StatusOK, itemResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"item": {
@@ -113,7 +113,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				If:    mockcond.QueryParam("query", "SELECT * FROM Account STARTPOSITION 0 MAXRESULTS 1"),
 				Then:  mockserver.Response(http.StatusOK, accountEmptyResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{},
 				Errors: map[string]error{
@@ -129,7 +129,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusBadRequest, errorResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{},
 				Errors: map[string]error{
@@ -156,7 +156,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, itemResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"account": {
@@ -217,7 +217,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, graphQLResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customer": {
@@ -264,7 +264,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, graphQLResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customer": {
@@ -321,7 +321,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusInternalServerError),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customer": {
@@ -358,7 +358,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, graphQLEmptyResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customer": {
@@ -395,7 +395,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, graphQLErrorResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customer": {
@@ -422,7 +422,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/read_test.go
+++ b/providers/quickbooks/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -29,7 +29,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseItem := testutils.DataFromFile(t, "item-read.json")
 	responseError := testutils.DataFromFile(t, "error-bad-request.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("query", "SELECT * FROM Account STARTPOSITION 1 MAXRESULTS 1000"),
 				Then:  mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -86,7 +86,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("query", "SELECT * FROM Customer STARTPOSITION 1 MAXRESULTS 1000"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomer),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -105,7 +105,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("query", "SELECT * FROM Account STARTPOSITION 1 MAXRESULTS 1000"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountWithNextPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "1001",
@@ -124,7 +124,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -151,7 +151,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -179,7 +179,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -206,7 +206,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -233,7 +233,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("query", "SELECT * FROM Account STARTPOSITION 1 MAXRESULTS 1000"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountEmpty),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				Data:     []common.ReadResultRow{},
@@ -267,7 +267,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.QueryParam("query", "SELECT * FROM Item STARTPOSITION 1 MAXRESULTS 1000"),
 				Then:  mockserver.Response(http.StatusOK, responseItem),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -304,7 +304,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomerWithCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -348,7 +348,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -371,7 +371,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/quickbooks/write_test.go
+++ b/providers/quickbooks/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createAccountResponse := testutils.DataFromFile(t, "create-account.json")
 	writeErrorResponse := testutils.DataFromFile(t, "write-error.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -135,7 +135,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, createAccountResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "88",
@@ -208,7 +208,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/metadata_test.go
+++ b/providers/recurly/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"accounts", "subscriptions", "plans"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"accounts": {
@@ -805,7 +805,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/read_test.go
+++ b/providers/recurly/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseInvoicesFirst := testutils.DataFromFile(t, "read-invoices.json")
 	responseInvoicesLast := testutils.DataFromFile(t, "read-invoices-last.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/accounts"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountsFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -85,7 +85,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/invoices"),
 				Then:  mockserver.Response(http.StatusOK, responseInvoicesFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -127,7 +127,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseAccountsLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -158,7 +158,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseInvoicesLast),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -184,7 +184,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/recurly/write_test.go
+++ b/providers/recurly/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCreateSubscription := testutils.DataFromFile(t, "create-subscription.json")
 	responseUpdateSubscription := testutils.DataFromFile(t, "update-subscription.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -45,7 +45,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusCreated, responseCreateSubscription),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "ierqn34o3hoife",
@@ -92,7 +92,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateSubscription),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sub_2x3y4z5a6b7c8901",
@@ -148,7 +148,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusCreated, testutils.DataFromFile(t, "create-account.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "acc_test_789xyz",
@@ -201,7 +201,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "create-account.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "acc_test_789xyz",
@@ -261,7 +261,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusCreated, testutils.DataFromFile(t, "create-coupons.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "coupon_bf2023_holiday",
@@ -294,7 +294,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/revenuecat/delete_test.go
+++ b/providers/revenuecat/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) { //nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -114,7 +114,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/revenuecat/metadata_test.go
+++ b/providers/revenuecat/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Unknown object requested",
 			Input:      []string{"nonexistent_object"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"nonexistent_object": common.ErrObjectNotSupported,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe apps object with metadata",
 			Input:      []string{"apps"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"apps": {
@@ -58,7 +58,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe customers object with metadata",
 			Input:      []string{"customers"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -88,7 +88,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"entitlements", "offerings"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"entitlements": {
@@ -120,7 +120,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/revenuecat/read_test.go
+++ b/providers/revenuecat/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestRead(t *testing.T) {
@@ -40,7 +40,7 @@ func TestRead(t *testing.T) {
 	  "url":"/v2/projects/proj_123/products"
 	}`)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -69,7 +69,7 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -97,7 +97,7 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -121,10 +121,10 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     2,
-				NextPage: testroutines.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_2",
+				NextPage: testconn.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_2",
 				Done:     false,
 			},
 		},
@@ -149,7 +149,7 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -189,10 +189,10 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
-				NextPage: testroutines.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_1",
+				NextPage: testconn.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_1",
 				Done:     false,
 			},
 		},
@@ -201,7 +201,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "products",
 				Fields:     datautils.NewStringSet("id"),
-				NextPage:   testroutines.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_1",
+				NextPage:   testconn.URLTestServer + "/v2/projects/proj_123/products?starting_after=prod_1",
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -217,7 +217,7 @@ func TestRead(t *testing.T) {
 				},
 				Default: mockserver.ResponseString(500, `{"error":"unexpected request"}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -229,7 +229,7 @@ func TestRead(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/revenuecat/write_test.go
+++ b/providers/revenuecat/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	respOffering := testutils.DataFromFile(t, "write/offering.json")
 	respProduct := testutils.DataFromFile(t, "write/product.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -53,7 +53,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, respApp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "app_xyz123",
@@ -75,7 +75,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, respApp),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "app_xyz123",
@@ -98,7 +98,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, respCustomer),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cust_abc456",
@@ -119,7 +119,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, respEntitlement),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "entl_abc123",
@@ -141,7 +141,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, respEntitlement),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "entl_abc123",
@@ -162,7 +162,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, respWebhook),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "whi_xyz789",
@@ -184,7 +184,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, respWebhook),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "whi_xyz789",
@@ -205,7 +205,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, respOffering),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "ofng_abc789",
@@ -227,7 +227,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, respOffering),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "ofng_abc789",
@@ -249,7 +249,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusCreated, respProduct),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "prod_xyz789",
@@ -261,7 +261,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestReadConnector(tt.Server.URL, "proj_123")
 			})
 		})

--- a/providers/ringcentral/handlers_test.go
+++ b/providers/ringcentral/handlers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	okResponse := testutils.DataFromFile(t, "meetings.json")
 	unsupportedObjects := testutils.DataFromFile(t, "404.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusNotFound, unsupportedObjects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrRetryable,
@@ -49,7 +49,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, okResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"meetings": {
@@ -150,7 +150,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -177,7 +177,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	statesResponse := testutils.DataFromFile(t, "read-comm-handling-states.json")
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -197,7 +197,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/restapi/v1.0/account/~/extension/~/address-book/contact"),
 				Then:  mockserver.Response(http.StatusOK, contactsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -231,7 +231,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/restapi/v1.0/account/~/extension/~/address-book/contact"),
 				Then:  mockserver.Response(http.StatusOK, statesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -323,7 +323,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/metadata_test.go
+++ b/providers/sageintacct/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	responseUserSchema := testutils.DataFromFile(t, "user-metadata.json")
 	responseUnsupportedObject := testutils.DataFromFile(t, "unsupported-object-metadata.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -31,7 +31,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUnsupportedObject),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{},
 				Errors: map[string]error{
@@ -46,7 +46,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseUserSchema),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"company-config/user": {
@@ -181,7 +181,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/read_test.go
+++ b/providers/sageintacct/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseBudget := testutils.DataFromFile(t, "read-budget.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -41,7 +41,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseBudget),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -80,7 +80,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sageintacct/write_test.go
+++ b/providers/sageintacct/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createPaymentResponse := testutils.DataFromFile(t, "create-payment.json")
 	updatePaymentSummaryResponse := testutils.DataFromFile(t, "update-payment-summary.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -88,7 +88,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/delete_test.go
+++ b/providers/salesfinity/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name: "Delete successfully",
 			Input: common.DeleteParams{
@@ -39,7 +39,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/metadata_test.go
+++ b/providers/salesfinity/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	analyticsSdrPerformanceResponse := testutils.DataFromFile(t, "analytics-sdr-performance.json")
 	contactListsCsvResponse := testutils.DataFromFile(t, "contact-lists-csv.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, callLogsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"call-log": {
@@ -128,7 +128,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, analyticsListPerformanceResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"analytics/list-performance": {
@@ -213,7 +213,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, analyticsSdrPerformanceResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"analytics/sdr-performance": {
@@ -298,7 +298,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, contactListsCsvResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contact-lists/csv": {
@@ -341,7 +341,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusInternalServerError),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"call-log": mockutils.ExpectedSubsetErrors{
@@ -362,7 +362,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, []byte("{}")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"call-log": mockutils.ExpectedSubsetErrors{
@@ -383,7 +383,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, []byte(`{"data": []}`)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"call-log": mockutils.ExpectedSubsetErrors{
@@ -399,7 +399,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/read_test.go
+++ b/providers/salesfinity/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) {
 	responseCallLogFirstPage := testutils.DataFromFile(t, "call-log.json")
 	responseCallLogLastPage := testutils.DataFromFile(t, "read-call-log-last-page.json")
 	responseContactListsCsv := testutils.DataFromFile(t, "contact-lists-csv.json")
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 
 		{
 			Name: "Read empty items",
@@ -60,7 +60,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLog),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLogFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -113,7 +113,7 @@ func TestRead(t *testing.T) {
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v1/call-log?limit=100&sort=-updatedAt&page=2",
+				NextPage: testconn.URLTestServer + "/v1/call-log?limit=100&sort=-updatedAt&page=2",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -123,7 +123,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "call-log",
 				Fields:     connectors.Fields("_id", "updatedAt", "from"),
-				NextPage:   testroutines.URLTestServer + "/v1/call-log?limit=100&sort=-updatedAt&page=2",
+				NextPage:   testconn.URLTestServer + "/v1/call-log?limit=100&sort=-updatedAt&page=2",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -133,7 +133,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLogLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLog),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -205,7 +205,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactListsCsv),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -254,7 +254,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLog),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -289,7 +289,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCallLogFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 0,
 				Data: []common.ReadResultRow{}, // records filtered out
@@ -316,7 +316,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactListsCsv),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -341,7 +341,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesfinity/write_test.go
+++ b/providers/salesfinity/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestWrite(t *testing.T) {
 
 	responseContactListsWrite := testutils.DataFromFile(t, "contact-lists-write-response.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name: "Create contact list successfully",
 			Input: common.WriteParams{
@@ -31,7 +31,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactListsWrite),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "6972b6679feab382af08f409",
@@ -67,7 +67,7 @@ func TestWrite(t *testing.T) {
 					"updatedAt": "2026-01-22T23:44:39.646Z"
 				}`)),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "minimal_list_id_123",
@@ -84,7 +84,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/delete_test.go
+++ b/providers/salesflare/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -45,7 +45,7 @@ func TestCalendarDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/metadata_test.go
+++ b/providers/salesflare/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,12 +16,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseOpportunities := testutils.DataFromFile(t, "read/opportunities.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for multiple objects",
 			Input:      []string{"me/contacts", "workflows"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"me/contacts": {
@@ -66,7 +66,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseOpportunities),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"tags": {
@@ -100,7 +100,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/read_test.go
+++ b/providers/salesflare/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts/1-first-page.json")
 	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts/2-empty-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "contacts", Fields: connectors.Fields("firstname")},
@@ -53,7 +53,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseContactsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -67,7 +67,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"domain": "salesflare.com",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/contacts?" +
+				NextPage: testconn.URLTestServer + "/contacts?" +
 					"limit=10000&" +
 					"offset=1&" +
 					"modification_after=2024-09-19T12:30:45.000Z&" +
@@ -99,7 +99,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesflare/write_test.go
+++ b/providers/salesflare/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorBadRequest := testutils.DataFromFile(t, "write/bad-request.json")
 	responseContact := testutils.DataFromFile(t, "write/contacts-new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -54,7 +54,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "285528841",
@@ -87,7 +87,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/batch-write_test.go
+++ b/providers/salesforce/batch-write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -34,7 +34,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.TestCaseBatchWrite{
+	tests := []testconn.TestCaseBatchWrite{
 		{
 			Name: "At least one object name must be queried",
 			Input: &common.BatchWriteParam{
@@ -66,7 +66,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errBadRequest),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: []any{"record was not processed due to other records failures: " +
@@ -97,7 +97,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errCreatePartial),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: nil,
@@ -141,7 +141,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status:       common.BatchStatusFailure,
 				Errors:       []any{common.ErrEmptyJSONHTTPResponse},
@@ -167,7 +167,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusSuccess,
 				Errors: []any{},
@@ -194,7 +194,7 @@ func TestBatchCreate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
+			tt.Run(t, func() (testconn.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -225,7 +225,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		},
 	}}
 
-	tests := []testroutines.TestCaseBatchWrite{
+	tests := []testconn.TestCaseBatchWrite{
 		{
 			Name: "General high level error not tied to any record",
 			Input: &common.BatchWriteParam{
@@ -241,7 +241,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusBadRequest, errNoIDs),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: nil,
@@ -285,7 +285,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, errUpdatePartial),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusFailure,
 				Errors: nil,
@@ -328,7 +328,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetBatchWrite,
+			Comparator: testconn.ComparatorSubsetBatchWrite,
 			Expected: &common.BatchWriteResult{
 				Status: common.BatchStatusSuccess,
 				Errors: []any{},
@@ -355,7 +355,7 @@ func TestBatchUpdate(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchWriter, error) {
+			tt.Run(t, func() (testconn.TestableBatchWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/bulk-delete_test.go
+++ b/providers/salesforce/bulk-delete_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -67,7 +67,7 @@ func TestBulkDelete(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 
 type bulkDeleteTestCase bulkWriteTestCase
 
-func (c bulkDeleteTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkDeleteTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.BulkDelete(t.Context(), c.Input)

--- a/providers/salesforce/bulk-info_test.go
+++ b/providers/salesforce/bulk-info_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -279,31 +279,31 @@ func testConciseJobInfoComparator(
 }
 
 type (
-	testCaseTypeJobInfo                 = testroutines.TestCase[string, *GetJobInfoResult]
+	testCaseTypeJobInfo                 = testconn.TestCase[string, *GetJobInfoResult]
 	bulkJobInfoTestCase                 testCaseTypeJobInfo
 	bulkJobInfoQueryTestCase            testCaseTypeJobInfo
-	testCaseTypeJobResults              = testroutines.TestCase[string, *JobResults]
+	testCaseTypeJobResults              = testconn.TestCase[string, *JobResults]
 	bulkJobResultTestCase               testCaseTypeJobResults
-	testCaseTypeHTTPResponse            = testroutines.TestCase[string, *http.Response]
+	testCaseTypeHTTPResponse            = testconn.TestCase[string, *http.Response]
 	bulkGetSuccessfulJobResultsTestCase testCaseTypeHTTPResponse
 	bulkGetBulkQueryResultsTestCase     testCaseTypeHTTPResponse
 )
 
-func (c bulkJobInfoTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkJobInfoTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.GetJobInfo(t.Context(), c.Input)
 	testCaseTypeJobInfo(c).Validate(t, err, output)
 }
 
-func (c bulkJobInfoQueryTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkJobInfoQueryTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.GetBulkQueryInfo(t.Context(), c.Input)
 	testCaseTypeJobInfo(c).Validate(t, err, output)
 }
 
-func (c bulkJobResultTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkJobResultTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.GetJobResults(t.Context(), c.Input)
@@ -311,7 +311,7 @@ func (c bulkJobResultTestCase) Run(t *testing.T, builder testroutines.ConnectorB
 }
 
 // nolint: lll
-func (c bulkGetSuccessfulJobResultsTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkGetSuccessfulJobResultsTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 
@@ -324,7 +324,7 @@ func (c bulkGetSuccessfulJobResultsTestCase) Run(t *testing.T, builder testrouti
 }
 
 // nolint: lll
-func (c bulkGetBulkQueryResultsTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkGetBulkQueryResultsTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 

--- a/providers/salesforce/bulk-query_test.go
+++ b/providers/salesforce/bulk-query_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -101,11 +101,11 @@ type (
 		query          string
 		includeDeleted bool
 	}
-	bulkQueryTestCaseType = testroutines.TestCase[bulkQueryInput, *GetJobInfoResult]
+	bulkQueryTestCaseType = testconn.TestCase[bulkQueryInput, *GetJobInfoResult]
 	bulkQueryTestCase     bulkQueryTestCaseType
 )
 
-func (c bulkQueryTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkQueryTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.BulkQuery(t.Context(), c.Input.query, c.Input.includeDeleted)

--- a/providers/salesforce/bulk-read_test.go
+++ b/providers/salesforce/bulk-read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -90,11 +90,11 @@ func TestBulkRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 }
 
 type (
-	bulkReadTestCaseType = testroutines.TestCase[common.ReadParams, *GetJobInfoResult]
+	bulkReadTestCaseType = testconn.TestCase[common.ReadParams, *GetJobInfoResult]
 	bulkReadTestCase     bulkReadTestCaseType
 )
 
-func (c bulkReadTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkReadTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.BulkRead(t.Context(), c.Input)

--- a/providers/salesforce/bulk-write_test.go
+++ b/providers/salesforce/bulk-write_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -207,11 +207,11 @@ func createBulkJobServer(
 }
 
 type (
-	bulkWriteTestCaseType = testroutines.TestCase[BulkOperationParams, *BulkOperationResult]
+	bulkWriteTestCaseType = testconn.TestCase[BulkOperationParams, *BulkOperationResult]
 	bulkWriteTestCase     bulkWriteTestCaseType
 )
 
-func (c bulkWriteTestCase) Run(t *testing.T, builder testroutines.ConnectorBuilder[*Connector]) {
+func (c bulkWriteTestCase) Run(t *testing.T, builder testconn.ConnectorBuilder[*Connector]) {
 	t.Helper()
 	conn := builder.Build(t, c.Name)
 	output, err := conn.BulkWrite(t.Context(), c.Input)

--- a/providers/salesforce/delete_test.go
+++ b/providers/salesforce/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseErrorFormat := testutils.DataFromFile(t, "crm/delete/not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -86,7 +86,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -102,7 +102,7 @@ func TestDeletePardot(t *testing.T) { // nolint:funlen,cyclop
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -174,7 +174,7 @@ func TestDeletePardot(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/metadata_test.go
+++ b/providers/salesforce/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseAccountsMeta := testutils.DataFromFile(t, "metadata/read/accounts-sampled.json")
 	responseCustomObjMeta := testutils.DataFromFile(t, "metadata/read/custom-object-with-custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -45,7 +45,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				}]}`),
 				Then: mockserver.Response(http.StatusOK, responseOrgMeta),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"organization": {
@@ -156,7 +156,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				}]}`),
 				Then: mockserver.Response(http.StatusOK, responseCustomObjMeta),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"testobject15__c": {
@@ -215,7 +215,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				}]}`),
 				Then: mockserver.Response(http.StatusOK, responseAccountsMeta),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"account": {
@@ -268,7 +268,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -284,7 +284,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -295,7 +295,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"EmAiLs"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"emails": {
@@ -359,7 +359,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 			) *testutils.CompareResult {
 				result := testutils.NewCompareResult()
 				// Usual subset comparison.
-				result.Merge(testroutines.ComparatorSubsetMetadata(serverURL, actual, expected))
+				result.Merge(testconn.ComparatorSubsetMetadata(serverURL, actual, expected))
 
 				// The "language" field must be excluded from the response.
 				if _, present := actual.Result["prospects"].Fields["language__c"]; present {
@@ -419,7 +419,7 @@ func TestListObjectMetadataPardot(t *testing.T) { // nolint:funlen,gocognit,cycl
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})
@@ -440,7 +440,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseUserInfo := testutils.DataFromFile(t, "metadata/write/user-info.json")
 	duplicatePermissionAssignment := testutils.DataFromFile(t, "metadata/write/err-duplicate-permission-assignment.json")
 
-	tests := []testroutines.TestCaseUpsertMetadata{
+	tests := []testconn.TestCaseUpsertMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -667,7 +667,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataUpdater, error) {
+			tt.RunWithContext(t, ctx, func() (testconn.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -677,7 +677,7 @@ func TestUpsertMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 func TestUpsertMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseUpsertMetadata{
+	tests := []testconn.TestCaseUpsertMetadata{
 		{
 			Name: "Access token must be injected into the context",
 			Input: &common.UpsertMetadataParams{
@@ -700,7 +700,7 @@ func TestUpsertMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocogni
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataUpdater, error) {
+			tt.Run(t, func() (testconn.TestableMetadataUpdater, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -714,7 +714,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseDeleteFields := testutils.DataFromFile(t, "metadata/delete/delete-fields-response.xml")
 	responseFieldNotFound := testutils.DataFromFile(t, "metadata/delete/delete-field-not-found.xml")
 
-	tests := []testroutines.TestCaseDeleteMetadata{
+	tests := []testconn.TestCaseDeleteMetadata{
 		{
 			Name:         "At least one field must be provided",
 			Input:        nil,
@@ -776,7 +776,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 			ctx := common.WithAuthToken(t.Context(), "TEST_ACCESS_TOKEN")
 
-			tt.RunWithContext(t, ctx, func() (testroutines.TestableMetadataDeleter, error) {
+			tt.RunWithContext(t, ctx, func() (testconn.TestableMetadataDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -786,7 +786,7 @@ func TestDeleteMetadataCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 func TestDeleteMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDeleteMetadata{
+	tests := []testconn.TestCaseDeleteMetadata{
 		{
 			Name: "Access token must be injected into the context",
 			Input: &common.DeleteMetadataParams{
@@ -804,7 +804,7 @@ func TestDeleteMetadataNoAccessTokenCRM(t *testing.T) { // nolint:funlen,gocogni
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataDeleter, error) {
+			tt.Run(t, func() (testconn.TestableMetadataDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/proxy_test.go
+++ b/providers/salesforce/proxy_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestProxy(t *testing.T) { // nolint:funlen,cyclop
 	t.Parallel()
 
-	tests := []testroutines.Proxy{
+	tests := []testconn.Proxy{
 		{
 			Name: "Salesforce CRM Proxy",
 			Builder: func() (connectors.ProxyConnector, error) {

--- a/providers/salesforce/read_test.go
+++ b/providers/salesforce/read_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseOpportunityWithAccount := testutils.DataFromFile(t, "read-opportunity-with-account.json")
 	responseOpportunityWithContacts := testutils.DataFromFile(t, "read-opportunity-with-contacts.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     8,
 				NextPage: "/services/data/v60.0/query/01g3A00007lZwLKQA0-2000",
@@ -121,7 +121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 20,
 				Data: []common.ReadResultRow{{
@@ -160,7 +160,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -230,7 +230,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -301,7 +301,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -321,7 +321,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -376,7 +376,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseEmailsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -439,7 +439,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Fields:     connectors.Fields("name"),
 				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
 					time.FixedZone("UTC-8", -8*60*60)),
-				NextPage: testroutines.URLTestServer + "/api/v5/objects/emails?fields=id,name,subject,clientType,prospectId,listEmailId,updatedAt&nextPageToken=eyJvcmRlckJ5IjoiIiwiZmlsdGVycyI6W10sImxpbWl0IjoxLCJyZXN1bWVWYWx1ZSI6eyJpZCI6MzQyNzc4NjN9LCJwYWdlIjoyLCJyZWNDb3VudCI6MiwiZXhwaXJlVGltZSI6IjIwMjUtMDUtMTZUMjA6Mzc6MTMtMDc6MDAiLCJkZWxldGVkIjpudWxsfQ==", // nolint:lll
+				NextPage: testconn.URLTestServer + "/api/v5/objects/emails?fields=id,name,subject,clientType,prospectId,listEmailId,updatedAt&nextPageToken=eyJvcmRlckJ5IjoiIiwiZmlsdGVycyI6W10sImxpbWl0IjoxLCJyZXN1bWVWYWx1ZSI6eyJpZCI6MzQyNzc4NjN9LCJwYWdlIjoyLCJyZWNDb3VudCI6MiwiZXhwaXJlVGltZSI6IjIwMjUtMDUtMTZUMjA6Mzc6MTMtMDc6MDAiLCJkZWxldGVkIjpudWxsfQ==", // nolint:lll
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -475,7 +475,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseProspects),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -530,7 +530,7 @@ func TestReadPardot(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/search_test.go
+++ b/providers/salesforce/search_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseOpportunityWithAccount := testutils.DataFromFile(t, "read-opportunity-with-account.json")
 	responseOpportunityWithContacts := testutils.DataFromFile(t, "read-opportunity-with-contacts.json")
 
-	tests := []testroutines.TestCaseSearch{
+	tests := []testconn.TestCaseSearch{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -80,7 +80,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseLeadsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     8,
 				NextPage: "/services/data/v60.0/query/01g3A00007lZwLKQA0-2000",
@@ -106,7 +106,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 20,
 				Data: []common.ReadResultRow{{
@@ -146,7 +146,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithAccount),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -217,7 +217,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseOpportunityWithContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -288,7 +288,7 @@ func TestSearch(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableSearcher, error) {
+			tt.Run(t, func() (testconn.TestableSearcher, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesforce/write_test.go
+++ b/providers/salesforce/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseCreateOK := testutils.DataFromFile(t, "create-ok.json")
 	responseOKWithErrors := testutils.DataFromFile(t, "success-with-errors.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -117,7 +117,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -133,7 +133,7 @@ func TestWritePardot(t *testing.T) { // nolint:funlen,cyclop
 		"Pardot-Business-Unit-Id": []string{"test-business-unit-id"},
 	}
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -202,7 +202,7 @@ func TestWritePardot(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnectorAccountEngagement(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/delete_test.go
+++ b/providers/salesloft/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	listSchema := testutils.DataFromFile(t, "write-signals-error.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete param object must be included",
 			Server:       mockserver.Dummy(),
@@ -62,7 +62,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/metadata_test.go
+++ b/providers/salesloft/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseCustomFieldsFirstPage := testutils.DataFromFile(t, "read/custom-fields/first-page.json")
 	responseCustomFieldsSecondPage := testutils.DataFromFile(t, "read/custom-fields/last-page.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -39,7 +39,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"activities/calls"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"activities/calls": {
@@ -63,7 +63,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"account_tiers", "actions"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"account_tiers": {
@@ -131,7 +131,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, responseCustomFieldsSecondPage),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"people": {
@@ -175,7 +175,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/read_test.go
+++ b/providers/salesloft/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -26,7 +26,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	accountsSince, err := time.Parse(time.RFC3339Nano, "2024-06-07T10:51:20.851224-04:00")
 	mockutils.NoErrors(t, err)
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/people"),
 				Then:  mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     25,
 				NextPage: "",
@@ -107,7 +107,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/people"),
 				Then:  mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 25,
 				// We are only interested to validate only first Read Row!
@@ -142,7 +142,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/people"),
 				Then:  mockserver.Response(http.StatusOK, responseListPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 25,
 				Data: []common.ReadResultRow{{
@@ -173,7 +173,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/users"),
 				Then:  mockserver.Response(http.StatusOK, responseListUsers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -204,7 +204,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListAccounts),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 4,
 				// Fewer than DefaultPageSize records means this is the last page — no next cursor needed.
@@ -229,7 +229,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseListAccountsSince),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				// Fewer than DefaultPageSize records means this is the last page — no next cursor needed.
@@ -245,7 +245,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/salesloft/records_test.go
+++ b/providers/salesloft/records_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -26,7 +26,7 @@ func TestGetRecordByIds(t *testing.T) {
 	responseGetAccounts := testutils.DataFromFile(t, "get-records-accounts.json")
 	responseGetUsers := testutils.DataFromFile(t, "read-list-users.json")
 
-	tests := []testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
+	tests := []testconn.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
 		{
 			Name:         "Missing object name returns error",
 			Server:       mockserver.Dummy(),

--- a/providers/salesloft/write_test.go
+++ b/providers/salesloft/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	createAccountRes := testutils.DataFromFile(t, "write-create-account.json")
 	createTaskRes := testutils.DataFromFile(t, "write-create-task.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -81,7 +81,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createAccountRes),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1",
@@ -107,7 +107,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createTaskRes),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "175204275",
@@ -129,7 +129,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				Then: mockserver.ResponseString(http.StatusOK, `{"data":{"id":22463,"view":"companies",
 					"name":"Hierarchy overview","view_params":{},"is_default":false,"shared":false}}`),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "22463",
@@ -149,7 +149,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/delete_test.go
+++ b/providers/sellsy/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFound := testutils.DataFromFile(t, "delete/err-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -58,7 +58,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/metadata_test.go
+++ b/providers/sellsy/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseCustomFields := testutils.DataFromFile(t, "read/custom-fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successful metadata for Tasks and Favourite Filters",
 			Input: []string{"tasks", "companies/favourite-filters"},
@@ -25,7 +25,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, nil),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"tasks": {
@@ -78,7 +78,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/v2/custom-fields"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"contacts": {
@@ -134,7 +134,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/read_test.go
+++ b/providers/sellsy/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseContactsEmptyPage := testutils.DataFromFile(t, "read/contacts/empty.json")
 	responseTasksLabelsFirstPage := testutils.DataFromFile(t, "read/tasks-labels/1-first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -78,7 +78,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, nil),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -102,7 +102,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"mobile_number": "+33612345678",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
+				NextPage: testconn.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -112,7 +112,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "contacts",
 				Fields:     connectors.Fields("last_name"),
-				NextPage:   testroutines.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
+				NextPage:   testconn.URLTestServer + "/v2/contacts/search?limit=100&offset=WyI0Il0=",
 				Since:      time.Date(2025, 8, 22, 8, 22, 56, 0, time.UTC),
 				Until:      time.Date(2025, 8, 25, 8, 32, 0, 0, time.UTC),
 			},
@@ -139,7 +139,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, nil),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, nil),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     0,
 				Data:     []common.ReadResultRow{},
@@ -206,7 +206,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseTasksLabelsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -221,7 +221,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"rank":      float64(0),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+				NextPage: testconn.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -231,7 +231,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "tasks/labels",
 				Fields:     connectors.Fields("name"),
-				NextPage:   testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+				NextPage:   testconn.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -245,11 +245,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				// Response doesn't matter for second page, reuse first page output.
 				Then: mockserver.Response(http.StatusOK, responseTasksLabelsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				Data:     []common.ReadResultRow{},
-				NextPage: testroutines.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
+				NextPage: testconn.URLTestServer + "/v2/tasks/labels?limit=100&offset=WyIwIiwiMyJd",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -261,7 +261,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/sellsy/write_test.go
+++ b/providers/sellsy/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseBadRequest := testutils.DataFromFile(t, "write/contacts/err-bad-request.json")
 	responseContacts := testutils.DataFromFile(t, "write/contacts/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "39",
@@ -71,7 +71,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseContacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "39",
@@ -91,7 +91,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/delete_test.go
+++ b/providers/shopify/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 	requestCustomerDelete := testutils.DataFromFile(t, "delete/request-customer-delete.json")
 	requestProductDelete := testutils.DataFromFile(t, "delete/request-product-delete.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object name must be included",
 			Server:       mockserver.Dummy(),
@@ -78,7 +78,7 @@ func TestDelete(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/metadata_test.go
+++ b/providers/shopify/metadata_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 func TestListObjectMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully fetch metadata for Product object",
 			Input: []string{"products"},
@@ -24,7 +24,7 @@ func TestListObjectMetadata(t *testing.T) {
 				If:    mockcond.Path("/admin/api/2025-10/graphql.json"),
 				Then:  mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "metadata/product.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"products": {
@@ -55,7 +55,7 @@ func TestListObjectMetadata(t *testing.T) {
 				If:    mockcond.Path("/admin/api/2025-10/graphql.json"),
 				Then:  mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "metadata/order.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"orders": {
@@ -91,7 +91,7 @@ func TestListObjectMetadata(t *testing.T) {
 				If:    mockcond.Path("/admin/api/2025-10/graphql.json"),
 				Then:  mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "metadata/customer.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"customers": {
@@ -131,7 +131,7 @@ func TestListObjectMetadata(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/read_test.go
+++ b/providers/shopify/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestRead(t *testing.T) {
 	requestCustomers := testutils.DataFromFile(t, "read/request/customers.json")
 	requestOrders := testutils.DataFromFile(t, "read/request/orders.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -59,7 +59,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseProducts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -104,7 +104,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseProductsWithNextPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -137,7 +137,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomers),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -171,7 +171,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseOrders),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -198,7 +198,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/shopify/write_test.go
+++ b/providers/shopify/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	requestProductCreate := testutils.DataFromFile(t, "write/request-product-create.json")
 	requestProductUpdate := testutils.DataFromFile(t, "write/request-product-update.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomerCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "gid://shopify/Customer/1073340122",
@@ -100,7 +100,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomerUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "gid://shopify/Customer/1018520244",
@@ -129,7 +129,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseProductCreate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "gid://shopify/Product/1072482054",
@@ -158,7 +158,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				},
 				Then: mockserver.Response(http.StatusOK, responseProductUpdate),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "gid://shopify/Product/1072482054",
@@ -174,7 +174,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/slack/internal/webhook/message_test.go
+++ b/providers/slack/internal/webhook/message_test.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"testing"
 
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -12,12 +12,12 @@ func TestEvent(t *testing.T) {
 	responseConversationDeleted := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "channel-deleted.json")
 	responseConversationArchived := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "channel-archived.json")
 
-	for _, tt := range []testroutines.TestCaseSubscriptionEvent{
+	for _, tt := range []testconn.TestCaseSubscriptionEvent{
 		{
 			Name:  "Created event",
 			Input: responseConversationCreated,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "create",
 					RawEventName:       "channel_created",
 					ObjectName:         "conversations",
@@ -30,8 +30,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Deleted event",
 			Input: responseConversationDeleted,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "delete",
 					RawEventName:       "channel_deleted",
 					ObjectName:         "conversations",
@@ -44,8 +44,8 @@ func TestEvent(t *testing.T) {
 		{
 			Name:  "Archived event",
 			Input: responseConversationArchived,
-			Expected: []testroutines.SubscriptionEventExpected{{
-				Data: testroutines.SubscriptionEventExpectedData{
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
 					EventType:          "other",
 					RawEventName:       "channel_archive",
 					ObjectName:         "conversations",

--- a/providers/slack/internal/webhook/verifier_test.go
+++ b/providers/slack/internal/webhook/verifier_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -33,10 +33,10 @@ func TestVerifyWebhookMessage(t *testing.T) {
 	validSlackSignature := computeSlackSignature(testSigningKey, validTimestamp, string(eventMessage))
 	invalidSlackSignature := "mismatching-signature-from-provider"
 
-	tests := []testroutines.TestCaseVerifyWebhookMessage{
+	tests := []testconn.TestCaseVerifyWebhookMessage{
 		{
 			Name: "Missing signature header in input",
-			Input: testroutines.WebhookMessageVerificationParams{
+			Input: testconn.WebhookMessageVerificationParams{
 				Request: &common.WebhookRequest{
 					Headers: http.Header{
 						"X-Slack-Request-Timestamp": []string{validTimestamp},
@@ -53,7 +53,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 		},
 		{
 			Name: "Missing timestamp header in input",
-			Input: testroutines.WebhookMessageVerificationParams{
+			Input: testconn.WebhookMessageVerificationParams{
 				Request: &common.WebhookRequest{
 					Headers: http.Header{
 						"X-Slack-Signature": []string{validSlackSignature},
@@ -70,7 +70,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 		},
 		{
 			Name: "Invalid signature",
-			Input: testroutines.WebhookMessageVerificationParams{
+			Input: testconn.WebhookMessageVerificationParams{
 				Request: &common.WebhookRequest{
 					Headers: http.Header{
 						"X-Slack-Signature":         []string{invalidSlackSignature},
@@ -84,7 +84,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 		},
 		{
 			Name: "Invalid timestamp",
-			Input: testroutines.WebhookMessageVerificationParams{
+			Input: testconn.WebhookMessageVerificationParams{
 				Request: &common.WebhookRequest{
 					Headers: http.Header{
 						"X-Slack-Signature":         []string{validSlackSignature},
@@ -101,7 +101,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 		},
 		{
 			Name: "Valid signature",
-			Input: testroutines.WebhookMessageVerificationParams{
+			Input: testconn.WebhookMessageVerificationParams{
 				Request: &common.WebhookRequest{
 					Headers: http.Header{
 						"X-Slack-Signature":         []string{validSlackSignature},
@@ -119,7 +119,7 @@ func TestVerifyWebhookMessage(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWebhookMessageVerifier, error) {
+			tt.Run(t, func() (testconn.TestableWebhookMessageVerifier, error) {
 				return constructTestVerifier(tt.Server)
 			})
 		})

--- a/providers/slack/metadata_test.go
+++ b/providers/slack/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 	conversationsResponse := testutils.DataFromFile(t, "conversations-list.json")
 	usersResponse := testutils.DataFromFile(t, "users-list.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -36,7 +36,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 				},
 				Then: mockserver.Response(http.StatusOK, conversationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"conversations": {
@@ -68,7 +68,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 				},
 				Then: mockserver.Response(http.StatusOK, usersResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"users": {
@@ -106,7 +106,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 					},
 				},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"conversations": {
@@ -134,7 +134,7 @@ func TestListObjectMetadata(t *testing.T) { //nolint:funlen,gocognit,cyclop,main
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/read-by-ids_test.go
+++ b/providers/slack/read-by-ids_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 	responseConversation1 := testutils.DataFromFile(t, "read/conversation-1.json")
 	responseConversation2 := testutils.DataFromFile(t, "read/conversation-2.json")
 
-	tests := []testroutines.TestCaseGetRecordsByIds{
+	tests := []testconn.TestCaseGetRecordsByIds{
 		{
 			Name:         "Empty record identifiers",
 			Server:       mockserver.Dummy(),
@@ -26,7 +26,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		},
 		{
 			Name: "Read conversations by identifiers",
-			Input: testroutines.ReadByIdsParams{
+			Input: testconn.ReadByIdsParams{
 				ObjectName: "conversations",
 				RecordIds:  []string{"C0BA24516MS", "C0B9V3RLZ4M"},
 				Fields:     []string{"name"},
@@ -49,7 +49,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 					Then: mockserver.Response(http.StatusOK, responseConversation2),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSortedSubsetReadByIds,
+			Comparator: testconn.ComparatorSortedSubsetReadByIds,
 			Expected: []common.ReadResultRow{{
 				Id:     "C0B9V3RLZ4M",
 				Fields: map[string]any{"name": "holidays"},
@@ -68,7 +68,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableBatchReader, error) {
+			tt.Run(t, func() (testconn.TestableBatchReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/read_test.go
+++ b/providers/slack/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	listConnectInvitesResponse := testutils.DataFromFile(t, "conversations-list-connect-invites.json")
 	requestSharedInviteResponse := testutils.DataFromFile(t, "conversations-request-shared-invite.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -42,7 +42,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, conversationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -73,7 +73,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, usersResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -103,7 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, conversationsFirstPageResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "dGVhbS1jaGFubmVsOkM=",
@@ -148,7 +148,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, listConnectInvitesResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -178,7 +178,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, requestSharedInviteResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -214,7 +214,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, conversationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -274,7 +274,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, usersResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -332,7 +332,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, conversationsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -346,7 +346,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/slack/write_test.go
+++ b/providers/slack/write_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	t.Parallel()
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -293,7 +293,7 @@ func TestWrite(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server)
 			})
 		})

--- a/providers/smartlead/delete_test.go
+++ b/providers/smartlead/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	responseNotFoundErr := testutils.DataFromFile(t, "delete-not-found-resource.json")
 	responseCampaign := testutils.DataFromFile(t, "delete-campaign.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -67,7 +67,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/metadata_test.go
+++ b/providers/smartlead/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"campaigns", "email-accounts"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"campaigns": {
@@ -69,7 +69,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/read_test.go
+++ b/providers/smartlead/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responseCampaignsEmpty := testutils.DataFromFile(t, "read-campaign-empty.json")
 	responseInvalidPath := testutils.DataFromFile(t, "read-invalid-path.html")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -79,7 +79,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v1/campaigns"),
 				Then:  mockserver.Response(http.StatusOK, responseCampaigns),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -113,7 +113,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/smartlead/write_test.go
+++ b/providers/smartlead/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	responseClient := testutils.DataFromFile(t, "write-client-new.json")
 	responseAccount := testutils.DataFromFile(t, "write-account-new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -120,7 +120,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/delete_test.go
+++ b/providers/snapchatads/delete_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 	errorNotFound := testutils.DataFromFile(t, "delete-missing-members.json")
 	membersResponse := testutils.DataFromFile(t, "delete_members.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConn(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/metadata_test.go
+++ b/providers/snapchatads/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	membersResponse := testutils.DataFromFile(t, "members.json")
 	rolesResponse := testutils.DataFromFile(t, "roles.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:  "Successfully describe multiple objects with metadata",
 			Input: []string{"members", "roles"},
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 					Then: mockserver.Response(http.StatusOK, organizationIdResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"members": {
@@ -109,7 +109,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/read_test.go
+++ b/providers/snapchatads/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	membersResponse := testutils.DataFromFile(t, "members.json")
 	rolesResponse := testutils.DataFromFile(t, "roles.json")
 	billingcentersResponse := testutils.DataFromFile(t, "billingcenters.json")
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:  "Read list of members",
 			Input: common.ReadParams{ObjectName: "members", Fields: connectors.Fields("")},
@@ -103,7 +103,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, organizationIdResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -132,7 +132,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/snapchatads/write_test.go
+++ b/providers/snapchatads/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 	billingcentersResponse := testutils.DataFromFile(t, "write_billingcenters.json")
 	rolesResponse := testutils.DataFromFile(t, "write_roles.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:  "Create a billingcenters as POST",
 			Input: common.WriteParams{ObjectName: "billingcenters", RecordData: "dummy"},
@@ -197,7 +197,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/delete_test.go
+++ b/providers/stripe/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	errorNotFound := testutils.DataFromFile(t, "delete/err-not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -66,7 +66,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/metadata_test.go
+++ b/providers/stripe/metadata_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -22,7 +22,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"butterflies"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"butterflies": common.ErrObjectNotSupported,
@@ -33,7 +33,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"coupons", "products"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"coupons": {
@@ -65,7 +65,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Checkout Sessions",
 			Input:      []string{"checkout/sessions"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"checkout/sessions": {
@@ -94,7 +94,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/read_test.go
+++ b/providers/stripe/read_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -27,7 +27,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseCheckoutSessionsWithItems := testutils.DataFromFile(t, "read/checkout-sessions/with-line-items.json")
 	responseInvoices := testutils.DataFromFile(t, "read/invoices/incremental.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -83,7 +83,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/accounts"),
 				Then:  mockserver.Response(http.StatusOK, responseAccountsLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -109,7 +109,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v1/customers"),
 				Then:  mockserver.Response(http.StatusOK, responseCustomersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -131,7 +131,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 					Id: "cus_Rd3NjdGWtynChD",
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD",
+				NextPage: testconn.URLTestServer + "/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -143,7 +143,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Fields:     connectors.Fields("name"),
 				NextPage:   "/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD",
 			},
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If:    mockcond.Path("/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD"),
@@ -186,7 +186,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCheckoutSessionsWithItems),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -231,7 +231,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseInvoices),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -247,7 +247,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					},
 					Id: "in_1RnN00ES6gLOjP91auKbmxwS",
 				}},
-				NextPage: testroutines.URLTestServer + "/v1/invoices?" +
+				NextPage: testconn.URLTestServer + "/v1/invoices?" +
 					"created[gte]=1753116395&limit=100&starting_after=in_1RnN00ES6gLOjP91auKbmxwS",
 				Done: false,
 			},
@@ -267,7 +267,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersWithMetadata),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -334,7 +334,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Then: mockserver.Response(http.StatusOK, responseCustomersLastPage),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetReadSorted,
+			Comparator: testconn.ComparatorSubsetReadSorted,
 			Expected: &common.ReadResult{
 				Rows: 3,
 				Data: []common.ReadResultRow{{
@@ -362,7 +362,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				// We are not done reading
 				NextPage: `[{
 					"context": "acct_1Nv0FGQ9RKHgCVdK",
-					"value": "` + testroutines.URLTestServer + `/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD"
+					"value": "` + testconn.URLTestServer + `/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD"
 				}]`,
 				Done: false,
 			},
@@ -376,7 +376,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Opts:       ReadParamsOpts{ReadForAllConnectedAccounts: true},
 				NextPage: `[{
 					"context": "acct_1Nv0FGQ9RKHgCVdK",
-					"value": "` + testroutines.URLTestServer + `/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD"
+					"value": "` + testconn.URLTestServer + `/v1/customers?limit=100&starting_after=cus_Rd3NjdGWtynChD"
 				}]`,
 			},
 			Server: mockserver.Conditional{
@@ -391,7 +391,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCustomersLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -414,7 +414,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/stripe/write_test.go
+++ b/providers/stripe/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 	errorSetupPaymentIntent := testutils.DataFromFile(t, "general-errors/error-setup-payment-intent.json")
 	responseCreateCustomer := testutils.DataFromFile(t, "write/customers/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -91,7 +91,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateCustomer),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "cus_RfIicOKc1UqLHJ",
@@ -111,7 +111,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/delete_test.go
+++ b/providers/supersend/delete_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -101,7 +101,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/metadata_test.go
+++ b/providers/supersend/metadata_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -23,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object requested",
 			Input:      []string{"unknown"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"unknown": common.ErrObjectNotSupported,
@@ -38,7 +38,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				"placement-tests", "identities", "conversation/latest-by-profile",
 			},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"teams": {
@@ -321,7 +321,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/read_test.go
+++ b/providers/supersend/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	responseSendersLastPage := testutils.DataFromFile(t, "read/senders-last-page.json")
 	responseConversations := testutils.DataFromFile(t, "read/conversations.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Input:        common.ReadParams{},
@@ -47,7 +47,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseTeams),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -95,7 +95,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSendersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -124,7 +124,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v1/senders?limit=100&offset=100",
+				NextPage: testconn.URLTestServer + "/v1/senders?limit=100&offset=100",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -134,7 +134,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Input: common.ReadParams{
 				ObjectName: "senders",
 				Fields:     connectors.Fields("id", "email"),
-				NextPage:   testroutines.URLTestServer + "/v1/senders?limit=100&offset=200",
+				NextPage:   testconn.URLTestServer + "/v1/senders?limit=100&offset=200",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -145,7 +145,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSendersLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -179,7 +179,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseConversations),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -228,7 +228,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseSendersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{
@@ -251,7 +251,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						},
 					},
 				},
-				NextPage: testroutines.URLTestServer + "/v1/senders?limit=50&offset=50",
+				NextPage: testconn.URLTestServer + "/v1/senders?limit=50&offset=50",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -262,7 +262,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/supersend/write_test.go
+++ b/providers/supersend/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -26,7 +26,7 @@ func TestWrite(t *testing.T) {
 	createSenderProfileResponse := testutils.DataFromFile(t, "write/create-sender-profile.json")
 	updateSenderProfileResponse := testutils.DataFromFile(t, "write/update-sender-profile.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -72,7 +72,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createTeamResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "team-123",
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createLabelResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "label-456",
@@ -131,7 +131,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, updateLabelResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "label-456",
@@ -161,7 +161,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createSenderResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sender-789",
@@ -190,7 +190,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, updateSenderResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sender-789",
@@ -219,7 +219,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createCampaignResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "campaign-001",
@@ -247,7 +247,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, updateCampaignResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "campaign-001",
@@ -277,7 +277,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createContactResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "contact-001",
@@ -306,7 +306,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, updateContactResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "contact-001",
@@ -335,7 +335,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, createSenderProfileResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sp-001",
@@ -363,7 +363,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, updateSenderProfileResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "sp-001",
@@ -380,7 +380,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/talkdesk/handlers_test.go
+++ b/providers/talkdesk/handlers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -33,7 +33,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	contacts := testutils.DataFromFile(t, "contacts.json")
 	activities := testutils.DataFromFile(t, "activities.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -53,7 +53,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/contacts"),
 				Then:  mockserver.Response(http.StatusOK, contacts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -95,7 +95,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/identity/activities"),
 				Then:  mockserver.Response(http.StatusOK, activities),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -152,7 +152,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamleader/read_test.go
+++ b/providers/teamleader/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 
 	responseContactFirst := testutils.DataFromFile(t, "contacts-first-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/contacts.list"),
 				Then:  mockserver.Response(http.StatusOK, responseContactFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -72,7 +72,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamleader/write_test.go
+++ b/providers/teamleader/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createContactsResponse := testutils.DataFromFile(t, "create-contacts.json")
 	createCompaniesResponse := testutils.DataFromFile(t, "create-companies.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -80,7 +80,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/delete_test.go
+++ b/providers/teamwork/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseNotFoundError := testutils.DataFromFile(t, "delete/not-found.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -75,7 +75,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/metadata_test.go
+++ b/providers/teamwork/metadata_test.go
@@ -6,18 +6,18 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:       "Successful metadata for projects and tasks",
 			Input:      []string{"projects", "tasks"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"projects": {
@@ -67,7 +67,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/read_test.go
+++ b/providers/teamwork/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseNotebooksFirstPage := testutils.DataFromFile(t, "read/notebooks/1-first-page.json")
 	responseNotebooksSecondPage := testutils.DataFromFile(t, "read/notebooks/2-second-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:  "Error response is parsed",
 			Input: common.ReadParams{ObjectName: "companies", Fields: connectors.Fields("name")},
@@ -51,7 +51,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompaniesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -71,7 +71,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"id": float64(1412778),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/projects/api/v3/companies.json?" +
+				NextPage: testconn.URLTestServer + "/projects/api/v3/companies.json?" +
 					"page=2&pageSize=500&" +
 					"updatedAfter=2024-09-19T12:30:45Z",
 				Done: false,
@@ -112,14 +112,14 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseNotebooksFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
 					Fields: map[string]any{"name": "Second notebook"},
 					Raw:    map[string]any{"id": float64(305625)},
 				}},
-				NextPage: testroutines.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
+				NextPage: testconn.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -129,7 +129,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "notebooks",
 				Fields:     connectors.Fields("name"),
-				NextPage:   testroutines.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
+				NextPage:   testconn.URLTestServer + "/projects/api/v3/notebooks.json?page=2&pageSize=1",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -140,7 +140,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseNotebooksSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -159,7 +159,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/teamwork/write_test.go
+++ b/providers/teamwork/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	responseConflictError := testutils.DataFromFile(t, "write/conflict.json")
 	responseCompanies := testutils.DataFromFile(t, "write/companies/new.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -52,7 +52,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompanies),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1412996",
@@ -82,7 +82,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, responseCompanies),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1412996",
@@ -100,7 +100,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/delete_test.go
+++ b/providers/webex/delete_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 // nolint:funlen,gocognit,cyclop
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/metadata_test.go
+++ b/providers/webex/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	rolesResponse := testutils.DataFromFile(t, "read-roles.json")
 	groupsResponse := testutils.DataFromFile(t, "read-groups.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -37,7 +37,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, peopleResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"people": {
@@ -146,7 +146,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusOK, groupsResponse),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"groups": {
@@ -201,7 +201,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				},
 				Then: mockserver.Response(http.StatusInternalServerError),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"people": mockutils.ExpectedSubsetErrors{
@@ -217,7 +217,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/read_test.go
+++ b/providers/webex/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) {
 	responseReadPeopleFirstPage := testutils.DataFromFile(t, "read-people-first-page.json")
 	responseReadPeopleSecondPage := testutils.DataFromFile(t, "read-people-second-page.json")
 	responseReadGroupsFiltered := testutils.DataFromFile(t, "read-groups-filtered.json")
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "people",
 				Fields:     connectors.Fields("id", "displayName"),
-				NextPage:   testroutines.URLTestServer + "/v1/invalidpath",
+				NextPage:   testconn.URLTestServer + "/v1/invalidpath",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -89,7 +89,7 @@ func TestRead(t *testing.T) {
 				If:    mockcond.Path("/v1/people"),
 				Then:  mockserver.Response(http.StatusOK, responseReadPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) {
 					mockserver.Response(http.StatusOK, responseReadPeopleFirstPage),
 				),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) {
 			Input: common.ReadParams{
 				ObjectName: "people",
 				Fields:     connectors.Fields("id", "displayName", "emails"),
-				NextPage:   testroutines.URLTestServer + "/v1/people?max=1&cursor=next_cursor_token",
+				NextPage:   testconn.URLTestServer + "/v1/people?max=1&cursor=next_cursor_token",
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -167,7 +167,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseReadPeopleSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -209,7 +209,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseReadPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -243,7 +243,7 @@ func TestRead(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read-groups.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -277,7 +277,7 @@ func TestRead(t *testing.T) {
 				If:    mockcond.Path("/v1/groups"),
 				Then:  mockserver.Response(http.StatusOK, responseReadGroupsFiltered),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -311,7 +311,7 @@ func TestRead(t *testing.T) {
 				If:    mockcond.Path("/v1/groups"),
 				Then:  mockserver.Response(http.StatusOK, testutils.DataFromFile(t, "read-groups.json")),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 0,
 				Data: []common.ReadResultRow{},
@@ -331,7 +331,7 @@ func TestRead(t *testing.T) {
 				If:    mockcond.Path("/v1/people"),
 				Then:  mockserver.Response(http.StatusOK, responseReadPeople),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{
@@ -356,7 +356,7 @@ func TestRead(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/webex/write_test.go
+++ b/providers/webex/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) {
 
 	responseCreateUpdatePerson := testutils.DataFromFile(t, "create-update-person.json")
 	responseUpdateGroup := testutils.DataFromFile(t, "write-group.json")
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -46,7 +46,7 @@ func TestWrite(t *testing.T) {
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateUpdatePerson),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9",
@@ -82,7 +82,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreateUpdatePerson),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9",
@@ -115,7 +115,7 @@ func TestWrite(t *testing.T) {
 				},
 				Then: mockserver.Response(http.StatusOK, responseUpdateGroup),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "Y2lzY29zcyZj",
@@ -133,7 +133,7 @@ func TestWrite(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/metadata_test.go
+++ b/providers/xero/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 	accountResponse := testutils.DataFromFile(t, "accounts.json")
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -39,7 +39,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 				}},
 			}.Server(),
 
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"accounts": {
@@ -221,7 +221,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop,mai
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/read_test.go
+++ b/providers/xero/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 	responsePaymentOrdersFirst := testutils.DataFromFile(t, "purchase-orders-first.json")
 	responsePaymentOrdersSecond := testutils.DataFromFile(t, "purchase-orders-second.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -39,7 +39,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api.xro/2.0/PurchaseOrders"),
 				Then:  mockserver.Response(http.StatusOK, responsePaymentOrdersFirst),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -83,7 +83,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api.xro/2.0/PurchaseOrders"),
 				Then:  mockserver.Response(http.StatusOK, responsePaymentOrdersSecond),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -98,7 +98,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/xero/write_test.go
+++ b/providers/xero/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	createContactGroupResponse := testutils.DataFromFile(t, "create-contactGroups.json")
 	updateContactGroupResponse := testutils.DataFromFile(t, "update-contactGroups.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/delete_test.go
+++ b/providers/zendesksupport/delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -16,7 +16,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 
 	responseServerError := testutils.DataFromFile(t, "server-error.json")
 
-	tests := []testroutines.TestCaseDelete{
+	tests := []testconn.TestCaseDelete{
 		{
 			Name:         "Delete object must be included",
 			Server:       mockserver.Dummy(),
@@ -61,7 +61,7 @@ func TestDelete(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableDeleter, error) {
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/metadata_test.go
+++ b/providers/zendesksupport/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -17,7 +17,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 
 	responseTicketsCustomFields := testutils.DataFromFile(t, "read/custom_fields/ticket_fields.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -28,7 +28,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Unknown object",
 			Input:      []string{"articles"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"articles": common.ErrObjectNotSupported,
@@ -39,7 +39,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"brands"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"brands": {
@@ -72,7 +72,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"bookmarks", "ticket_audits"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"bookmarks": {
@@ -109,7 +109,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If:    mockcond.Path("/api/v2/ticket_fields"),
 				Then:  mockserver.Response(http.StatusOK, responseTicketsCustomFields),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"tickets": {
@@ -168,7 +168,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			Name:       "Successfully describe one object with metadata",
 			Input:      []string{"articles/labels"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"articles/labels": {
@@ -193,7 +193,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/read_test.go
+++ b/providers/zendesksupport/read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -24,7 +24,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseTriggersLastPage := testutils.DataFromFile(t, "read/triggers-2-last-page.json")
 	responseReadPosts := testutils.DataFromFile(t, "read/help-center-posts.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -87,7 +87,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				Setup:  mockserver.ContentJSON(),
 				Always: mockserver.Response(http.StatusOK, responseTriggersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "https://d3v-ampersand.zendesk.com/api/v2/triggers?page%5Bafter%5D=eyJvIjoicG9zaXRpb24scG9zaXRpb24sdGl0bGUsaWQiLCJ2IjoiYVFFQUFBQUFBQUFBYVFFQUFBQUFBQUFBY3gwQUFBQk9iM1JwWm5rZ1lYTnphV2R1WldVZ2IyWWdZWE56YVdkdWJXVnVkR21UOTlOQStoY0FBQT09In0%3D&page%5Bsize%5D=1", // nolint:lll
@@ -103,7 +103,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/api/v2/triggers"),
 				Then:  mockserver.Response(http.StatusOK, responseTriggersLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -129,7 +129,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseReadPosts),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -157,7 +157,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -173,7 +173,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 	responseUsersLastPage := testutils.DataFromFile(t, "read/incremental/users-2-last-page.json")
 	responseOrganizations := testutils.DataFromFile(t, "read/incremental/organizations.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name: "Incremental Tickets no since with custom fields",
 			Input: common.ReadParams{
@@ -194,7 +194,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 					Then: mockserver.Response(http.StatusOK, responseTicketsCustomFields),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -243,7 +243,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 					Then: mockserver.Response(http.StatusOK, responseTicketsCustomFields),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected:   &common.ReadResult{Rows: 1, NextPage: "", Done: true},
 		},
 		{
@@ -261,7 +261,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -288,7 +288,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersLastPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -315,7 +315,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 				},
 				Then: mockserver.Response(http.StatusOK, responseOrganizations),
 			}.Server(),
-			Comparator: testroutines.ComparatorPagination,
+			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows:     1,
 				NextPage: "",
@@ -330,7 +330,7 @@ func TestIncrementalRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zendesksupport/write_test.go
+++ b/providers/zendesksupport/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 	responseRecordValidationError := testutils.DataFromFile(t, "record-validation.json")
 	createBrand := testutils.DataFromFile(t, "create-brand.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -123,7 +123,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 				},
 				Then: mockserver.Response(http.StatusOK, createBrand),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "31207417638931",
@@ -163,7 +163,7 @@ func TestWriteZendeskSupportModule(t *testing.T) { // nolint:funlen,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})
@@ -175,7 +175,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 
 	responseCreatePost := testutils.DataFromFile(t, "write-post.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:  "Creating a help center post invokes correct endpoint",
 			Input: common.WriteParams{ObjectName: "posts", RecordData: "dummy"},
@@ -187,7 +187,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 				},
 				Then: mockserver.Response(http.StatusOK, responseCreatePost),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "33507191590803",
@@ -207,7 +207,7 @@ func TestWriteHelpCenterModule(t *testing.T) { //nolint:funlen,gocognit,cyclop,m
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/internal/mail/metadata_test.go
+++ b/providers/zoho/internal/mail/metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	accountsResponse := testutils.DataFromFile(t, "accounts.json")
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -30,7 +30,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Unsupported object collects per-object error",
 			Input:      []string{"folders"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"folders": common.ErrObjectNotSupported,
@@ -48,7 +48,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 					Then: mockserver.Response(http.StatusOK, accountsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"accounts": {
@@ -79,7 +79,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 					Then: mockserver.Response(http.StatusOK, notesResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"notes": {
@@ -102,7 +102,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tc := testroutines.TestCase[[]string, *common.ListObjectMetadataResult](tt)
+			tc := testconn.TestCase[[]string, *common.ListObjectMetadataResult](tt)
 			t.Cleanup(tc.Close)
 
 			adapter := constructTestAdapter(t, tt.Server.URL, "")

--- a/providers/zoho/internal/mail/read_test.go
+++ b/providers/zoho/internal/mail/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 	notesResponse := testutils.DataFromFile(t, "notes.json")
 	messagesResponse := testutils.DataFromFile(t, "messages.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object name and fields are required",
 			Input:        common.ReadParams{ObjectName: "notes"},
@@ -46,7 +46,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 					Then: mockserver.Response(http.StatusOK, accountsResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -79,7 +79,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 					Then: mockserver.Response(http.StatusOK, notesResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -116,7 +116,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 					}`),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 2,
 				Data: []common.ReadResultRow{{
@@ -124,7 +124,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 					Fields: map[string]any{"id": "t1"},
 					Raw:    map[string]any{"id": "t1"},
 				}},
-				NextPage: testroutines.URLTestServer + "/api/tasks/me?from=2&limit=2",
+				NextPage: testconn.URLTestServer + "/api/tasks/me?from=2&limit=2",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -147,7 +147,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 					Then: mockserver.Response(http.StatusOK, messagesResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -161,7 +161,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 						"fromAddress": "alice@zylker.com",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/api/accounts/" + testAccountID + "/messages/view?start=2&limit=1",
+				NextPage: testconn.URLTestServer + "/api/accounts/" + testAccountID + "/messages/view?start=2&limit=1",
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -173,7 +173,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tc := testroutines.TestCase[common.ReadParams, *common.ReadResult](tt)
+			tc := testconn.TestCase[common.ReadParams, *common.ReadResult](tt)
 			t.Cleanup(tc.Close)
 
 			adapter := constructTestAdapter(t, tt.Server.URL, testAccountID)

--- a/providers/zoho/internal/mail/write_test.go
+++ b/providers/zoho/internal/mail/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 	taskCreateResponse := testutils.DataFromFile(t, "write_task_create.json")
 	folderCreateResponse := testutils.DataFromFile(t, "write_folder_create.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object name is required",
 			Input:        common.WriteParams{},
@@ -53,7 +53,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 					Then: mockserver.Response(http.StatusCreated, noteCreateResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "1711974988431110001",
@@ -78,7 +78,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 					Then: mockserver.Response(http.StatusOK, taskCreateResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "48184000000093001",
@@ -103,7 +103,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 					Then: mockserver.Response(http.StatusCreated, folderCreateResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "2560636000000076007",
@@ -130,7 +130,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 						`{"status": {"code": 200, "description": "success"}}`),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			// The rename endpoint returns status only (no data object), so we report
 			// success without a record id.
 			Expected:     &common.WriteResult{Success: true},
@@ -143,7 +143,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,maintidx
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tc := testroutines.TestCase[common.WriteParams, *common.WriteResult](tt)
+			tc := testconn.TestCase[common.WriteParams, *common.WriteResult](tt)
 			t.Cleanup(tc.Close)
 
 			adapter := constructTestAdapter(t, tt.Server.URL, testAccountID)

--- a/providers/zoho/metadata_test.go
+++ b/providers/zoho/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	dealResponse := testutils.DataFromFile(t, "deals.json")
 	unsupported := testutils.DataFromFile(t, "arsenal.json")
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be provided",
 			Input:        nil,
@@ -35,7 +35,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusBadRequest, unsupported),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"arsenal": mockutils.ExpectedSubsetErrors{
@@ -56,7 +56,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					Then: mockserver.Response(http.StatusOK, dealResponse),
 				}},
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"Deals": {
@@ -119,7 +119,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/read_test.go
+++ b/providers/zoho/read_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	callsResponse := testutils.DataFromFile(t, "calls.json")
 	unsupportedResponse := testutils.DataFromFile(t, "unsupportedread.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoho/records_test.go
+++ b/providers/zoho/records_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestGetRecordsByIds(t *testing.T) {
 
 	contactsResponse := testutils.DataFromFile(t, "contacts.json")
 
-	tests := []testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
+	tests := []testconn.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]{
 		{
 			Name: "Empty record IDs returns error",
 			Input: GetRecordsByIdsInput{

--- a/providers/zoho/write_test.go
+++ b/providers/zoho/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -18,7 +18,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 	leadsWriteResponse := testutils.DataFromFile(t, "leads-write.json")
 	updateContactsResponse := testutils.DataFromFile(t, "updatecontact.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Object Name is required",
 			Server:       mockserver.Dummy(),
@@ -123,7 +123,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/metadata_test.go
+++ b/providers/zoom/metadata_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
-	tests := []testroutines.TestCaseListObjectMetadata{
+	tests := []testconn.TestCaseListObjectMetadata{
 		{
 			Name:         "At least one object name must be queried",
 			Input:        nil,
@@ -23,7 +23,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Unknown object requested",
 			Input:      []string{"godzilla"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Errors: map[string]error{
 					"godzilla": common.ErrObjectNotSupported,
@@ -34,7 +34,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"users", "groups"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"users": {
@@ -62,7 +62,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 			Name:       "Successfully describe multiple objects with metadata",
 			Input:      []string{"activities_report", "devices_groups"},
 			Server:     mockserver.Dummy(),
-			Comparator: testroutines.ComparatorSubsetMetadata,
+			Comparator: testconn.ComparatorSubsetMetadata,
 			Expected: &common.ListObjectMetadataResult{
 				Result: map[string]common.ObjectMetadata{
 					"activities_report": {
@@ -113,7 +113,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen
 		// nolint:varnamelen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableMetadataReader, error) {
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/read_test.go
+++ b/providers/zoom/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	responseRecordingsFirstPage := testutils.DataFromFile(t, "recordings-first-page.json")
 	responseRecordingsSecondPage := testutils.DataFromFile(t, "recordings-second-page.json")
 
-	tests := []testroutines.TestCaseRead{
+	tests := []testconn.TestCaseRead{
 		{
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
@@ -51,7 +51,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/users"),
 				Then:  mockserver.Response(http.StatusOK, responseUsersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -66,7 +66,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"status":          "active",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/users?next_page_token=8V8HigQkzm2O5r9RUn31D9ZyJHgrmFfbLa2&page_size=300", //nolint:lll
+				NextPage: testconn.URLTestServer + "/v2/users?next_page_token=8V8HigQkzm2O5r9RUn31D9ZyJHgrmFfbLa2&page_size=300", //nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -81,7 +81,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/users"),
 				Then:  mockserver.Response(http.StatusOK, responseUsersSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -110,7 +110,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/archive_files"),
 				Then:  mockserver.Response(http.StatusOK, responseArchiveFilesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -125,7 +125,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"parent_meeting_id": "atsXxhSEQWit9t+U02HXNQ==",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/archive_files?next_page_token=At6eWnFZ1FB3arCXnRxqHLXKhbDW18yz2i2&page_size=300", //nolint:lll
+				NextPage: testconn.URLTestServer + "/v2/archive_files?next_page_token=At6eWnFZ1FB3arCXnRxqHLXKhbDW18yz2i2&page_size=300", //nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -140,7 +140,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/archive_files"),
 				Then:  mockserver.Response(http.StatusOK, responseArchiveFilesSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -176,7 +176,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		//		},
 		//		Then: mockserver.Response(http.StatusOK, responseRecordingsFirstPage),
 		//	}.Server(),
-		//	Comparator: testroutines.ComparatorSubsetRead,
+		//	Comparator: testconn.ComparatorSubsetRead,
 		//	Expected: &common.ReadResult{
 		//		Rows: 1,
 		//		Data: []common.ReadResultRow{{
@@ -193,7 +193,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 		//				"recording_count": float64(22),
 		//			},
 		//		}},
-		//		NextPage: common.NextPageToken(testroutines.URLTestServer + "/v2/users/me/recordings?" +
+		//		NextPage: common.NextPageToken(testconn.URLTestServer + "/v2/users/me/recordings?" +
 		//			"from=" + time.Now().AddDate(0, 0, -29).Format("2006-01-02") + "&next_page_token=Tva2CuIdTgsv8wAnhyAdU3m06Y2HuLQtlh3&page_size=300&to=" + time.Now().Format("2006-01-02")), //nolint:lll
 		//		Done: false,
 		//	},
@@ -209,7 +209,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				If:    mockcond.Path("/v2/users/me/recordings"),
 				Then:  mockserver.Response(http.StatusOK, responseRecordingsSecondPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -248,7 +248,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseRecordingsFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -265,7 +265,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"recording_count": float64(22),
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/users/me/recordings?" +
+				NextPage: testconn.URLTestServer + "/v2/users/me/recordings?" +
 					"from=2024-01-01&next_page_token=Tva2CuIdTgsv8wAnhyAdU3m06Y2HuLQtlh3&page_size=300&to=2024-03-31",
 				Done: false,
 			},
@@ -286,7 +286,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseArchiveFilesFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -301,7 +301,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"parent_meeting_id": "atsXxhSEQWit9t+U02HXNQ==",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/archive_files?" +
+				NextPage: testconn.URLTestServer + "/v2/archive_files?" +
 					"from=2024-06-01&next_page_token=At6eWnFZ1FB3arCXnRxqHLXKhbDW18yz2i2&page_size=300",
 				Done: false,
 			},
@@ -323,7 +323,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 				},
 				Then: mockserver.Response(http.StatusOK, responseUsersFirstPage),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetRead,
+			Comparator: testconn.ComparatorSubsetRead,
 			Expected: &common.ReadResult{
 				Rows: 1,
 				Data: []common.ReadResultRow{{
@@ -336,7 +336,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 						"email": "jchill@example.com",
 					},
 				}},
-				NextPage: testroutines.URLTestServer + "/v2/users?next_page_token=8V8HigQkzm2O5r9RUn31D9ZyJHgrmFfbLa2&page_size=300", //nolint:lll
+				NextPage: testconn.URLTestServer + "/v2/users?next_page_token=8V8HigQkzm2O5r9RUn31D9ZyJHgrmFfbLa2&page_size=300", //nolint:lll
 				Done:     false,
 			},
 			ExpectedErrs: nil,
@@ -346,7 +346,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableReader, error) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/providers/zoom/write_test.go
+++ b/providers/zoom/write_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	responseCreateUser := testutils.DataFromFile(t, "./write/create-users.json")
 	responseCreateContactsGroup := testutils.DataFromFile(t, "./write/create-contacts-groups.json")
 
-	tests := []testroutines.TestCaseWrite{
+	tests := []testconn.TestCaseWrite{
 		{
 			Name:         "Write object must be included",
 			Server:       mockserver.Dummy(),
@@ -50,7 +50,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateTrackingField),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "a32CJji-weJ92",
@@ -73,7 +73,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				If:    mockcond.MethodPUT(),
 				Then:  mockserver.Response(http.StatusOK, responseUpdateTrackingField),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "a32CJji-weJ92",
@@ -95,7 +95,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateUser),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "KDcuGIm1QgePTO8WbOqwIQ",
@@ -118,7 +118,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 				If:    mockcond.MethodPOST(),
 				Then:  mockserver.Response(http.StatusOK, responseCreateContactsGroup),
 			}.Server(),
-			Comparator: testroutines.ComparatorSubsetWrite,
+			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{
 				Success:  true,
 				RecordId: "A4ql1FjgL913r",
@@ -136,7 +136,7 @@ func TestWrite(t *testing.T) { //nolint:funlen
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			tt.Run(t, func() (testroutines.TestableWriter, error) {
+			tt.Run(t, func() (testconn.TestableWriter, error) {
 				return constructTestConnector(tt.Server.URL)
 			})
 		})

--- a/test/utils/testconn/README.md
+++ b/test/utils/testconn/README.md
@@ -1,4 +1,4 @@
-# Package testroutines
+# Package testconn
 
 ## Purpose
 
@@ -8,11 +8,11 @@ This package provides base test case for creating `Test Suites`.
 
 Most common connector methods can be tested using:
 
-* testroutines.Read - Read
-* testroutines.Write - Write
-* testroutines.Metadata - ListObjectMetadata
-* testroutines.Delete - Delete
-* testroutines.BatchWrite - BatchWrite
+* testconn.Read - Read
+* testconn.Write - Write
+* testconn.Metadata - ListObjectMetadata
+* testconn.Delete - Delete
+* testconn.BatchWrite - BatchWrite
 
 They can be used as a template to declare your unique test case type.
 The main difference among them is
@@ -61,7 +61,7 @@ func TestRead(t *testing.T) {
   // ...
 
   // Suite definition
-  tests := []testroutines.Read{
+  tests := []testconn.Read{
     {
       Name:         "Title of the test",
       Input:        &common.ReadParams{} // This object represents `InputType`
@@ -91,7 +91,7 @@ Comparing just a few objects or a subset of fields is often sufficient. For exam
     Name: "Incremental read of conversations via search",
     Input: common.ReadParams{...},
     Server: mockserver.Conditional{...}.Server(),
-    Comparator: testroutines.ComparatorSubsetRead,
+    Comparator: testconn.ComparatorSubsetRead,
     Expected: &common.ReadResult{
         Rows: 1,
         Data: []common.ReadResultRow{{
@@ -104,13 +104,13 @@ Comparing just a few objects or a subset of fields is often sufficient. For exam
                 "ai_agent_participated": false,
             },
         }},
-        NextPage: testroutines.URLTestServer + "/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
+        NextPage: testconn.URLTestServer + "/conversations/search?starting_after=WzE3MjY3NTIxNDUwMDAsNSwyXQ==",
         Done:     false,
     },
     ExpectedErrs: nil,
 }
 ```
 This approach ensures the test is concise while still validating the critical aspects of the behavior.
-It's important to note that any reference to the original connector BaseURL should be replaced with `testroutines.URLTestServer`
+It's important to note that any reference to the original connector BaseURL should be replaced with `testconn.URLTestServer`
 either in `ReadResult` or `ReadParams`.
 During runtime, this value will be correctly substituted, satisfying the intended behavior.

--- a/test/utils/testconn/batch-write.go
+++ b/test/utils/testconn/batch-write.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/comparator.go
+++ b/test/utils/testconn/comparator.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"encoding/json"
@@ -112,7 +112,7 @@ func ComparatorSortedSubsetReadByIds(serverURL string,
 // Example:
 //
 //		common.ReadResult{
-//			NextPage: testroutines.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI="
+//			NextPage: testconn.URLTestServer + "/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI="
 //	 }
 //
 // At runtime this may look as follows: http://127.0.0.1:38653/v3/contacts?cursor=bGltaXQ9MSZuZXh0PTI=.

--- a/test/utils/testconn/connector.go
+++ b/test/utils/testconn/connector.go
@@ -1,6 +1,6 @@
-// Package testroutines holds a collection of common test procedures.
+// Package testconn holds a collection of common test procedures.
 // They provide a framework to write mock tests.
-package testroutines
+package testconn
 
 import (
 	"context"

--- a/test/utils/testconn/delete-metadata.go
+++ b/test/utils/testconn/delete-metadata.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"context"

--- a/test/utils/testconn/delete.go
+++ b/test/utils/testconn/delete.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/metadata.go
+++ b/test/utils/testconn/metadata.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/outline.go
+++ b/test/utils/testconn/outline.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"net/http/httptest"

--- a/test/utils/testconn/post-auth-info.go
+++ b/test/utils/testconn/post-auth-info.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/proxy.go
+++ b/test/utils/testconn/proxy.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/read-by-ids.go
+++ b/test/utils/testconn/read-by-ids.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/read.go
+++ b/test/utils/testconn/read.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"
@@ -31,7 +31,7 @@ func (r TestCaseRead) Run(t *testing.T, builder ConnectorBuilder[TestableReader]
 //
 //	common.ReadParams{
 //		ObjectName: "tags",
-//		NextPage:   testroutines.URLTestServer + "/v1/tags?limit=100&skip=100",
+//		NextPage:   testconn.URLTestServer + "/v1/tags?limit=100&skip=100",
 //	}
 func prepareReadParams(serverURL string, config common.ReadParams) common.ReadParams {
 	config.NextPage = common.NextPageToken(

--- a/test/utils/testconn/search.go
+++ b/test/utils/testconn/search.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"
@@ -31,7 +31,7 @@ func (s TestCaseSearch) Run(t *testing.T, builder ConnectorBuilder[TestableSearc
 //
 //	common.SearchParams{
 //		ObjectName: "tags",
-//		NextPage:   testroutines.URLTestServer + "/v1/tags?limit=100&skip=100",
+//		NextPage:   testconn.URLTestServer + "/v1/tags?limit=100&skip=100",
 //	}
 func prepareSearchParams(serverURL string, params common.SearchParams) *common.SearchParams {
 	params.NextPage = common.NextPageToken(

--- a/test/utils/testconn/subscription-delete.go
+++ b/test/utils/testconn/subscription-delete.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/subscription-event.go
+++ b/test/utils/testconn/subscription-event.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"fmt"

--- a/test/utils/testconn/subscription-update.go
+++ b/test/utils/testconn/subscription-update.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/subscriptions-create.go
+++ b/test/utils/testconn/subscriptions-create.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/upsert-metadata.go
+++ b/test/utils/testconn/upsert-metadata.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"context"

--- a/test/utils/testconn/webook-message-verifier.go
+++ b/test/utils/testconn/webook-message-verifier.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testconn/write.go
+++ b/test/utils/testconn/write.go
@@ -1,4 +1,4 @@
-package testroutines
+package testconn
 
 import (
 	"testing"

--- a/test/utils/testscenario/subscription-cud.go
+++ b/test/utils/testscenario/subscription-cud.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 type ConnectorSubscriptionManager interface {
-	testroutines.TestableSubscriptionCreator
-	testroutines.TestableSubscriptionUpdater
-	testroutines.TestableSubscriptionRemover
+	testconn.TestableSubscriptionCreator
+	testconn.TestableSubscriptionUpdater
+	testconn.TestableSubscriptionRemover
 }
 
 // SubscriptionCreateUpdateDelete is a test scenario utilizing

--- a/test/utils/testscenario/subscription-messaging.go
+++ b/test/utils/testscenario/subscription-messaging.go
@@ -10,12 +10,12 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 type ConnectorWebhookSubscriber interface {
-	testroutines.TestableSubscriptionCreator
-	testroutines.TestableWebhookMessageVerifier
+	testconn.TestableSubscriptionCreator
+	testconn.TestableWebhookMessageVerifier
 	connectors.ReadConnector
 	connectors.WriteConnector
 	connectors.DeleteConnector
@@ -236,7 +236,7 @@ func cleanupSubscription(ctx context.Context,
 			return
 		}
 
-		remover, ok := conn.(testroutines.TestableSubscriptionRemover)
+		remover, ok := conn.(testconn.TestableSubscriptionRemover)
 		if !ok {
 			fmt.Println(
 				"REMINDER: subscription is still active and must be removed manually.\n" +

--- a/test/utils/testscenario/webhook-messaging.go
+++ b/test/utils/testscenario/webhook-messaging.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 // WebhookRouter holds a set of conditional webhook handlers that dispatch webhook requests
@@ -49,7 +49,7 @@ type WebhookRouteFunc func(writer http.ResponseWriter, request *http.Request, re
 // is closed, the webhook server is shut down and the function returns.
 func RunWebhookConsumer(
 	ctx context.Context,
-	conn testroutines.TestableWebhookMessageVerifier,
+	conn testconn.TestableWebhookMessageVerifier,
 	webhookRouter WebhookRouter,
 	verificationParams *common.VerificationParams,
 ) {

--- a/test/utils/testscenario/webhook.go
+++ b/test/utils/testscenario/webhook.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 const (
@@ -81,7 +81,7 @@ func waitForWebhookURLInput(ctx context.Context) (string, bool) {
 // Webhook handler will send webhookMessageResult using go channel.
 func startWebhookHandler(
 	ctx context.Context,
-	conn testroutines.TestableWebhookMessageVerifier,
+	conn testconn.TestableWebhookMessageVerifier,
 	router WebhookRouter,
 	verificationParams *common.VerificationParams,
 	messageChannel chan webhookMessageResult,
@@ -146,7 +146,7 @@ type webhookMessageResult struct {
 // Returns an http.HandlerFunc that can be registered with an HTTP server.
 func createWebhookHandler(
 	ctx context.Context,
-	conn testroutines.TestableWebhookMessageVerifier,
+	conn testconn.TestableWebhookMessageVerifier,
 	router WebhookRouter,
 	verificationParams *common.VerificationParams,
 	messageChannel chan webhookMessageResult,
@@ -174,7 +174,7 @@ func createWebhookHandler(
 
 func defaultWebhookHandler(w http.ResponseWriter,
 	r *http.Request,
-	conn testroutines.TestableWebhookMessageVerifier,
+	conn testconn.TestableWebhookMessageVerifier,
 	ctx context.Context,
 	body []byte,
 	verificationParams *common.VerificationParams,


### PR DESCRIPTION
# Description

Rename `testroutines` to `testconn`.

As a result, when a developer wants to write unit tests for a connector, one would type `testconn.TestCase...` and then choose the method of interest. I believe that it is more telling than the word routine and `testconn` as a concept is not taken in the library.

# Steps

1. Replace all `testroutines` to  `testconn`.
2. Rename directory too.
No build, no linter issues.