### PR TITLE
[CON-3243] feat: add google calendar subscription events classification

### DIFF
--- a/providers/google/connector.go
+++ b/providers/google/connector.go
@@ -285,7 +285,17 @@ type (
 	CalendarWatchResponse      = calendar.WatchResponse
 	CalendarSubscriptionResult = calendar.CalendarSubscriptionResult
 	CalendarVerificationParams = calendar.VerificationParams
+	CalendarSubscriptionEvent  = calendar.SubscriptionEvent
 )
+
+// CalendarSubscriptionEventsFromRecords classifies GetRecordsByIds rows into
+// create/update/delete events. updatedMin must be the same checkpoint passed to
+// GetRecordsByIds (recordIds[0]).
+func CalendarSubscriptionEventsFromRecords(
+	rows []common.ReadResultRow, updatedMin string,
+) []CalendarSubscriptionEvent {
+	return calendar.SubscriptionEventsFromRecords(rows, updatedMin)
+}
 
 // CalendarVerifier is a standalone Google Calendar webhook verifier.
 //

--- a/providers/google/internal/calendar/errors.go
+++ b/providers/google/internal/calendar/errors.go
@@ -17,6 +17,7 @@ var (
 	errInvalidRequestType         = errors.New("invalid request type")
 	errUnsupportedSubscribeObject = errors.New("unsupported subscribe object")
 	errFieldNotFound              = errors.New("field not found")
+	errInvalidTimestamp           = errors.New("invalid timestamp")
 )
 
 var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals

--- a/providers/google/internal/calendar/subscriptionEvent.go
+++ b/providers/google/internal/calendar/subscriptionEvent.go
@@ -1,0 +1,160 @@
+package calendar
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// Deleted events come back from events.list with status "cancelled" when showDeleted=true,
+// which is how GetRecordsByIds queries.
+const statusCancelled = "cancelled"
+
+// SubscriptionEvent is one Calendar event to be classified, built from a GetRecordsByIds row.
+//
+// Calendar pushes have an empty body, so the subscribe pipeline fetches the changed events
+// first and classifies them afterwards. Keeping that split, GetRecordsByIds is a plain read
+// and EventType does the classification here. A Calendar event has no event-type field (Gmail
+// gets one from its history categories), so the type is inferred from the status and the
+// created time relative to the fetch window (UpdatedMin, the checkpoint GetRecordsByIds used).
+type SubscriptionEvent struct {
+	// RecordID is the Calendar event ID.
+	RecordID string
+	// Status is the event status; "cancelled" means the event was deleted.
+	Status string
+	// Created is the event creation time (RFC3339), compared against UpdatedMin to tell a
+	// new event from an edit to an existing one.
+	Created string
+	// Updated is the last-modification time (RFC3339), used as the event timestamp.
+	Updated string
+	// UpdatedMin is the fetch window checkpoint (recordIds[0] passed to GetRecordsByIds).
+	UpdatedMin string
+	// Raw is the full event object from the provider.
+	Raw map[string]any
+}
+
+var _ common.SubscriptionEvent = SubscriptionEvent{}
+
+// EventType infers the event type from the row. A cancelled event is a delete; otherwise an
+// event created within the fetch window is a create, and an older one is an update.
+//
+// updatedMin defines the window and must parse, or we error. A non-cancelled event with no
+// usable created time falls back to update.
+func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
+	if strings.EqualFold(e.Status, statusCancelled) {
+		return common.SubscriptionEventTypeDelete, nil
+	}
+
+	window, err := time.Parse(time.RFC3339, e.UpdatedMin)
+	if err != nil {
+		return common.SubscriptionEventTypeOther,
+			fmt.Errorf("%w: updatedMin %q: %w", errInvalidTimestamp, e.UpdatedMin, err)
+	}
+
+	created, err := time.Parse(time.RFC3339, e.Created)
+	if err != nil {
+		// No created time to compare against, so treat it as an edit.
+		return common.SubscriptionEventTypeUpdate, nil // nolint: nilerr
+	}
+
+	// Created at or after the window start means it's new within this fetch.
+	if !created.Before(window) {
+		return common.SubscriptionEventTypeCreate, nil
+	}
+
+	return common.SubscriptionEventTypeUpdate, nil
+}
+
+// RawEventName returns the event status (e.g. "confirmed", "cancelled"). Calendar has no
+// event-name field, so status is the nearest thing.
+func (e SubscriptionEvent) RawEventName() (string, error) {
+	return e.Status, nil
+}
+
+// ObjectName returns the Calendar object name. Only "events" is supported for subscriptions.
+func (e SubscriptionEvent) ObjectName() (string, error) {
+	return objectNameEvents, nil
+}
+
+// Workspace doesn't apply to Calendar — there's no per-event mailbox like Gmail's address.
+func (e SubscriptionEvent) Workspace() (string, error) {
+	return "", nil
+}
+
+// RecordId returns the Calendar event ID, which the pipeline uses to hydrate the event.
+func (e SubscriptionEvent) RecordId() (string, error) {
+	return e.RecordID, nil
+}
+
+// EventTimeStampNano returns the last-modification time in nanoseconds, or the current time
+// if Updated is missing or unparseable.
+func (e SubscriptionEvent) EventTimeStampNano() (int64, error) {
+	updated, err := time.Parse(time.RFC3339, e.Updated)
+	if err != nil {
+		return time.Now().UnixNano(), nil // nolint: nilerr
+	}
+
+	return updated.UnixNano(), nil
+}
+
+// RawMap returns the full event object for the outgoing webhook's RawEvent.
+func (e SubscriptionEvent) RawMap() (map[string]any, error) {
+	if e.Raw == nil {
+		return map[string]any{}, nil
+	}
+
+	return maps.Clone(e.Raw), nil
+}
+
+// PreLoadData is a no-op; a Calendar event already holds everything it needs. It's here only
+// to satisfy common.SubscriptionEvent.
+func (e SubscriptionEvent) PreLoadData(_ *common.SubscriptionEventPreLoadData) error {
+	return nil
+}
+
+// SubscriptionEventsFromRecords turns GetRecordsByIds rows into events to classify, tagging
+// each with the fetch window so EventType can tell a new event from an edit. updatedMin must
+// be the same checkpoint passed to GetRecordsByIds (recordIds[0]).
+func SubscriptionEventsFromRecords(rows []common.ReadResultRow, updatedMin string) []SubscriptionEvent {
+	events := make([]SubscriptionEvent, 0, len(rows))
+
+	for _, row := range rows {
+		events = append(events, SubscriptionEvent{
+			RecordID:   rowString(row, "id", row.Id),
+			Status:     rowString(row, "status", ""),
+			Created:    rowString(row, "created", ""),
+			Updated:    rowString(row, "updated", ""),
+			UpdatedMin: updatedMin,
+			Raw:        row.Raw,
+		})
+	}
+
+	return events
+}
+
+// rowString reads a string field from a row, checking Raw first and then Fields (whose keys
+// are lowercased). Returns fallback if neither has it.
+func rowString(row common.ReadResultRow, key, fallback string) string {
+	if v, ok := stringFromMap(row.Raw, key); ok {
+		return v
+	}
+
+	if v, ok := stringFromMap(row.Fields, strings.ToLower(key)); ok {
+		return v
+	}
+
+	return fallback
+}
+
+func stringFromMap(m map[string]any, key string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+
+	v, ok := m[key].(string)
+
+	return v, ok && v != ""
+}

--- a/providers/google/internal/calendar/subscriptionEvent_test.go
+++ b/providers/google/internal/calendar/subscriptionEvent_test.go
@@ -1,0 +1,133 @@
+package calendar
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"gotest.tools/v3/assert"
+)
+
+func TestSubscriptionEventEventType(t *testing.T) {
+	t.Parallel()
+
+	const updatedMin = "2026-06-17T00:00:00.000Z"
+
+	tests := []struct {
+		name    string
+		event   SubscriptionEvent
+		want    common.SubscriptionEventType
+		wantErr bool
+	}{
+		{
+			name:  "cancelled status is a delete",
+			event: SubscriptionEvent{Status: "cancelled", Created: "2026-06-01T09:00:00.000Z", UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeDelete,
+		},
+		{
+			name:  "cancelled wins even when created within the window",
+			event: SubscriptionEvent{Status: "cancelled", Created: "2026-06-18T09:00:00.000Z", UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeDelete,
+		},
+		{
+			name:  "created within the window is a create",
+			event: SubscriptionEvent{Status: "confirmed", Created: "2026-06-18T09:00:00.000Z", UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeCreate,
+		},
+		{
+			name:  "created exactly at the window boundary is a create",
+			event: SubscriptionEvent{Status: "confirmed", Created: updatedMin, UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeCreate,
+		},
+		{
+			name:  "created before the window is an update",
+			event: SubscriptionEvent{Status: "confirmed", Created: "2026-06-01T09:00:00.000Z", UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name:  "missing created falls back to update",
+			event: SubscriptionEvent{Status: "confirmed", Created: "", UpdatedMin: updatedMin},
+			want:  common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name:    "unparseable updatedMin errors",
+			event:   SubscriptionEvent{Status: "confirmed", Created: "2026-06-18T09:00:00.000Z", UpdatedMin: "not-a-time"},
+			want:    common.SubscriptionEventTypeOther,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.event.EventType()
+
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, err != nil, tt.wantErr)
+		})
+	}
+}
+
+func TestSubscriptionEventsFromRecords(t *testing.T) {
+	t.Parallel()
+
+	const updatedMin = "2026-06-17T00:00:00.000Z"
+
+	rows := []common.ReadResultRow{
+		{
+			Id: "evt-confirmed-1",
+			Raw: map[string]any{
+				"id":      "evt-confirmed-1",
+				"status":  "confirmed",
+				"created": "2026-06-01T09:42:20.000Z", // created before the window: an update
+				"updated": "2026-06-18T09:00:00.000Z",
+			},
+		},
+		{
+			Id: "evt-cancelled-1",
+			Raw: map[string]any{
+				"id":      "evt-cancelled-1",
+				"status":  "cancelled", // cancelled: a delete
+				"created": "2026-06-01T09:42:17.000Z",
+				"updated": "2026-06-18T09:30:00.000Z",
+			},
+		},
+		{
+			// id/status/created only in the marshaled Fields (lowercased keys), not Raw.
+			Fields: map[string]any{
+				"id":      "evt-new-1",
+				"status":  "confirmed",
+				"created": "2026-06-18T11:00:00.000Z", // created inside the window: a create
+			},
+		},
+	}
+
+	events := SubscriptionEventsFromRecords(rows, updatedMin)
+	assert.Equal(t, len(events), 3)
+
+	// Every event should be tagged with the window.
+	for _, evt := range events {
+		assert.Equal(t, evt.UpdatedMin, updatedMin)
+	}
+
+	wantTypes := []common.SubscriptionEventType{
+		common.SubscriptionEventTypeUpdate,
+		common.SubscriptionEventTypeDelete,
+		common.SubscriptionEventTypeCreate,
+	}
+
+	for i, evt := range events {
+		got, err := evt.EventType()
+		assert.NilError(t, err)
+		assert.Equal(t, got, wantTypes[i], "event %d", i)
+	}
+
+	// Fields-only row still resolves its id and object name.
+	id, err := events[2].RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, id, "evt-new-1")
+
+	obj, err := events[0].ObjectName()
+	assert.NilError(t, err)
+	assert.Equal(t, obj, objectNameEvents)
+}

--- a/providers/google/records_test.go
+++ b/providers/google/records_test.go
@@ -191,3 +191,140 @@ func TestMailGetRecordsByIds(t *testing.T) { //nolint:funlen
 		})
 	}
 }
+
+// TestCalendarGetRecordsByIds covers the Calendar subscribe fetch. recordIds[0] is the
+// updatedMin checkpoint (not an event id); the method paginates events.list and only
+// supports the "events" object.
+func TestCalendarGetRecordsByIds(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	eventsPage1 := testutils.DataFromFile(t, "calendar/records-by-ids/events-page-1.json")
+	eventsPage2 := testutils.DataFromFile(t, "calendar/records-by-ids/events-page-2.json")
+
+	const (
+		eventsPath = "/calendar/v3/calendars/primary/events"
+		updatedMin = "2026-06-17T00:00:00.000Z"
+	)
+
+	tests := []struct {
+		name          string
+		object        string
+		ids           []string
+		server        func() *mockserver.Switch
+		expectErr     bool
+		expectRowIds  []string // sorted
+		expectNoError bool
+	}{
+		{
+			name:   "Unsupported object returns ErrGetRecordNotSupportedForObject",
+			object: "calendarList",
+			ids:    []string{updatedMin},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{Setup: mockserver.ContentJSON()}
+			},
+			expectErr: true,
+		},
+		{
+			name:   "Empty recordIds errors before hitting the provider",
+			object: "events",
+			ids:    []string{},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{Setup: mockserver.ContentJSON()}
+			},
+			expectErr: true,
+		},
+		{
+			name:   "Blank updatedMin errors before hitting the provider",
+			object: "events",
+			ids:    []string{""},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{Setup: mockserver.ContentJSON()}
+			},
+			expectErr: true,
+		},
+		{
+			name:   "Paginates across pages following nextPageToken",
+			object: "events",
+			ids:    []string{updatedMin},
+			server: func() *mockserver.Switch {
+				return &mockserver.Switch{
+					Setup: mockserver.ContentJSON(),
+					Cases: []mockserver.Case{
+						{
+							// page-1 carries nextPageToken "TOKEN2"; the follow-up request
+							// for page-2 is the only one carrying pageToken.
+							If:   mockcond.QueryParam("pageToken", "TOKEN2"),
+							Then: mockserver.Response(http.StatusOK, eventsPage2),
+						},
+					},
+					Default: mockserver.Response(http.StatusOK, eventsPage1),
+				}
+			},
+			expectRowIds:  []string{"evt-cancelled-1", "evt-confirmed-1"},
+			expectNoError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := tt.server().Server()
+			t.Cleanup(srv.Close)
+
+			conn, err := constructTestCalendarConnector(srv.URL)
+			if err != nil {
+				t.Fatalf("failed to construct test connector: %v", err)
+			}
+
+			rows, err := conn.GetRecordsByIds(t.Context(), tt.object, tt.ids, nil, nil)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (rows: %v)", rows)
+				}
+
+				return
+			}
+
+			if tt.expectNoError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotIds := make([]string, 0, len(rows))
+			for _, row := range rows {
+				gotIds = append(gotIds, calendarRowID(row))
+			}
+
+			sort.Strings(gotIds)
+
+			if len(gotIds) != len(tt.expectRowIds) {
+				t.Fatalf("expected %d rows, got %d (ids: %v)", len(tt.expectRowIds), len(gotIds), gotIds)
+			}
+
+			for i, want := range tt.expectRowIds {
+				if gotIds[i] != want {
+					t.Fatalf("row %d: expected id %q, got %q (all: %v)", i, want, gotIds[i], gotIds)
+				}
+			}
+		})
+	}
+}
+
+// calendarRowID gets the event id from a row. Depending on which fields were requested it
+// may sit on Id, in Fields, or only in Raw, so check all three.
+func calendarRowID(row common.ReadResultRow) string {
+	if row.Id != "" {
+		return row.Id
+	}
+
+	if v, ok := row.Fields["id"].(string); ok && v != "" {
+		return v
+	}
+
+	if v, ok := row.Raw["id"].(string); ok {
+		return v
+	}
+
+	return ""
+}

--- a/test/google/calendar/classify/main.go
+++ b/test/google/calendar/classify/main.go
@@ -1,0 +1,187 @@
+// Live test for Calendar subscription-event classification — the step the subscribe pipeline
+// runs on the rows GetRecordsByIds returns. It exercises all three event types against a real
+// calendar and checks that CalendarSubscriptionEventsFromRecords labels each one correctly.
+//
+// To get a create, an update and a delete on the same fetch, we straddle a checkpoint:
+//  1. Create the update and delete targets before the checkpoint.
+//  2. Capture the checkpoint (updatedMin). The sleeps on either side keep the "before" events
+//     and the "after" changes clearly apart even if the local and Google clocks drift a little.
+//  3. After the checkpoint, create a third event (the create), edit the update target (an
+//     update: created before, changed after) and delete the delete target.
+//  4. Fetch from the checkpoint, classify the rows, and check each event came out as expected.
+//
+// Run with: go run ./test/google/calendar/classify/main.go
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/google"
+	connTest "github.com/amp-labs/connectors/test/google"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+// separation keeps the pre-checkpoint events and post-checkpoint changes on opposite sides of
+// the checkpoint even with some clock skew between here and Google.
+const separation = 5 * time.Second
+
+type dateTime struct {
+	DateTime string `json:"dateTime"`
+	TimeZone string `json:"timeZone"`
+}
+
+type eventPayload struct {
+	Start   dateTime `json:"start"`
+	End     dateTime `json:"end"`
+	Summary string   `json:"summary"`
+}
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetGoogleCalendarConnector(ctx)
+
+	// Step 1: the "old" events, created before the checkpoint.
+	updateID := createEvent(ctx, conn, "classify-update-"+gofakeit.UUID())
+	deleteID := createEvent(ctx, conn, "classify-delete-"+gofakeit.UUID())
+	slog.Info("Created pre-checkpoint events", "updateTarget", updateID, "deleteTarget", deleteID)
+
+	// Step 2: checkpoint, fenced by sleeps so the old events land before it.
+	time.Sleep(separation)
+	checkpoint := datautils.Time.FormatRFC3339inUTCWithMilliseconds(time.Now())
+	slog.Info("Captured checkpoint (updatedMin)", "checkpoint", checkpoint)
+	time.Sleep(separation)
+
+	// Steps 3-5: the changes, all after the checkpoint.
+	createID := createEvent(ctx, conn, "classify-create-"+gofakeit.UUID())
+	slog.Info("Created post-checkpoint event", "createTarget", createID)
+
+	updateEvent(ctx, conn, updateID, "classify-update-edited-"+gofakeit.UUID())
+	slog.Info("Updated event", "id", updateID)
+
+	deleteEvent(ctx, conn, deleteID)
+	slog.Info("Deleted event", "id", deleteID)
+
+	// Step 6: fetch the window and classify.
+	rows, err := conn.GetRecordsByIds(ctx, "events", []string{checkpoint},
+		[]string{"id", "summary", "status", "created", "updated"}, nil)
+	if err != nil {
+		utils.Fail("error fetching records by updatedMin", "error", err)
+	}
+
+	slog.Info("Fetched changed events", "count", len(rows))
+
+	events := google.CalendarSubscriptionEventsFromRecords(rows, checkpoint)
+
+	typeByID := make(map[string]common.SubscriptionEventType, len(events))
+
+	for _, evt := range events {
+		id, err := evt.RecordId()
+		if err != nil {
+			utils.Fail("error reading record id", "error", err)
+		}
+
+		eventType, err := evt.EventType()
+		if err != nil {
+			utils.Fail("error classifying event", "error", err, "id", id)
+		}
+
+		typeByID[id] = eventType
+		slog.Info("Classified", "id", id, "type", eventType)
+	}
+
+	// Cleanup the two events left behind (the delete target is already gone).
+	defer func() {
+		deleteEvent(ctx, conn, createID)
+		deleteEvent(ctx, conn, updateID)
+		slog.Info("Cleaned up create/update targets")
+	}()
+
+	expect(typeByID, createID, common.SubscriptionEventTypeCreate)
+	expect(typeByID, updateID, common.SubscriptionEventTypeUpdate)
+	expect(typeByID, deleteID, common.SubscriptionEventTypeDelete)
+
+	slog.Info("✓ Test completed successfully!")
+}
+
+// expect fails the run unless the classified type for id matches want.
+func expect(typeByID map[string]common.SubscriptionEventType, id string, want common.SubscriptionEventType) {
+	got, ok := typeByID[id]
+	if !ok {
+		utils.Fail("event not returned by the updatedMin fetch", "id", id, "want", want)
+	}
+
+	if got != want {
+		utils.Fail("event classified incorrectly", "id", id, "want", want, "got", got)
+	}
+
+	slog.Info("✓ Correctly classified", "id", id, "type", want)
+}
+
+func createEvent(ctx context.Context, conn *google.Connector, summary string) string {
+	start := time.Now().Add(time.Hour)
+	end := start.Add(time.Hour)
+
+	result, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "events",
+		RecordData: eventPayload{
+			Start:   dateTime{DateTime: datautils.Time.FormatRFC3339inUTCWithMilliseconds(start), TimeZone: "America/Los_Angeles"},
+			End:     dateTime{DateTime: datautils.Time.FormatRFC3339inUTCWithMilliseconds(end), TimeZone: "America/Los_Angeles"},
+			Summary: summary,
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating event", "error", err, "summary", summary)
+	}
+
+	if result.RecordId == "" {
+		utils.Fail("create returned no record id", "summary", summary)
+	}
+
+	return result.RecordId
+}
+
+// updateEvent patches an existing event. Calendar update replaces the resource, so start/end
+// are resent alongside the new summary to keep the event valid.
+func updateEvent(ctx context.Context, conn *google.Connector, id, summary string) {
+	start := time.Now().Add(time.Hour)
+	end := start.Add(time.Hour)
+
+	result, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "events",
+		RecordId:   id,
+		RecordData: eventPayload{
+			Start:   dateTime{DateTime: datautils.Time.FormatRFC3339inUTCWithMilliseconds(start), TimeZone: "America/Los_Angeles"},
+			End:     dateTime{DateTime: datautils.Time.FormatRFC3339inUTCWithMilliseconds(end), TimeZone: "America/Los_Angeles"},
+			Summary: summary,
+		},
+	})
+	if err != nil {
+		utils.Fail("error updating event", "error", err, "id", id)
+	}
+
+	if !result.Success {
+		utils.Fail("update operation failed", "id", id)
+	}
+}
+
+func deleteEvent(ctx context.Context, conn *google.Connector, id string) {
+	result, err := conn.Delete(ctx, common.DeleteParams{ObjectName: "events", RecordId: id})
+	if err != nil {
+		utils.Fail("error deleting event", "error", err, "id", id)
+	}
+
+	if !result.Success {
+		utils.Fail("delete operation failed", "id", id)
+	}
+}


### PR DESCRIPTION
A follow up PR for classifying the event types.
Adds Calendar subscription-event classification for each event returned by
`GetRecordsByIds`, derives whether it's a create, update, or delete.

Calendar events have no event-type field (unlike Gmail's history categories),
so the type is inferred:

- `status == "cancelled"` → **delete** (surfaced because we read with `showDeleted=true`)
- created within the fetch window (`created >= updatedMin`) → **create**
- otherwise → **update**

Added the tests as well