### PR TITLE
[CON-3311] feat(stripe): Read customers for accounts

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,7 +21,9 @@ extend-exclude = [
     # Test files (contain mock data with intentional strings)
     "*_test.go",
     # Files with external API field names (non-standard spellings)
-    "providers/salesforce/metadata.go"
+    "providers/salesforce/metadata.go",
+    # Files that are hard coded exceptions
+    "providers/jobber/subscriptionEvent.go", # Field "occuredAt" with 1 "r" is a valid key used by the provider.
 ]
 
 ignore-hidden = true

--- a/providers/google/internal/calendar/subscriptionEvent.go
+++ b/providers/google/internal/calendar/subscriptionEvent.go
@@ -90,7 +90,7 @@ func (e SubscriptionEvent) RecordId() (string, error) {
 }
 
 // EventTimeStampNano returns the last-modification time in nanoseconds, or the current time
-// if Updated is missing or unparseable.
+// if Updated is missing or unparsable.
 func (e SubscriptionEvent) EventTimeStampNano() (int64, error) {
 	updated, err := time.Parse(time.RFC3339, e.Updated)
 	if err != nil {

--- a/providers/jobber/subscriptionEvent.go
+++ b/providers/jobber/subscriptionEvent.go
@@ -180,10 +180,10 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 }
 
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
-	// Apps created before 2023-12-08 receive the misspelled "occuredAt" key.
+	// Apps created before 2023-12-08 receive the misspelled "occurredAt" key.
 	timestamp, err := evt.eventField("occurredAt")
 	if err != nil {
-		timestamp, err = evt.eventField("occuredAt")
+		timestamp, err = evt.eventField("occurredAt")
 		if err != nil {
 			return 0, err
 		}

--- a/providers/jobber/subscriptionEvent.go
+++ b/providers/jobber/subscriptionEvent.go
@@ -180,10 +180,10 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 }
 
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
-	// Apps created before 2023-12-08 receive the misspelled "occurredAt" key.
+	// Apps created before 2023-12-08 receive the misspelled "occuredAt" key.
 	timestamp, err := evt.eventField("occurredAt")
 	if err != nil {
-		timestamp, err = evt.eventField("occurredAt")
+		timestamp, err = evt.eventField("occuredAt")
 		if err != nil {
 			return 0, err
 		}

--- a/test/stripe/read/customers/main.go
+++ b/test/stripe/read/customers/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/stripe"
 	connTest "github.com/amp-labs/connectors/test/stripe"
 	"github.com/amp-labs/connectors/test/utils"
 )
@@ -26,11 +27,14 @@ func main() {
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "customers",
 		Fields:     connectors.Fields("email", "name"),
+		Opts: stripe.ReadParamsOpts{
+			ReadForAllConnectedAccounts: true,
+		},
 	})
 	if err != nil {
 		utils.Fail("error reading from provider", "error", err)
 	}
 
 	slog.Info("Reading...")
-	utils.DumpJSON(res, os.Stdout)
+	utils.PrintReadResultWithoutRaw(res, os.Stdout)
 }

--- a/test/utils/print.go
+++ b/test/utils/print.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func PrintReadResultWithoutRaw(result *common.ReadResult, w io.Writer) {
+	convertedValue := substituteErrorsToStrings(result)
+
+	type readResultRow struct {
+		Fields       map[string]any              `json:"fields"`
+		Associations map[string][]map[string]any `json:"associations,omitempty"`
+		Id           string                      `json:"id,omitempty"`
+	}
+
+	type readResult struct {
+		Rows     int64           `json:"rows"`
+		Data     []readResultRow `json:"data"`
+		NextPage string          `json:"nextPage,omitempty"`
+		Done     bool            `json:"done,omitempty"`
+	}
+
+	data, err := json.Marshal(convertedValue)
+	if err != nil {
+		Fail("error marshaling convertedValue: %w", "error", err)
+	}
+
+	readData := readResult{}
+	if err = json.Unmarshal(data, &readData); err != nil {
+		Fail("error unmarshaling data into readData: %w", "error", err)
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+
+	if err = encoder.Encode(readData); err != nil {
+		Fail("error marshaling to JSON: %w", "error", err)
+	}
+}


### PR DESCRIPTION
# Description

* Read customers for all connected accounts.
* Fixed `typos.toml` to exlclude recently added file. Linter formatter modified this file by mistake causing a failing test. It is a false positive.

# Live Test

## Given remote state
```
acct_1Tr30XES6g9burIq:  JamesSalazar@example.com
  (has 1 customer)
acct_1Tr2z4ES6gU0n1bq:  johndoe@example.com
  (has 2 customers)
acct_1Tr2xTES6gzFlS40:  furever@example.com
  (has 1 customer)
```

## Read customers
<img width="830" height="1224" alt="image" src="https://github.com/user-attachments/assets/aaae0155-db32-4fec-9bb8-2c2f27c483cf" />
