### PR TITLE
fix(semgrep): Add dependabot PR cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Cooldown -- minimum age requirement for a release before Dependabot opens a PR,
+    # which helps avoid taking a version that was just published and may still be unstable or risky
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Description

Fixes semgrep rule:
```
package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown
```

Semgrep logs: [example](https://github.com/amp-labs/connectors/actions/runs/28809816525/job/85434546577).