### PR TITLE
[ENG-4121] feat(stripe): Metadata for Treasury, OpenAPI tool

### DIFF
--- a/providers/pylon/utils.go
+++ b/providers/pylon/utils.go
@@ -40,7 +40,7 @@ func buildIssueBody(params common.ReadParams) (map[string]any, error) {
 		"limit": pageSize,
 	}
 
-	subfilters := make([]map[string]any, 0, 2) //nolint:gomnd,mnd
+	subfilters := make([]map[string]any, 0, 2) //nolint:mnd
 
 	if !params.Since.IsZero() {
 		subfilters = append(subfilters, map[string]any{

--- a/providers/stripe/internal/metadata/schemas.json
+++ b/providers/stripe/internal/metadata/schemas.json
@@ -10,11 +10,11 @@
           "responseKey": "data",
           "fields": {
             "business_profile": {
-              "displayName": "business_profile",
+              "displayName": "Business Profile",
               "valueType": "other"
             },
             "business_type": {
-              "displayName": "business_type",
+              "displayName": "Business Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -37,81 +37,81 @@
               ]
             },
             "capabilities": {
-              "displayName": "capabilities",
+              "displayName": "Capabilities",
               "valueType": "other",
               "providerType": "object"
             },
             "charges_enabled": {
-              "displayName": "charges_enabled",
+              "displayName": "Charges Enabled",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "company": {
-              "displayName": "company",
+              "displayName": "Company",
               "valueType": "other",
               "providerType": "object"
             },
             "controller": {
-              "displayName": "controller",
+              "displayName": "Controller",
               "valueType": "other",
               "providerType": "object"
             },
             "country": {
-              "displayName": "country",
+              "displayName": "Country",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "default_currency": {
-              "displayName": "default_currency",
+              "displayName": "Default Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "details_submitted": {
-              "displayName": "details_submitted",
+              "displayName": "Details Submitted",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "email": {
-              "displayName": "email",
+              "displayName": "Email",
               "valueType": "string",
               "providerType": "string"
             },
             "external_accounts": {
-              "displayName": "external_accounts",
+              "displayName": "External Accounts",
               "valueType": "other",
               "providerType": "object"
             },
             "future_requirements": {
-              "displayName": "future_requirements",
+              "displayName": "Future Requirements",
               "valueType": "other",
               "providerType": "object"
             },
             "groups": {
-              "displayName": "groups",
+              "displayName": "Groups",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "individual": {
-              "displayName": "individual",
+              "displayName": "Individual",
               "valueType": "other",
               "providerType": "object"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -122,26 +122,26 @@
               ]
             },
             "payouts_enabled": {
-              "displayName": "payouts_enabled",
+              "displayName": "Payouts Enabled",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "requirements": {
-              "displayName": "requirements",
+              "displayName": "Requirements",
               "valueType": "other",
               "providerType": "object"
             },
             "settings": {
-              "displayName": "settings",
+              "displayName": "Settings",
               "valueType": "other"
             },
             "tos_acceptance": {
-              "displayName": "tos_acceptance",
+              "displayName": "Tos Acceptance",
               "valueType": "other",
               "providerType": "object"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -171,27 +171,27 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "domain_name": {
-              "displayName": "domain_name",
+              "displayName": "Domain Name",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -209,57 +209,57 @@
           "responseKey": "data",
           "fields": {
             "account": {
-              "displayName": "account",
+              "displayName": "Account",
               "valueType": "other"
             },
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_refunded": {
-              "displayName": "amount_refunded",
+              "displayName": "Amount Refunded",
               "valueType": "int",
               "providerType": "integer"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "charge": {
-              "displayName": "charge",
+              "displayName": "Charge",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "fee_source": {
-              "displayName": "fee_source",
+              "displayName": "Fee Source",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -270,16 +270,16 @@
               ]
             },
             "originating_transaction": {
-              "displayName": "originating_transaction",
+              "displayName": "Originating Transaction",
               "valueType": "other"
             },
             "refunded": {
-              "displayName": "refunded",
+              "displayName": "Refunded",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "refunds": {
-              "displayName": "refunds",
+              "displayName": "Refunds",
               "valueType": "other",
               "providerType": "object"
             }
@@ -291,17 +291,17 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "available_on": {
-              "displayName": "available_on",
+              "displayName": "Available On",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_type": {
-              "displayName": "balance_type",
+              "displayName": "Balance Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -324,47 +324,47 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "exchange_rate": {
-              "displayName": "exchange_rate",
+              "displayName": "Exchange Rate",
               "valueType": "other",
               "providerType": "number"
             },
             "fee": {
-              "displayName": "fee",
+              "displayName": "Fee",
               "valueType": "int",
               "providerType": "integer"
             },
             "fee_details": {
-              "displayName": "fee_details",
+              "displayName": "Fee Details",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "net": {
-              "displayName": "net",
+              "displayName": "Net",
               "valueType": "int",
               "providerType": "integer"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -375,21 +375,21 @@
               ]
             },
             "reporting_category": {
-              "displayName": "reporting_category",
+              "displayName": "Reporting Category",
               "valueType": "string",
               "providerType": "string"
             },
             "source": {
-              "displayName": "source",
+              "displayName": "Source",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -603,17 +603,17 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "available_on": {
-              "displayName": "available_on",
+              "displayName": "Available On",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_type": {
-              "displayName": "balance_type",
+              "displayName": "Balance Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -636,47 +636,47 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "exchange_rate": {
-              "displayName": "exchange_rate",
+              "displayName": "Exchange Rate",
               "valueType": "other",
               "providerType": "number"
             },
             "fee": {
-              "displayName": "fee",
+              "displayName": "Fee",
               "valueType": "int",
               "providerType": "integer"
             },
             "fee_details": {
-              "displayName": "fee_details",
+              "displayName": "Fee Details",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "net": {
-              "displayName": "net",
+              "displayName": "Net",
               "valueType": "int",
               "providerType": "integer"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -687,21 +687,21 @@
               ]
             },
             "reporting_category": {
-              "displayName": "reporting_category",
+              "displayName": "Reporting Category",
               "valueType": "string",
               "providerType": "string"
             },
             "source": {
-              "displayName": "source",
+              "displayName": "Source",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -915,7 +915,7 @@
           "responseKey": "data",
           "fields": {
             "alert_type": {
-              "displayName": "alert_type",
+              "displayName": "Alert Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -926,17 +926,17 @@
               ]
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -947,7 +947,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -966,12 +966,12 @@
               ]
             },
             "title": {
-              "displayName": "title",
+              "displayName": "Title",
               "valueType": "string",
               "providerType": "string"
             },
             "usage_threshold": {
-              "displayName": "usage_threshold",
+              "displayName": "Usage Threshold",
               "valueType": "other"
             }
           }
@@ -982,39 +982,39 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "credit": {
-              "displayName": "credit",
+              "displayName": "Credit",
               "valueType": "other"
             },
             "credit_grant": {
-              "displayName": "credit_grant",
+              "displayName": "Credit Grant",
               "valueType": "other"
             },
             "debit": {
-              "displayName": "debit",
+              "displayName": "Debit",
               "valueType": "other"
             },
             "effective_at": {
-              "displayName": "effective_at",
+              "displayName": "Effective At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1025,11 +1025,11 @@
               ]
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1051,17 +1051,17 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "other",
               "providerType": "object"
             },
             "applicability_config": {
-              "displayName": "applicability_config",
+              "displayName": "Applicability Config",
               "valueType": "other",
               "providerType": "object"
             },
             "category": {
-              "displayName": "category",
+              "displayName": "Category",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1076,51 +1076,51 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "effective_at": {
-              "displayName": "effective_at",
+              "displayName": "Effective At",
               "valueType": "int",
               "providerType": "integer"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1131,21 +1131,21 @@
               ]
             },
             "priority": {
-              "displayName": "priority",
+              "displayName": "Priority",
               "valueType": "int",
               "providerType": "integer"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             },
             "updated": {
-              "displayName": "updated",
+              "displayName": "Updated",
               "valueType": "int",
               "providerType": "integer"
             },
             "voided_at": {
-              "displayName": "voided_at",
+              "displayName": "Voided At",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -1157,32 +1157,32 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "customer_mapping": {
-              "displayName": "customer_mapping",
+              "displayName": "Customer Mapping",
               "valueType": "other",
               "providerType": "object"
             },
             "default_aggregation": {
-              "displayName": "default_aggregation",
+              "displayName": "Default Aggregation",
               "valueType": "other",
               "providerType": "object"
             },
             "display_name": {
-              "displayName": "display_name",
+              "displayName": "Display Name",
               "valueType": "string",
               "providerType": "string"
             },
             "event_name": {
-              "displayName": "event_name",
+              "displayName": "Event Name",
               "valueType": "string",
               "providerType": "string"
             },
             "event_time_window": {
-              "displayName": "event_time_window",
+              "displayName": "Event Time Window",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1197,17 +1197,17 @@
               ]
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1218,7 +1218,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1233,17 +1233,17 @@
               ]
             },
             "status_transitions": {
-              "displayName": "status_transitions",
+              "displayName": "Status Transitions",
               "valueType": "other",
               "providerType": "object"
             },
             "updated": {
-              "displayName": "updated",
+              "displayName": "Updated",
               "valueType": "int",
               "providerType": "integer"
             },
             "value_settings": {
-              "displayName": "value_settings",
+              "displayName": "Value Settings",
               "valueType": "other",
               "providerType": "object"
             }
@@ -1255,66 +1255,66 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "business_profile": {
-              "displayName": "business_profile",
+              "displayName": "Business Profile",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "default_return_url": {
-              "displayName": "default_return_url",
+              "displayName": "Default Return Url",
               "valueType": "string",
               "providerType": "string"
             },
             "features": {
-              "displayName": "features",
+              "displayName": "Features",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "is_default": {
-              "displayName": "is_default",
+              "displayName": "Is Default",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "login_page": {
-              "displayName": "login_page",
+              "displayName": "Login Page",
               "valueType": "other",
               "providerType": "object"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1325,7 +1325,7 @@
               ]
             },
             "updated": {
-              "displayName": "updated",
+              "displayName": "Updated",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -1337,111 +1337,111 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_captured": {
-              "displayName": "amount_captured",
+              "displayName": "Amount Captured",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_refunded": {
-              "displayName": "amount_refunded",
+              "displayName": "Amount Refunded",
               "valueType": "int",
               "providerType": "integer"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "application_fee": {
-              "displayName": "application_fee",
+              "displayName": "Application Fee",
               "valueType": "other"
             },
             "application_fee_amount": {
-              "displayName": "application_fee_amount",
+              "displayName": "Application Fee Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "billing_details": {
-              "displayName": "billing_details",
+              "displayName": "Billing Details",
               "valueType": "other",
               "providerType": "object"
             },
             "calculated_statement_descriptor": {
-              "displayName": "calculated_statement_descriptor",
+              "displayName": "Calculated Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "captured": {
-              "displayName": "captured",
+              "displayName": "Captured",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "disputed": {
-              "displayName": "disputed",
+              "displayName": "Disputed",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "failure_balance_transaction": {
-              "displayName": "failure_balance_transaction",
+              "displayName": "Failure Balance Transaction",
               "valueType": "other"
             },
             "failure_code": {
-              "displayName": "failure_code",
+              "displayName": "Failure Code",
               "valueType": "string",
               "providerType": "string"
             },
             "failure_message": {
-              "displayName": "failure_message",
+              "displayName": "Failure Message",
               "valueType": "string",
               "providerType": "string"
             },
             "fraud_details": {
-              "displayName": "fraud_details",
+              "displayName": "Fraud Details",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1452,90 +1452,90 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "outcome": {
-              "displayName": "outcome",
+              "displayName": "Outcome",
               "valueType": "other"
             },
             "paid": {
-              "displayName": "paid",
+              "displayName": "Paid",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             },
             "payment_method": {
-              "displayName": "payment_method",
+              "displayName": "Payment Method",
               "valueType": "string",
               "providerType": "string"
             },
             "payment_method_details": {
-              "displayName": "payment_method_details",
+              "displayName": "Payment Method Details",
               "valueType": "other"
             },
             "presentment_details": {
-              "displayName": "presentment_details",
+              "displayName": "Presentment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "radar_options": {
-              "displayName": "radar_options",
+              "displayName": "Radar Options",
               "valueType": "other",
               "providerType": "object"
             },
             "receipt_email": {
-              "displayName": "receipt_email",
+              "displayName": "Receipt Email",
               "valueType": "string",
               "providerType": "string"
             },
             "receipt_number": {
-              "displayName": "receipt_number",
+              "displayName": "Receipt Number",
               "valueType": "string",
               "providerType": "string"
             },
             "receipt_url": {
-              "displayName": "receipt_url",
+              "displayName": "Receipt Url",
               "valueType": "string",
               "providerType": "string"
             },
             "refunded": {
-              "displayName": "refunded",
+              "displayName": "Refunded",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "refunds": {
-              "displayName": "refunds",
+              "displayName": "Refunds",
               "valueType": "other",
               "providerType": "object"
             },
             "review": {
-              "displayName": "review",
+              "displayName": "Review",
               "valueType": "other"
             },
             "shipping": {
-              "displayName": "shipping",
+              "displayName": "Shipping",
               "valueType": "other"
             },
             "source_transfer": {
-              "displayName": "source_transfer",
+              "displayName": "Source Transfer",
               "valueType": "other"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "statement_descriptor_suffix": {
-              "displayName": "statement_descriptor_suffix",
+              "displayName": "Statement Descriptor Suffix",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1554,15 +1554,15 @@
               ]
             },
             "transfer": {
-              "displayName": "transfer",
+              "displayName": "Transfer",
               "valueType": "other"
             },
             "transfer_data": {
-              "displayName": "transfer_data",
+              "displayName": "Transfer Data",
               "valueType": "other"
             },
             "transfer_group": {
-              "displayName": "transfer_group",
+              "displayName": "Transfer Group",
               "valueType": "string",
               "providerType": "string"
             }
@@ -1574,35 +1574,35 @@
           "responseKey": "data",
           "fields": {
             "adaptive_pricing": {
-              "displayName": "adaptive_pricing",
+              "displayName": "Adaptive Pricing",
               "valueType": "other"
             },
             "after_expiration": {
-              "displayName": "after_expiration",
+              "displayName": "After Expiration",
               "valueType": "other"
             },
             "allow_promotion_codes": {
-              "displayName": "allow_promotion_codes",
+              "displayName": "Allow Promotion Codes",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "amount_subtotal": {
-              "displayName": "amount_subtotal",
+              "displayName": "Amount Subtotal",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_total": {
-              "displayName": "amount_total",
+              "displayName": "Amount Total",
               "valueType": "int",
               "providerType": "integer"
             },
             "automatic_tax": {
-              "displayName": "automatic_tax",
+              "displayName": "Automatic Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "billing_address_collection": {
-              "displayName": "billing_address_collection",
+              "displayName": "Billing Address Collection",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1617,72 +1617,72 @@
               ]
             },
             "branding_settings": {
-              "displayName": "branding_settings",
+              "displayName": "Branding Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "cancel_url": {
-              "displayName": "cancel_url",
+              "displayName": "Cancel Url",
               "valueType": "string",
               "providerType": "string"
             },
             "client_reference_id": {
-              "displayName": "client_reference_id",
+              "displayName": "Client Reference Id",
               "valueType": "string",
               "providerType": "string"
             },
             "client_secret": {
-              "displayName": "client_secret",
+              "displayName": "Client Secret",
               "valueType": "string",
               "providerType": "string"
             },
             "collected_information": {
-              "displayName": "collected_information",
+              "displayName": "Collected Information",
               "valueType": "other"
             },
             "consent": {
-              "displayName": "consent",
+              "displayName": "Consent",
               "valueType": "other"
             },
             "consent_collection": {
-              "displayName": "consent_collection",
+              "displayName": "Consent Collection",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "currency_conversion": {
-              "displayName": "currency_conversion",
+              "displayName": "Currency Conversion",
               "valueType": "other"
             },
             "custom_fields": {
-              "displayName": "custom_fields",
+              "displayName": "Custom Fields",
               "valueType": "other",
               "providerType": "array"
             },
             "custom_text": {
-              "displayName": "custom_text",
+              "displayName": "Custom Text",
               "valueType": "other",
               "providerType": "object"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_creation": {
-              "displayName": "customer_creation",
+              "displayName": "Customer Creation",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1697,59 +1697,59 @@
               ]
             },
             "customer_details": {
-              "displayName": "customer_details",
+              "displayName": "Customer Details",
               "valueType": "other"
             },
             "customer_email": {
-              "displayName": "customer_email",
+              "displayName": "Customer Email",
               "valueType": "string",
               "providerType": "string"
             },
             "discounts": {
-              "displayName": "discounts",
+              "displayName": "Discounts",
               "valueType": "other",
               "providerType": "array"
             },
             "excluded_payment_method_types": {
-              "displayName": "excluded_payment_method_types",
+              "displayName": "Excluded Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "integration_identifier": {
-              "displayName": "integration_identifier",
+              "displayName": "Integration Identifier",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice": {
-              "displayName": "invoice",
+              "displayName": "Invoice",
               "valueType": "other"
             },
             "invoice_creation": {
-              "displayName": "invoice_creation",
+              "displayName": "Invoice Creation",
               "valueType": "other"
             },
             "line_items": {
-              "displayName": "line_items",
+              "displayName": "Line Items",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "locale": {
-              "displayName": "locale",
+              "displayName": "Locale",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1920,16 +1920,16 @@
               ]
             },
             "managed_payments": {
-              "displayName": "managed_payments",
+              "displayName": "Managed Payments",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "mode": {
-              "displayName": "mode",
+              "displayName": "Mode",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1948,12 +1948,12 @@
               ]
             },
             "name_collection": {
-              "displayName": "name_collection",
+              "displayName": "Name Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1964,12 +1964,12 @@
               ]
             },
             "optional_items": {
-              "displayName": "optional_items",
+              "displayName": "Optional Items",
               "valueType": "other",
               "providerType": "array"
             },
             "origin_context": {
-              "displayName": "origin_context",
+              "displayName": "Origin Context",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -1984,15 +1984,15 @@
               ]
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             },
             "payment_link": {
-              "displayName": "payment_link",
+              "displayName": "Payment Link",
               "valueType": "other"
             },
             "payment_method_collection": {
-              "displayName": "payment_method_collection",
+              "displayName": "Payment Method Collection",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2007,20 +2007,20 @@
               ]
             },
             "payment_method_configuration_details": {
-              "displayName": "payment_method_configuration_details",
+              "displayName": "Payment Method Configuration Details",
               "valueType": "other"
             },
             "payment_method_options": {
-              "displayName": "payment_method_options",
+              "displayName": "Payment Method Options",
               "valueType": "other"
             },
             "payment_method_types": {
-              "displayName": "payment_method_types",
+              "displayName": "Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "payment_status": {
-              "displayName": "payment_status",
+              "displayName": "Payment Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2039,26 +2039,26 @@
               ]
             },
             "permissions": {
-              "displayName": "permissions",
+              "displayName": "Permissions",
               "valueType": "other"
             },
             "phone_number_collection": {
-              "displayName": "phone_number_collection",
+              "displayName": "Phone Number Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "presentment_details": {
-              "displayName": "presentment_details",
+              "displayName": "Presentment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "recovered_from": {
-              "displayName": "recovered_from",
+              "displayName": "Recovered From",
               "valueType": "string",
               "providerType": "string"
             },
             "redirect_on_completion": {
-              "displayName": "redirect_on_completion",
+              "displayName": "Redirect On Completion",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2077,33 +2077,33 @@
               ]
             },
             "return_url": {
-              "displayName": "return_url",
+              "displayName": "Return Url",
               "valueType": "string",
               "providerType": "string"
             },
             "saved_payment_method_options": {
-              "displayName": "saved_payment_method_options",
+              "displayName": "Saved Payment Method Options",
               "valueType": "other"
             },
             "setup_intent": {
-              "displayName": "setup_intent",
+              "displayName": "Setup Intent",
               "valueType": "other"
             },
             "shipping_address_collection": {
-              "displayName": "shipping_address_collection",
+              "displayName": "Shipping Address Collection",
               "valueType": "other"
             },
             "shipping_cost": {
-              "displayName": "shipping_cost",
+              "displayName": "Shipping Cost",
               "valueType": "other"
             },
             "shipping_options": {
-              "displayName": "shipping_options",
+              "displayName": "Shipping Options",
               "valueType": "other",
               "providerType": "array"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2122,7 +2122,7 @@
               ]
             },
             "submit_type": {
-              "displayName": "submit_type",
+              "displayName": "Submit Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2149,25 +2149,25 @@
               ]
             },
             "subscription": {
-              "displayName": "subscription",
+              "displayName": "Subscription",
               "valueType": "other"
             },
             "success_url": {
-              "displayName": "success_url",
+              "displayName": "Success Url",
               "valueType": "string",
               "providerType": "string"
             },
             "tax_id_collection": {
-              "displayName": "tax_id_collection",
+              "displayName": "Tax Id Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "total_details": {
-              "displayName": "total_details",
+              "displayName": "Total Details",
               "valueType": "other"
             },
             "ui_mode": {
-              "displayName": "ui_mode",
+              "displayName": "Ui Mode",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2186,12 +2186,12 @@
               ]
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             },
             "wallet_options": {
-              "displayName": "wallet_options",
+              "displayName": "Wallet Options",
               "valueType": "other"
             }
           }
@@ -2202,32 +2202,32 @@
           "responseKey": "data",
           "fields": {
             "amount_fees": {
-              "displayName": "amount_fees",
+              "displayName": "Amount Fees",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_subtotal": {
-              "displayName": "amount_subtotal",
+              "displayName": "Amount Subtotal",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_total": {
-              "displayName": "amount_total",
+              "displayName": "Amount Total",
               "valueType": "int",
               "providerType": "integer"
             },
             "beneficiary": {
-              "displayName": "beneficiary",
+              "displayName": "Beneficiary",
               "valueType": "other",
               "providerType": "object"
             },
             "canceled_at": {
-              "displayName": "canceled_at",
+              "displayName": "Canceled At",
               "valueType": "int",
               "providerType": "integer"
             },
             "cancellation_reason": {
-              "displayName": "cancellation_reason",
+              "displayName": "Cancellation Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2246,67 +2246,67 @@
               ]
             },
             "certificate": {
-              "displayName": "certificate",
+              "displayName": "Certificate",
               "valueType": "string",
               "providerType": "string"
             },
             "confirmed_at": {
-              "displayName": "confirmed_at",
+              "displayName": "Confirmed At",
               "valueType": "int",
               "providerType": "integer"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "delayed_at": {
-              "displayName": "delayed_at",
+              "displayName": "Delayed At",
               "valueType": "int",
               "providerType": "integer"
             },
             "delivered_at": {
-              "displayName": "delivered_at",
+              "displayName": "Delivered At",
               "valueType": "int",
               "providerType": "integer"
             },
             "delivery_details": {
-              "displayName": "delivery_details",
+              "displayName": "Delivery Details",
               "valueType": "other",
               "providerType": "array"
             },
             "expected_delivery_year": {
-              "displayName": "expected_delivery_year",
+              "displayName": "Expected Delivery Year",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "metric_tons": {
-              "displayName": "metric_tons",
+              "displayName": "Metric Tons",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2317,16 +2317,16 @@
               ]
             },
             "product": {
-              "displayName": "product",
+              "displayName": "Product",
               "valueType": "other"
             },
             "product_substituted_at": {
-              "displayName": "product_substituted_at",
+              "displayName": "Product Substituted At",
               "valueType": "int",
               "providerType": "integer"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2360,42 +2360,42 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "current_prices_per_metric_ton": {
-              "displayName": "current_prices_per_metric_ton",
+              "displayName": "Current Prices Per Metric Ton",
               "valueType": "other",
               "providerType": "object"
             },
             "delivery_year": {
-              "displayName": "delivery_year",
+              "displayName": "Delivery Year",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metric_tons_available": {
-              "displayName": "metric_tons_available",
+              "displayName": "Metric Tons Available",
               "valueType": "string",
               "providerType": "string"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2406,7 +2406,7 @@
               ]
             },
             "suppliers": {
-              "displayName": "suppliers",
+              "displayName": "Suppliers",
               "valueType": "other",
               "providerType": "array"
             }
@@ -2418,32 +2418,32 @@
           "responseKey": "data",
           "fields": {
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "info_url": {
-              "displayName": "info_url",
+              "displayName": "Info Url",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "locations": {
-              "displayName": "locations",
+              "displayName": "Locations",
               "valueType": "other",
               "providerType": "array"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2454,7 +2454,7 @@
               ]
             },
             "removal_pathway": {
-              "displayName": "removal_pathway",
+              "displayName": "Removal Pathway",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2484,17 +2484,17 @@
           "responseKey": "data",
           "fields": {
             "default_currency": {
-              "displayName": "default_currency",
+              "displayName": "Default Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2505,27 +2505,27 @@
               ]
             },
             "supported_bank_account_currencies": {
-              "displayName": "supported_bank_account_currencies",
+              "displayName": "Supported Bank Account Currencies",
               "valueType": "other",
               "providerType": "object"
             },
             "supported_payment_currencies": {
-              "displayName": "supported_payment_currencies",
+              "displayName": "Supported Payment Currencies",
               "valueType": "other",
               "providerType": "array"
             },
             "supported_payment_methods": {
-              "displayName": "supported_payment_methods",
+              "displayName": "Supported Payment Methods",
               "valueType": "other",
               "providerType": "array"
             },
             "supported_transfer_countries": {
-              "displayName": "supported_transfer_countries",
+              "displayName": "Supported Transfer Countries",
               "valueType": "other",
               "providerType": "array"
             },
             "verification_fields": {
-              "displayName": "verification_fields",
+              "displayName": "Verification Fields",
               "valueType": "other",
               "providerType": "object"
             }
@@ -2537,32 +2537,32 @@
           "responseKey": "data",
           "fields": {
             "amount_off": {
-              "displayName": "amount_off",
+              "displayName": "Amount Off",
               "valueType": "int",
               "providerType": "integer"
             },
             "applies_to": {
-              "displayName": "applies_to",
+              "displayName": "Applies To",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "currency_options": {
-              "displayName": "currency_options",
+              "displayName": "Currency Options",
               "valueType": "other",
               "providerType": "object"
             },
             "duration": {
-              "displayName": "duration",
+              "displayName": "Duration",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2581,37 +2581,37 @@
               ]
             },
             "duration_in_months": {
-              "displayName": "duration_in_months",
+              "displayName": "Duration In Months",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "max_redemptions": {
-              "displayName": "max_redemptions",
+              "displayName": "Max Redemptions",
               "valueType": "int",
               "providerType": "integer"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2622,22 +2622,22 @@
               ]
             },
             "percent_off": {
-              "displayName": "percent_off",
+              "displayName": "Percent Off",
               "valueType": "other",
               "providerType": "number"
             },
             "redeem_by": {
-              "displayName": "redeem_by",
+              "displayName": "Redeem By",
               "valueType": "int",
               "providerType": "integer"
             },
             "times_redeemed": {
-              "displayName": "times_redeemed",
+              "displayName": "Times Redeemed",
               "valueType": "int",
               "providerType": "integer"
             },
             "valid": {
-              "displayName": "valid",
+              "displayName": "Valid",
               "valueType": "boolean",
               "providerType": "boolean"
             }
@@ -2649,89 +2649,89 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_shipping": {
-              "displayName": "amount_shipping",
+              "displayName": "Amount Shipping",
               "valueType": "int",
               "providerType": "integer"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_balance_transaction": {
-              "displayName": "customer_balance_transaction",
+              "displayName": "Customer Balance Transaction",
               "valueType": "other"
             },
             "discount_amount": {
-              "displayName": "discount_amount",
+              "displayName": "Discount Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "discount_amounts": {
-              "displayName": "discount_amounts",
+              "displayName": "Discount Amounts",
               "valueType": "other",
               "providerType": "array"
             },
             "effective_at": {
-              "displayName": "effective_at",
+              "displayName": "Effective At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice": {
-              "displayName": "invoice",
+              "displayName": "Invoice",
               "valueType": "other"
             },
             "lines": {
-              "displayName": "lines",
+              "displayName": "Lines",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "memo": {
-              "displayName": "memo",
+              "displayName": "Memo",
               "valueType": "string",
               "providerType": "string"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "number": {
-              "displayName": "number",
+              "displayName": "Number",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2742,32 +2742,32 @@
               ]
             },
             "out_of_band_amount": {
-              "displayName": "out_of_band_amount",
+              "displayName": "Out Of Band Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "pdf": {
-              "displayName": "pdf",
+              "displayName": "Pdf",
               "valueType": "string",
               "providerType": "string"
             },
             "post_payment_amount": {
-              "displayName": "post_payment_amount",
+              "displayName": "Post Payment Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "pre_payment_amount": {
-              "displayName": "pre_payment_amount",
+              "displayName": "Pre Payment Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "pretax_credit_amounts": {
-              "displayName": "pretax_credit_amounts",
+              "displayName": "Pretax Credit Amounts",
               "valueType": "other",
               "providerType": "array"
             },
             "reason": {
-              "displayName": "reason",
+              "displayName": "Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2790,16 +2790,16 @@
               ]
             },
             "refunds": {
-              "displayName": "refunds",
+              "displayName": "Refunds",
               "valueType": "other",
               "providerType": "array"
             },
             "shipping_cost": {
-              "displayName": "shipping_cost",
+              "displayName": "Shipping Cost",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2814,32 +2814,32 @@
               ]
             },
             "subtotal": {
-              "displayName": "subtotal",
+              "displayName": "Subtotal",
               "valueType": "int",
               "providerType": "integer"
             },
             "subtotal_excluding_tax": {
-              "displayName": "subtotal_excluding_tax",
+              "displayName": "Subtotal Excluding Tax",
               "valueType": "int",
               "providerType": "integer"
             },
             "total": {
-              "displayName": "total",
+              "displayName": "Total",
               "valueType": "int",
               "providerType": "integer"
             },
             "total_excluding_tax": {
-              "displayName": "total_excluding_tax",
+              "displayName": "Total Excluding Tax",
               "valueType": "int",
               "providerType": "integer"
             },
             "total_taxes": {
-              "displayName": "total_taxes",
+              "displayName": "Total Taxes",
               "valueType": "other",
               "providerType": "array"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2858,7 +2858,7 @@
               ]
             },
             "voided_at": {
-              "displayName": "voided_at",
+              "displayName": "Voided At",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -2870,108 +2870,108 @@
           "responseKey": "data",
           "fields": {
             "address": {
-              "displayName": "address",
+              "displayName": "Address",
               "valueType": "other"
             },
             "balance": {
-              "displayName": "balance",
+              "displayName": "Balance",
               "valueType": "int",
               "providerType": "integer"
             },
             "business_name": {
-              "displayName": "business_name",
+              "displayName": "Business Name",
               "valueType": "string",
               "providerType": "string"
             },
             "cash_balance": {
-              "displayName": "cash_balance",
+              "displayName": "Cash Balance",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "default_source": {
-              "displayName": "default_source",
+              "displayName": "Default Source",
               "valueType": "other"
             },
             "delinquent": {
-              "displayName": "delinquent",
+              "displayName": "Delinquent",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "discount": {
-              "displayName": "discount",
+              "displayName": "Discount",
               "valueType": "other"
             },
             "email": {
-              "displayName": "email",
+              "displayName": "Email",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "individual_name": {
-              "displayName": "individual_name",
+              "displayName": "Individual Name",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice_credit_balance": {
-              "displayName": "invoice_credit_balance",
+              "displayName": "Invoice Credit Balance",
               "valueType": "other",
               "providerType": "object"
             },
             "invoice_prefix": {
-              "displayName": "invoice_prefix",
+              "displayName": "Invoice Prefix",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice_settings": {
-              "displayName": "invoice_settings",
+              "displayName": "Invoice Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "next_invoice_sequence": {
-              "displayName": "next_invoice_sequence",
+              "displayName": "Next Invoice Sequence",
               "valueType": "int",
               "providerType": "integer"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -2982,36 +2982,36 @@
               ]
             },
             "phone": {
-              "displayName": "phone",
+              "displayName": "Phone",
               "valueType": "string",
               "providerType": "string"
             },
             "preferred_locales": {
-              "displayName": "preferred_locales",
+              "displayName": "Preferred Locales",
               "valueType": "other",
               "providerType": "array"
             },
             "shipping": {
-              "displayName": "shipping",
+              "displayName": "Shipping",
               "valueType": "other"
             },
             "sources": {
-              "displayName": "sources",
+              "displayName": "Sources",
               "valueType": "other",
               "providerType": "object"
             },
             "subscriptions": {
-              "displayName": "subscriptions",
+              "displayName": "Subscriptions",
               "valueType": "other",
               "providerType": "object"
             },
             "tax": {
-              "displayName": "tax",
+              "displayName": "Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "tax_exempt": {
-              "displayName": "tax_exempt",
+              "displayName": "Tax Exempt",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3030,12 +3030,12 @@
               ]
             },
             "tax_ids": {
-              "displayName": "tax_ids",
+              "displayName": "Tax Ids",
               "valueType": "other",
               "providerType": "object"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             }
           }
@@ -3046,66 +3046,66 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transactions": {
-              "displayName": "balance_transactions",
+              "displayName": "Balance Transactions",
               "valueType": "other",
               "providerType": "array"
             },
             "charge": {
-              "displayName": "charge",
+              "displayName": "Charge",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "enhanced_eligibility_types": {
-              "displayName": "enhanced_eligibility_types",
+              "displayName": "Enhanced Eligibility Types",
               "valueType": "other",
               "providerType": "array"
             },
             "evidence": {
-              "displayName": "evidence",
+              "displayName": "Evidence",
               "valueType": "other",
               "providerType": "object"
             },
             "evidence_details": {
-              "displayName": "evidence_details",
+              "displayName": "Evidence Details",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "is_charge_refundable": {
-              "displayName": "is_charge_refundable",
+              "displayName": "Is Charge Refundable",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3116,21 +3116,21 @@
               ]
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             },
             "payment_method_details": {
-              "displayName": "payment_method_details",
+              "displayName": "Payment Method Details",
               "valueType": "other",
               "providerType": "object"
             },
             "reason": {
-              "displayName": "reason",
+              "displayName": "Reason",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3176,37 +3176,37 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "lookup_key": {
-              "displayName": "lookup_key",
+              "displayName": "Lookup Key",
               "valueType": "string",
               "providerType": "string"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3224,42 +3224,42 @@
           "responseKey": "data",
           "fields": {
             "account": {
-              "displayName": "account",
+              "displayName": "Account",
               "valueType": "string",
               "providerType": "string"
             },
             "api_version": {
-              "displayName": "api_version",
+              "displayName": "Api Version",
               "valueType": "string",
               "providerType": "string"
             },
             "context": {
-              "displayName": "context",
+              "displayName": "Context",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "data": {
-              "displayName": "data",
+              "displayName": "Data",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3270,16 +3270,16 @@
               ]
             },
             "pending_webhooks": {
-              "displayName": "pending_webhooks",
+              "displayName": "Pending Webhooks",
               "valueType": "int",
               "providerType": "integer"
             },
             "request": {
-              "displayName": "request",
+              "displayName": "Request",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "string",
               "providerType": "string"
             }
@@ -3291,41 +3291,41 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "expired": {
-              "displayName": "expired",
+              "displayName": "Expired",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "file": {
-              "displayName": "file",
+              "displayName": "File",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3336,7 +3336,7 @@
               ]
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }
@@ -3348,32 +3348,32 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "filename": {
-              "displayName": "filename",
+              "displayName": "Filename",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "links": {
-              "displayName": "links",
+              "displayName": "Links",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3384,7 +3384,7 @@
               ]
             },
             "purpose": {
-              "displayName": "purpose",
+              "displayName": "Purpose",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3475,22 +3475,22 @@
               ]
             },
             "size": {
-              "displayName": "size",
+              "displayName": "Size",
               "valueType": "int",
               "providerType": "integer"
             },
             "title": {
-              "displayName": "title",
+              "displayName": "Title",
               "valueType": "string",
               "providerType": "string"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "string",
               "providerType": "string"
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }
@@ -3502,24 +3502,24 @@
           "responseKey": "data",
           "fields": {
             "account_holder": {
-              "displayName": "account_holder",
+              "displayName": "Account Holder",
               "valueType": "other"
             },
             "account_numbers": {
-              "displayName": "account_numbers",
+              "displayName": "Account Numbers",
               "valueType": "other",
               "providerType": "array"
             },
             "balance": {
-              "displayName": "balance",
+              "displayName": "Balance",
               "valueType": "other"
             },
             "balance_refresh": {
-              "displayName": "balance_refresh",
+              "displayName": "Balance Refresh",
               "valueType": "other"
             },
             "category": {
-              "displayName": "category",
+              "displayName": "Category",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3542,37 +3542,37 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "display_name": {
-              "displayName": "display_name",
+              "displayName": "Display Name",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "institution_name": {
-              "displayName": "institution_name",
+              "displayName": "Institution Name",
               "valueType": "string",
               "providerType": "string"
             },
             "last4": {
-              "displayName": "last4",
+              "displayName": "Last4",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3583,20 +3583,20 @@
               ]
             },
             "ownership": {
-              "displayName": "ownership",
+              "displayName": "Ownership",
               "valueType": "other"
             },
             "ownership_refresh": {
-              "displayName": "ownership_refresh",
+              "displayName": "Ownership Refresh",
               "valueType": "other"
             },
             "permissions": {
-              "displayName": "permissions",
+              "displayName": "Permissions",
               "valueType": "other",
               "providerType": "array"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3615,12 +3615,12 @@
               ]
             },
             "status_details": {
-              "displayName": "status_details",
+              "displayName": "Status Details",
               "valueType": "other",
               "providerType": "object"
             },
             "subcategory": {
-              "displayName": "subcategory",
+              "displayName": "Subcategory",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3651,17 +3651,17 @@
               ]
             },
             "subscriptions": {
-              "displayName": "subscriptions",
+              "displayName": "Subscriptions",
               "valueType": "other",
               "providerType": "array"
             },
             "supported_payment_method_types": {
-              "displayName": "supported_payment_method_types",
+              "displayName": "Supported Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "transaction_refresh": {
-              "displayName": "transaction_refresh",
+              "displayName": "Transaction Refresh",
               "valueType": "other"
             }
           }
@@ -3672,27 +3672,27 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3703,29 +3703,29 @@
               ]
             },
             "payment_method": {
-              "displayName": "payment_method",
+              "displayName": "Payment Method",
               "valueType": "string",
               "providerType": "string"
             },
             "replacements": {
-              "displayName": "replacements",
+              "displayName": "Replacements",
               "valueType": "other",
               "providerType": "array"
             },
             "request_context": {
-              "displayName": "request_context",
+              "displayName": "Request Context",
               "valueType": "other"
             },
             "request_details": {
-              "displayName": "request_details",
+              "displayName": "Request Details",
               "valueType": "other"
             },
             "response_details": {
-              "displayName": "response_details",
+              "displayName": "Response Details",
               "valueType": "other"
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }
@@ -3737,42 +3737,42 @@
           "responseKey": "data",
           "fields": {
             "client_reference_id": {
-              "displayName": "client_reference_id",
+              "displayName": "Client Reference Id",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "document": {
-              "displayName": "document",
+              "displayName": "Document",
               "valueType": "other",
               "providerType": "object"
             },
             "email": {
-              "displayName": "email",
+              "displayName": "Email",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "id_number": {
-              "displayName": "id_number",
+              "displayName": "Id Number",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3783,22 +3783,22 @@
               ]
             },
             "options": {
-              "displayName": "options",
+              "displayName": "Options",
               "valueType": "other",
               "providerType": "object"
             },
             "phone": {
-              "displayName": "phone",
+              "displayName": "Phone",
               "valueType": "other",
               "providerType": "object"
             },
             "selfie": {
-              "displayName": "selfie",
+              "displayName": "Selfie",
               "valueType": "other",
               "providerType": "object"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3817,12 +3817,12 @@
               ]
             },
             "verification_flow": {
-              "displayName": "verification_flow",
+              "displayName": "Verification Flow",
               "valueType": "string",
               "providerType": "string"
             },
             "verification_session": {
-              "displayName": "verification_session",
+              "displayName": "Verification Session",
               "valueType": "string",
               "providerType": "string"
             }
@@ -3834,45 +3834,45 @@
           "responseKey": "data",
           "fields": {
             "client_reference_id": {
-              "displayName": "client_reference_id",
+              "displayName": "Client Reference Id",
               "valueType": "string",
               "providerType": "string"
             },
             "client_secret": {
-              "displayName": "client_secret",
+              "displayName": "Client Secret",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "last_error": {
-              "displayName": "last_error",
+              "displayName": "Last Error",
               "valueType": "other"
             },
             "last_verification_report": {
-              "displayName": "last_verification_report",
+              "displayName": "Last Verification Report",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3883,34 +3883,34 @@
               ]
             },
             "options": {
-              "displayName": "options",
+              "displayName": "Options",
               "valueType": "other"
             },
             "provided_details": {
-              "displayName": "provided_details",
+              "displayName": "Provided Details",
               "valueType": "other"
             },
             "redaction": {
-              "displayName": "redaction",
+              "displayName": "Redaction",
               "valueType": "other"
             },
             "related_customer": {
-              "displayName": "related_customer",
+              "displayName": "Related Customer",
               "valueType": "string",
               "providerType": "string"
             },
             "related_customer_account": {
-              "displayName": "related_customer_account",
+              "displayName": "Related Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "related_person": {
-              "displayName": "related_person",
+              "displayName": "Related Person",
               "valueType": "other",
               "providerType": "object"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3933,7 +3933,7 @@
               ]
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -3952,17 +3952,17 @@
               ]
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             },
             "verification_flow": {
-              "displayName": "verification_flow",
+              "displayName": "Verification Flow",
               "valueType": "string",
               "providerType": "string"
             },
             "verified_outputs": {
-              "displayName": "verified_outputs",
+              "displayName": "Verified Outputs",
               "valueType": "other"
             }
           }
@@ -3973,46 +3973,46 @@
           "responseKey": "data",
           "fields": {
             "amount_paid": {
-              "displayName": "amount_paid",
+              "displayName": "Amount Paid",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_requested": {
-              "displayName": "amount_requested",
+              "displayName": "Amount Requested",
               "valueType": "int",
               "providerType": "integer"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice": {
-              "displayName": "invoice",
+              "displayName": "Invoice",
               "valueType": "other"
             },
             "is_default": {
-              "displayName": "is_default",
+              "displayName": "Is Default",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4023,17 +4023,17 @@
               ]
             },
             "payment": {
-              "displayName": "payment",
+              "displayName": "Payment",
               "valueType": "other",
               "providerType": "object"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "status_transitions": {
-              "displayName": "status_transitions",
+              "displayName": "Status Transitions",
               "valueType": "other",
               "providerType": "object"
             }
@@ -4045,32 +4045,32 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "nickname": {
-              "displayName": "nickname",
+              "displayName": "Nickname",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4081,7 +4081,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4096,7 +4096,7 @@
               ]
             },
             "version": {
-              "displayName": "version",
+              "displayName": "Version",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -4108,70 +4108,70 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "date": {
-              "displayName": "date",
+              "displayName": "Date",
               "valueType": "int",
               "providerType": "integer"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "discountable": {
-              "displayName": "discountable",
+              "displayName": "Discountable",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "discounts": {
-              "displayName": "discounts",
+              "displayName": "Discounts",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice": {
-              "displayName": "invoice",
+              "displayName": "Invoice",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "net_amount": {
-              "displayName": "net_amount",
+              "displayName": "Net Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4182,45 +4182,45 @@
               ]
             },
             "parent": {
-              "displayName": "parent",
+              "displayName": "Parent",
               "valueType": "other"
             },
             "period": {
-              "displayName": "period",
+              "displayName": "Period",
               "valueType": "other",
               "providerType": "object"
             },
             "pricing": {
-              "displayName": "pricing",
+              "displayName": "Pricing",
               "valueType": "other"
             },
             "proration": {
-              "displayName": "proration",
+              "displayName": "Proration",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "proration_details": {
-              "displayName": "proration_details",
+              "displayName": "Proration Details",
               "valueType": "other",
               "providerType": "object"
             },
             "quantity": {
-              "displayName": "quantity",
+              "displayName": "Quantity",
               "valueType": "int",
               "providerType": "integer"
             },
             "quantity_decimal": {
-              "displayName": "quantity_decimal",
+              "displayName": "Quantity Decimal",
               "valueType": "string",
               "providerType": "string"
             },
             "tax_rates": {
-              "displayName": "tax_rates",
+              "displayName": "Tax Rates",
               "valueType": "other",
               "providerType": "array"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             }
           }
@@ -4231,81 +4231,81 @@
           "responseKey": "data",
           "fields": {
             "account_country": {
-              "displayName": "account_country",
+              "displayName": "Account Country",
               "valueType": "string",
               "providerType": "string"
             },
             "account_name": {
-              "displayName": "account_name",
+              "displayName": "Account Name",
               "valueType": "string",
               "providerType": "string"
             },
             "account_tax_ids": {
-              "displayName": "account_tax_ids",
+              "displayName": "Account Tax Ids",
               "valueType": "other",
               "providerType": "array"
             },
             "amount_due": {
-              "displayName": "amount_due",
+              "displayName": "Amount Due",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_overpaid": {
-              "displayName": "amount_overpaid",
+              "displayName": "Amount Overpaid",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_paid": {
-              "displayName": "amount_paid",
+              "displayName": "Amount Paid",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_paid_off_stripe": {
-              "displayName": "amount_paid_off_stripe",
+              "displayName": "Amount Paid Off Stripe",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_remaining": {
-              "displayName": "amount_remaining",
+              "displayName": "Amount Remaining",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_shipping": {
-              "displayName": "amount_shipping",
+              "displayName": "Amount Shipping",
               "valueType": "int",
               "providerType": "integer"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "attempt_count": {
-              "displayName": "attempt_count",
+              "displayName": "Attempt Count",
               "valueType": "int",
               "providerType": "integer"
             },
             "attempted": {
-              "displayName": "attempted",
+              "displayName": "Attempted",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "auto_advance": {
-              "displayName": "auto_advance",
+              "displayName": "Auto Advance",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "automatic_tax": {
-              "displayName": "automatic_tax",
+              "displayName": "Automatic Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "automatically_finalizes_at": {
-              "displayName": "automatically_finalizes_at",
+              "displayName": "Automatically Finalizes At",
               "valueType": "int",
               "providerType": "integer"
             },
             "billing_reason": {
-              "displayName": "billing_reason",
+              "displayName": "Billing Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4348,7 +4348,7 @@
               ]
             },
             "collection_method": {
-              "displayName": "collection_method",
+              "displayName": "Collection Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4363,58 +4363,58 @@
               ]
             },
             "confirmation_secret": {
-              "displayName": "confirmation_secret",
+              "displayName": "Confirmation Secret",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "custom_fields": {
-              "displayName": "custom_fields",
+              "displayName": "Custom Fields",
               "valueType": "other",
               "providerType": "array"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_address": {
-              "displayName": "customer_address",
+              "displayName": "Customer Address",
               "valueType": "other"
             },
             "customer_email": {
-              "displayName": "customer_email",
+              "displayName": "Customer Email",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_name": {
-              "displayName": "customer_name",
+              "displayName": "Customer Name",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_phone": {
-              "displayName": "customer_phone",
+              "displayName": "Customer Phone",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_shipping": {
-              "displayName": "customer_shipping",
+              "displayName": "Customer Shipping",
               "valueType": "other"
             },
             "customer_tax_exempt": {
-              "displayName": "customer_tax_exempt",
+              "displayName": "Customer Tax Exempt",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4433,112 +4433,112 @@
               ]
             },
             "customer_tax_ids": {
-              "displayName": "customer_tax_ids",
+              "displayName": "Customer Tax Ids",
               "valueType": "other",
               "providerType": "array"
             },
             "default_payment_method": {
-              "displayName": "default_payment_method",
+              "displayName": "Default Payment Method",
               "valueType": "other"
             },
             "default_source": {
-              "displayName": "default_source",
+              "displayName": "Default Source",
               "valueType": "other"
             },
             "default_tax_rates": {
-              "displayName": "default_tax_rates",
+              "displayName": "Default Tax Rates",
               "valueType": "other",
               "providerType": "array"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "discounts": {
-              "displayName": "discounts",
+              "displayName": "Discounts",
               "valueType": "other",
               "providerType": "array"
             },
             "due_date": {
-              "displayName": "due_date",
+              "displayName": "Due Date",
               "valueType": "int",
               "providerType": "integer"
             },
             "effective_at": {
-              "displayName": "effective_at",
+              "displayName": "Effective At",
               "valueType": "int",
               "providerType": "integer"
             },
             "ending_balance": {
-              "displayName": "ending_balance",
+              "displayName": "Ending Balance",
               "valueType": "int",
               "providerType": "integer"
             },
             "footer": {
-              "displayName": "footer",
+              "displayName": "Footer",
               "valueType": "string",
               "providerType": "string"
             },
             "from_invoice": {
-              "displayName": "from_invoice",
+              "displayName": "From Invoice",
               "valueType": "other"
             },
             "hosted_invoice_url": {
-              "displayName": "hosted_invoice_url",
+              "displayName": "Hosted Invoice Url",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice_pdf": {
-              "displayName": "invoice_pdf",
+              "displayName": "Invoice Pdf",
               "valueType": "string",
               "providerType": "string"
             },
             "issuer": {
-              "displayName": "issuer",
+              "displayName": "Issuer",
               "valueType": "other",
               "providerType": "object"
             },
             "last_finalization_error": {
-              "displayName": "last_finalization_error",
+              "displayName": "Last Finalization Error",
               "valueType": "other"
             },
             "latest_revision": {
-              "displayName": "latest_revision",
+              "displayName": "Latest Revision",
               "valueType": "other"
             },
             "lines": {
-              "displayName": "lines",
+              "displayName": "Lines",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "next_payment_attempt": {
-              "displayName": "next_payment_attempt",
+              "displayName": "Next Payment Attempt",
               "valueType": "int",
               "providerType": "integer"
             },
             "number": {
-              "displayName": "number",
+              "displayName": "Number",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4549,72 +4549,72 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "parent": {
-              "displayName": "parent",
+              "displayName": "Parent",
               "valueType": "other"
             },
             "payment_settings": {
-              "displayName": "payment_settings",
+              "displayName": "Payment Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "payments": {
-              "displayName": "payments",
+              "displayName": "Payments",
               "valueType": "other",
               "providerType": "object"
             },
             "period_end": {
-              "displayName": "period_end",
+              "displayName": "Period End",
               "valueType": "int",
               "providerType": "integer"
             },
             "period_start": {
-              "displayName": "period_start",
+              "displayName": "Period Start",
               "valueType": "int",
               "providerType": "integer"
             },
             "post_payment_credit_notes_amount": {
-              "displayName": "post_payment_credit_notes_amount",
+              "displayName": "Post Payment Credit Notes Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "pre_payment_credit_notes_amount": {
-              "displayName": "pre_payment_credit_notes_amount",
+              "displayName": "Pre Payment Credit Notes Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "receipt_number": {
-              "displayName": "receipt_number",
+              "displayName": "Receipt Number",
               "valueType": "string",
               "providerType": "string"
             },
             "rendering": {
-              "displayName": "rendering",
+              "displayName": "Rendering",
               "valueType": "other"
             },
             "shipping_cost": {
-              "displayName": "shipping_cost",
+              "displayName": "Shipping Cost",
               "valueType": "other"
             },
             "shipping_details": {
-              "displayName": "shipping_details",
+              "displayName": "Shipping Details",
               "valueType": "other"
             },
             "starting_balance": {
-              "displayName": "starting_balance",
+              "displayName": "Starting Balance",
               "valueType": "int",
               "providerType": "integer"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4641,56 +4641,56 @@
               ]
             },
             "status_transitions": {
-              "displayName": "status_transitions",
+              "displayName": "Status Transitions",
               "valueType": "other",
               "providerType": "object"
             },
             "subtotal": {
-              "displayName": "subtotal",
+              "displayName": "Subtotal",
               "valueType": "int",
               "providerType": "integer"
             },
             "subtotal_excluding_tax": {
-              "displayName": "subtotal_excluding_tax",
+              "displayName": "Subtotal Excluding Tax",
               "valueType": "int",
               "providerType": "integer"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             },
             "threshold_reason": {
-              "displayName": "threshold_reason",
+              "displayName": "Threshold Reason",
               "valueType": "other",
               "providerType": "object"
             },
             "total": {
-              "displayName": "total",
+              "displayName": "Total",
               "valueType": "int",
               "providerType": "integer"
             },
             "total_discount_amounts": {
-              "displayName": "total_discount_amounts",
+              "displayName": "Total Discount Amounts",
               "valueType": "other",
               "providerType": "array"
             },
             "total_excluding_tax": {
-              "displayName": "total_excluding_tax",
+              "displayName": "Total Excluding Tax",
               "valueType": "int",
               "providerType": "integer"
             },
             "total_pretax_credit_amounts": {
-              "displayName": "total_pretax_credit_amounts",
+              "displayName": "Total Pretax Credit Amounts",
               "valueType": "other",
               "providerType": "array"
             },
             "total_taxes": {
-              "displayName": "total_taxes",
+              "displayName": "Total Taxes",
               "valueType": "other",
               "providerType": "array"
             },
             "webhooks_delivered_at": {
-              "displayName": "webhooks_delivered_at",
+              "displayName": "Webhooks Delivered At",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -4702,21 +4702,21 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_details": {
-              "displayName": "amount_details",
+              "displayName": "Amount Details",
               "valueType": "other"
             },
             "approved": {
-              "displayName": "approved",
+              "displayName": "Approved",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "authorization_method": {
-              "displayName": "authorization_method",
+              "displayName": "Authorization Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4743,17 +4743,17 @@
               ]
             },
             "balance_transactions": {
-              "displayName": "balance_transactions",
+              "displayName": "Balance Transactions",
               "valueType": "other",
               "providerType": "array"
             },
             "card": {
-              "displayName": "card",
+              "displayName": "Card",
               "valueType": "other",
               "providerType": "object"
             },
             "card_presence": {
-              "displayName": "card_presence",
+              "displayName": "Card Presence",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4768,68 +4768,68 @@
               ]
             },
             "cardholder": {
-              "displayName": "cardholder",
+              "displayName": "Cardholder",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "fleet": {
-              "displayName": "fleet",
+              "displayName": "Fleet",
               "valueType": "other"
             },
             "fraud_challenges": {
-              "displayName": "fraud_challenges",
+              "displayName": "Fraud Challenges",
               "valueType": "other",
               "providerType": "array"
             },
             "fuel": {
-              "displayName": "fuel",
+              "displayName": "Fuel",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "merchant_amount": {
-              "displayName": "merchant_amount",
+              "displayName": "Merchant Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "merchant_currency": {
-              "displayName": "merchant_currency",
+              "displayName": "Merchant Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "merchant_data": {
-              "displayName": "merchant_data",
+              "displayName": "Merchant Data",
               "valueType": "other",
               "providerType": "object"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "network_data": {
-              "displayName": "network_data",
+              "displayName": "Network Data",
               "valueType": "other"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4840,16 +4840,16 @@
               ]
             },
             "pending_request": {
-              "displayName": "pending_request",
+              "displayName": "Pending Request",
               "valueType": "other"
             },
             "request_history": {
-              "displayName": "request_history",
+              "displayName": "Request History",
               "valueType": "other",
               "providerType": "array"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4872,30 +4872,30 @@
               ]
             },
             "token": {
-              "displayName": "token",
+              "displayName": "Token",
               "valueType": "other"
             },
             "transactions": {
-              "displayName": "transactions",
+              "displayName": "Transactions",
               "valueType": "other",
               "providerType": "array"
             },
             "treasury": {
-              "displayName": "treasury",
+              "displayName": "Treasury",
               "valueType": "other"
             },
             "verification_data": {
-              "displayName": "verification_data",
+              "displayName": "Verification Data",
               "valueType": "other",
               "providerType": "object"
             },
             "verified_by_fraud_challenge": {
-              "displayName": "verified_by_fraud_challenge",
+              "displayName": "Verified By Fraud Challenge",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "wallet": {
-              "displayName": "wallet",
+              "displayName": "Wallet",
               "valueType": "string",
               "providerType": "string"
             }
@@ -4907,50 +4907,50 @@
           "responseKey": "data",
           "fields": {
             "billing": {
-              "displayName": "billing",
+              "displayName": "Billing",
               "valueType": "other",
               "providerType": "object"
             },
             "company": {
-              "displayName": "company",
+              "displayName": "Company",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "email": {
-              "displayName": "email",
+              "displayName": "Email",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "individual": {
-              "displayName": "individual",
+              "displayName": "Individual",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4961,26 +4961,26 @@
               ]
             },
             "phone_number": {
-              "displayName": "phone_number",
+              "displayName": "Phone Number",
               "valueType": "string",
               "providerType": "string"
             },
             "preferred_locales": {
-              "displayName": "preferred_locales",
+              "displayName": "Preferred Locales",
               "valueType": "other",
               "providerType": "array"
             },
             "requirements": {
-              "displayName": "requirements",
+              "displayName": "Requirements",
               "valueType": "other",
               "providerType": "object"
             },
             "spending_controls": {
-              "displayName": "spending_controls",
+              "displayName": "Spending Controls",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -4999,7 +4999,7 @@
               ]
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5021,12 +5021,12 @@
           "responseKey": "data",
           "fields": {
             "brand": {
-              "displayName": "brand",
+              "displayName": "Brand",
               "valueType": "string",
               "providerType": "string"
             },
             "cancellation_reason": {
-              "displayName": "cancellation_reason",
+              "displayName": "Cancellation Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5049,75 +5049,75 @@
               ]
             },
             "cardholder": {
-              "displayName": "cardholder",
+              "displayName": "Cardholder",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "cvc": {
-              "displayName": "cvc",
+              "displayName": "Cvc",
               "valueType": "string",
               "providerType": "string"
             },
             "exp_month": {
-              "displayName": "exp_month",
+              "displayName": "Exp Month",
               "valueType": "int",
               "providerType": "integer"
             },
             "exp_year": {
-              "displayName": "exp_year",
+              "displayName": "Exp Year",
               "valueType": "int",
               "providerType": "integer"
             },
             "financial_account": {
-              "displayName": "financial_account",
+              "displayName": "Financial Account",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "last4": {
-              "displayName": "last4",
+              "displayName": "Last4",
               "valueType": "string",
               "providerType": "string"
             },
             "latest_fraud_warning": {
-              "displayName": "latest_fraud_warning",
+              "displayName": "Latest Fraud Warning",
               "valueType": "other"
             },
             "lifecycle_controls": {
-              "displayName": "lifecycle_controls",
+              "displayName": "Lifecycle Controls",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "number": {
-              "displayName": "number",
+              "displayName": "Number",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5128,19 +5128,19 @@
               ]
             },
             "personalization_design": {
-              "displayName": "personalization_design",
+              "displayName": "Personalization Design",
               "valueType": "other"
             },
             "replaced_by": {
-              "displayName": "replaced_by",
+              "displayName": "Replaced By",
               "valueType": "other"
             },
             "replacement_for": {
-              "displayName": "replacement_for",
+              "displayName": "Replacement For",
               "valueType": "other"
             },
             "replacement_reason": {
-              "displayName": "replacement_reason",
+              "displayName": "Replacement Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5167,21 +5167,21 @@
               ]
             },
             "second_line": {
-              "displayName": "second_line",
+              "displayName": "Second Line",
               "valueType": "string",
               "providerType": "string"
             },
             "shipping": {
-              "displayName": "shipping",
+              "displayName": "Shipping",
               "valueType": "other"
             },
             "spending_controls": {
-              "displayName": "spending_controls",
+              "displayName": "Spending Controls",
               "valueType": "other",
               "providerType": "object"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5200,7 +5200,7 @@
               ]
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5215,7 +5215,7 @@
               ]
             },
             "wallets": {
-              "displayName": "wallets",
+              "displayName": "Wallets",
               "valueType": "other"
             }
           }
@@ -5226,42 +5226,42 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transactions": {
-              "displayName": "balance_transactions",
+              "displayName": "Balance Transactions",
               "valueType": "other",
               "providerType": "array"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "evidence": {
-              "displayName": "evidence",
+              "displayName": "Evidence",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "loss_reason": {
-              "displayName": "loss_reason",
+              "displayName": "Loss Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5348,12 +5348,12 @@
               ]
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5364,7 +5364,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5391,11 +5391,11 @@
               ]
             },
             "transaction": {
-              "displayName": "transaction",
+              "displayName": "Transaction",
               "valueType": "other"
             },
             "treasury": {
-              "displayName": "treasury",
+              "displayName": "Treasury",
               "valueType": "other"
             }
           }
@@ -5406,45 +5406,45 @@
           "responseKey": "data",
           "fields": {
             "card_logo": {
-              "displayName": "card_logo",
+              "displayName": "Card Logo",
               "valueType": "other"
             },
             "carrier_text": {
-              "displayName": "carrier_text",
+              "displayName": "Carrier Text",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "lookup_key": {
-              "displayName": "lookup_key",
+              "displayName": "Lookup Key",
               "valueType": "string",
               "providerType": "string"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5455,21 +5455,21 @@
               ]
             },
             "physical_bundle": {
-              "displayName": "physical_bundle",
+              "displayName": "Physical Bundle",
               "valueType": "other"
             },
             "preferences": {
-              "displayName": "preferences",
+              "displayName": "Preferences",
               "valueType": "other",
               "providerType": "object"
             },
             "rejection_reasons": {
-              "displayName": "rejection_reasons",
+              "displayName": "Rejection Reasons",
               "valueType": "other",
               "providerType": "object"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5499,27 +5499,27 @@
           "responseKey": "data",
           "fields": {
             "features": {
-              "displayName": "features",
+              "displayName": "Features",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5530,7 +5530,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5549,7 +5549,7 @@
               ]
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5571,80 +5571,80 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_details": {
-              "displayName": "amount_details",
+              "displayName": "Amount Details",
               "valueType": "other"
             },
             "authorization": {
-              "displayName": "authorization",
+              "displayName": "Authorization",
               "valueType": "other"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "card": {
-              "displayName": "card",
+              "displayName": "Card",
               "valueType": "other"
             },
             "cardholder": {
-              "displayName": "cardholder",
+              "displayName": "Cardholder",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "dispute": {
-              "displayName": "dispute",
+              "displayName": "Dispute",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "merchant_amount": {
-              "displayName": "merchant_amount",
+              "displayName": "Merchant Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "merchant_currency": {
-              "displayName": "merchant_currency",
+              "displayName": "Merchant Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "merchant_data": {
-              "displayName": "merchant_data",
+              "displayName": "Merchant Data",
               "valueType": "other",
               "providerType": "object"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "network_data": {
-              "displayName": "network_data",
+              "displayName": "Network Data",
               "valueType": "other"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5655,19 +5655,19 @@
               ]
             },
             "purchase_details": {
-              "displayName": "purchase_details",
+              "displayName": "Purchase Details",
               "valueType": "other"
             },
             "token": {
-              "displayName": "token",
+              "displayName": "Token",
               "valueType": "other"
             },
             "treasury": {
-              "displayName": "treasury",
+              "displayName": "Treasury",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5682,7 +5682,7 @@
               ]
             },
             "wallet": {
-              "displayName": "wallet",
+              "displayName": "Wallet",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5708,44 +5708,44 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_capturable": {
-              "displayName": "amount_capturable",
+              "displayName": "Amount Capturable",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_details": {
-              "displayName": "amount_details",
+              "displayName": "Amount Details",
               "valueType": "other"
             },
             "amount_received": {
-              "displayName": "amount_received",
+              "displayName": "Amount Received",
               "valueType": "int",
               "providerType": "integer"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "application_fee_amount": {
-              "displayName": "application_fee_amount",
+              "displayName": "Application Fee Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "automatic_payment_methods": {
-              "displayName": "automatic_payment_methods",
+              "displayName": "Automatic Payment Methods",
               "valueType": "other"
             },
             "canceled_at": {
-              "displayName": "canceled_at",
+              "displayName": "Canceled At",
               "valueType": "int",
               "providerType": "integer"
             },
             "cancellation_reason": {
-              "displayName": "cancellation_reason",
+              "displayName": "Cancellation Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5784,7 +5784,7 @@
               ]
             },
             "capture_method": {
-              "displayName": "capture_method",
+              "displayName": "Capture Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5803,12 +5803,12 @@
               ]
             },
             "client_secret": {
-              "displayName": "client_secret",
+              "displayName": "Client Secret",
               "valueType": "string",
               "providerType": "string"
             },
             "confirmation_method": {
-              "displayName": "confirmation_method",
+              "displayName": "Confirmation Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5823,72 +5823,72 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "excluded_payment_method_types": {
-              "displayName": "excluded_payment_method_types",
+              "displayName": "Excluded Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "hooks": {
-              "displayName": "hooks",
+              "displayName": "Hooks",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "last_payment_error": {
-              "displayName": "last_payment_error",
+              "displayName": "Last Payment Error",
               "valueType": "other"
             },
             "latest_charge": {
-              "displayName": "latest_charge",
+              "displayName": "Latest Charge",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "managed_payments": {
-              "displayName": "managed_payments",
+              "displayName": "Managed Payments",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "next_action": {
-              "displayName": "next_action",
+              "displayName": "Next Action",
               "valueType": "other"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5899,51 +5899,51 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "payment_details": {
-              "displayName": "payment_details",
+              "displayName": "Payment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "payment_method": {
-              "displayName": "payment_method",
+              "displayName": "Payment Method",
               "valueType": "other"
             },
             "payment_method_configuration_details": {
-              "displayName": "payment_method_configuration_details",
+              "displayName": "Payment Method Configuration Details",
               "valueType": "other"
             },
             "payment_method_options": {
-              "displayName": "payment_method_options",
+              "displayName": "Payment Method Options",
               "valueType": "other"
             },
             "payment_method_types": {
-              "displayName": "payment_method_types",
+              "displayName": "Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "presentment_details": {
-              "displayName": "presentment_details",
+              "displayName": "Presentment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "processing": {
-              "displayName": "processing",
+              "displayName": "Processing",
               "valueType": "other"
             },
             "receipt_email": {
-              "displayName": "receipt_email",
+              "displayName": "Receipt Email",
               "valueType": "string",
               "providerType": "string"
             },
             "review": {
-              "displayName": "review",
+              "displayName": "Review",
               "valueType": "other"
             },
             "setup_future_usage": {
-              "displayName": "setup_future_usage",
+              "displayName": "Setup Future Usage",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -5958,21 +5958,21 @@
               ]
             },
             "shipping": {
-              "displayName": "shipping",
+              "displayName": "Shipping",
               "valueType": "other"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "statement_descriptor_suffix": {
-              "displayName": "statement_descriptor_suffix",
+              "displayName": "Statement Descriptor Suffix",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6007,11 +6007,11 @@
               ]
             },
             "transfer_data": {
-              "displayName": "transfer_data",
+              "displayName": "Transfer Data",
               "valueType": "other"
             },
             "transfer_group": {
-              "displayName": "transfer_group",
+              "displayName": "Transfer Group",
               "valueType": "string",
               "providerType": "string"
             }
@@ -6023,41 +6023,41 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "after_completion": {
-              "displayName": "after_completion",
+              "displayName": "After Completion",
               "valueType": "other",
               "providerType": "object"
             },
             "allow_promotion_codes": {
-              "displayName": "allow_promotion_codes",
+              "displayName": "Allow Promotion Codes",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "application_fee_amount": {
-              "displayName": "application_fee_amount",
+              "displayName": "Application Fee Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "application_fee_percent": {
-              "displayName": "application_fee_percent",
+              "displayName": "Application Fee Percent",
               "valueType": "other",
               "providerType": "number"
             },
             "automatic_tax": {
-              "displayName": "automatic_tax",
+              "displayName": "Automatic Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "billing_address_collection": {
-              "displayName": "billing_address_collection",
+              "displayName": "Billing Address Collection",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6072,26 +6072,26 @@
               ]
             },
             "consent_collection": {
-              "displayName": "consent_collection",
+              "displayName": "Consent Collection",
               "valueType": "other"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "custom_fields": {
-              "displayName": "custom_fields",
+              "displayName": "Custom Fields",
               "valueType": "other",
               "providerType": "array"
             },
             "custom_text": {
-              "displayName": "custom_text",
+              "displayName": "Custom Text",
               "valueType": "other",
               "providerType": "object"
             },
             "customer_creation": {
-              "displayName": "customer_creation",
+              "displayName": "Customer Creation",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6106,45 +6106,45 @@
               ]
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "inactive_message": {
-              "displayName": "inactive_message",
+              "displayName": "Inactive Message",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice_creation": {
-              "displayName": "invoice_creation",
+              "displayName": "Invoice Creation",
               "valueType": "other"
             },
             "line_items": {
-              "displayName": "line_items",
+              "displayName": "Line Items",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "managed_payments": {
-              "displayName": "managed_payments",
+              "displayName": "Managed Payments",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name_collection": {
-              "displayName": "name_collection",
+              "displayName": "Name Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6155,20 +6155,20 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "optional_items": {
-              "displayName": "optional_items",
+              "displayName": "Optional Items",
               "valueType": "other",
               "providerType": "array"
             },
             "payment_intent_data": {
-              "displayName": "payment_intent_data",
+              "displayName": "Payment Intent Data",
               "valueType": "other"
             },
             "payment_method_collection": {
-              "displayName": "payment_method_collection",
+              "displayName": "Payment Method Collection",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6183,34 +6183,34 @@
               ]
             },
             "payment_method_options": {
-              "displayName": "payment_method_options",
+              "displayName": "Payment Method Options",
               "valueType": "other"
             },
             "payment_method_types": {
-              "displayName": "payment_method_types",
+              "displayName": "Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "phone_number_collection": {
-              "displayName": "phone_number_collection",
+              "displayName": "Phone Number Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "restrictions": {
-              "displayName": "restrictions",
+              "displayName": "Restrictions",
               "valueType": "other"
             },
             "shipping_address_collection": {
-              "displayName": "shipping_address_collection",
+              "displayName": "Shipping Address Collection",
               "valueType": "other"
             },
             "shipping_options": {
-              "displayName": "shipping_options",
+              "displayName": "Shipping Options",
               "valueType": "other",
               "providerType": "array"
             },
             "submit_type": {
-              "displayName": "submit_type",
+              "displayName": "Submit Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6237,20 +6237,20 @@
               ]
             },
             "subscription_data": {
-              "displayName": "subscription_data",
+              "displayName": "Subscription Data",
               "valueType": "other"
             },
             "tax_id_collection": {
-              "displayName": "tax_id_collection",
+              "displayName": "Tax Id Collection",
               "valueType": "other",
               "providerType": "object"
             },
             "transfer_data": {
-              "displayName": "transfer_data",
+              "displayName": "Transfer Data",
               "valueType": "other"
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }
@@ -6262,217 +6262,217 @@
           "responseKey": "data",
           "fields": {
             "acss_debit": {
-              "displayName": "acss_debit",
+              "displayName": "Acss Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "affirm": {
-              "displayName": "affirm",
+              "displayName": "Affirm",
               "valueType": "other",
               "providerType": "object"
             },
             "afterpay_clearpay": {
-              "displayName": "afterpay_clearpay",
+              "displayName": "Afterpay Clearpay",
               "valueType": "other",
               "providerType": "object"
             },
             "alipay": {
-              "displayName": "alipay",
+              "displayName": "Alipay",
               "valueType": "other",
               "providerType": "object"
             },
             "alma": {
-              "displayName": "alma",
+              "displayName": "Alma",
               "valueType": "other",
               "providerType": "object"
             },
             "amazon_pay": {
-              "displayName": "amazon_pay",
+              "displayName": "Amazon Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "apple_pay": {
-              "displayName": "apple_pay",
+              "displayName": "Apple Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "string",
               "providerType": "string"
             },
             "au_becs_debit": {
-              "displayName": "au_becs_debit",
+              "displayName": "Au Becs Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "bacs_debit": {
-              "displayName": "bacs_debit",
+              "displayName": "Bacs Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "bancontact": {
-              "displayName": "bancontact",
+              "displayName": "Bancontact",
               "valueType": "other",
               "providerType": "object"
             },
             "billie": {
-              "displayName": "billie",
+              "displayName": "Billie",
               "valueType": "other",
               "providerType": "object"
             },
             "bizum": {
-              "displayName": "bizum",
+              "displayName": "Bizum",
               "valueType": "other",
               "providerType": "object"
             },
             "blik": {
-              "displayName": "blik",
+              "displayName": "Blik",
               "valueType": "other",
               "providerType": "object"
             },
             "boleto": {
-              "displayName": "boleto",
+              "displayName": "Boleto",
               "valueType": "other",
               "providerType": "object"
             },
             "card": {
-              "displayName": "card",
+              "displayName": "Card",
               "valueType": "other",
               "providerType": "object"
             },
             "cartes_bancaires": {
-              "displayName": "cartes_bancaires",
+              "displayName": "Cartes Bancaires",
               "valueType": "other",
               "providerType": "object"
             },
             "cashapp": {
-              "displayName": "cashapp",
+              "displayName": "Cashapp",
               "valueType": "other",
               "providerType": "object"
             },
             "crypto": {
-              "displayName": "crypto",
+              "displayName": "Crypto",
               "valueType": "other",
               "providerType": "object"
             },
             "customer_balance": {
-              "displayName": "customer_balance",
+              "displayName": "Customer Balance",
               "valueType": "other",
               "providerType": "object"
             },
             "eps": {
-              "displayName": "eps",
+              "displayName": "Eps",
               "valueType": "other",
               "providerType": "object"
             },
             "fpx": {
-              "displayName": "fpx",
+              "displayName": "Fpx",
               "valueType": "other",
               "providerType": "object"
             },
             "giropay": {
-              "displayName": "giropay",
+              "displayName": "Giropay",
               "valueType": "other",
               "providerType": "object"
             },
             "google_pay": {
-              "displayName": "google_pay",
+              "displayName": "Google Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "grabpay": {
-              "displayName": "grabpay",
+              "displayName": "Grabpay",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "ideal": {
-              "displayName": "ideal",
+              "displayName": "Ideal",
               "valueType": "other",
               "providerType": "object"
             },
             "is_default": {
-              "displayName": "is_default",
+              "displayName": "Is Default",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "jcb": {
-              "displayName": "jcb",
+              "displayName": "Jcb",
               "valueType": "other",
               "providerType": "object"
             },
             "kakao_pay": {
-              "displayName": "kakao_pay",
+              "displayName": "Kakao Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "klarna": {
-              "displayName": "klarna",
+              "displayName": "Klarna",
               "valueType": "other",
               "providerType": "object"
             },
             "konbini": {
-              "displayName": "konbini",
+              "displayName": "Konbini",
               "valueType": "other",
               "providerType": "object"
             },
             "kr_card": {
-              "displayName": "kr_card",
+              "displayName": "Kr Card",
               "valueType": "other",
               "providerType": "object"
             },
             "link": {
-              "displayName": "link",
+              "displayName": "Link",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "mb_way": {
-              "displayName": "mb_way",
+              "displayName": "Mb Way",
               "valueType": "other",
               "providerType": "object"
             },
             "mobilepay": {
-              "displayName": "mobilepay",
+              "displayName": "Mobilepay",
               "valueType": "other",
               "providerType": "object"
             },
             "multibanco": {
-              "displayName": "multibanco",
+              "displayName": "Multibanco",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "naver_pay": {
-              "displayName": "naver_pay",
+              "displayName": "Naver Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "nz_bank_account": {
-              "displayName": "nz_bank_account",
+              "displayName": "Nz Bank Account",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6483,117 +6483,117 @@
               ]
             },
             "oxxo": {
-              "displayName": "oxxo",
+              "displayName": "Oxxo",
               "valueType": "other",
               "providerType": "object"
             },
             "p24": {
-              "displayName": "p24",
+              "displayName": "P24",
               "valueType": "other",
               "providerType": "object"
             },
             "parent": {
-              "displayName": "parent",
+              "displayName": "Parent",
               "valueType": "string",
               "providerType": "string"
             },
             "pay_by_bank": {
-              "displayName": "pay_by_bank",
+              "displayName": "Pay By Bank",
               "valueType": "other",
               "providerType": "object"
             },
             "payco": {
-              "displayName": "payco",
+              "displayName": "Payco",
               "valueType": "other",
               "providerType": "object"
             },
             "paynow": {
-              "displayName": "paynow",
+              "displayName": "Paynow",
               "valueType": "other",
               "providerType": "object"
             },
             "paypal": {
-              "displayName": "paypal",
+              "displayName": "Paypal",
               "valueType": "other",
               "providerType": "object"
             },
             "payto": {
-              "displayName": "payto",
+              "displayName": "Payto",
               "valueType": "other",
               "providerType": "object"
             },
             "pix": {
-              "displayName": "pix",
+              "displayName": "Pix",
               "valueType": "other",
               "providerType": "object"
             },
             "promptpay": {
-              "displayName": "promptpay",
+              "displayName": "Promptpay",
               "valueType": "other",
               "providerType": "object"
             },
             "revolut_pay": {
-              "displayName": "revolut_pay",
+              "displayName": "Revolut Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "samsung_pay": {
-              "displayName": "samsung_pay",
+              "displayName": "Samsung Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "satispay": {
-              "displayName": "satispay",
+              "displayName": "Satispay",
               "valueType": "other",
               "providerType": "object"
             },
             "scalapay": {
-              "displayName": "scalapay",
+              "displayName": "Scalapay",
               "valueType": "other",
               "providerType": "object"
             },
             "sepa_debit": {
-              "displayName": "sepa_debit",
+              "displayName": "Sepa Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "sofort": {
-              "displayName": "sofort",
+              "displayName": "Sofort",
               "valueType": "other",
               "providerType": "object"
             },
             "sunbit": {
-              "displayName": "sunbit",
+              "displayName": "Sunbit",
               "valueType": "other",
               "providerType": "object"
             },
             "swish": {
-              "displayName": "swish",
+              "displayName": "Swish",
               "valueType": "other",
               "providerType": "object"
             },
             "twint": {
-              "displayName": "twint",
+              "displayName": "Twint",
               "valueType": "other",
               "providerType": "object"
             },
             "upi": {
-              "displayName": "upi",
+              "displayName": "Upi",
               "valueType": "other",
               "providerType": "object"
             },
             "us_bank_account": {
-              "displayName": "us_bank_account",
+              "displayName": "Us Bank Account",
               "valueType": "other",
               "providerType": "object"
             },
             "wechat_pay": {
-              "displayName": "wechat_pay",
+              "displayName": "Wechat Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "zip": {
-              "displayName": "zip",
+              "displayName": "Zip",
               "valueType": "other",
               "providerType": "object"
             }
@@ -6605,57 +6605,57 @@
           "responseKey": "data",
           "fields": {
             "amazon_pay": {
-              "displayName": "amazon_pay",
+              "displayName": "Amazon Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "apple_pay": {
-              "displayName": "apple_pay",
+              "displayName": "Apple Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "domain_name": {
-              "displayName": "domain_name",
+              "displayName": "Domain Name",
               "valueType": "string",
               "providerType": "string"
             },
             "enabled": {
-              "displayName": "enabled",
+              "displayName": "Enabled",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "google_pay": {
-              "displayName": "google_pay",
+              "displayName": "Google Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "klarna": {
-              "displayName": "klarna",
+              "displayName": "Klarna",
               "valueType": "other",
               "providerType": "object"
             },
             "link": {
-              "displayName": "link",
+              "displayName": "Link",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6666,7 +6666,7 @@
               ]
             },
             "paypal": {
-              "displayName": "paypal",
+              "displayName": "Paypal",
               "valueType": "other",
               "providerType": "object"
             }
@@ -6678,27 +6678,27 @@
           "responseKey": "data",
           "fields": {
             "acss_debit": {
-              "displayName": "acss_debit",
+              "displayName": "Acss Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "affirm": {
-              "displayName": "affirm",
+              "displayName": "Affirm",
               "valueType": "other",
               "providerType": "object"
             },
             "afterpay_clearpay": {
-              "displayName": "afterpay_clearpay",
+              "displayName": "Afterpay Clearpay",
               "valueType": "other",
               "providerType": "object"
             },
             "alipay": {
-              "displayName": "alipay",
+              "displayName": "Alipay",
               "valueType": "other",
               "providerType": "object"
             },
             "allow_redisplay": {
-              "displayName": "allow_redisplay",
+              "displayName": "Allow Redisplay",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6717,196 +6717,196 @@
               ]
             },
             "alma": {
-              "displayName": "alma",
+              "displayName": "Alma",
               "valueType": "other",
               "providerType": "object"
             },
             "amazon_pay": {
-              "displayName": "amazon_pay",
+              "displayName": "Amazon Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "au_becs_debit": {
-              "displayName": "au_becs_debit",
+              "displayName": "Au Becs Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "bacs_debit": {
-              "displayName": "bacs_debit",
+              "displayName": "Bacs Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "bancontact": {
-              "displayName": "bancontact",
+              "displayName": "Bancontact",
               "valueType": "other",
               "providerType": "object"
             },
             "billie": {
-              "displayName": "billie",
+              "displayName": "Billie",
               "valueType": "other",
               "providerType": "object"
             },
             "billing_details": {
-              "displayName": "billing_details",
+              "displayName": "Billing Details",
               "valueType": "other",
               "providerType": "object"
             },
             "bizum": {
-              "displayName": "bizum",
+              "displayName": "Bizum",
               "valueType": "other",
               "providerType": "object"
             },
             "blik": {
-              "displayName": "blik",
+              "displayName": "Blik",
               "valueType": "other",
               "providerType": "object"
             },
             "boleto": {
-              "displayName": "boleto",
+              "displayName": "Boleto",
               "valueType": "other",
               "providerType": "object"
             },
             "card": {
-              "displayName": "card",
+              "displayName": "Card",
               "valueType": "other",
               "providerType": "object"
             },
             "card_present": {
-              "displayName": "card_present",
+              "displayName": "Card Present",
               "valueType": "other",
               "providerType": "object"
             },
             "cashapp": {
-              "displayName": "cashapp",
+              "displayName": "Cashapp",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "crypto": {
-              "displayName": "crypto",
+              "displayName": "Crypto",
               "valueType": "other",
               "providerType": "object"
             },
             "custom": {
-              "displayName": "custom",
+              "displayName": "Custom",
               "valueType": "other",
               "providerType": "object"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "customer_balance": {
-              "displayName": "customer_balance",
+              "displayName": "Customer Balance",
               "valueType": "other",
               "providerType": "object"
             },
             "eps": {
-              "displayName": "eps",
+              "displayName": "Eps",
               "valueType": "other",
               "providerType": "object"
             },
             "fpx": {
-              "displayName": "fpx",
+              "displayName": "Fpx",
               "valueType": "other",
               "providerType": "object"
             },
             "giropay": {
-              "displayName": "giropay",
+              "displayName": "Giropay",
               "valueType": "other",
               "providerType": "object"
             },
             "grabpay": {
-              "displayName": "grabpay",
+              "displayName": "Grabpay",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "ideal": {
-              "displayName": "ideal",
+              "displayName": "Ideal",
               "valueType": "other",
               "providerType": "object"
             },
             "interac_present": {
-              "displayName": "interac_present",
+              "displayName": "Interac Present",
               "valueType": "other",
               "providerType": "object"
             },
             "kakao_pay": {
-              "displayName": "kakao_pay",
+              "displayName": "Kakao Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "klarna": {
-              "displayName": "klarna",
+              "displayName": "Klarna",
               "valueType": "other",
               "providerType": "object"
             },
             "konbini": {
-              "displayName": "konbini",
+              "displayName": "Konbini",
               "valueType": "other",
               "providerType": "object"
             },
             "kr_card": {
-              "displayName": "kr_card",
+              "displayName": "Kr Card",
               "valueType": "other",
               "providerType": "object"
             },
             "link": {
-              "displayName": "link",
+              "displayName": "Link",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "mb_way": {
-              "displayName": "mb_way",
+              "displayName": "Mb Way",
               "valueType": "other",
               "providerType": "object"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "mobilepay": {
-              "displayName": "mobilepay",
+              "displayName": "Mobilepay",
               "valueType": "other",
               "providerType": "object"
             },
             "multibanco": {
-              "displayName": "multibanco",
+              "displayName": "Multibanco",
               "valueType": "other",
               "providerType": "object"
             },
             "naver_pay": {
-              "displayName": "naver_pay",
+              "displayName": "Naver Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "nz_bank_account": {
-              "displayName": "nz_bank_account",
+              "displayName": "Nz Bank Account",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -6917,102 +6917,102 @@
               ]
             },
             "oxxo": {
-              "displayName": "oxxo",
+              "displayName": "Oxxo",
               "valueType": "other",
               "providerType": "object"
             },
             "p24": {
-              "displayName": "p24",
+              "displayName": "P24",
               "valueType": "other",
               "providerType": "object"
             },
             "pay_by_bank": {
-              "displayName": "pay_by_bank",
+              "displayName": "Pay By Bank",
               "valueType": "other",
               "providerType": "object"
             },
             "payco": {
-              "displayName": "payco",
+              "displayName": "Payco",
               "valueType": "other",
               "providerType": "object"
             },
             "paynow": {
-              "displayName": "paynow",
+              "displayName": "Paynow",
               "valueType": "other",
               "providerType": "object"
             },
             "paypal": {
-              "displayName": "paypal",
+              "displayName": "Paypal",
               "valueType": "other",
               "providerType": "object"
             },
             "payto": {
-              "displayName": "payto",
+              "displayName": "Payto",
               "valueType": "other",
               "providerType": "object"
             },
             "pix": {
-              "displayName": "pix",
+              "displayName": "Pix",
               "valueType": "other",
               "providerType": "object"
             },
             "promptpay": {
-              "displayName": "promptpay",
+              "displayName": "Promptpay",
               "valueType": "other",
               "providerType": "object"
             },
             "radar_options": {
-              "displayName": "radar_options",
+              "displayName": "Radar Options",
               "valueType": "other",
               "providerType": "object"
             },
             "revolut_pay": {
-              "displayName": "revolut_pay",
+              "displayName": "Revolut Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "samsung_pay": {
-              "displayName": "samsung_pay",
+              "displayName": "Samsung Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "satispay": {
-              "displayName": "satispay",
+              "displayName": "Satispay",
               "valueType": "other",
               "providerType": "object"
             },
             "scalapay": {
-              "displayName": "scalapay",
+              "displayName": "Scalapay",
               "valueType": "other",
               "providerType": "object"
             },
             "sepa_debit": {
-              "displayName": "sepa_debit",
+              "displayName": "Sepa Debit",
               "valueType": "other",
               "providerType": "object"
             },
             "sofort": {
-              "displayName": "sofort",
+              "displayName": "Sofort",
               "valueType": "other",
               "providerType": "object"
             },
             "sunbit": {
-              "displayName": "sunbit",
+              "displayName": "Sunbit",
               "valueType": "other",
               "providerType": "object"
             },
             "swish": {
-              "displayName": "swish",
+              "displayName": "Swish",
               "valueType": "other",
               "providerType": "object"
             },
             "twint": {
-              "displayName": "twint",
+              "displayName": "Twint",
               "valueType": "other",
               "providerType": "object"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7247,22 +7247,22 @@
               ]
             },
             "upi": {
-              "displayName": "upi",
+              "displayName": "Upi",
               "valueType": "other",
               "providerType": "object"
             },
             "us_bank_account": {
-              "displayName": "us_bank_account",
+              "displayName": "Us Bank Account",
               "valueType": "other",
               "providerType": "object"
             },
             "wechat_pay": {
-              "displayName": "wechat_pay",
+              "displayName": "Wechat Pay",
               "valueType": "other",
               "providerType": "object"
             },
             "zip": {
-              "displayName": "zip",
+              "displayName": "Zip",
               "valueType": "other",
               "providerType": "object"
             }
@@ -7274,88 +7274,88 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "application_fee": {
-              "displayName": "application_fee",
+              "displayName": "Application Fee",
               "valueType": "other"
             },
             "application_fee_amount": {
-              "displayName": "application_fee_amount",
+              "displayName": "Application Fee Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "arrival_date": {
-              "displayName": "arrival_date",
+              "displayName": "Arrival Date",
               "valueType": "int",
               "providerType": "integer"
             },
             "automatic": {
-              "displayName": "automatic",
+              "displayName": "Automatic",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "destination": {
-              "displayName": "destination",
+              "displayName": "Destination",
               "valueType": "other"
             },
             "failure_balance_transaction": {
-              "displayName": "failure_balance_transaction",
+              "displayName": "Failure Balance Transaction",
               "valueType": "other"
             },
             "failure_code": {
-              "displayName": "failure_code",
+              "displayName": "Failure Code",
               "valueType": "string",
               "providerType": "string"
             },
             "failure_message": {
-              "displayName": "failure_message",
+              "displayName": "Failure Message",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "method": {
-              "displayName": "method",
+              "displayName": "Method",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7366,16 +7366,16 @@
               ]
             },
             "original_payout": {
-              "displayName": "original_payout",
+              "displayName": "Original Payout",
               "valueType": "other"
             },
             "payout_method": {
-              "displayName": "payout_method",
+              "displayName": "Payout Method",
               "valueType": "string",
               "providerType": "string"
             },
             "reconciliation_status": {
-              "displayName": "reconciliation_status",
+              "displayName": "Reconciliation Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7394,30 +7394,30 @@
               ]
             },
             "reversed_by": {
-              "displayName": "reversed_by",
+              "displayName": "Reversed By",
               "valueType": "other"
             },
             "source_type": {
-              "displayName": "source_type",
+              "displayName": "Source Type",
               "valueType": "string",
               "providerType": "string"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "trace_id": {
-              "displayName": "trace_id",
+              "displayName": "Trace Id",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7439,22 +7439,22 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_decimal": {
-              "displayName": "amount_decimal",
+              "displayName": "Amount Decimal",
               "valueType": "string",
               "providerType": "string"
             },
             "billing_scheme": {
-              "displayName": "billing_scheme",
+              "displayName": "Billing Scheme",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7469,22 +7469,22 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "interval": {
-              "displayName": "interval",
+              "displayName": "Interval",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7507,32 +7507,32 @@
               ]
             },
             "interval_count": {
-              "displayName": "interval_count",
+              "displayName": "Interval Count",
               "valueType": "int",
               "providerType": "integer"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "meter": {
-              "displayName": "meter",
+              "displayName": "Meter",
               "valueType": "string",
               "providerType": "string"
             },
             "nickname": {
-              "displayName": "nickname",
+              "displayName": "Nickname",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7543,16 +7543,16 @@
               ]
             },
             "product": {
-              "displayName": "product",
+              "displayName": "Product",
               "valueType": "other"
             },
             "tiers": {
-              "displayName": "tiers",
+              "displayName": "Tiers",
               "valueType": "other",
               "providerType": "array"
             },
             "tiers_mode": {
-              "displayName": "tiers_mode",
+              "displayName": "Tiers Mode",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7567,16 +7567,16 @@
               ]
             },
             "transform_usage": {
-              "displayName": "transform_usage",
+              "displayName": "Transform Usage",
               "valueType": "other"
             },
             "trial_period_days": {
-              "displayName": "trial_period_days",
+              "displayName": "Trial Period Days",
               "valueType": "int",
               "providerType": "integer"
             },
             "usage_type": {
-              "displayName": "usage_type",
+              "displayName": "Usage Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7598,12 +7598,12 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "billing_scheme": {
-              "displayName": "billing_scheme",
+              "displayName": "Billing Scheme",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7618,51 +7618,51 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "currency_options": {
-              "displayName": "currency_options",
+              "displayName": "Currency Options",
               "valueType": "other",
               "providerType": "object"
             },
             "custom_unit_amount": {
-              "displayName": "custom_unit_amount",
+              "displayName": "Custom Unit Amount",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "lookup_key": {
-              "displayName": "lookup_key",
+              "displayName": "Lookup Key",
               "valueType": "string",
               "providerType": "string"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "nickname": {
-              "displayName": "nickname",
+              "displayName": "Nickname",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7673,15 +7673,15 @@
               ]
             },
             "product": {
-              "displayName": "product",
+              "displayName": "Product",
               "valueType": "other"
             },
             "recurring": {
-              "displayName": "recurring",
+              "displayName": "Recurring",
               "valueType": "other"
             },
             "tax_behavior": {
-              "displayName": "tax_behavior",
+              "displayName": "Tax Behavior",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7700,12 +7700,12 @@
               ]
             },
             "tiers": {
-              "displayName": "tiers",
+              "displayName": "Tiers",
               "valueType": "other",
               "providerType": "array"
             },
             "tiers_mode": {
-              "displayName": "tiers_mode",
+              "displayName": "Tiers Mode",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7720,11 +7720,11 @@
               ]
             },
             "transform_quantity": {
-              "displayName": "transform_quantity",
+              "displayName": "Transform Quantity",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7739,12 +7739,12 @@
               ]
             },
             "unit_amount": {
-              "displayName": "unit_amount",
+              "displayName": "Unit Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "unit_amount_decimal": {
-              "displayName": "unit_amount_decimal",
+              "displayName": "Unit Amount Decimal",
               "valueType": "string",
               "providerType": "string"
             }
@@ -7756,56 +7756,56 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "default_price": {
-              "displayName": "default_price",
+              "displayName": "Default Price",
               "valueType": "other"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "images": {
-              "displayName": "images",
+              "displayName": "Images",
               "valueType": "other",
               "providerType": "array"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "marketing_features": {
-              "displayName": "marketing_features",
+              "displayName": "Marketing Features",
               "valueType": "other",
               "providerType": "array"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7816,35 +7816,35 @@
               ]
             },
             "package_dimensions": {
-              "displayName": "package_dimensions",
+              "displayName": "Package Dimensions",
               "valueType": "other"
             },
             "shippable": {
-              "displayName": "shippable",
+              "displayName": "Shippable",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "tax_code": {
-              "displayName": "tax_code",
+              "displayName": "Tax Code",
               "valueType": "other"
             },
             "unit_label": {
-              "displayName": "unit_label",
+              "displayName": "Unit Label",
               "valueType": "string",
               "providerType": "string"
             },
             "updated": {
-              "displayName": "updated",
+              "displayName": "Updated",
               "valueType": "int",
               "providerType": "integer"
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }
@@ -7856,56 +7856,56 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "code": {
-              "displayName": "code",
+              "displayName": "Code",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "max_redemptions": {
-              "displayName": "max_redemptions",
+              "displayName": "Max Redemptions",
               "valueType": "int",
               "providerType": "integer"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7916,17 +7916,17 @@
               ]
             },
             "promotion": {
-              "displayName": "promotion",
+              "displayName": "Promotion",
               "valueType": "other",
               "providerType": "object"
             },
             "restrictions": {
-              "displayName": "restrictions",
+              "displayName": "Restrictions",
               "valueType": "other",
               "providerType": "object"
             },
             "times_redeemed": {
-              "displayName": "times_redeemed",
+              "displayName": "Times Redeemed",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -7938,36 +7938,36 @@
           "responseKey": "data",
           "fields": {
             "amount_subtotal": {
-              "displayName": "amount_subtotal",
+              "displayName": "Amount Subtotal",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_total": {
-              "displayName": "amount_total",
+              "displayName": "Amount Total",
               "valueType": "int",
               "providerType": "integer"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "application_fee_amount": {
-              "displayName": "application_fee_amount",
+              "displayName": "Application Fee Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "application_fee_percent": {
-              "displayName": "application_fee_percent",
+              "displayName": "Application Fee Percent",
               "valueType": "other",
               "providerType": "number"
             },
             "automatic_tax": {
-              "displayName": "automatic_tax",
+              "displayName": "Automatic Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "collection_method": {
-              "displayName": "collection_method",
+              "displayName": "Collection Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -7982,99 +7982,99 @@
               ]
             },
             "computed": {
-              "displayName": "computed",
+              "displayName": "Computed",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "default_tax_rates": {
-              "displayName": "default_tax_rates",
+              "displayName": "Default Tax Rates",
               "valueType": "other",
               "providerType": "array"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "discounts": {
-              "displayName": "discounts",
+              "displayName": "Discounts",
               "valueType": "other",
               "providerType": "array"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "footer": {
-              "displayName": "footer",
+              "displayName": "Footer",
               "valueType": "string",
               "providerType": "string"
             },
             "from_quote": {
-              "displayName": "from_quote",
+              "displayName": "From Quote",
               "valueType": "other"
             },
             "header": {
-              "displayName": "header",
+              "displayName": "Header",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice": {
-              "displayName": "invoice",
+              "displayName": "Invoice",
               "valueType": "other"
             },
             "invoice_settings": {
-              "displayName": "invoice_settings",
+              "displayName": "Invoice Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "line_items": {
-              "displayName": "line_items",
+              "displayName": "Line Items",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "number": {
-              "displayName": "number",
+              "displayName": "Number",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8085,11 +8085,11 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8112,34 +8112,34 @@
               ]
             },
             "status_transitions": {
-              "displayName": "status_transitions",
+              "displayName": "Status Transitions",
               "valueType": "other",
               "providerType": "object"
             },
             "subscription": {
-              "displayName": "subscription",
+              "displayName": "Subscription",
               "valueType": "other"
             },
             "subscription_data": {
-              "displayName": "subscription_data",
+              "displayName": "Subscription Data",
               "valueType": "other",
               "providerType": "object"
             },
             "subscription_schedule": {
-              "displayName": "subscription_schedule",
+              "displayName": "Subscription Schedule",
               "valueType": "other"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             },
             "total_details": {
-              "displayName": "total_details",
+              "displayName": "Total Details",
               "valueType": "other",
               "providerType": "object"
             },
             "transfer_data": {
-              "displayName": "transfer_data",
+              "displayName": "Transfer Data",
               "valueType": "other"
             }
           }
@@ -8150,36 +8150,36 @@
           "responseKey": "data",
           "fields": {
             "actionable": {
-              "displayName": "actionable",
+              "displayName": "Actionable",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "charge": {
-              "displayName": "charge",
+              "displayName": "Charge",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "fraud_type": {
-              "displayName": "fraud_type",
+              "displayName": "Fraud Type",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8190,7 +8190,7 @@
               ]
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             }
           }
@@ -8201,27 +8201,27 @@
           "responseKey": "data",
           "fields": {
             "alias": {
-              "displayName": "alias",
+              "displayName": "Alias",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "created_by": {
-              "displayName": "created_by",
+              "displayName": "Created By",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "item_type": {
-              "displayName": "item_type",
+              "displayName": "Item Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8276,27 +8276,27 @@
               ]
             },
             "list_items": {
-              "displayName": "list_items",
+              "displayName": "List Items",
               "valueType": "other",
               "providerType": "object"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8314,69 +8314,69 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "charge": {
-              "displayName": "charge",
+              "displayName": "Charge",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "destination_details": {
-              "displayName": "destination_details",
+              "displayName": "Destination Details",
               "valueType": "other",
               "providerType": "object"
             },
             "failure_balance_transaction": {
-              "displayName": "failure_balance_transaction",
+              "displayName": "Failure Balance Transaction",
               "valueType": "other"
             },
             "failure_reason": {
-              "displayName": "failure_reason",
+              "displayName": "Failure Reason",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "instructions_email": {
-              "displayName": "instructions_email",
+              "displayName": "Instructions Email",
               "valueType": "string",
               "providerType": "string"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "next_action": {
-              "displayName": "next_action",
+              "displayName": "Next Action",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8387,11 +8387,11 @@
               ]
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             },
             "pending_reason": {
-              "displayName": "pending_reason",
+              "displayName": "Pending Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8410,12 +8410,12 @@
               ]
             },
             "presentment_details": {
-              "displayName": "presentment_details",
+              "displayName": "Presentment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "reason": {
-              "displayName": "reason",
+              "displayName": "Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8438,21 +8438,21 @@
               ]
             },
             "receipt_number": {
-              "displayName": "receipt_number",
+              "displayName": "Receipt Number",
               "valueType": "string",
               "providerType": "string"
             },
             "source_transfer_reversal": {
-              "displayName": "source_transfer_reversal",
+              "displayName": "Source Transfer Reversal",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "transfer_reversal": {
-              "displayName": "transfer_reversal",
+              "displayName": "Transfer Reversal",
               "valueType": "other"
             }
           }
@@ -8463,27 +8463,27 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "error": {
-              "displayName": "error",
+              "displayName": "Error",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8494,26 +8494,26 @@
               ]
             },
             "parameters": {
-              "displayName": "parameters",
+              "displayName": "Parameters",
               "valueType": "other",
               "providerType": "object"
             },
             "report_type": {
-              "displayName": "report_type",
+              "displayName": "Report Type",
               "valueType": "string",
               "providerType": "string"
             },
             "result": {
-              "displayName": "result",
+              "displayName": "Result",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "succeeded_at": {
-              "displayName": "succeeded_at",
+              "displayName": "Succeeded At",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -8525,37 +8525,37 @@
           "responseKey": "data",
           "fields": {
             "data_available_end": {
-              "displayName": "data_available_end",
+              "displayName": "Data Available End",
               "valueType": "int",
               "providerType": "integer"
             },
             "data_available_start": {
-              "displayName": "data_available_start",
+              "displayName": "Data Available Start",
               "valueType": "int",
               "providerType": "integer"
             },
             "default_columns": {
-              "displayName": "default_columns",
+              "displayName": "Default Columns",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8566,12 +8566,12 @@
               ]
             },
             "updated": {
-              "displayName": "updated",
+              "displayName": "Updated",
               "valueType": "int",
               "providerType": "integer"
             },
             "version": {
-              "displayName": "version",
+              "displayName": "Version",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -8583,16 +8583,16 @@
           "responseKey": "data",
           "fields": {
             "billing_zip": {
-              "displayName": "billing_zip",
+              "displayName": "Billing Zip",
               "valueType": "string",
               "providerType": "string"
             },
             "charge": {
-              "displayName": "charge",
+              "displayName": "Charge",
               "valueType": "other"
             },
             "closed_reason": {
-              "displayName": "closed_reason",
+              "displayName": "Closed Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8631,31 +8631,31 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "ip_address": {
-              "displayName": "ip_address",
+              "displayName": "Ip Address",
               "valueType": "string",
               "providerType": "string"
             },
             "ip_address_location": {
-              "displayName": "ip_address_location",
+              "displayName": "Ip Address Location",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8666,12 +8666,12 @@
               ]
             },
             "open": {
-              "displayName": "open",
+              "displayName": "Open",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "opened_reason": {
-              "displayName": "opened_reason",
+              "displayName": "Opened Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8686,16 +8686,16 @@
               ]
             },
             "payment_intent": {
-              "displayName": "payment_intent",
+              "displayName": "Payment Intent",
               "valueType": "other"
             },
             "reason": {
-              "displayName": "reason",
+              "displayName": "Reason",
               "valueType": "string",
               "providerType": "string"
             },
             "session": {
-              "displayName": "session",
+              "displayName": "Session",
               "valueType": "other"
             }
           }
@@ -8706,20 +8706,20 @@
           "responseKey": "data",
           "fields": {
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "attach_to_self": {
-              "displayName": "attach_to_self",
+              "displayName": "Attach To Self",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "automatic_payment_methods": {
-              "displayName": "automatic_payment_methods",
+              "displayName": "Automatic Payment Methods",
               "valueType": "other"
             },
             "cancellation_reason": {
-              "displayName": "cancellation_reason",
+              "displayName": "Cancellation Reason",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8738,76 +8738,76 @@
               ]
             },
             "client_secret": {
-              "displayName": "client_secret",
+              "displayName": "Client Secret",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "excluded_payment_method_types": {
-              "displayName": "excluded_payment_method_types",
+              "displayName": "Excluded Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "flow_directions": {
-              "displayName": "flow_directions",
+              "displayName": "Flow Directions",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "last_setup_error": {
-              "displayName": "last_setup_error",
+              "displayName": "Last Setup Error",
               "valueType": "other"
             },
             "latest_attempt": {
-              "displayName": "latest_attempt",
+              "displayName": "Latest Attempt",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "managed_payments": {
-              "displayName": "managed_payments",
+              "displayName": "Managed Payments",
               "valueType": "other"
             },
             "mandate": {
-              "displayName": "mandate",
+              "displayName": "Mandate",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "next_action": {
-              "displayName": "next_action",
+              "displayName": "Next Action",
               "valueType": "other"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8818,32 +8818,32 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "payment_method": {
-              "displayName": "payment_method",
+              "displayName": "Payment Method",
               "valueType": "other"
             },
             "payment_method_configuration_details": {
-              "displayName": "payment_method_configuration_details",
+              "displayName": "Payment Method Configuration Details",
               "valueType": "other"
             },
             "payment_method_options": {
-              "displayName": "payment_method_options",
+              "displayName": "Payment Method Options",
               "valueType": "other"
             },
             "payment_method_types": {
-              "displayName": "payment_method_types",
+              "displayName": "Payment Method Types",
               "valueType": "other",
               "providerType": "array"
             },
             "single_use_mandate": {
-              "displayName": "single_use_mandate",
+              "displayName": "Single Use Mandate",
               "valueType": "other"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8874,7 +8874,7 @@
               ]
             },
             "usage": {
-              "displayName": "usage",
+              "displayName": "Usage",
               "valueType": "string",
               "providerType": "string"
             }
@@ -8886,46 +8886,46 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "delivery_estimate": {
-              "displayName": "delivery_estimate",
+              "displayName": "Delivery Estimate",
               "valueType": "other"
             },
             "display_name": {
-              "displayName": "display_name",
+              "displayName": "Display Name",
               "valueType": "string",
               "providerType": "string"
             },
             "fixed_amount": {
-              "displayName": "fixed_amount",
+              "displayName": "Fixed Amount",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8936,7 +8936,7 @@
               ]
             },
             "tax_behavior": {
-              "displayName": "tax_behavior",
+              "displayName": "Tax Behavior",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8955,11 +8955,11 @@
               ]
             },
             "tax_code": {
-              "displayName": "tax_code",
+              "displayName": "Tax Code",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -8977,36 +8977,36 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "data_load_time": {
-              "displayName": "data_load_time",
+              "displayName": "Data Load Time",
               "valueType": "int",
               "providerType": "integer"
             },
             "error": {
-              "displayName": "error",
+              "displayName": "Error",
               "valueType": "other",
               "providerType": "object"
             },
             "file": {
-              "displayName": "file",
+              "displayName": "File",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9017,22 +9017,22 @@
               ]
             },
             "result_available_until": {
-              "displayName": "result_available_until",
+              "displayName": "Result Available Until",
               "valueType": "int",
               "providerType": "integer"
             },
             "sql": {
-              "displayName": "sql",
+              "displayName": "Sql",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "title": {
-              "displayName": "title",
+              "displayName": "Title",
               "valueType": "string",
               "providerType": "string"
             }
@@ -9044,49 +9044,49 @@
           "responseKey": "data",
           "fields": {
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "billing_mode": {
-              "displayName": "billing_mode",
+              "displayName": "Billing Mode",
               "valueType": "other",
               "providerType": "object"
             },
             "canceled_at": {
-              "displayName": "canceled_at",
+              "displayName": "Canceled At",
               "valueType": "int",
               "providerType": "integer"
             },
             "completed_at": {
-              "displayName": "completed_at",
+              "displayName": "Completed At",
               "valueType": "int",
               "providerType": "integer"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "current_phase": {
-              "displayName": "current_phase",
+              "displayName": "Current Phase",
               "valueType": "other"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "default_settings": {
-              "displayName": "default_settings",
+              "displayName": "Default Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "end_behavior": {
-              "displayName": "end_behavior",
+              "displayName": "End Behavior",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9109,22 +9109,22 @@
               ]
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9135,22 +9135,22 @@
               ]
             },
             "phases": {
-              "displayName": "phases",
+              "displayName": "Phases",
               "valueType": "other",
               "providerType": "array"
             },
             "released_at": {
-              "displayName": "released_at",
+              "displayName": "Released At",
               "valueType": "int",
               "providerType": "integer"
             },
             "released_subscription": {
-              "displayName": "released_subscription",
+              "displayName": "Released Subscription",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9177,11 +9177,11 @@
               ]
             },
             "subscription": {
-              "displayName": "subscription",
+              "displayName": "Subscription",
               "valueType": "other"
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             }
           }
@@ -9192,63 +9192,63 @@
           "responseKey": "data",
           "fields": {
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "other"
             },
             "application_fee_percent": {
-              "displayName": "application_fee_percent",
+              "displayName": "Application Fee Percent",
               "valueType": "other",
               "providerType": "number"
             },
             "automatic_tax": {
-              "displayName": "automatic_tax",
+              "displayName": "Automatic Tax",
               "valueType": "other",
               "providerType": "object"
             },
             "billing_cycle_anchor": {
-              "displayName": "billing_cycle_anchor",
+              "displayName": "Billing Cycle Anchor",
               "valueType": "int",
               "providerType": "integer"
             },
             "billing_cycle_anchor_config": {
-              "displayName": "billing_cycle_anchor_config",
+              "displayName": "Billing Cycle Anchor Config",
               "valueType": "other"
             },
             "billing_mode": {
-              "displayName": "billing_mode",
+              "displayName": "Billing Mode",
               "valueType": "other",
               "providerType": "object"
             },
             "billing_schedules": {
-              "displayName": "billing_schedules",
+              "displayName": "Billing Schedules",
               "valueType": "other",
               "providerType": "array"
             },
             "billing_thresholds": {
-              "displayName": "billing_thresholds",
+              "displayName": "Billing Thresholds",
               "valueType": "other"
             },
             "cancel_at": {
-              "displayName": "cancel_at",
+              "displayName": "Cancel At",
               "valueType": "int",
               "providerType": "integer"
             },
             "cancel_at_period_end": {
-              "displayName": "cancel_at_period_end",
+              "displayName": "Cancel At Period End",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "canceled_at": {
-              "displayName": "canceled_at",
+              "displayName": "Canceled At",
               "valueType": "int",
               "providerType": "integer"
             },
             "cancellation_details": {
-              "displayName": "cancellation_details",
+              "displayName": "Cancellation Details",
               "valueType": "other"
             },
             "collection_method": {
-              "displayName": "collection_method",
+              "displayName": "Collection Method",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9263,97 +9263,97 @@
               ]
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "days_until_due": {
-              "displayName": "days_until_due",
+              "displayName": "Days Until Due",
               "valueType": "int",
               "providerType": "integer"
             },
             "default_payment_method": {
-              "displayName": "default_payment_method",
+              "displayName": "Default Payment Method",
               "valueType": "other"
             },
             "default_source": {
-              "displayName": "default_source",
+              "displayName": "Default Source",
               "valueType": "other"
             },
             "default_tax_rates": {
-              "displayName": "default_tax_rates",
+              "displayName": "Default Tax Rates",
               "valueType": "other",
               "providerType": "array"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "discounts": {
-              "displayName": "discounts",
+              "displayName": "Discounts",
               "valueType": "other",
               "providerType": "array"
             },
             "ended_at": {
-              "displayName": "ended_at",
+              "displayName": "Ended At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "invoice_settings": {
-              "displayName": "invoice_settings",
+              "displayName": "Invoice Settings",
               "valueType": "other",
               "providerType": "object"
             },
             "items": {
-              "displayName": "items",
+              "displayName": "Items",
               "valueType": "other",
               "providerType": "object"
             },
             "latest_invoice": {
-              "displayName": "latest_invoice",
+              "displayName": "Latest Invoice",
               "valueType": "other"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "managed_payments": {
-              "displayName": "managed_payments",
+              "displayName": "Managed Payments",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "next_pending_invoice_item_invoice": {
-              "displayName": "next_pending_invoice_item_invoice",
+              "displayName": "Next Pending Invoice Item Invoice",
               "valueType": "int",
               "providerType": "integer"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9364,45 +9364,45 @@
               ]
             },
             "on_behalf_of": {
-              "displayName": "on_behalf_of",
+              "displayName": "On Behalf Of",
               "valueType": "other"
             },
             "pause_collection": {
-              "displayName": "pause_collection",
+              "displayName": "Pause Collection",
               "valueType": "other"
             },
             "payment_settings": {
-              "displayName": "payment_settings",
+              "displayName": "Payment Settings",
               "valueType": "other"
             },
             "pending_invoice_item_interval": {
-              "displayName": "pending_invoice_item_interval",
+              "displayName": "Pending Invoice Item Interval",
               "valueType": "other"
             },
             "pending_setup_intent": {
-              "displayName": "pending_setup_intent",
+              "displayName": "Pending Setup Intent",
               "valueType": "other"
             },
             "pending_update": {
-              "displayName": "pending_update",
+              "displayName": "Pending Update",
               "valueType": "other"
             },
             "presentment_details": {
-              "displayName": "presentment_details",
+              "displayName": "Presentment Details",
               "valueType": "other",
               "providerType": "object"
             },
             "schedule": {
-              "displayName": "schedule",
+              "displayName": "Schedule",
               "valueType": "other"
             },
             "start_date": {
-              "displayName": "start_date",
+              "displayName": "Start Date",
               "valueType": "int",
               "providerType": "integer"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9441,24 +9441,24 @@
               ]
             },
             "test_clock": {
-              "displayName": "test_clock",
+              "displayName": "Test Clock",
               "valueType": "other"
             },
             "transfer_data": {
-              "displayName": "transfer_data",
+              "displayName": "Transfer Data",
               "valueType": "other"
             },
             "trial_end": {
-              "displayName": "trial_end",
+              "displayName": "Trial End",
               "valueType": "int",
               "providerType": "integer"
             },
             "trial_settings": {
-              "displayName": "trial_settings",
+              "displayName": "Trial Settings",
               "valueType": "other"
             },
             "trial_start": {
-              "displayName": "trial_start",
+              "displayName": "Trial Start",
               "valueType": "int",
               "providerType": "integer"
             }
@@ -9470,42 +9470,42 @@
           "responseKey": "data",
           "fields": {
             "active_from": {
-              "displayName": "active_from",
+              "displayName": "Active From",
               "valueType": "int",
               "providerType": "integer"
             },
             "country": {
-              "displayName": "country",
+              "displayName": "Country",
               "valueType": "string",
               "providerType": "string"
             },
             "country_options": {
-              "displayName": "country_options",
+              "displayName": "Country Options",
               "valueType": "other",
               "providerType": "object"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "expires_at": {
-              "displayName": "expires_at",
+              "displayName": "Expires At",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9516,7 +9516,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9542,22 +9542,22 @@
           "responseKey": "data",
           "fields": {
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9575,36 +9575,36 @@
           "responseKey": "data",
           "fields": {
             "country": {
-              "displayName": "country",
+              "displayName": "Country",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "customer": {
-              "displayName": "customer",
+              "displayName": "Customer",
               "valueType": "other"
             },
             "customer_account": {
-              "displayName": "customer_account",
+              "displayName": "Customer Account",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -9615,11 +9615,11 @@
               ]
             },
             "owner": {
-              "displayName": "owner",
+              "displayName": "Owner",
               "valueType": "other"
             },
             "type": {
-              "displayName": "type",
+              "displayName": "Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10094,12 +10094,12 @@
               ]
             },
             "value": {
-              "displayName": "value",
+              "displayName": "Value",
               "valueType": "string",
               "providerType": "string"
             },
             "verification": {
-              "displayName": "verification",
+              "displayName": "Verification",
               "valueType": "other"
             }
           }
@@ -10110,56 +10110,56 @@
           "responseKey": "data",
           "fields": {
             "active": {
-              "displayName": "active",
+              "displayName": "Active",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "country": {
-              "displayName": "country",
+              "displayName": "Country",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "display_name": {
-              "displayName": "display_name",
+              "displayName": "Display Name",
               "valueType": "string",
               "providerType": "string"
             },
             "effective_percentage": {
-              "displayName": "effective_percentage",
+              "displayName": "Effective Percentage",
               "valueType": "other",
               "providerType": "number"
             },
             "flat_amount": {
-              "displayName": "flat_amount",
+              "displayName": "Flat Amount",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "inclusive": {
-              "displayName": "inclusive",
+              "displayName": "Inclusive",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "jurisdiction": {
-              "displayName": "jurisdiction",
+              "displayName": "Jurisdiction",
               "valueType": "string",
               "providerType": "string"
             },
             "jurisdiction_level": {
-              "displayName": "jurisdiction_level",
+              "displayName": "Jurisdiction Level",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10190,17 +10190,17 @@
               ]
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10211,12 +10211,12 @@
               ]
             },
             "percentage": {
-              "displayName": "percentage",
+              "displayName": "Percentage",
               "valueType": "other",
               "providerType": "number"
             },
             "rate_type": {
-              "displayName": "rate_type",
+              "displayName": "Rate Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10231,12 +10231,12 @@
               ]
             },
             "state": {
-              "displayName": "state",
+              "displayName": "State",
               "valueType": "string",
               "providerType": "string"
             },
             "tax_type": {
-              "displayName": "tax_type",
+              "displayName": "Tax Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10306,42 +10306,42 @@
           "responseKey": "data",
           "fields": {
             "bbpos_wisepad3": {
-              "displayName": "bbpos_wisepad3",
+              "displayName": "Bbpos Wisepad3",
               "valueType": "other",
               "providerType": "object"
             },
             "bbpos_wisepos_e": {
-              "displayName": "bbpos_wisepos_e",
+              "displayName": "Bbpos Wisepos E",
               "valueType": "other",
               "providerType": "object"
             },
             "cellular": {
-              "displayName": "cellular",
+              "displayName": "Cellular",
               "valueType": "other",
               "providerType": "object"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "is_account_default": {
-              "displayName": "is_account_default",
+              "displayName": "Is Account Default",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10352,57 +10352,57 @@
               ]
             },
             "offline": {
-              "displayName": "offline",
+              "displayName": "Offline",
               "valueType": "other",
               "providerType": "object"
             },
             "reboot_window": {
-              "displayName": "reboot_window",
+              "displayName": "Reboot Window",
               "valueType": "other",
               "providerType": "object"
             },
             "stripe_s700": {
-              "displayName": "stripe_s700",
+              "displayName": "Stripe S700",
               "valueType": "other",
               "providerType": "object"
             },
             "stripe_s710": {
-              "displayName": "stripe_s710",
+              "displayName": "Stripe S710",
               "valueType": "other",
               "providerType": "object"
             },
             "tipping": {
-              "displayName": "tipping",
+              "displayName": "Tipping",
               "valueType": "other",
               "providerType": "object"
             },
             "verifone_m425": {
-              "displayName": "verifone_m425",
+              "displayName": "Verifone M425",
               "valueType": "other",
               "providerType": "object"
             },
             "verifone_p400": {
-              "displayName": "verifone_p400",
+              "displayName": "Verifone P400",
               "valueType": "other",
               "providerType": "object"
             },
             "verifone_p630": {
-              "displayName": "verifone_p630",
+              "displayName": "Verifone P630",
               "valueType": "other",
               "providerType": "object"
             },
             "verifone_ux700": {
-              "displayName": "verifone_ux700",
+              "displayName": "Verifone Ux700",
               "valueType": "other",
               "providerType": "object"
             },
             "verifone_v660p": {
-              "displayName": "verifone_v660p",
+              "displayName": "Verifone V660p",
               "valueType": "other",
               "providerType": "object"
             },
             "wifi": {
-              "displayName": "wifi",
+              "displayName": "Wifi",
               "valueType": "other",
               "providerType": "object"
             }
@@ -10414,57 +10414,57 @@
           "responseKey": "data",
           "fields": {
             "address": {
-              "displayName": "address",
+              "displayName": "Address",
               "valueType": "other",
               "providerType": "object"
             },
             "address_kana": {
-              "displayName": "address_kana",
+              "displayName": "Address Kana",
               "valueType": "other",
               "providerType": "object"
             },
             "address_kanji": {
-              "displayName": "address_kanji",
+              "displayName": "Address Kanji",
               "valueType": "other",
               "providerType": "object"
             },
             "configuration_overrides": {
-              "displayName": "configuration_overrides",
+              "displayName": "Configuration Overrides",
               "valueType": "string",
               "providerType": "string"
             },
             "display_name": {
-              "displayName": "display_name",
+              "displayName": "Display Name",
               "valueType": "string",
               "providerType": "string"
             },
             "display_name_kana": {
-              "displayName": "display_name_kana",
+              "displayName": "Display Name Kana",
               "valueType": "string",
               "providerType": "string"
             },
             "display_name_kanji": {
-              "displayName": "display_name_kanji",
+              "displayName": "Display Name Kanji",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10475,7 +10475,7 @@
               ]
             },
             "phone": {
-              "displayName": "phone",
+              "displayName": "Phone",
               "valueType": "string",
               "providerType": "string"
             }
@@ -10487,16 +10487,16 @@
           "responseKey": "data",
           "fields": {
             "action": {
-              "displayName": "action",
+              "displayName": "Action",
               "valueType": "other"
             },
             "device_sw_version": {
-              "displayName": "device_sw_version",
+              "displayName": "Device Sw Version",
               "valueType": "string",
               "providerType": "string"
             },
             "device_type": {
-              "displayName": "device_type",
+              "displayName": "Device Type",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10579,41 +10579,41 @@
               ]
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "ip_address": {
-              "displayName": "ip_address",
+              "displayName": "Ip Address",
               "valueType": "string",
               "providerType": "string"
             },
             "label": {
-              "displayName": "label",
+              "displayName": "Label",
               "valueType": "string",
               "providerType": "string"
             },
             "last_seen_at": {
-              "displayName": "last_seen_at",
+              "displayName": "Last Seen At",
               "valueType": "int",
               "providerType": "integer"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "location": {
-              "displayName": "location",
+              "displayName": "Location",
               "valueType": "other"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10624,12 +10624,12 @@
               ]
             },
             "serial_number": {
-              "displayName": "serial_number",
+              "displayName": "Serial Number",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10651,37 +10651,37 @@
           "responseKey": "data",
           "fields": {
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "deletes_after": {
-              "displayName": "deletes_after",
+              "displayName": "Deletes After",
               "valueType": "int",
               "providerType": "integer"
             },
             "frozen_time": {
-              "displayName": "frozen_time",
+              "displayName": "Frozen Time",
               "valueType": "int",
               "providerType": "integer"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "name": {
-              "displayName": "name",
+              "displayName": "Name",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10692,7 +10692,7 @@
               ]
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10711,7 +10711,7 @@
               ]
             },
             "status_details": {
-              "displayName": "status_details",
+              "displayName": "Status Details",
               "valueType": "other",
               "providerType": "object"
             }
@@ -10723,61 +10723,61 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "expected_availability_date": {
-              "displayName": "expected_availability_date",
+              "displayName": "Expected Availability Date",
               "valueType": "int",
               "providerType": "integer"
             },
             "failure_code": {
-              "displayName": "failure_code",
+              "displayName": "Failure Code",
               "valueType": "string",
               "providerType": "string"
             },
             "failure_message": {
-              "displayName": "failure_message",
+              "displayName": "Failure Message",
               "valueType": "string",
               "providerType": "string"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10788,16 +10788,16 @@
               ]
             },
             "source": {
-              "displayName": "source",
+              "displayName": "Source",
               "valueType": "other"
             },
             "statement_descriptor": {
-              "displayName": "statement_descriptor",
+              "displayName": "Statement Descriptor",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10824,7 +10824,7 @@
               ]
             },
             "transfer_group": {
-              "displayName": "transfer_group",
+              "displayName": "Transfer Group",
               "valueType": "string",
               "providerType": "string"
             }
@@ -10836,59 +10836,59 @@
           "responseKey": "data",
           "fields": {
             "amount": {
-              "displayName": "amount",
+              "displayName": "Amount",
               "valueType": "int",
               "providerType": "integer"
             },
             "amount_reversed": {
-              "displayName": "amount_reversed",
+              "displayName": "Amount Reversed",
               "valueType": "int",
               "providerType": "integer"
             },
             "balance_transaction": {
-              "displayName": "balance_transaction",
+              "displayName": "Balance Transaction",
               "valueType": "other"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "currency": {
-              "displayName": "currency",
+              "displayName": "Currency",
               "valueType": "string",
               "providerType": "string"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "destination": {
-              "displayName": "destination",
+              "displayName": "Destination",
               "valueType": "other"
             },
             "destination_payment": {
-              "displayName": "destination_payment",
+              "displayName": "Destination Payment",
               "valueType": "other"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10899,28 +10899,244 @@
               ]
             },
             "reversals": {
-              "displayName": "reversals",
+              "displayName": "Reversals",
               "valueType": "other",
               "providerType": "object"
             },
             "reversed": {
-              "displayName": "reversed",
+              "displayName": "Reversed",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "source_transaction": {
-              "displayName": "source_transaction",
+              "displayName": "Source Transaction",
               "valueType": "other"
             },
             "source_type": {
-              "displayName": "source_type",
+              "displayName": "Source Type",
               "valueType": "string",
               "providerType": "string"
             },
             "transfer_group": {
-              "displayName": "transfer_group",
+              "displayName": "Transfer Group",
               "valueType": "string",
               "providerType": "string"
+            }
+          }
+        },
+        "treasury/credit_reversals": {
+          "displayName": "Credit Reversals",
+          "path": "treasury/credit_reversals",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "Metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "network": {
+              "displayName": "Network",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "ach",
+                  "displayValue": "ach"
+                },
+                {
+                  "value": "stripe",
+                  "displayValue": "stripe"
+                }
+              ]
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.credit_reversal",
+                  "displayValue": "treasury.credit_reversal"
+                }
+              ]
+            },
+            "received_credit": {
+              "displayName": "Received Credit",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "canceled",
+                  "displayValue": "canceled"
+                },
+                {
+                  "value": "posted",
+                  "displayValue": "posted"
+                },
+                {
+                  "value": "processing",
+                  "displayValue": "processing"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/debit_reversals": {
+          "displayName": "Debit Reversals",
+          "path": "treasury/debit_reversals",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "linked_flows": {
+              "displayName": "Linked Flows",
+              "valueType": "other"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "Metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "network": {
+              "displayName": "Network",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "ach",
+                  "displayValue": "ach"
+                },
+                {
+                  "value": "card",
+                  "displayValue": "card"
+                }
+              ]
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.debit_reversal",
+                  "displayValue": "treasury.debit_reversal"
+                }
+              ]
+            },
+            "received_debit": {
+              "displayName": "Received Debit",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "processing",
+                  "displayValue": "processing"
+                },
+                {
+                  "value": "succeeded",
+                  "displayValue": "succeeded"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
             }
           }
         },
@@ -10930,62 +11146,62 @@
           "responseKey": "data",
           "fields": {
             "active_features": {
-              "displayName": "active_features",
+              "displayName": "Active Features",
               "valueType": "other",
               "providerType": "array"
             },
             "balance": {
-              "displayName": "balance",
+              "displayName": "Balance",
               "valueType": "other",
               "providerType": "object"
             },
             "country": {
-              "displayName": "country",
+              "displayName": "Country",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "features": {
-              "displayName": "features",
+              "displayName": "Features",
               "valueType": "other",
               "providerType": "object"
             },
             "financial_addresses": {
-              "displayName": "financial_addresses",
+              "displayName": "Financial Addresses",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "is_default": {
-              "displayName": "is_default",
+              "displayName": "Is Default",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "nickname": {
-              "displayName": "nickname",
+              "displayName": "Nickname",
               "valueType": "string",
               "providerType": "string"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -10996,21 +11212,21 @@
               ]
             },
             "pending_features": {
-              "displayName": "pending_features",
+              "displayName": "Pending Features",
               "valueType": "other",
               "providerType": "array"
             },
             "platform_restrictions": {
-              "displayName": "platform_restrictions",
+              "displayName": "Platform Restrictions",
               "valueType": "other"
             },
             "restricted_features": {
-              "displayName": "restricted_features",
+              "displayName": "Restricted Features",
               "valueType": "other",
               "providerType": "array"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -11025,14 +11241,1023 @@
               ]
             },
             "status_details": {
-              "displayName": "status_details",
+              "displayName": "Status Details",
               "valueType": "other",
               "providerType": "object"
             },
             "supported_currencies": {
-              "displayName": "supported_currencies",
+              "displayName": "Supported Currencies",
               "valueType": "other",
               "providerType": "array"
+            }
+          }
+        },
+        "treasury/inbound_transfers": {
+          "displayName": "Inbound Transfers",
+          "path": "treasury/inbound_transfers",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "cancelable": {
+              "displayName": "Cancelable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "failure_details": {
+              "displayName": "Failure Details",
+              "valueType": "other"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "linked_flows": {
+              "displayName": "Linked Flows",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "Metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.inbound_transfer",
+                  "displayValue": "treasury.inbound_transfer"
+                }
+              ]
+            },
+            "origin_payment_method": {
+              "displayName": "Origin Payment Method",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "origin_payment_method_details": {
+              "displayName": "Origin Payment Method Details",
+              "valueType": "other"
+            },
+            "returned": {
+              "displayName": "Returned",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "statement_descriptor": {
+              "displayName": "Statement Descriptor",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "canceled",
+                  "displayValue": "canceled"
+                },
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "processing",
+                  "displayValue": "processing"
+                },
+                {
+                  "value": "succeeded",
+                  "displayValue": "succeeded"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/outbound_payments": {
+          "displayName": "Outbound Payments",
+          "path": "treasury/outbound_payments",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "cancelable": {
+              "displayName": "Cancelable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "customer": {
+              "displayName": "Customer",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "destination_payment_method": {
+              "displayName": "Destination Payment Method",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "destination_payment_method_details": {
+              "displayName": "Destination Payment Method Details",
+              "valueType": "other"
+            },
+            "end_user_details": {
+              "displayName": "End User Details",
+              "valueType": "other"
+            },
+            "expected_arrival_date": {
+              "displayName": "Expected Arrival Date",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "Metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.outbound_payment",
+                  "displayValue": "treasury.outbound_payment"
+                }
+              ]
+            },
+            "returned_details": {
+              "displayName": "Returned Details",
+              "valueType": "other"
+            },
+            "statement_descriptor": {
+              "displayName": "Statement Descriptor",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "canceled",
+                  "displayValue": "canceled"
+                },
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "posted",
+                  "displayValue": "posted"
+                },
+                {
+                  "value": "processing",
+                  "displayValue": "processing"
+                },
+                {
+                  "value": "returned",
+                  "displayValue": "returned"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "tracking_details": {
+              "displayName": "Tracking Details",
+              "valueType": "other"
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/outbound_transfers": {
+          "displayName": "Outbound Transfers",
+          "path": "treasury/outbound_transfers",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "cancelable": {
+              "displayName": "Cancelable",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "destination_payment_method": {
+              "displayName": "Destination Payment Method",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "destination_payment_method_details": {
+              "displayName": "Destination Payment Method Details",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "expected_arrival_date": {
+              "displayName": "Expected Arrival Date",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "Metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.outbound_transfer",
+                  "displayValue": "treasury.outbound_transfer"
+                }
+              ]
+            },
+            "returned_details": {
+              "displayName": "Returned Details",
+              "valueType": "other"
+            },
+            "statement_descriptor": {
+              "displayName": "Statement Descriptor",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "canceled",
+                  "displayValue": "canceled"
+                },
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "posted",
+                  "displayValue": "posted"
+                },
+                {
+                  "value": "processing",
+                  "displayValue": "processing"
+                },
+                {
+                  "value": "returned",
+                  "displayValue": "returned"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "tracking_details": {
+              "displayName": "Tracking Details",
+              "valueType": "other"
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/received_credits": {
+          "displayName": "Received Credits",
+          "path": "treasury/received_credits",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "failure_code": {
+              "displayName": "Failure Code",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "account_closed",
+                  "displayValue": "account_closed"
+                },
+                {
+                  "value": "account_frozen",
+                  "displayValue": "account_frozen"
+                },
+                {
+                  "value": "international_transaction",
+                  "displayValue": "international_transaction"
+                },
+                {
+                  "value": "other",
+                  "displayValue": "other"
+                }
+              ]
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initiating_payment_method_details": {
+              "displayName": "Initiating Payment Method Details",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "linked_flows": {
+              "displayName": "Linked Flows",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "network": {
+              "displayName": "Network",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "ach",
+                  "displayValue": "ach"
+                },
+                {
+                  "value": "card",
+                  "displayValue": "card"
+                },
+                {
+                  "value": "stripe",
+                  "displayValue": "stripe"
+                },
+                {
+                  "value": "us_domestic_wire",
+                  "displayValue": "us_domestic_wire"
+                }
+              ]
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.received_credit",
+                  "displayValue": "treasury.received_credit"
+                }
+              ]
+            },
+            "reversal_details": {
+              "displayName": "Reversal Details",
+              "valueType": "other"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "succeeded",
+                  "displayValue": "succeeded"
+                }
+              ]
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/received_debits": {
+          "displayName": "Received Debits",
+          "path": "treasury/received_debits",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "failure_code": {
+              "displayName": "Failure Code",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "account_closed",
+                  "displayValue": "account_closed"
+                },
+                {
+                  "value": "account_frozen",
+                  "displayValue": "account_frozen"
+                },
+                {
+                  "value": "insufficient_funds",
+                  "displayValue": "insufficient_funds"
+                },
+                {
+                  "value": "international_transaction",
+                  "displayValue": "international_transaction"
+                },
+                {
+                  "value": "other",
+                  "displayValue": "other"
+                }
+              ]
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "hosted_regulatory_receipt_url": {
+              "displayName": "Hosted Regulatory Receipt Url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "initiating_payment_method_details": {
+              "displayName": "Initiating Payment Method Details",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "linked_flows": {
+              "displayName": "Linked Flows",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "network": {
+              "displayName": "Network",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "ach",
+                  "displayValue": "ach"
+                },
+                {
+                  "value": "card",
+                  "displayValue": "card"
+                },
+                {
+                  "value": "stripe",
+                  "displayValue": "stripe"
+                }
+              ]
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.received_debit",
+                  "displayValue": "treasury.received_debit"
+                }
+              ]
+            },
+            "reversal_details": {
+              "displayName": "Reversal Details",
+              "valueType": "other"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "failed",
+                  "displayValue": "failed"
+                },
+                {
+                  "value": "succeeded",
+                  "displayValue": "succeeded"
+                }
+              ]
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            }
+          }
+        },
+        "treasury/transaction_entries": {
+          "displayName": "Transaction Entries",
+          "path": "treasury/transaction_entries",
+          "responseKey": "data",
+          "fields": {
+            "balance_impact": {
+              "displayName": "Balance Impact",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "effective_at": {
+              "displayName": "Effective At",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "flow": {
+              "displayName": "Flow",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "flow_details": {
+              "displayName": "Flow Details",
+              "valueType": "other"
+            },
+            "flow_type": {
+              "displayName": "Flow Type",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "credit_reversal",
+                  "displayValue": "credit_reversal"
+                },
+                {
+                  "value": "debit_reversal",
+                  "displayValue": "debit_reversal"
+                },
+                {
+                  "value": "inbound_transfer",
+                  "displayValue": "inbound_transfer"
+                },
+                {
+                  "value": "issuing_authorization",
+                  "displayValue": "issuing_authorization"
+                },
+                {
+                  "value": "other",
+                  "displayValue": "other"
+                },
+                {
+                  "value": "outbound_payment",
+                  "displayValue": "outbound_payment"
+                },
+                {
+                  "value": "outbound_transfer",
+                  "displayValue": "outbound_transfer"
+                },
+                {
+                  "value": "received_credit",
+                  "displayValue": "received_credit"
+                },
+                {
+                  "value": "received_debit",
+                  "displayValue": "received_debit"
+                }
+              ]
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.transaction_entry",
+                  "displayValue": "treasury.transaction_entry"
+                }
+              ]
+            },
+            "transaction": {
+              "displayName": "Transaction",
+              "valueType": "other"
+            },
+            "type": {
+              "displayName": "Type",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "credit_reversal",
+                  "displayValue": "credit_reversal"
+                },
+                {
+                  "value": "credit_reversal_posting",
+                  "displayValue": "credit_reversal_posting"
+                },
+                {
+                  "value": "debit_reversal",
+                  "displayValue": "debit_reversal"
+                },
+                {
+                  "value": "inbound_transfer",
+                  "displayValue": "inbound_transfer"
+                },
+                {
+                  "value": "inbound_transfer_return",
+                  "displayValue": "inbound_transfer_return"
+                },
+                {
+                  "value": "issuing_authorization_hold",
+                  "displayValue": "issuing_authorization_hold"
+                },
+                {
+                  "value": "issuing_authorization_release",
+                  "displayValue": "issuing_authorization_release"
+                },
+                {
+                  "value": "other",
+                  "displayValue": "other"
+                },
+                {
+                  "value": "outbound_payment",
+                  "displayValue": "outbound_payment"
+                },
+                {
+                  "value": "outbound_payment_cancellation",
+                  "displayValue": "outbound_payment_cancellation"
+                },
+                {
+                  "value": "outbound_payment_failure",
+                  "displayValue": "outbound_payment_failure"
+                },
+                {
+                  "value": "outbound_payment_posting",
+                  "displayValue": "outbound_payment_posting"
+                },
+                {
+                  "value": "outbound_payment_return",
+                  "displayValue": "outbound_payment_return"
+                },
+                {
+                  "value": "outbound_transfer",
+                  "displayValue": "outbound_transfer"
+                },
+                {
+                  "value": "outbound_transfer_cancellation",
+                  "displayValue": "outbound_transfer_cancellation"
+                },
+                {
+                  "value": "outbound_transfer_failure",
+                  "displayValue": "outbound_transfer_failure"
+                },
+                {
+                  "value": "outbound_transfer_posting",
+                  "displayValue": "outbound_transfer_posting"
+                },
+                {
+                  "value": "outbound_transfer_return",
+                  "displayValue": "outbound_transfer_return"
+                },
+                {
+                  "value": "received_credit",
+                  "displayValue": "received_credit"
+                },
+                {
+                  "value": "received_debit",
+                  "displayValue": "received_debit"
+                }
+              ]
+            }
+          }
+        },
+        "treasury/transactions": {
+          "displayName": "Transactions",
+          "path": "treasury/transactions",
+          "responseKey": "data",
+          "fields": {
+            "amount": {
+              "displayName": "Amount",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "balance_impact": {
+              "displayName": "Balance Impact",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "created": {
+              "displayName": "Created",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "currency": {
+              "displayName": "Currency",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "entries": {
+              "displayName": "Entries",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "financial_account": {
+              "displayName": "Financial Account",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "flow": {
+              "displayName": "Flow",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "flow_details": {
+              "displayName": "Flow Details",
+              "valueType": "other"
+            },
+            "flow_type": {
+              "displayName": "Flow Type",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "credit_reversal",
+                  "displayValue": "credit_reversal"
+                },
+                {
+                  "value": "debit_reversal",
+                  "displayValue": "debit_reversal"
+                },
+                {
+                  "value": "inbound_transfer",
+                  "displayValue": "inbound_transfer"
+                },
+                {
+                  "value": "issuing_authorization",
+                  "displayValue": "issuing_authorization"
+                },
+                {
+                  "value": "other",
+                  "displayValue": "other"
+                },
+                {
+                  "value": "outbound_payment",
+                  "displayValue": "outbound_payment"
+                },
+                {
+                  "value": "outbound_transfer",
+                  "displayValue": "outbound_transfer"
+                },
+                {
+                  "value": "received_credit",
+                  "displayValue": "received_credit"
+                },
+                {
+                  "value": "received_debit",
+                  "displayValue": "received_debit"
+                }
+              ]
+            },
+            "id": {
+              "displayName": "Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "livemode": {
+              "displayName": "Livemode",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "object": {
+              "displayName": "Object",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "treasury.transaction",
+                  "displayValue": "treasury.transaction"
+                }
+              ]
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "open",
+                  "displayValue": "open"
+                },
+                {
+                  "value": "posted",
+                  "displayValue": "posted"
+                },
+                {
+                  "value": "void",
+                  "displayValue": "void"
+                }
+              ]
+            },
+            "status_transitions": {
+              "displayName": "Status Transitions",
+              "valueType": "other",
+              "providerType": "object"
             }
           }
         },
@@ -11042,47 +12267,47 @@
           "responseKey": "data",
           "fields": {
             "api_version": {
-              "displayName": "api_version",
+              "displayName": "Api Version",
               "valueType": "string",
               "providerType": "string"
             },
             "application": {
-              "displayName": "application",
+              "displayName": "Application",
               "valueType": "string",
               "providerType": "string"
             },
             "created": {
-              "displayName": "created",
+              "displayName": "Created",
               "valueType": "int",
               "providerType": "integer"
             },
             "description": {
-              "displayName": "description",
+              "displayName": "Description",
               "valueType": "string",
               "providerType": "string"
             },
             "enabled_events": {
-              "displayName": "enabled_events",
+              "displayName": "Enabled Events",
               "valueType": "other",
               "providerType": "array"
             },
             "id": {
-              "displayName": "id",
+              "displayName": "Id",
               "valueType": "string",
               "providerType": "string"
             },
             "livemode": {
-              "displayName": "livemode",
+              "displayName": "Livemode",
               "valueType": "boolean",
               "providerType": "boolean"
             },
             "metadata": {
-              "displayName": "metadata",
+              "displayName": "Metadata",
               "valueType": "other",
               "providerType": "object"
             },
             "object": {
-              "displayName": "object",
+              "displayName": "Object",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -11093,17 +12318,17 @@
               ]
             },
             "secret": {
-              "displayName": "secret",
+              "displayName": "Secret",
               "valueType": "string",
               "providerType": "string"
             },
             "status": {
-              "displayName": "status",
+              "displayName": "Status",
               "valueType": "string",
               "providerType": "string"
             },
             "url": {
-              "displayName": "url",
+              "displayName": "Url",
               "valueType": "string",
               "providerType": "string"
             }

--- a/providers/stripe/metadata_test.go
+++ b/providers/stripe/metadata_test.go
@@ -39,21 +39,21 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					"coupons": {
 						DisplayName: "Coupons",
 						FieldsMap: map[string]string{
-							"id":               "id",
-							"livemode":         "livemode",
-							"currency":         "currency",
-							"currency_options": "currency_options",
-							"percent_off":      "percent_off",
+							"id":               "Id",
+							"livemode":         "Livemode",
+							"currency":         "Currency",
+							"currency_options": "Currency Options",
+							"percent_off":      "Percent Off",
 						},
 					},
 					"products": {
 						DisplayName: "Products",
 						FieldsMap: map[string]string{
-							"id":            "id",
-							"images":        "images",
-							"default_price": "default_price",
-							"tax_code":      "tax_code",
-							"unit_label":    "unit_label",
+							"id":            "Id",
+							"images":        "Images",
+							"default_price": "Default Price",
+							"tax_code":      "Tax Code",
+							"unit_label":    "Unit Label",
 						},
 					},
 				},
@@ -72,12 +72,12 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 						DisplayName: "Payment Checkout Sessions",
 						Fields: map[string]common.FieldMetadata{
 							"line_items": {
-								DisplayName:  "line_items",
+								DisplayName:  "Line Items",
 								ValueType:    "other",
 								ProviderType: "object",
 							},
 							"currency": {
-								DisplayName:  "currency",
+								DisplayName:  "Currency",
 								ValueType:    "string",
 								ProviderType: "string",
 							},

--- a/providers/stripe/read.go
+++ b/providers/stripe/read.go
@@ -388,6 +388,24 @@ var incrementalObjects = datautils.NewSet( // nolint:gochecknoglobals
 	"treasury/financial_accounts",
 )
 
+// scopedObjectsForFinancialAccount lists Treasury objects that are context-scoped by financial_account.
+//
+// Requests to these endpoints must be resolved against a FinancialAccount,
+// which is discovered through treasury/financial_accounts.
+// The connector uses those accounts as context to list the corresponding objects.
+// TODO must be used by Read method (remove the `unused` tag).
+var scopedObjectsForFinancialAccount = datautils.NewSet( // nolint:gochecknoglobals,unused
+	"treasury/outbound_payments",
+	"treasury/received_credits",
+	"treasury/debit_reversals",
+	"treasury/inbound_transfers",
+	"treasury/received_debits",
+	"treasury/transaction_entries",
+	"treasury/outbound_transfers",
+	"treasury/transactions",
+	"treasury/credit_reversals",
+)
+
 func fieldsSelector(node *ajson.Node, fields []string) (map[string]any, string, error) {
 	root, err := jsonquery.Convertor.ObjectToMap(node)
 	if err != nil {

--- a/scripts/openapi/gong/metadata/main.go
+++ b/scripts/openapi/gong/metadata/main.go
@@ -18,7 +18,7 @@ var (
 	// Even though OpenAPI docs and official documentation say that some query parameters are required
 	// in practice you still can make an API call without any specified.
 	// Must include "calls" object.
-	queryParamFilterExceptions = datautils.NewSet("calls", "flows") // nolint:gochecknoglobals
+	queryParamFilterExceptions = datautils.NewSet("/v2/calls", "/v2/flows") // nolint:gochecknoglobals
 
 	ignoreEndpoints = []string{ // nolint:gochecknoglobals
 		"/v2/settings/scorecards",

--- a/scripts/openapi/stripe/scripts/metadata/main.go
+++ b/scripts/openapi/stripe/scripts/metadata/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/goutils"
 	"github.com/amp-labs/connectors/internal/staticschema"
@@ -12,6 +13,7 @@ import (
 	utilsopenapi "github.com/amp-labs/connectors/scripts/openapi/utils"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 	"github.com/amp-labs/connectors/tools/scrapper"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 var (
@@ -64,7 +66,7 @@ func main() { // nolint:funlen
 			api3.Pluralize,
 		),
 		api3.WithParameterFilterGetMethod(
-			api3.OnlyOptionalQueryParameters,
+			OnlyOptionalQueryParametersOrTreasuryApi,
 		),
 		api3.WithArrayItemAutoSelection(),
 		api3.WithDuplicatesResolver(api3.SingleItemDuplicatesResolver(func(endpoint string) string {
@@ -98,8 +100,16 @@ func main() { // nolint:funlen
 		}
 
 		for _, field := range object.Fields {
+			fieldMetadata := staticschema.FieldMetadataMapV2{
+				field.Name: staticschema.FieldMetadata{
+					DisplayName:  formatFieldDisplayName(field.Name),
+					ValueType:    utilsopenapi.GetFieldValueType(field),
+					ProviderType: field.Type,
+					Values:       utilsopenapi.GetFieldValueOptions(field),
+				},
+			}
 			schemas.Add("", objectName, object.DisplayName, urlPath, object.ResponseKey,
-				utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, object.Custom)
+				fieldMetadata, nil, object.Custom)
 		}
 
 		for _, queryParam := range object.QueryParams {
@@ -111,6 +121,14 @@ func main() { // nolint:funlen
 	goutils.MustBeNil(files.OutputStripe.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
 
 	slog.Info("Completed.")
+}
+
+func formatFieldDisplayName(fieldName string) string {
+	displayName := fieldName
+	displayName = naming.SeparateUnderscoreWords(displayName)
+	displayName = naming.CapitalizeFirstLetterEveryWord(displayName)
+
+	return displayName
 }
 
 func arrayLocator(objectName, fieldName string) bool {
@@ -140,4 +158,21 @@ func processResourceTitles(displayName string) string {
 	}
 
 	return displayName
+}
+
+func OnlyOptionalQueryParametersOrTreasuryApi(urlPath string, operation *openapi3.Operation) bool {
+	for _, parameter := range operation.Parameters {
+		// Required query params are not supported.
+		if parameter.Value.In == "query" && parameter.Value.Required {
+			// Treasury endpoints are an exception.
+			if strings.Contains(urlPath, "/v1/treasury/") &&
+				strings.Contains(parameter.Value.Name, "financial_account") {
+				return true
+			}
+
+			return false
+		}
+	}
+
+	return true
 }

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -51,7 +51,7 @@ func (p PathItem[C]) RetrieveSchemaOperation(
 		return nil, false, nil
 	}
 
-	if ok := operationMethodFilter(p.objectName, operation); !ok {
+	if ok := operationMethodFilter(p.urlPath, operation); !ok {
 		// Omit this schema, operation for this object is not what we are looking for.
 		return nil, false, nil
 	}

--- a/tools/fileconv/api3/parameters.go
+++ b/tools/fileconv/api3/parameters.go
@@ -80,7 +80,7 @@ func Pluralize(displayName string) string {
 }
 
 // ReadOperationMethodFilter callback that filters REST operations based on endpoint parameters.
-type ReadOperationMethodFilter func(objectName string, operation *openapi3.Operation) bool
+type ReadOperationMethodFilter func(objectPath string, operation *openapi3.Operation) bool
 
 // OnlyOptionalQueryParameters operation must include only optional query parameters.
 func OnlyOptionalQueryParameters(objectName string, operation *openapi3.Operation) bool {


### PR DESCRIPTION
# Description

The Stripe OpenAPI metadata generation script now extracts objects from the Treasury API.

Previously, endpoints with required query parameters were excluded from extraction. Treasury API endpoints are now treated as an exception because the required `financial_account` query parameter will be supported by the connector in next PRs.

Additionally, the `ReadOperationMethodFilter` in the OpenAPI extraction tool now receives the `urlPath` instead of the `objectName`. Unlike `objectName`, the URL path is stable and does not change during extraction, making filtering more predictable and easier to maintain.
