### PR TITLE
tidy(connectwise): Omit empty conditions query param

### DIFF
--- a/providers/connectwise/read.go
+++ b/providers/connectwise/read.go
@@ -67,7 +67,7 @@ func makeReadCondition(params common.ReadParams) (string, bool) {
 		conditions = append(conditions, condition)
 	}
 
-	return strings.Join(conditions, " AND "), true
+	return strings.Join(conditions, " AND "), len(conditions) != 0
 }
 
 func (c *Connector) parseReadResponse(

--- a/providers/connectwise/read_test.go
+++ b/providers/connectwise/read_test.go
@@ -115,7 +115,10 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.Path("/v4_6_release/apis/3.0/company/contacts"),
+				If: mockcond.And{
+					mockcond.Path("/v4_6_release/apis/3.0/company/contacts"),
+					mockcond.QueryParamsMissing("conditions"),
+				},
 				Then: mockserver.ResponseChainedFuncs(
 					mockserver.Header("Link", linkHeaderRaw),
 					mockserver.Response(http.StatusOK, responseContacts),


### PR DESCRIPTION
# Description

* No functional change.
* Connector sends `conditions` query param for incremental reading.
* The query param should be omitted if both Since/Until are empty. This improves intent.

# Unit Tests

Added condition to respond only if query param is missing.
<img width="684" height="113" alt="image" src="https://github.com/user-attachments/assets/f3484241-adde-4304-a180-9bd8efdb6caa" />

Existing test checks that connector sends Since value as conditions query param:
<img width="844" height="160" alt="image" src="https://github.com/user-attachments/assets/723625b0-205e-4b63-a343-ae45d6321a77" />

# Live Tests
<img width="785" height="1016" alt="image" src="https://github.com/user-attachments/assets/6423bebf-2706-4fc0-a926-8631603a8b74" />


