### PR TITLE
fix(square): treat missing records key as empty page

### DIFF
--- a/providers/square/read.go
+++ b/providers/square/read.go
@@ -60,11 +60,20 @@ func (c *Connector) parseReadResponse(
 
 	return common.ParseResult(
 		resp,
-		common.MakeRecordsFunc(cfg.responseKey),
+		makeRecordsFunc(cfg.responseKey),
 		makeNextRecordsURL(),
 		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
 		params.Fields,
 	)
+}
+
+// makeRecordsFunc extracts the records array under responseKey. Square omits the
+// key entirely on an empty last page (the body is just `{}`), so we look it up
+// optionally and treat a missing key as zero records rather than an error.
+func makeRecordsFunc(responseKey string) common.NodeRecordsFunc {
+	return func(node *ajson.Node) ([]*ajson.Node, error) {
+		return jsonquery.New(node).ArrayOptional(responseKey)
+	}
 }
 
 // Square paginates list endpoints with a top-level `cursor` field that is

--- a/providers/square/read_test.go
+++ b/providers/square/read_test.go
@@ -196,6 +196,26 @@ func TestRead(t *testing.T) {
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "Read payments last page omits the records key entirely",
+			Input: common.ReadParams{
+				ObjectName: "payments",
+				Fields:     connectors.Fields("id", "status"),
+				NextPage:   "bk9iU0RGNGdGZ0VxZ1pQ",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v2/payments"),
+				Then:  mockserver.Response(http.StatusOK, []byte(`{}`)),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     0,
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "Read customers ignores Since because the list endpoint has no time filter",
 			Input: common.ReadParams{
 				ObjectName: "customers",


### PR DESCRIPTION
Reading a paginated Square object (e.g. `payments`) errored with `key not found: [payments]` on an empty page, because Square omits the records key entirely (body is just `{}`) and we used `ArrayRequired`.

Fix: extract records with `ArrayOptional` so an empty page returns 0 rows and `Done: true`.

