### PR TITLE
fix(slack): Remove SigningSecret from Connector metadata definition

### DIFF
--- a/providers/slack.go
+++ b/providers/slack.go
@@ -46,14 +46,6 @@ func init() {
 		},
 		PostAuthInfoNeeded: true,
 		Metadata: &ProviderMetadata{
-			Input: []MetadataItemInput{
-				{
-					DisplayName: "Signing Secret",
-					DocsURL:     "https://docs.slack.dev/authentication/verifying-requests-from-slack/#validating-a-request",
-					Name:        "signingSecret",
-					Prompt:      "Grab your Slack 'Signing Secret', available in the app admin panel under Basic Info.",
-				},
-			},
 			PostAuthentication: []MetadataItemPostAuthentication{
 				{
 					Name: "teamId",


### PR DESCRIPTION
# Background

UI blocks Slack setup from proceeding due to required `SigningSecret`. Even though it is mentioned in the catalog there is no way to indicate that it is optional for non-modular connectors (connector without modules).

# Fix

Reverting the definition for the time being.