### PR TITLE
feat(subscribe): expose inline record on webhook events

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -848,6 +848,19 @@ type SubscriptionUpdateEvent interface {
 	UpdatedFields() ([]string, error)
 }
 
+// SubscriptionEventWithRecord is an optional interface implemented by providers
+// whose webhook payload already carries the full provider record inline (e.g.
+// ConnectWise ships it as the "Entity" field). When implemented, the record can
+// be field-mapped downstream without a separate GetRecordsByIds fetch.
+type SubscriptionEventWithRecord interface {
+	SubscriptionEvent
+
+	// Record returns the full provider record carried inline in the webhook
+	// payload. The returned map should use the same field shape a read returns
+	// (i.e. ReadResultRow.Fields), so it can be run through the same mapping.
+	Record() (map[string]any, error)
+}
+
 // CollapsedSubscriptionEvent some providers send multiple events in a single webhook payload.
 // This interface is used to extract individual events to SubscriptionEvent type
 // from a collapsed event for webhook parsing and processing.

--- a/providers/connectwise/internal/webhook/message.go
+++ b/providers/connectwise/internal/webhook/message.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 
@@ -15,9 +16,10 @@ type CollapsedSubscriptionEvent map[string]any
 type Event map[string]any
 
 var (
-	_ common.SubscriptionEvent          = Event{}
-	_ common.SubscriptionUpdateEvent    = Event{}
-	_ common.CollapsedSubscriptionEvent = CollapsedSubscriptionEvent{}
+	_ common.SubscriptionEvent           = Event{}
+	_ common.SubscriptionUpdateEvent     = Event{}
+	_ common.SubscriptionEventWithRecord = Event{}
+	_ common.CollapsedSubscriptionEvent  = CollapsedSubscriptionEvent{}
 )
 
 func (e CollapsedSubscriptionEvent) RawMap() (map[string]any, error) {
@@ -96,6 +98,23 @@ func (e Event) PreLoadData(data *common.SubscriptionEventPreLoadData) error {
 
 func (e Event) UpdatedFields() ([]string, error) {
 	return nil, nil
+}
+
+// Record returns the full record carried inline in the webhook payload.
+// ConnectWise embeds the changed record as an escaped JSON string under the
+// "Entity" field, so we unmarshal it into the same shape a read returns.
+func (e Event) Record() (map[string]any, error) {
+	entity, ok := e["Entity"].(string)
+	if !ok || entity == "" {
+		return nil, fmt.Errorf("%w: 'Entity'", common.ErrMissingField)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal([]byte(entity), &record); err != nil {
+		return nil, fmt.Errorf("parsing connectwise webhook 'Entity': %w", err)
+	}
+
+	return record, nil
 }
 
 // ObjectNameToObjectType maps ConnectWise connector object names

--- a/providers/connectwise/internal/webhook/message_test.go
+++ b/providers/connectwise/internal/webhook/message_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
@@ -54,6 +55,40 @@ func TestEvent(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			tt.Run(t)
 		})
+	}
+}
+
+func TestEventRecord(t *testing.T) {
+	t.Parallel()
+
+	collapsed := testutils.DataFromFileAs[CollapsedSubscriptionEvent](t, "contact-update.json")
+
+	events, err := collapsed.SubscriptionEventList()
+	if err != nil {
+		t.Fatalf("SubscriptionEventList: %v", err)
+	}
+
+	withRecord, ok := events[0].(common.SubscriptionEventWithRecord)
+	if !ok {
+		t.Fatal("connectwise Event does not implement SubscriptionEventWithRecord")
+	}
+
+	record, err := withRecord.Record()
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	result := testutils.NewCompareResult()
+	result.Assert("id", record["id"], float64(57961))
+	result.Assert("firstName", record["firstName"], "Xzavier Sawayn")
+	result.Validate(t, "inline Entity should unmarshal into the record")
+}
+
+func TestEventRecordMissingEntity(t *testing.T) {
+	t.Parallel()
+
+	if _, err := (Event{"Action": "updated", "ID": float64(1)}).Record(); err == nil {
+		t.Fatal("expected error when 'Entity' is absent")
 	}
 }
 


### PR DESCRIPTION
Add an optional `SubscriptionEventWithRecord` interface for providers whose
webhook payload already carries the full record inline, and implement it for
ConnectWise (the record ships as an escaped JSON string under `Entity`).

This lets the server field-map subscribe events into fields/mappedFields
without a separate GetRecordsByIds fetch, giving ConnectWise subscribe events
the same shape as reads (and SF/HS subscribe events).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>