### PR TITLE
[ENG-4121] feat(stripe): Read Treasury objects

### DIFF
--- a/common/urlbuilder/url.go
+++ b/common/urlbuilder/url.go
@@ -88,6 +88,19 @@ func FromRawURL(rawURL *url.URL) (*URL, error) {
 	}, nil
 }
 
+// Clone returns a deep copy of the URL.
+func (u *URL) Clone() *URL {
+	// Copy url.URL
+	delegate := *u.delegate // nolint:staticcheck
+
+	return &URL{
+		delegate:             new(delegate),
+		queryParams:          maps.Clone(u.queryParams),
+		unencodedQueryParams: maps.Clone(u.unencodedQueryParams),
+		encodingExceptions:   maps.Clone(u.encodingExceptions),
+	}
+}
+
 func (u *URL) WithQueryParamList(name string, values []string) {
 	u.queryParams[name] = values
 }

--- a/providers/stripe/internal/reader/accounts.go
+++ b/providers/stripe/internal/reader/accounts.go
@@ -36,7 +36,7 @@ func (s *Strategy) readForConnectedAccounts(
 		}
 	}
 
-	return executeReadTasks(ctx, tasks)
+	return executeReadTasksAccounts(ctx, tasks)
 }
 
 // readNextPageConnectedAccounts resumes paginated reads for connected accounts.
@@ -65,7 +65,7 @@ func (s *Strategy) readNextPageConnectedAccounts(ctx context.Context,
 		}
 	}
 
-	return executeReadTasks(ctx, tasks)
+	return executeReadTasksAccounts(ctx, tasks)
 }
 
 type accountsListResponse struct {

--- a/providers/stripe/internal/reader/financial-accounts.go
+++ b/providers/stripe/internal/reader/financial-accounts.go
@@ -1,0 +1,230 @@
+package reader
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/parallelfetch"
+)
+
+// readTreasuryForMainAccount creates parallel read tasks for financial accounts
+// belonging to the platform's main account.
+//
+// Each request includes the financial_account query parameter to identify the
+// target Treasury financial account. Requests are executed in the context of
+// the platform account and do not include a connected account header.
+func (s *Strategy) readTreasuryForMainAccount(ctx context.Context,
+	objectName string,
+	fields datautils.StringSet,
+	urlTemplate *urlbuilder.URL,
+	financialAccounts map[string]FinancialAccount,
+) (*common.ReadResult, error) {
+	tasks := make([]parallelfetch.Task[string, common.ReadResult], len(financialAccounts))
+
+	index := 0
+	for _, financialAccount := range financialAccounts {
+		tasks[index] = func(ctx context.Context) (taskID string, data *common.ReadResult, err error) {
+			taskUrl := urlTemplate.Clone()
+			taskUrl.WithQueryParam("financial_account", financialAccount.Id)
+			result, err := s.readRecords(ctx, objectName, fields, taskUrl)
+
+			return financialAccount.Id, result, err
+		}
+		index += 1
+	}
+
+	return executeReadTasksTreasury(ctx, tasks, financialAccounts)
+}
+
+// readTreasuryForConnectedAccounts creates parallel read tasks for financial accounts
+// belonging to connected accounts.
+//
+// Each request includes:
+//   - the financial_account query parameter to identify the target Treasury account.
+//   - the Stripe-Account header to execute the request in the context of the
+//     connected account that owns the financial account.
+func (s *Strategy) readTreasuryForConnectedAccounts(
+	ctx context.Context,
+	params common.ReadParams,
+	urlTemplate *urlbuilder.URL,
+	financialAccounts map[string]FinancialAccount,
+) (*common.ReadResult, error) {
+	tasks := make([]parallelfetch.Task[string, common.ReadResult], len(financialAccounts))
+
+	index := 0
+	for _, financialAccount := range financialAccounts {
+		tasks[index] = func(ctx context.Context) (taskID string, data *common.ReadResult, err error) {
+			taskUrl := urlTemplate.Clone()
+			taskUrl.WithQueryParam("financial_account", financialAccount.Id)
+			header := makeConnectedAccountHeader(financialAccount.ConnectedAccountId)
+			result, err := s.readRecords(ctx, params.ObjectName, params.Fields, taskUrl, header)
+
+			return financialAccount.Id, result, err
+		}
+		index += 1
+	}
+
+	return executeReadTasksTreasury(ctx, tasks, financialAccounts)
+}
+
+// readNextPageTreasury resumes paginated reads for Treasury financial accounts.
+//
+// The aggregate token contains the next page URL and FinancialAccount context
+// for each account that still has unread pages. This method uses that state to
+// create independent requests for each financial account and executes them in
+// parallel.
+//
+// The FinancialAccount context determines whether the request targets the
+// platform account or a connected account. For connected accounts, the request
+// includes the Stripe-Account header. For the platform account, no additional
+// header is required.
+//
+// The financial_account query parameter is always added because of the
+// Treasury API requirement.
+//
+// Example: a user may have paused reading the "treasury/inbound_transfers" object
+// after processing some pages for 3 financial accounts owned by connected account
+// "A" and 2 financial accounts owned by connected account "B". The aggregate token
+// contains the next page position and account context for each of
+// those 5 finnancial accounts.
+//
+// NOTE: Unlike readNextPageConnectedAccounts, tasks are indexed by Financial
+// Account ID rather than Connected Account ID. Multiple financial accounts can
+// belong to the same connected account, so Connected Account IDs are not unique
+// task identifiers in this flow.
+func (s *Strategy) readNextPageTreasury(ctx context.Context,
+	params common.ReadParams,
+	aggregateToken readhelper.AggregateNextPage[FinancialAccount],
+) (*common.ReadResult, error) {
+	tasks := make([]parallelfetch.Task[string, common.ReadResult], len(aggregateToken))
+	financialAccounts := make(map[string]FinancialAccount)
+
+	for index, token := range aggregateToken {
+		financialAccount := token.Context
+		financialAccounts[financialAccount.Id] = financialAccount
+		nextPageToken := token.Value.String()
+
+		urlTemplate, err := urlbuilder.New(nextPageToken)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create parallel task for next page of each financial account.
+		tasks[index] = func(ctx context.Context) (taskID string, data *common.ReadResult, err error) {
+			var headers []common.Header
+			if financialAccount.ConnectedAccountId != "" {
+				headers = append(headers, makeConnectedAccountHeader(financialAccount.ConnectedAccountId))
+			}
+
+			// financial_account query param should be already present.
+			// Set it anyway to be explicit.
+			taskUrl := urlTemplate.Clone()
+			taskUrl.WithQueryParam("financial_account", financialAccount.Id)
+			result, err := s.readRecords(ctx, params.ObjectName, params.Fields, taskUrl, headers...)
+
+			return financialAccount.Id, result, err
+		}
+	}
+
+	return executeReadTasksTreasury(ctx, tasks, financialAccounts)
+}
+
+// FinancialAccount represents an association between Connected Account and Financial account.
+// When ConnectedAccountId is empty then this financial account belongs to the main platform account.
+// Additionally, this struct is used to construct aggregate page token and that is the reason the `json` tags are used.
+// This is a context for the next page token.
+type FinancialAccount struct {
+	Id                 string `json:"finAccId"`
+	ConnectedAccountId string `json:"conAccId"`
+}
+
+type financialAccountsListResponse struct {
+	HasMore bool `json:"has_more"`
+	Data    []struct {
+		Id string `json:"id"`
+	} `json:"data"`
+}
+
+// listAllFinancialAccounts retrieves all financial accounts for the provided connected account IDs.
+//
+// If connectedAccountIds is nil or empty, the financial accounts for the platform account are returned.
+func (s *Strategy) listAllFinancialAccounts(ctx context.Context,
+	connectedAccountIds []string,
+) (map[string]FinancialAccount, error) {
+	// Retrieve financial accounts for the platform account.
+	if len(connectedAccountIds) == 0 {
+		return s.listFinancialAccountsForAccount(ctx, nil)
+	}
+
+	// Retrieve and aggregate financial accounts for each connected account.
+	financialAccounts := make([]map[string]FinancialAccount, 0)
+
+	for _, accountId := range connectedAccountIds {
+		accounts, err := s.listFinancialAccountsForAccount(ctx, new(accountId))
+		if err != nil {
+			return nil, err
+		}
+
+		financialAccounts = append(financialAccounts, accounts)
+	}
+
+	return datautils.MergeMaps(financialAccounts...), nil
+}
+
+func (s *Strategy) listFinancialAccountsForAccount(ctx context.Context, // nolint:cyclop
+	accountId *string,
+) (map[string]FinancialAccount, error) {
+	url, err := s.base.GetURL("treasury/financial_accounts")
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("limit", strconv.Itoa(DefaultPageSize))
+
+	financialAccounts := make(map[string]FinancialAccount)
+
+	for {
+		headers := make([]common.Header, 0, 1)
+		if accountId != nil {
+			// Stripe requires the Stripe-Account header to make requests on behalf of a connected account.
+			headers = append(headers, makeConnectedAccountHeader(*accountId))
+		}
+
+		res, err := s.base.JSONHTTPClient().Get(ctx, url.String(), headers...)
+		if err != nil {
+			return nil, err
+		}
+
+		accounts, err := common.UnmarshalJSON[financialAccountsListResponse](res)
+		if err != nil {
+			return nil, err
+		}
+
+		var lastItemId string
+
+		for _, item := range accounts.Data {
+			// Record the connected account that owns this financial account.
+			var connectedAccountId string
+			if accountId != nil {
+				connectedAccountId = *accountId
+			}
+
+			lastItemId = item.Id
+			financialAccounts[item.Id] = FinancialAccount{
+				Id:                 item.Id,
+				ConnectedAccountId: connectedAccountId,
+			}
+		}
+
+		if !accounts.HasMore || len(financialAccounts) == 0 || lastItemId == "" {
+			return financialAccounts, nil // => Desired return with collected ids.
+		}
+
+		// Prepare next page URL using the last account ID
+		url.WithQueryParam("starting_after", lastItemId)
+	}
+}

--- a/providers/stripe/internal/reader/financial-accounts_test.go
+++ b/providers/stripe/internal/reader/financial-accounts_test.go
@@ -1,0 +1,284 @@
+package reader
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestReadForTreasury(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseAccountsFirstPage := testutils.DataFromFile(t, "accounts/1-first-page.json")
+	responseAccountsLastPage := testutils.DataFromFile(t, "accounts/2-last-page.json")
+	responseAcc1FinAccounts1 := testutils.DataFromFile(t, "financial-account/con-acc-1/1-first-page.json")
+	responseAcc1FinAccounts2 := testutils.DataFromFile(t, "financial-account/con-acc-1/2-last-page.json")
+	responseAcc2FinAccounts1 := testutils.DataFromFile(t, "financial-account/con-acc-2/1-last-page.json")
+	responseAcc1Fin00aTransactions := testutils.DataFromFile(t, "transaction_entries/con-acc-1-fin-a.json")
+	responseAcc1Fin00bTransactions := testutils.DataFromFile(t, "transaction_entries/con-acc-1-fin-b.json")
+	responseAcc2Fin00cTransactions := testutils.DataFromFile(t, "transaction_entries/con-acc-2-fin-c.json")
+
+	tests := []testconn.TestCaseRead{
+		{
+			Name: "Read Treasury transactions for all connected accounts",
+			// Read all connected accounts (2 pages).
+			// Read all financial accounts (2 pages).
+			// Account 1 has Fin00a and Fin00b.
+			// Account 2 has Fin00c.
+			// Read transactions for Acc1 Fin00a (1 page).
+			// Read transactions for Acc1 Fin00b (1 page).
+			// Read transactions for Acc2 Fin00c (1 page).
+			Input: common.ReadParams{
+				ObjectName: "treasury/transaction_entries",
+				Fields:     connectors.Fields("id"),
+				Opts:       ReadParamsOpts{ReadForAllConnectedAccounts: true},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{
+					// ========
+					// Connected accounts
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/accounts"),
+							mockcond.QueryParamsMissing("starting_after"),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAccountsFirstPage),
+					},
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/accounts"),
+							mockcond.QueryParam("starting_after", "acct_1Nv0FGQ9RKHgCVdK"),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAccountsLastPage),
+					},
+					// ========
+					// Financial accounts (for Connected Account 1)
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/financial_accounts"),
+							mockcond.QueryParamsMissing("starting_after"), // first page
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1FinAccounts1),
+					},
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/financial_accounts"),
+							mockcond.QueryParam("starting_after", "finAcc_00a_a3738395bf7b"),
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1FinAccounts2),
+					},
+					// ========
+					// Financial accounts (for Connected Account 1)
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/financial_accounts"),
+							mockcond.QueryParamsMissing("starting_after"),
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_2c81631b20648a90"}, // Account #2
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc2FinAccounts1),
+					},
+					// ========
+					// Transactions for Connected Account 1
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/transaction_entries"),
+							mockcond.QueryParam("financial_account", "finAcc_00a_a3738395bf7b"), // Fin #A
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1Fin00aTransactions),
+					},
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/transaction_entries"),
+							mockcond.QueryParam("financial_account", "finAcc_00b_a9981a9bdebe"), // Fin #B
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1Fin00bTransactions),
+					},
+					// ========
+					// Transactions for Connected Account 2
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/transaction_entries"),
+							mockcond.QueryParam("financial_account", "finAcc_00c_a9981a9bdebe"), // Fin #C
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_2c81631b20648a90"}, // Account #2
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc2Fin00cTransactions),
+					},
+				},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetReadSorted,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "transaction_0a0_b6317b07df58",
+					},
+					Raw: map[string]any{"object": "treasury.transaction_entry"},
+					Id:  "transaction_0a0_b6317b07df58",
+				}, {
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "transaction_0b0_76f1bb782252",
+					},
+					Raw: map[string]any{"object": "treasury.transaction_entry"},
+					Id:  "transaction_0b0_76f1bb782252",
+				}, {
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_2c81631b20648a90",
+						"id":                           "transaction_0c0_ea539fa34e3e",
+					},
+					Raw: map[string]any{"object": "treasury.transaction_entry"},
+					Id:  "transaction_0c0_ea539fa34e3e",
+				}},
+				// We are not done reading
+				NextPage: `[{
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00a_a3738395bf7b"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00a_a3738395bf7b&limit=100&starting_after=transaction_0a0_b6317b07df58"
+				}, {
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00b_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00b_a9981a9bdebe&limit=100&starting_after=transaction_0b0_76f1bb782252"
+				}, {
+					"context": {
+						"conAccId": "acct_2c81631b20648a90",
+						"finAccId": "finAcc_00c_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00c_a9981a9bdebe&limit=100&starting_after=transaction_0c0_ea539fa34e3e"
+				}]`,
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read next page Treasury transactions with aggregate token",
+			Input: common.ReadParams{
+				ObjectName: "customers",
+				Fields:     connectors.Fields("id"),
+				Opts:       ReadParamsOpts{ReadForAllConnectedAccounts: true},
+				NextPage: `[{
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00a_a3738395bf7b"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00a_a3738395bf7b&limit=100&starting_after=transaction_0a0_b6317b07df58"
+				}, {
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00b_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00b_a9981a9bdebe&limit=100&starting_after=transaction_0b0_76f1bb782252"
+				}, {
+					"context": {
+						"conAccId": "acct_2c81631b20648a90",
+						"finAccId": "finAcc_00c_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00c_a9981a9bdebe&limit=100&starting_after=transaction_0c0_ea539fa34e3e"
+				}]`,
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.Path("/v1/treasury/transaction_entries"),
+						mockcond.QueryParam("financial_account", "finAcc_00a_a3738395bf7b"),
+						mockcond.QueryParam("starting_after", "transaction_0a0_b6317b07df58"),
+						mockcond.Header(map[string][]string{"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}}),
+					},
+					Then: mockserver.ResponseString(http.StatusOK, `{"data":[{"id":"1"}]}`),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v1/treasury/transaction_entries"),
+						mockcond.QueryParam("financial_account", "finAcc_00b_a9981a9bdebe"),
+						mockcond.QueryParam("starting_after", "transaction_0b0_76f1bb782252"),
+						mockcond.Header(map[string][]string{"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}}),
+					},
+					Then: mockserver.ResponseString(http.StatusOK, `{"data":[{"id":"2"}], "has_more":true}`),
+				}, {
+					If: mockcond.And{
+						mockcond.Path("/v1/treasury/transaction_entries"),
+						mockcond.QueryParam("financial_account", "finAcc_00c_a9981a9bdebe"),
+						mockcond.QueryParam("starting_after", "transaction_0c0_ea539fa34e3e"),
+						mockcond.Header(map[string][]string{"Stripe-Account": {"acct_2c81631b20648a90"}}),
+					},
+					Then: mockserver.ResponseString(http.StatusOK, `{"data":[{"id":"3"}]}`),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetReadSorted,
+			Expected: &common.ReadResult{
+				Rows: 3,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "1",
+					},
+					Raw: map[string]any{"id": "1"}, Id: "1",
+				}, {
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "2",
+					},
+					Raw: map[string]any{"id": "2"}, Id: "2",
+				}, {
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_2c81631b20648a90",
+						"id":                           "3",
+					},
+					Raw: map[string]any{"id": "3"}, Id: "3",
+				}},
+				NextPage: `[{
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00b_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00b_a9981a9bdebe&limit=100&starting_after=2"
+				}]`,
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableReader, error) {
+				return constructTestStrategy(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/stripe/internal/reader/objects.go
+++ b/providers/stripe/internal/reader/objects.go
@@ -54,8 +54,7 @@ var incrementalObjects = datautils.NewSet( // nolint:gochecknoglobals
 // Requests to these endpoints must be resolved against a FinancialAccount,
 // which is discovered through treasury/financial_accounts.
 // The connector uses those accounts as context to list the corresponding objects.
-// TODO must be used by Read method (remove the `unused` tag).
-var scopedObjectsForFinancialAccount = datautils.NewSet( // nolint:gochecknoglobals,unused
+var scopedObjectsForFinancialAccount = datautils.NewSet( // nolint:gochecknoglobals
 	"treasury/outbound_payments",
 	"treasury/received_credits",
 	"treasury/debit_reversals",

--- a/providers/stripe/internal/reader/read.go
+++ b/providers/stripe/internal/reader/read.go
@@ -23,13 +23,49 @@ type ReadParamsOpts struct {
 	ReadForAllConnectedAccounts bool
 }
 
-// Read retrieves a list of records for a given object type.
+// Read retrieves a list of records for the specified object name.
 //
 // Supported features:
-//   - NextPage: Supports pagination for objects that Stripe paginates.
-//   - AssociatedObjects: Fetches nested objects by specifying fields to expand.
-//     See [Stripe expanding objects docs](https://docs.stripe.com/api/expanding_objects).
-//   - Incremental Reading: Not supported (the `Since` parameter is ignored).
+//   - NextPage: Pagination is supported. For Connected Accounts and Treasury
+//     financial accounts, next-page tokens use aggregate contextual format.
+//   - Fields: JSONPath-based field selection and on-demand expansion are
+//     supported. See https://docs.stripe.com/api/expanding_objects.
+//   - Incremental Reading: Not supported; the "Since" parameter is ignored.
+//
+// Domain:
+//   - Objects owned by the main platform account and Connected Accounts are supported.
+//   - Treasury API objects are read through their associated financial accounts.
+//
+// Treasury reads:
+//   - Treasury objects require a financial_account ID in the request.
+//   - The connector first calls:
+//     https://docs.stripe.com/api/treasury/financial_accounts/list
+//   - It then calls the object endpoint for each financial account, for example:
+//     https://docs.stripe.com/api/treasury/transactions/list
+//     https://docs.stripe.com/api/treasury/inbound_transfers/list
+//     https://docs.stripe.com/api/treasury/outbound_transfers/list
+//     https://docs.stripe.com/api/treasury/outbound_payments/list
+//     https://docs.stripe.com/api/treasury/credit_reversals/list
+//     https://docs.stripe.com/api/treasury/debit_reversals/list
+//   - For Connected Accounts, the same flow is used with the Stripe-Account
+//     header set to the connected account ID.
+//
+// Rate limits and concurrency:
+//   - Stripe rate limits apply per API key and per connected account:
+//     https://docs.stripe.com/rate-limits
+//   - Financial accounts are discovered sequentially.
+//   - Treasury reads are executed in parallel up to maxReadConcurrency.
+//   - Lower maxReadConcurrency if rate-limit errors occur.
+//
+// Parallelization:
+//   - Connected accounts and financial accounts are discovered sequentially.
+//   - Requests are then parallelized to improve throughput.
+//
+// Relevant Stripe documentation:
+//   - Expanding objects fields: https://docs.stripe.com/api/expanding_objects
+//   - Connected accounts: https://docs.stripe.com/api/connected-accounts
+//   - Financial Accounts List: https://docs.stripe.com/api/treasury/financial_accounts/list
+//   - Treasury overview: https://docs.stripe.com/treasury
 func (s *Strategy) Read(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
 	if err := params.ValidateParams(true); err != nil {
 		return nil, err
@@ -44,23 +80,20 @@ func (s *Strategy) Read(ctx context.Context, params common.ReadParams) (*common.
 
 	// Handle next-page reading for either:
 	// (1) main account (regular pagination)
-	aggregateToken, ok := readhelper.GetAggregateToken[string](params.NextPage)
-	if !ok {
-		url, err := urlbuilder.New(params.NextPage.String())
-		if err != nil {
-			return nil, err
-		}
-
-		return s.readRecords(ctx, params.ObjectName, params.Fields, url)
-	}
-
 	// (2) connected accounts (resume parallelized reads)
-	return s.readNextPageConnectedAccounts(ctx, params, aggregateToken)
+	return s.readNextPage(ctx, params)
 }
 
-// readFirstPage reads the first page of object records for either the main account
-// or all connected accounts (if ReadForAllConnectedAccounts is enabled).
-func (s *Strategy) readFirstPage(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
+// readFirstPage reads the first page of object records for the requested scope.
+//
+// The read target determines whether the request is executed against the main
+// platform account, selected connected accounts, all connected accounts, or
+// Treasury financial accounts. Treasury reads have a separate execution flow
+// because requests are scoped by financial account and may require connected
+// account context.
+func (s *Strategy) readFirstPage(ctx context.Context, // nolint:cyclop
+	params common.ReadParams,
+) (*common.ReadResult, error) {
 	url, err := s.buildFirstPageReadURL(params)
 	if err != nil {
 		return nil, err
@@ -74,15 +107,72 @@ func (s *Strategy) readFirstPage(ctx context.Context, params common.ReadParams) 
 	case ReadScopeSelectedConnectedAccounts:
 		return s.readForConnectedAccounts(ctx, params, url, target.AccountIDs)
 	case ReadScopeAllConnectedAccounts:
-		accountIDs, err := s.listAllAccounts(ctx)
+		accountIds, err := s.listAllAccounts(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		return s.readForConnectedAccounts(ctx, params, url, accountIDs)
+		return s.readForConnectedAccounts(ctx, params, url, accountIds)
+	case ReadScopeMainAccountTreasury:
+		financialAccounts, err := s.listAllFinancialAccounts(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		return s.readTreasuryForMainAccount(ctx, params.ObjectName, params.Fields, url, financialAccounts)
+	case ReadScopeSelectedConnectedAccountsTreasury:
+		financialAccounts, err := s.listAllFinancialAccounts(ctx, target.AccountIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		return s.readTreasuryForConnectedAccounts(ctx, params, url, financialAccounts)
+	case ReadScopeAllConnectedAccountsTreasury:
+		accountIds, err := s.listAllAccounts(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		financialAccounts, err := s.listAllFinancialAccounts(ctx, accountIds)
+		if err != nil {
+			return nil, err
+		}
+
+		return s.readTreasuryForConnectedAccounts(ctx, params, url, financialAccounts)
 	default:
 		return nil, fmt.Errorf("%w: %v", ErrReadTargetUnknown, target.Scope)
 	}
+}
+
+// readNextPage resumes a paginated read using the provided next page token.
+//
+// The pagination flow depends on the type of token:
+//   - Aggregate tokens with string context resume reads across Connected Accounts.
+//   - Aggregate tokens with FinancialAccount context resume reads across Treasury
+//     financial accounts.
+//   - Standard next page URLs resume regular reads for objects owned by the main
+//     platform account.
+//
+// Aggregate pagination tokens contain the context required to reconstruct the
+// request for each account when multiple account scopes are being read in
+// parallel.
+func (s *Strategy) readNextPage(ctx context.Context, params common.ReadParams) (*common.ReadResult, error) {
+	if token, ok := readhelper.GetAggregateToken[string](params.NextPage); ok {
+		return s.readNextPageConnectedAccounts(ctx, params, token)
+	}
+
+	if token, ok := readhelper.GetAggregateToken[FinancialAccount](params.NextPage); ok {
+		return s.readNextPageTreasury(ctx, params, token)
+	}
+
+	// Default read of the next page.
+	// It is neither for connected account nor is it for Treasury API.
+	url, err := urlbuilder.New(params.NextPage.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return s.readRecords(ctx, params.ObjectName, params.Fields, url)
 }
 
 // readRecords performs a GET request to the specified URL and parses the response.

--- a/providers/stripe/internal/reader/strategy.go
+++ b/providers/stripe/internal/reader/strategy.go
@@ -11,10 +11,15 @@ const (
 	// Rate limit: [https://docs.stripe.com/rate-limits](https://docs.stripe.com/rate-limits)
 	maxReadConcurrency = 3
 
-	// fieldConnectedAccountID is the field name used to store the connected account identifier
+	// fieldConnectedAccountId is the field name used to store the connected account identifier
 	// in ReadResult.Data[*].Fields.
 	// This field is populated when ReadParamsOpts.ReadForAllConnectedAccounts is set to true.
-	fieldConnectedAccountID = "AMPERSAND-connectedAccountId"
+	fieldConnectedAccountId = "AMPERSAND-connectedAccountId"
+
+	// fieldFinancialAccountId is the field name used to store the financial account identifier
+	// in ReadResult.Data[*].Fields.
+	// This field is populated when read Object is part of the Treasury API.
+	fieldFinancialAccountId = "AMPERSAND-financialAccountId"
 
 	// DefaultPageSize is number of elements per page.
 	DefaultPageSize = 100

--- a/providers/stripe/internal/reader/tasks.go
+++ b/providers/stripe/internal/reader/tasks.go
@@ -9,6 +9,12 @@ import (
 	"github.com/amp-labs/connectors/internal/parallelfetch"
 )
 
+// ReadScope defines the target scope for a read operation.
+//
+// It is the high-level branching point for the read execution flow.
+// Non-Treasury scopes execute standard API reads against the platform account
+// or connected accounts.
+// Treasury scopes execute reads against Treasury financial accounts.
 type ReadScope int
 
 var ErrReadTargetUnknown = errors.New("unsupported read target")
@@ -17,6 +23,9 @@ const (
 	ReadScopeMainAccount ReadScope = iota
 	ReadScopeSelectedConnectedAccounts
 	ReadScopeAllConnectedAccounts
+	ReadScopeMainAccountTreasury
+	ReadScopeSelectedConnectedAccountsTreasury
+	ReadScopeAllConnectedAccountsTreasury
 )
 
 type readTarget struct {
@@ -27,10 +36,18 @@ type readTarget struct {
 func inferReadTarget(params common.ReadParams) readTarget {
 	opts, ok := params.Opts.(ReadParamsOpts)
 	if !ok {
+		if scopedObjectsForFinancialAccount.Has(params.ObjectName) {
+			return readTarget{Scope: ReadScopeMainAccountTreasury}
+		}
+
 		return readTarget{Scope: ReadScopeMainAccount}
 	}
 
 	if len(opts.ReadForConnectedAccounts) > 0 {
+		if scopedObjectsForFinancialAccount.Has(params.ObjectName) {
+			return readTarget{Scope: ReadScopeSelectedConnectedAccountsTreasury}
+		}
+
 		return readTarget{
 			Scope:      ReadScopeSelectedConnectedAccounts,
 			AccountIDs: opts.ReadForConnectedAccounts,
@@ -38,20 +55,30 @@ func inferReadTarget(params common.ReadParams) readTarget {
 	}
 
 	if opts.ReadForAllConnectedAccounts {
+		if scopedObjectsForFinancialAccount.Has(params.ObjectName) {
+			return readTarget{Scope: ReadScopeAllConnectedAccountsTreasury}
+		}
+
 		return readTarget{Scope: ReadScopeAllConnectedAccounts}
+	}
+
+	if scopedObjectsForFinancialAccount.Has(params.ObjectName) {
+		return readTarget{Scope: ReadScopeMainAccountTreasury}
 	}
 
 	return readTarget{Scope: ReadScopeMainAccount}
 }
 
-// executeReadTasks runs multiple read tasks in parallel and aggregates their results.
-// Used when reading for multiple connected accounts.
+// executeReadTasksAccounts executes multiple read tasks in parallel and aggregates their results.
+//
+// Used when reading objects across multiple Connected Accounts.
 //
 // Behavior:
-//   - Each result row is marked with its source connected account ID via fieldConnectedAccountID
-//   - Returns an aggregated next page token if any individual read has more data
-//   - Joins all errors and returns them as a single error
-func executeReadTasks(ctx context.Context,
+//   - Each result row is annotated with its source Connected Account ID using fieldConnectedAccountId.
+//   - If any task has remaining pages, an aggregate next page token is created
+//     containing the next page state and Connected Account ID required to resume each unfinished read.
+//   - Errors from all tasks are joined and returned as a single error.
+func executeReadTasksAccounts(ctx context.Context,
 	tasks []parallelfetch.Task[string, common.ReadResult],
 ) (*common.ReadResult, error) {
 	result := parallelfetch.Execute(ctx, tasks, maxReadConcurrency)
@@ -61,14 +88,55 @@ func executeReadTasks(ctx context.Context,
 
 	return readhelper.AggregateReadResults(
 		result.Records,
-		func(accountID string) string {
+		func(accountId string) string {
 			// Account ID uniquely identifies the source for next-page token resolution.
 			// This will be used to construct Headers for the next page read operation.
-			return accountID
+			return accountId
 		},
-		func(accountID string, row *common.ReadResultRow) {
+		func(accountId string, row *common.ReadResultRow) {
 			// Enhance fields to indicate what account this row is associated with.
-			row.Fields[fieldConnectedAccountID] = accountID
+			row.Fields[fieldConnectedAccountId] = accountId
+		},
+	), nil
+}
+
+// executeReadTasksTreasury executes multiple read tasks in parallel and aggregates their results.
+//
+// Used when reading objects across Treasury financial accounts.
+//
+// Behavior:
+//   - Each result row is annotated with its source Connected Account ID and
+//     Financial Account ID using fieldConnectedAccountId and fieldFinancialAccountId.
+//   - If any task has remaining pages, an aggregate next page token is created
+//     containing the next page state and FinancialAccount context required to
+//     resume each unfinished read. FinancialAccount context contains both the
+//     Connected Account ID and Financial Account ID.
+//   - Errors from all tasks are joined and returned as a single error.
+//
+// Input:
+//   - tasks maps financial account IDs to the corresponding parallel requests.
+//   - financialAccounts maps financial account IDs to their FinancialAccount
+//     context used for pagination continuation.
+func executeReadTasksTreasury(ctx context.Context,
+	tasks []parallelfetch.Task[string, common.ReadResult],
+	financialAccounts map[string]FinancialAccount,
+) (*common.ReadResult, error) {
+	result := parallelfetch.Execute(ctx, tasks, maxReadConcurrency)
+	if len(result.Errors) != 0 {
+		return nil, errors.Join(result.Errors.Values()...)
+	}
+
+	return readhelper.AggregateReadResults(
+		result.Records,
+		func(financialAccountId string) FinancialAccount {
+			// Financial Account ID uniquely identifies the source for next-page token resolution.
+			// This will be used to construct Headers/Query Params for the next page read operation.
+			return financialAccounts[financialAccountId]
+		},
+		func(financialAccountId string, row *common.ReadResultRow) {
+			// Enhance fields to indicate what financial and connected accounts this row is associated with.
+			row.Fields[fieldConnectedAccountId] = financialAccounts[financialAccountId].ConnectedAccountId
+			row.Fields[fieldFinancialAccountId] = financialAccountId
 		},
 	), nil
 }

--- a/providers/stripe/internal/reader/test/financial-account/con-acc-1/1-first-page.json
+++ b/providers/stripe/internal/reader/test/financial-account/con-acc-1/1-first-page.json
@@ -1,0 +1,56 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/financial_accounts",
+  "has_more": true,
+  "data": [
+    {
+      "id": "finAcc_00a_a3738395bf7b",
+      "object": "treasury.financial_account",
+      "active_features": [
+        "financial_addresses.aba",
+        "outbound_payments.ach",
+        "outbound_payments.us_domestic_wire"
+      ],
+      "balance": {
+        "cash": {
+          "usd": 0
+        },
+        "inbound_pending": {
+          "usd": 0
+        },
+        "outbound_pending": {
+          "usd": 0
+        }
+      },
+      "country": "US",
+      "created": 1680714349,
+      "financial_addresses": [
+        {
+          "aba": {
+            "account_holder_name": "Jenny Rosen",
+            "account_number_last4": "7890",
+            "bank_name": "STRIPE TEST BANK",
+            "routing_number": "0000000001"
+          },
+          "supported_networks": [
+            "ach",
+            "us_domestic_wire"
+          ],
+          "type": "aba"
+        }
+      ],
+      "livemode": true,
+      "metadata": null,
+      "pending_features": [],
+      "restricted_features": [],
+      "status": "open",
+      "status_details": {
+        "closed": null
+      },
+      "supported_currencies": [
+        "usd"
+      ],
+      "features": {}
+    }
+  ]
+}

--- a/providers/stripe/internal/reader/test/financial-account/con-acc-1/2-last-page.json
+++ b/providers/stripe/internal/reader/test/financial-account/con-acc-1/2-last-page.json
@@ -1,0 +1,13 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/financial_accounts",
+  "has_more": false,
+  "data": [
+    {
+      "id": "finAcc_00b_a9981a9bdebe",
+      "object": "treasury.financial_account",
+      "country": "US",
+      "status": "open"
+    }
+  ]
+}

--- a/providers/stripe/internal/reader/test/financial-account/con-acc-2/1-last-page.json
+++ b/providers/stripe/internal/reader/test/financial-account/con-acc-2/1-last-page.json
@@ -1,0 +1,13 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/financial_accounts",
+  "has_more": false,
+  "data": [
+    {
+      "id": "finAcc_00c_a9981a9bdebe",
+      "object": "treasury.financial_account",
+      "country": "US",
+      "status": "open"
+    }
+  ]
+}

--- a/providers/stripe/internal/reader/test/transaction_entries/con-acc-1-fin-a.json
+++ b/providers/stripe/internal/reader/test/transaction_entries/con-acc-1-fin-a.json
@@ -1,0 +1,25 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/transaction_entries",
+  "has_more": true,
+  "data": [
+    {
+      "id": "transaction_0a0_b6317b07df58",
+      "object": "treasury.transaction_entry",
+      "balance_impact": {
+        "cash": 0,
+        "inbound_pending": 0,
+        "outbound_pending": -1000
+      },
+      "created": 1680756271,
+      "currency": "usd",
+      "effective_at": 1680756271,
+      "financial_account": "finAcc_001_a3738395bf7b",
+      "flow": "obt_1MtkgV2eZvKYlo2CCxhXVFLB",
+      "flow_type": "outbound_transfer",
+      "livemode": false,
+      "transaction": "trxn_ABC_1",
+      "type": "outbound_transfer"
+    }
+  ]
+}

--- a/providers/stripe/internal/reader/test/transaction_entries/con-acc-1-fin-b.json
+++ b/providers/stripe/internal/reader/test/transaction_entries/con-acc-1-fin-b.json
@@ -1,0 +1,25 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/transaction_entries",
+  "has_more": true,
+  "data": [
+    {
+      "id": "transaction_0b0_76f1bb782252",
+      "object": "treasury.transaction_entry",
+      "balance_impact": {
+        "cash": 0,
+        "inbound_pending": 0,
+        "outbound_pending": -1000
+      },
+      "created": 1680756271,
+      "currency": "usd",
+      "effective_at": 1680756271,
+      "financial_account": "finAcc_001_a3738395bf7b",
+      "flow": "obt_1MtkgV2eZvKYlo2CCxhXVFLB",
+      "flow_type": "outbound_transfer",
+      "livemode": false,
+      "transaction": "trxn_ABC_2",
+      "type": "outbound_transfer"
+    }
+  ]
+}

--- a/providers/stripe/internal/reader/test/transaction_entries/con-acc-2-fin-c.json
+++ b/providers/stripe/internal/reader/test/transaction_entries/con-acc-2-fin-c.json
@@ -1,0 +1,25 @@
+{
+  "object": "list",
+  "url": "/v1/treasury/transaction_entries",
+  "has_more": true,
+  "data": [
+    {
+      "id": "transaction_0c0_ea539fa34e3e",
+      "object": "treasury.transaction_entry",
+      "balance_impact": {
+        "cash": 0,
+        "inbound_pending": 0,
+        "outbound_pending": -1000
+      },
+      "created": 1680756271,
+      "currency": "usd",
+      "effective_at": 1680756271,
+      "financial_account": "finAcc_002_a9981a9bdebe",
+      "flow": "obt_1MtkgV2eZvKYlo2CCxhXVFLB",
+      "flow_type": "outbound_transfer",
+      "livemode": false,
+      "transaction": "trxn_ABC_1",
+      "type": "outbound_transfer"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds support for reading objects from the Stripe Treasury API.

The read flow now branches based on both the target account scope and whether the requested object belongs to the Treasury API.

### First page

`readFirstPage` now supports six execution paths:

* `ReadScopeMainAccount`
* `ReadScopeSelectedConnectedAccounts`
* `ReadScopeAllConnectedAccounts`
* `ReadScopeMainAccountTreasury`
  * Discovers the platform account's financial accounts, then reads each financial account in parallel.
* `ReadScopeSelectedConnectedAccountsTreasury`
  * Discovers financial accounts for the selected connected accounts, then reads each financial account in parallel.
* `ReadScopeAllConnectedAccountsTreasury`
  * Discovers all connected accounts, then their financial accounts, and finally reads each financial account in parallel.

### Next page

`readNextPage` resumes pagination based on the next page token:

* Aggregate token with `string` context → Connected Account pagination.
* Aggregate token with `FinancialAccount` context → Treasury pagination (platform or connected account).
* Standard next page URL → Regular pagination for the platform account.

Treasury pagination uses aggregate next page tokens to preserve the `FinancialAccount` context (Connected Account ID + Financial Account ID) for each unfinished read. Although the next page URL already contains the `financial_account` query parameter, carrying the `FinancialAccount` context simplifies reconstructing parallel tasks because Financial Account IDs uniquely identify tasks, whereas Connected Account IDs may correspond to multiple financial accounts. The Connected Account ID from the context is also used to reconstruct the required `Stripe-Account` header. Additionally, the `FinancialAccount` context distinguishes Treasury aggregate tokens from aggregate tokens used for Connected Account reads of non-Treasury objects.


# Live Tests

### FinancialAccount
`FinancialAccount` is not yet available on sandbox and cannot be demonstrated.

### Customers for connected accounts
<img width="543" height="1272" alt="image" src="https://github.com/user-attachments/assets/522d5719-4b58-42a4-ba89-55d95c8f0dc9" />

### Customer for specific connected accounts
<img width="740" height="1043" alt="image" src="https://github.com/user-attachments/assets/77b0b9ae-1f84-48e7-b07c-223712d3ae1b" />

### Customer for main account
<img width="644" height="481" alt="image" src="https://github.com/user-attachments/assets/a432fa7b-1df7-4fec-a370-4a41f545fa32" />
