### PR TITLE
[ENG-4096] fix(salesforce): retry event relay RUN with namespaced full name

### DIFF
--- a/providers/salesforce/eventRelayNamespace_test.go
+++ b/providers/salesforce/eventRelayNamespace_test.go
@@ -1,0 +1,127 @@
+package salesforce
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"gotest.tools/v3/assert"
+)
+
+func TestFullNameMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		err          error
+		fullName     string
+		wantExpected string
+		wantOK       bool
+	}{
+		{
+			name: "namespaced full name mismatch is detected and expected name extracted",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body: []byte(`[{"message":"Full name amp_7172c2e551fc4382a034d2c27f23e8eb ` +
+					`does not match the full name speedboatdev__amp_7172c2e551fc4382a034d2c27f23e8eb",` +
+					`"errorCode":"FIELD_INTEGRITY_EXCEPTION"}]`),
+			},
+			fullName:     "amp_7172c2e551fc4382a034d2c27f23e8eb",
+			wantExpected: "speedboatdev__amp_7172c2e551fc4382a034d2c27f23e8eb",
+			wantOK:       true,
+		},
+		{
+			name: "real salesforce message with trailing entity clause",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body: []byte(`[{"message":"Full name amp_d91acb347f434502a3063f436d82263a ` +
+					`does not match the full name speedboatdev__amp_d91acb347f434502a3063f436d82263a ` +
+					`of the entity (id: 7k2gL0000046h6PQAQ).","errorCode":"FIELD_INTEGRITY_EXCEPTION","fields":[]}]`),
+			},
+			fullName:     "amp_d91acb347f434502a3063f436d82263a",
+			wantExpected: "speedboatdev__amp_d91acb347f434502a3063f436d82263a",
+			wantOK:       true,
+		},
+		{
+			name: "namespace containing a single underscore is captured in full",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body: []byte(`[{"message":"Full name amp_d91acb347f434502a3063f436d82263a ` +
+					`does not match the full name my_np__amp_d91acb347f434502a3063f436d82263a ` +
+					`of the entity (id: 7k2gL0000046h6PQAQ).","errorCode":"FIELD_INTEGRITY_EXCEPTION","fields":[]}]`),
+			},
+			fullName:     "amp_d91acb347f434502a3063f436d82263a",
+			wantExpected: "my_np__amp_d91acb347f434502a3063f436d82263a",
+			wantOK:       true,
+		},
+		{
+			name: "trailing sentence after expected name does not bleed into match",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body: []byte(`[{"message":"Full name amp_x does not match the full name acme__amp_x. ` +
+					`Please retry.","errorCode":"FIELD_INTEGRITY_EXCEPTION"}]`),
+			},
+			fullName:     "amp_x",
+			wantExpected: "acme__amp_x",
+			wantOK:       true,
+		},
+		{
+			name: "un-namespaced supplied name alone does not match",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body:   []byte(`[{"message":"Full name amp_x is invalid","errorCode":"FIELD_INTEGRITY_EXCEPTION"}]`),
+			},
+			fullName:     "amp_x",
+			wantExpected: "",
+			wantOK:       false,
+		},
+		{
+			name: "unrelated 400 is not a mismatch",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body:   []byte(`[{"message":"Something else went wrong","errorCode":"INVALID_FIELD"}]`),
+			},
+			fullName:     "amp_x",
+			wantExpected: "",
+			wantOK:       false,
+		},
+		{
+			name: "non-400 status is ignored",
+			err: &common.HTTPError{
+				Status: http.StatusInternalServerError,
+				Body:   []byte(`[{"message":"does not match the full name acme__amp_x"}]`),
+			},
+			fullName:     "amp_x",
+			wantExpected: "",
+			wantOK:       false,
+		},
+		{
+			name: "empty full name is ignored",
+			err: &common.HTTPError{
+				Status: http.StatusBadRequest,
+				Body:   []byte(`[{"message":"does not match the full name acme__amp_x"}]`),
+			},
+			fullName:     "",
+			wantExpected: "",
+			wantOK:       false,
+		},
+		{
+			name:         "non-HTTP error is ignored",
+			err:          errors.New("boom"),
+			fullName:     "amp_x",
+			wantExpected: "",
+			wantOK:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expected, ok := fullNameMismatch(tt.err, tt.fullName)
+			assert.Equal(t, ok, tt.wantOK)
+			assert.Equal(t, expected, tt.wantExpected)
+		})
+	}
+}

--- a/providers/salesforce/events.go
+++ b/providers/salesforce/events.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -309,22 +310,50 @@ func (c *Connector) RunEventRelay(ctx context.Context, cfg *EventRelayConfig) er
 		return err
 	}
 
-	config := &EventRelayConfig{
-		FullName: cfg.FullName,
-		Metadata: &EventRelayConfigMetadata{
-			State: "RUN",
-		},
-	}
-
-	// patch returns no content with 204. If it fails, it will return an error.
-	_, err = c.Client.Patch(ctx, url.String(), config)
+	err = c.patchEventRelayState(ctx, url.String(), cfg.FullName)
 	if err != nil {
-		return fmt.Errorf("error running event relay: %w", err)
+		// In a namespaced org (scratch/packaging orgs), Salesforce prepends the
+		// org namespace to the full name of metadata it creates (e.g. the
+		// EventRelayConfig created as "amp_x" becomes "acme__amp_x"). A PATCH
+		// that echoes the un-namespaced full name is then rejected. The error
+		// reports the expected namespaced full name, so adopt it and retry once.
+		expected, ok := fullNameMismatch(err, cfg.FullName)
+		if !ok {
+			return fmt.Errorf("error running event relay: %w", err)
+		}
+
+		logging.Logger(ctx).Info("event relay full name mismatch; retrying with namespaced full name",
+			"provided", cfg.FullName, "expected", expected)
+
+		if retryErr := c.patchEventRelayState(ctx, url.String(), expected); retryErr != nil {
+			// Join the retry error with the original mismatch error so both the
+			// namespace-corrected failure and the initial cause are preserved.
+			return fmt.Errorf("error running event relay after namespace retry: %w",
+				errors.Join(retryErr, err))
+		}
+
+		// Persist the corrected full name so callers store the namespaced value.
+		cfg.FullName = expected
 	}
 
 	cfg.Metadata.State = "RUN"
 
 	return nil
+}
+
+// patchEventRelayState PATCHes the EventRelayConfig at url to the RUN state
+// using the given full name. Salesforce returns 204 No Content on success.
+func (c *Connector) patchEventRelayState(ctx context.Context, url, fullName string) error {
+	config := &EventRelayConfig{
+		FullName: fullName,
+		Metadata: &EventRelayConfigMetadata{
+			State: "RUN",
+		},
+	}
+
+	_, err := c.Client.Patch(ctx, url, config)
+
+	return err
 }
 
 // nolint: lll
@@ -552,6 +581,51 @@ func isDuplicateDeveloperName(err error) bool {
 	}
 
 	return false
+}
+
+// fullNameMismatch reports whether err is a 400 response indicating the supplied
+// metadata FullName omitted the org's namespace prefix, and if so returns the
+// expected (namespaced) full name.
+//
+// In a namespaced org, Salesforce stores created metadata as
+// "<namespace>__<fullName>" and rejects a later reference to the un-namespaced
+// name with a message like: "Full name amp_<id> does not match the full name
+// speedboatdev__amp_<id> of the entity (id: ...)". Because the supplied full
+// name is known, we match "<namespace>__<fullName>" directly rather than
+// parsing the free-form message.
+//
+// A Salesforce namespace prefix is 1-15 alphanumeric characters, begins with a
+// letter, and cannot contain two consecutive underscores (single underscores
+// are allowed, e.g. "my_np"). The pattern below encodes that: a leading letter
+// followed by units of an optional single underscore plus an alphanumeric, so
+// underscores can never be consecutive or trailing — which also makes it stop
+// cleanly at the "__" that separates the namespace from the full name.
+// https://developer.salesforce.com/docs/atlas.en-us.pkg1_dev.meta/pkg1_dev/register_namespace_prefix.htm
+func fullNameMismatch(err error, fullName string) (string, bool) {
+	var httpErr *common.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusBadRequest || fullName == "" {
+		return "", false
+	}
+
+	var entries []sfAPIError
+	if jsonErr := json.Unmarshal(httpErr.Body, &entries); jsonErr != nil {
+		return "", false
+	}
+
+	// Matches "<namespace>__<fullName>", e.g. "speedboatdev__amp_<id>" or
+	// "my_np__amp_<id>".
+	pattern, compileErr := regexp.Compile(`\b[A-Za-z](?:_?[A-Za-z0-9])*__` + regexp.QuoteMeta(fullName))
+	if compileErr != nil {
+		return "", false
+	}
+
+	for _, e := range entries {
+		if match := pattern.FindString(e.Message); match != "" {
+			return match, true
+		}
+	}
+
+	return "", false
 }
 
 // recoverDuplicateByDeveloperName looks up a tooling entity by DeveloperName


### PR DESCRIPTION
New external client with namespace org has different convention in naming the event realy config and it returns error. 

This PR is capturing that error and retrying with the naming convention recommended from the error message. 

In a namespaced org (scratch/packaging orgs), Salesforce prepends the org
namespace to the full name of metadata it creates, so an EventRelayConfig
created as "amp_x" becomes "<ns>__amp_x". The follow-up PATCH that sets the
relay to the RUN state echoed the un-namespaced full name and was rejected
with "Full name amp_x does not match the full name <ns>__amp_x".

Detect that mismatch, extract the expected namespaced full name from the
error, and retry the PATCH once with it (persisting the corrected full name
back onto the config). Mirrors the existing isDuplicateDeveloperName recovery
pattern.
