### PR TITLE
[CON-3414]feat (Grain):  Grain add proxy 

### DIFF
--- a/providers/grain.go
+++ b/providers/grain.go
@@ -1,0 +1,41 @@
+package providers
+
+const Grain Provider = "grain"
+
+func init() {
+	SetInfo(Grain, ProviderInfo{
+		DisplayName: "Grain",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.grain.com/_/public-api",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://grain.com/app/settings/integrations?tab=api",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1784041266/media/grain.com_1784041265.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1784041233/media/grain.com_1784041231.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1784041266/media/grain.com_1784041265.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1784041233/media/grain.com_1784041231.svg",
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Checklist
- [x] Ran Linter
- [x] Catalog tests passing
- [x] Created PR from non-main branch

## Catalog variables
No workspace variable required. Grain uses a single base URL: https://api.grain.com/_/public-api
(The `/v2` version segment is left to the caller, so it is not part of the base URL.)

## Notes
- **Authentication:** Bearer access token (Personal or Workspace Access Token) in the `Authorization` header (format: `Bearer <token>`)
- **API Version:** `2025-10-31` — sent via the required `Public-Api-Version` header. It is builder-supplied on proxy calls (not injected by the connector), so callers control the version.
- **Documentation:** https://developers.grain.com/

# TESTS

## GET
URL: `localhost:4444/v2/recordings/{recording_id}/transcript`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/32e533aa-aa4e-4dde-83f2-0f7651728ae5" />


## POST
URL: `localhost:4444/v2/users`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/d54a78fb-0b6d-4c84-8bd8-2d5a42d90212" />

URL: `localhost:4444/v2/recordings`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/44778334-a94b-4156-aec9-c304039f4b61" />


URL: `localhost:4444/v2/teams`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/350819f1-85e7-4aca-ba94-329066873b65" />


URL: `localhost:4444/v2/meeting_types`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/3c73d014-b263-4dd0-bf6b-831cfefc01f8" />


## PATCH
URL: `localhost:4444/v2/recordings/{recording_id}`  body `{"title":"..."}` → `{"success":true}`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/f69c10d3-b51f-4594-ad7f-46de1d935836" />


## PUT
URL: `localhost:4444/v2/recordings/{recording_id}/tags`  body `{"tag":"proxy-test"}` → `{"success":true}`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/f7905f97-1ac7-4fd1-be86-da1107d7b2a8" />


## DELETE
URL: `localhost:4444/v2/recordings/{recording_id}/tags/proxy-test` → `{"success":true}`

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/8c53691f-bf9e-4db8-b00d-656e3c36756b" />


## Invalid requests
URL: `localhost:4444/v2/recordings/bad-id` → `404 {"error":"not_found"}` (provider error passed through unchanged)

<img width="1295" height="982" alt="image" src="https://github.com/user-attachments/assets/a5415fcf-8065-4624-87e3-f9a4ef8c8cc2" />

## LOGO AND ICON


#### Icon

<img width="193" height="194" alt="image" src="https://github.com/user-attachments/assets/7183396b-6907-4515-bab3-9ce38986c631" />

#### Logo

<img width="434" height="160" alt="image" src="https://github.com/user-attachments/assets/e9b6f588-72cf-43ea-a6ea-c85e16acad70" />

