### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	cloud.google.com/go/bigquery v1.75.0
 	github.com/PuerkitoBio/goquery v1.11.0
-	github.com/amp-labs/amp-common v0.0.0-20260706145943-7da2452b3407
+	github.com/amp-labs/amp-common v0.0.0-20260706184531-deda7496634f
 	github.com/antchfx/xmlquery v1.5.0
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43xxfqw=
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
-github.com/amp-labs/amp-common v0.0.0-20260706145943-7da2452b3407 h1:j2JYWb/pn8N6DtzMJVH9+U8dt9zlxPTEb0mK6bqWhUU=
-github.com/amp-labs/amp-common v0.0.0-20260706145943-7da2452b3407/go.mod h1:7O1Z5z2NC0E6o1NJ8fG58RqjKodzv6i1se8kMSo3H5U=
+github.com/amp-labs/amp-common v0.0.0-20260706184531-deda7496634f h1:IlVD8ykuASLwf+dVRn1ZY6KSPAc1/2Fc4f1TbKgV9M8=
+github.com/amp-labs/amp-common v0.0.0-20260706184531-deda7496634f/go.mod h1:7O1Z5z2NC0E6o1NJ8fG58RqjKodzv6i1se8kMSo3H5U=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.0 h1:uAi+mO40ZWfyU6mlUBxRVvL6uBNZ6LMU4M3+mQIBV4c=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [deda7496634fbed3f1764aed7e5806b640c511a4](https://github.com/amp-labs/amp-common/commit/deda7496634fbed3f1764aed7e5806b640c511a4) from [main](https://github.com/amp-labs/amp-common/tree/main)