### PR TITLE
feat(salesforce): fall back to NoTestRun when destructive apex deploy is rolled back by tests

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -475,28 +475,73 @@ func isVariableNotExistError(result *DeployResult) bool {
 // against that class would fail (Salesforce processes destructiveChanges before
 // running tests). The rollback therefore uses RunLocalTests, which Salesforce also
 // permits in production and which doesn't require any runTests entry.
+//
+// Fallback: RunLocalTests runs the org's local Apex tests as part of the deploy,
+// and Salesforce rolls the whole deploy back if that test run fails — including
+// when the org's overall coverage dips below 75% or an unrelated pre-existing test
+// fails. Neither is caused by our pure deletion. When the destructive components
+// themselves reported no failure (len(ComponentFailures) == 0) but the deploy was
+// rolled back by the test run, we retry once with NoTestRun so the deletion can
+// proceed. A genuine component-level problem (which appears in ComponentFailures)
+// is NOT retried. NoTestRun is rejected by Salesforce for production orgs, so the
+// fallback only helps sandbox/dev orgs — exactly where the coverage rollback bites.
 func (c *Connector) rollbackApexTrigger(ctx context.Context, triggerName string) error {
 	zipData, err := ConstructDestructiveApexTriggerZip(triggerName)
 	if err != nil {
 		return fmt.Errorf("failed to construct destructive apex trigger zip for %s: %w", triggerName, err)
 	}
 
-	deployID, err := c.DeployMetadataZipWithTests(ctx, zipData, metadata.TestLevelRunLocalTests, nil)
+	deployResult, err := c.deployDestructiveApex(ctx, zipData, metadata.TestLevelRunLocalTests)
 	if err != nil {
 		return fmt.Errorf("failed to deploy destructive apex trigger for %s: %w", triggerName, err)
 	}
 
-	deployResult, err := c.pollDeployStatus(ctx, deployID)
-	if err != nil {
-		return fmt.Errorf("failed to poll deploy status for destructive apex trigger %s: %w", triggerName, err)
+	if deployResult.Success {
+		return nil
 	}
 
-	if !deployResult.Success {
+	// A component failure means the destructive change itself was rejected — do not
+	// paper over it by skipping tests.
+	if len(deployResult.ComponentFailures) > 0 {
 		return fmt.Errorf("%w for trigger %s: %s",
 			errDestructiveDeployFailed, triggerName, formatDeployFailureDetails(deployResult))
 	}
 
+	// No component failures: the deploy was rolled back by the test run (coverage
+	// or an unrelated failing test), not by our deletion. Retry without tests.
+	slog.WarnContext(ctx, "destructive apex deploy rolled back by test run; retrying with NoTestRun",
+		"trigger", triggerName, "firstAttempt", formatDeployFailureDetails(deployResult))
+
+	deployResult, err = c.deployDestructiveApex(ctx, zipData, metadata.TestLevelNoTestRun)
+	if err != nil {
+		return fmt.Errorf("failed to deploy destructive apex trigger for %s (NoTestRun fallback): %w",
+			triggerName, err)
+	}
+
+	if !deployResult.Success {
+		return fmt.Errorf("%w for trigger %s (NoTestRun fallback): %s",
+			errDestructiveDeployFailed, triggerName, formatDeployFailureDetails(deployResult))
+	}
+
 	return nil
+}
+
+// deployDestructiveApex deploys the given destructive-changes zip at the supplied
+// test level and polls to completion, returning the final deploy result.
+func (c *Connector) deployDestructiveApex(
+	ctx context.Context, zipData []byte, testLevel metadata.TestLevel,
+) (*DeployResult, error) {
+	deployID, err := c.DeployMetadataZipWithTests(ctx, zipData, testLevel, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	deployResult, err := c.pollDeployStatus(ctx, deployID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll deploy status for deployId %s: %w", deployID, err)
+	}
+
+	return deployResult, nil
 }
 
 func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*DeployResult, error) {

--- a/providers/salesforce/apex_rollback_test.go
+++ b/providers/salesforce/apex_rollback_test.go
@@ -1,0 +1,199 @@
+package salesforce
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/metadata"
+)
+
+// TestRollbackApexTriggerFallsBackToNoTestRun verifies that when a destructive
+// apex deploy is rolled back by the test run (no component failures — e.g. the
+// org's overall coverage is below 75%), rollbackApexTrigger retries once with
+// NoTestRun and succeeds.
+func TestRollbackApexTriggerFallsBackToNoTestRun(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu               sync.Mutex
+		deployTestLevels []string // testLevel of each deploy request, in order
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+
+		w.Header().Set("Content-Type", "text/xml; charset=UTF-8")
+
+		switch {
+		case strings.Contains(body, "<md:deploy"):
+			level := soapTestLevel(body)
+
+			mu.Lock()
+			deployTestLevels = append(deployTestLevels, level)
+			mu.Unlock()
+
+			// Echo the test level into the deploy id so checkDeployStatus can key on it.
+			_, _ = io.WriteString(w, soapEnvelope(
+				`<deployResponse><result><id>deploy-`+level+`</id><done>false</done></result></deployResponse>`))
+
+		case strings.Contains(body, "<md:checkDeployStatus"):
+			// The RunLocalTests attempt is rolled back by the test run (success=false,
+			// no component failures); the NoTestRun attempt succeeds.
+			success := strings.Contains(body, "deploy-"+string(metadata.TestLevelNoTestRun))
+			_, _ = io.WriteString(w, soapEnvelope(checkStatusBody(success)))
+
+		default:
+			t.Errorf("unexpected SOAP request body: %s", body)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("constructTestConnector: %v", err)
+	}
+
+	ctx := common.WithAuthToken(context.Background(), "test-token")
+
+	if err := conn.rollbackApexTrigger(ctx, "CDC_Account"); err != nil {
+		t.Fatalf("rollbackApexTrigger returned error, want success after fallback: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	want := []string{string(metadata.TestLevelRunLocalTests), string(metadata.TestLevelNoTestRun)}
+	if len(deployTestLevels) != len(want) {
+		t.Fatalf("deploy count = %d (%v), want %d (%v)",
+			len(deployTestLevels), deployTestLevels, len(want), want)
+	}
+	for i, lvl := range want {
+		if deployTestLevels[i] != lvl {
+			t.Errorf("deploy[%d] testLevel = %q, want %q", i, deployTestLevels[i], lvl)
+		}
+	}
+}
+
+// TestRollbackApexTriggerComponentFailureNoRetry verifies that a genuine
+// component failure (the destructive change itself was rejected) is NOT retried
+// with NoTestRun — it surfaces as an error after a single deploy.
+func TestRollbackApexTriggerComponentFailureNoRetry(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu          sync.Mutex
+		deployCount int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readBody(t, r)
+
+		w.Header().Set("Content-Type", "text/xml; charset=UTF-8")
+
+		switch {
+		case strings.Contains(body, "<md:deploy"):
+			mu.Lock()
+			deployCount++
+			mu.Unlock()
+			_, _ = io.WriteString(w, soapEnvelope(
+				`<deployResponse><result><id>deploy-1</id><done>false</done></result></deployResponse>`))
+
+		case strings.Contains(body, "<md:checkDeployStatus"):
+			// Failure WITH a component failure — must not be retried.
+			_, _ = io.WriteString(w, soapEnvelope(
+				`<checkDeployStatusResponse><result>`+
+					`<done>true</done><status>Failed</status><success>false</success><id>deploy-1</id>`+
+					`<details><componentFailures>`+
+					`<componentType>ApexClass</componentType><fullName>CDC_Account_Handler</fullName>`+
+					`<problem>Something depends on this class</problem><problemType>Error</problemType>`+
+					`</componentFailures></details>`+
+					`</result></checkDeployStatusResponse>`))
+
+		default:
+			t.Errorf("unexpected SOAP request body: %s", body)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("constructTestConnector: %v", err)
+	}
+
+	ctx := common.WithAuthToken(context.Background(), "test-token")
+
+	if err := conn.rollbackApexTrigger(ctx, "CDC_Account"); err == nil {
+		t.Fatal("rollbackApexTrigger returned nil, want error for a component failure")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if deployCount != 1 {
+		t.Errorf("deploy count = %d, want 1 (a component failure must not be retried)", deployCount)
+	}
+}
+
+func readBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+
+	return string(b)
+}
+
+// soapTestLevel extracts the <md:testLevel> value from a deploy request body.
+func soapTestLevel(body string) string {
+	const open = "<md:testLevel>"
+
+	start := strings.Index(body, open)
+	if start < 0 {
+		return ""
+	}
+	start += len(open)
+
+	end := strings.Index(body[start:], "</md:testLevel>")
+	if end < 0 {
+		return ""
+	}
+
+	return body[start : start+end]
+}
+
+func soapEnvelope(inner string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">` +
+		`<soapenv:Body>` + inner + `</soapenv:Body></soapenv:Envelope>`
+}
+
+func checkStatusBody(success bool) string {
+	status := "Failed"
+	if success {
+		status = "Succeeded"
+	}
+
+	return `<checkDeployStatusResponse><result>` +
+		`<done>true</done><status>` + status + `</status>` +
+		`<success>` + boolStr(success) + `</success><id>deploy</id>` +
+		`<details></details>` +
+		`</result></checkDeployStatusResponse>`
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+
+	return "false"
+}


### PR DESCRIPTION
## What

`rollbackApexTrigger` now falls back to a `NoTestRun` destructive deploy when the initial `RunLocalTests` deploy is rolled back by the **test run** (not by the destructive change itself).

## Why

`rollbackApexTrigger` deploys the destructive-changes package with `RunLocalTests` so we don't remove apex that other code still depends on. But `RunLocalTests` runs the org's local Apex tests as part of the deploy, and Salesforce **rolls the whole deploy back** if that test run fails — including when:

- the org's overall coverage dips below 75%, or
- an unrelated, pre-existing test fails.

Neither is caused by our pure deletion, and **sandbox/dev orgs frequently trip it** (they routinely sit below the 75% gate). The result is that the trigger + handler + test class are never removed, which then blocks deleting the CDC custom field that references the handler.

## How

After the `RunLocalTests` deploy:

- **Component failure present** (`len(ComponentFailures) > 0`) → the destructive change itself was rejected → return the error, **no retry**.
- **No component failure but not success** → the deploy was rolled back by the test run → log a warning and **retry once with `NoTestRun`**.

`NoTestRun` is rejected by Salesforce for **production** orgs, so the fallback only helps sandbox/dev orgs — exactly where the coverage rollback bites. Production behavior is unchanged (a real coverage failure still fails).

Extracted `deployDestructiveApex(ctx, zip, testLevel)` (deploy + poll) shared by both attempts.

## Testing

New `apex_rollback_test.go` (white-box, mock SOAP server):
- `TestRollbackApexTriggerFallsBackToNoTestRun` — a test-run rollback with no component failures → asserts two deploys (`RunLocalTests` then `NoTestRun`) and overall success.
- `TestRollbackApexTriggerComponentFailureNoRetry` — a component failure → asserts a single deploy and an error (no retry).

`go build`, `go vet`, `gofmt`, and `go test ./providers/salesforce/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)