### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cloud.google.com/go/bigquery v1.77.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260713153615-309758a5659f
+	github.com/amp-labs/amp-common v0.0.0-20260714004203-f874c35bedc2
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
-github.com/amp-labs/amp-common v0.0.0-20260713153615-309758a5659f h1:yjWdiYH56CasDkzrh4b1a7yOxztnDTDJ+XWCqz9eKcw=
-github.com/amp-labs/amp-common v0.0.0-20260713153615-309758a5659f/go.mod h1:80jBzI5TKoKy2jyNMF52FrOu2iB65+C3rXU5+rVtJdE=
+github.com/amp-labs/amp-common v0.0.0-20260714004203-f874c35bedc2 h1:ygY7WWY6zhLJZ7CVo9ROv3hukhYLEnW31huWAVRkom0=
+github.com/amp-labs/amp-common v0.0.0-20260714004203-f874c35bedc2/go.mod h1:JDAlEjYIre1/sHFhjPTwTC/UWWyHyblcSL0ZcPNhh/A=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [f874c35bedc2014edeab2c30d8da22cfef1209f6](https://github.com/amp-labs/amp-common/commit/f874c35bedc2014edeab2c30d8da22cfef1209f6) from [main](https://github.com/amp-labs/amp-common/tree/main)