### PR TITLE
[ENG-4131]feat: add acculynx-includes-and-job-contact-associatio

### DIFF
--- a/providers/acculynx/associations.go
+++ b/providers/acculynx/associations.go
@@ -1,0 +1,76 @@
+package acculynx
+
+import "github.com/amp-labs/connectors/common"
+
+// jobContactsAssociation is the association key Hatch's config requests (see the
+// server's getHatchAssociations). It matches the embedded "contacts" array that
+// AccuLynx returns on /jobs when the read is issued with ?includes=contacts.
+const jobContactsAssociation = "contacts"
+
+// extractJobContacts attaches each job's embedded contacts as associations.
+//
+// AccuLynx returns the contacts inline on the job payload (with ?includes=contacts)
+// as an array of { contact: { id, ... }, isPrimary } entries. Unlike the HousecallPro
+// job->customer association (a single embedded object), a job carries an array of
+// contacts, so we emit one common.Association per entry, populating Raw from the
+// embedded contact (embed path -> server attaches it directly, no extra fetch) and
+// carrying isPrimary through in ProviderAssociationMetadata when present.
+func extractJobContacts(rows []common.ReadResultRow) {
+	for idx := range rows {
+		assocs := jobContactAssociations(rows[idx].Raw)
+		if len(assocs) == 0 {
+			continue
+		}
+
+		if rows[idx].Associations == nil {
+			rows[idx].Associations = make(map[string][]common.Association)
+		}
+
+		rows[idx].Associations[jobContactsAssociation] = assocs
+	}
+}
+
+// jobContactAssociations builds the contact associations from a job's raw payload.
+func jobContactAssociations(raw map[string]any) []common.Association {
+	entries, ok := raw["contacts"].([]any)
+	if !ok || len(entries) == 0 {
+		return nil
+	}
+
+	assocs := make([]common.Association, 0, len(entries))
+
+	for _, entry := range entries {
+		if assoc, ok := jobContactAssociation(entry); ok {
+			assocs = append(assocs, assoc)
+		}
+	}
+
+	return assocs
+}
+
+// jobContactAssociation converts a single job-contact entry into an Association.
+// Returns false when the entry is malformed or carries no contact id.
+func jobContactAssociation(entry any) (common.Association, bool) {
+	link, ok := entry.(map[string]any)
+	if !ok {
+		return common.Association{}, false
+	}
+
+	contact, ok := link["contact"].(map[string]any)
+	if !ok {
+		return common.Association{}, false
+	}
+
+	id, _ := contact["id"].(string)
+	if id == "" {
+		return common.Association{}, false
+	}
+
+	assoc := common.Association{ObjectId: id, Raw: contact}
+
+	if v, ok := link["isPrimary"]; ok {
+		assoc.ProviderAssociationMetadata = map[string]any{"isPrimary": v}
+	}
+
+	return assoc, true
+}

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
@@ -57,6 +59,18 @@ const (
 	objectSupplements = "supplements"
 	objectCalendars   = "calendars"
 )
+
+// includesByObject lists the AccuLynx ?includes= expansions applied
+// unconditionally on every read of the object. Contacts return phone/email as
+// reference-only stubs unless expanded, so we always request them — downstream
+// field filtering still drops fields the caller did not select. Object-scoped
+// (not org-scoped): the connector has no org context. Association-driven
+// includes (e.g. jobs -> contacts) are handled separately in applyIncludes.
+//
+//nolint:gochecknoglobals
+var includesByObject = map[string]string{
+	objectContacts: "emailAddress,phoneNumber",
+}
 
 type nestedSpec struct {
 	parentObject string
@@ -127,8 +141,23 @@ func (c *Connector) buildInitialURL(params common.ReadParams) (*urlbuilder.URL, 
 	}
 
 	applyPagination(url, objectName, params)
+	applyIncludes(url, objectName, params)
 
 	return url, nil
+}
+
+// applyIncludes appends AccuLynx ?includes= expansions to the read URL. Object
+// defaults come from includesByObject (always applied). Additionally, jobs
+// request the embedded contacts array only when the Job<->Contact association is
+// requested, so plain jobs reads are not bloated for orgs that did not opt in.
+func applyIncludes(url *urlbuilder.URL, objectName string, params common.ReadParams) {
+	if includes, ok := includesByObject[objectName]; ok {
+		url.WithQueryParam("includes", includes)
+	}
+
+	if objectName == objectJobs && slices.Contains(params.AssociatedObjects, jobContactsAssociation) {
+		url.WithQueryParam("includes", jobContactsAssociation)
+	}
 }
 
 func applyPagination(url *urlbuilder.URL, objectName string, params common.ReadParams) {
@@ -186,12 +215,26 @@ func (c *Connector) parseReadResponse(
 		}
 	}
 
+	marshaller := common.MakeMarshaledDataFunc(transformer)
+
+	// Attach the job's embedded contacts as associations when requested. The
+	// contacts ride inline on the job payload (?includes=contacts), so this is a
+	// pure post-process of the parsed rows — no extra API call.
+	if params.ObjectName == objectJobs &&
+		slices.Contains(params.AssociatedObjects, jobContactsAssociation) {
+		marshaller = readhelper.ChainedMarshaller(marshaller, func(rows []common.ReadResultRow) error {
+			extractJobContacts(rows)
+
+			return nil
+		})
+	}
+
 	return common.ParseResultFiltered(
 		params,
 		resp,
 		c.recordsFunc(params.ObjectName),
 		c.makeFilterFunc(params, reqURL),
-		common.MakeMarshaledDataFunc(transformer),
+		marshaller,
 		params.Fields,
 	)
 }

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -64,6 +64,12 @@ var jobInvoicesPage2Response []byte
 //go:embed test/read/job-history.json
 var jobHistoryResponse []byte
 
+//go:embed test/read/jobs-with-contacts.json
+var jobsWithContactsResponse []byte
+
+//go:embed test/read/contacts-includes.json
+var contactsIncludesResponse []byte
+
 func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
@@ -72,6 +78,139 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Name:         "Read object must be included",
 			Server:       mockserver.Dummy(),
 			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "Read contacts always requests emailAddress,phoneNumber includes",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("id"),
+				PageSize:   100,
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/contacts"),
+							mockcond.QueryParam("includes", "emailAddress,phoneNumber"),
+						},
+						Then: mockserver.Response(http.StatusOK, contactsIncludesResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsEmptyResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "ctc-100"},
+					Raw:    map[string]any{"id": "ctc-100"},
+				}},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read jobs with contacts association attaches embedded contacts",
+			Input: common.ReadParams{
+				ObjectName:        "jobs",
+				Fields:            connectors.Fields("id"),
+				AssociatedObjects: []string{"contacts"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs"),
+							mockcond.QueryParam("includes", "contacts"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobsWithContactsResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsEmptyResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{"id": "job-001"},
+						Raw:    map[string]any{"id": "job-001"},
+						Associations: map[string][]common.Association{
+							"contacts": {{
+								ObjectId:                    "ctc-100",
+								Raw:                         map[string]any{"id": "ctc-100", "firstName": "Diane"},
+								ProviderAssociationMetadata: map[string]any{"isPrimary": true},
+							}},
+						},
+					},
+					{
+						Fields: map[string]any{"id": "job-002"},
+						Raw:    map[string]any{"id": "job-002"},
+						Associations: map[string][]common.Association{
+							"contacts": {{
+								ObjectId:                    "ctc-200",
+								Raw:                         map[string]any{"id": "ctc-200"},
+								ProviderAssociationMetadata: map[string]any{"isPrimary": true},
+							}},
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read jobs without association omits includes and attaches no associations",
+			Input: common.ReadParams{
+				ObjectName: "jobs",
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs"),
+							mockcond.QueryParamsMissing("includes"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobsWithContactsResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsEmptyResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{Fields: map[string]any{"id": "job-001"}, Raw: map[string]any{"id": "job-001"}},
+					{Fields: map[string]any{"id": "job-002"}, Raw: map[string]any{"id": "job-002"}},
+				},
+				Done: true,
+			},
 		},
 		{
 			Name: "Object must be supported",

--- a/providers/acculynx/test/read/contacts-includes.json
+++ b/providers/acculynx/test/read/contacts-includes.json
@@ -1,0 +1,17 @@
+{
+  "count": 1,
+  "pageSize": 100,
+  "pageStartIndex": 0,
+  "items": [
+    {
+      "id": "ctc-100",
+      "firstName": "Diane",
+      "phoneNumbers": [
+        { "id": "pn-1", "number": "(703) 450-3818", "type": "Home", "primary": true }
+      ],
+      "emailAddresses": [
+        { "id": "em-1", "address": "diane@example.com", "primary": true }
+      ]
+    }
+  ]
+}

--- a/providers/acculynx/test/read/jobs-with-contacts.json
+++ b/providers/acculynx/test/read/jobs-with-contacts.json
@@ -1,0 +1,40 @@
+{
+  "count": 2,
+  "pageSize": 2,
+  "pageStartIndex": 0,
+  "items": [
+    {
+      "id": "job-001",
+      "currentMilestone": "Lead",
+      "modifiedDate": "2026-04-01T10:00:00Z",
+      "contacts": [
+        {
+          "id": "jc-001",
+          "contact": {
+            "id": "ctc-100",
+            "firstName": "Diane",
+            "lastName": "Tiblin"
+          },
+          "isPrimary": true,
+          "relationToPrimary": ""
+        }
+      ]
+    },
+    {
+      "id": "job-002",
+      "currentMilestone": "Approved",
+      "modifiedDate": "2026-04-15T14:30:00Z",
+      "contacts": [
+        {
+          "id": "jc-002",
+          "contact": {
+            "id": "ctc-200",
+            "firstName": "Alan"
+          },
+          "isPrimary": true,
+          "relationToPrimary": ""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What this change does?
- Contacts read now sends `?includes=emailAddress,phoneNumber` so `phoneNumbers`/`emailAddresses` come back with real values instead of `{id,_link}` reference stubs.
- Adds `Job↔Contact` associations: when requested, the jobs read sends `?includes=contacts` and attaches each embedded contact per row with `isPrimary` (embed path — no extra API calls). Mirrors the HousecallPro pattern, adapted for AccuLynx's array-of-contacts shape.


### Testing
- Unit tests: contacts include param, jobs association attach (+isPrimary), and gating (no include/association when not requested).
- Validated end-to-end against a live AccuLynx account via a local install.
#### Svix payload with associations : 

<img width="1436" height="885" alt="Screenshot 2026-07-15 at 11 22 06" src="https://github.com/user-attachments/assets/be335bc8-f51b-4f93-8424-591622815ea8" />
<img width="1470" height="981" alt="Screenshot 2026-07-15 at 11 20 16" src="https://github.com/user-attachments/assets/deafa6f9-febb-4789-9ad8-1c4279e87497" />


<img width="1447" height="906" alt="Screenshot 2026-07-15 at 11 20 27" src="https://github.com/user-attachments/assets/6bcf504f-af1c-450d-9dde-17dd3f7b6ee4" />

<img width="1494" height="980" alt="Screenshot 2026-07-15 at 11 20 37" src="https://github.com/user-attachments/assets/8226b392-0527-41c7-a848-4475caad8515" />

#### Svix payload for contacts

<img width="1481" height="945" alt="Screenshot 2026-07-15 at 11 23 29" src="https://github.com/user-attachments/assets/8c3cca12-4ad4-4add-880f-65f622e1818f" />
<img width="1471" height="928" alt="Screenshot 2026-07-15 at 11 23 38" src="https://github.com/user-attachments/assets/7489a2b3-2646-459e-bf95-d279aba428d1" />
<img width="1402" height="843" alt="Screenshot 2026-07-15 at 11 23 48" src="https://github.com/user-attachments/assets/5f691aa6-cc86-479f-a8a8-f469fc18f3f1" />

<img width="1387" height="550" alt="Screenshot 2026-07-15 at 10 12 36" src="https://github.com/user-attachments/assets/22b57d2c-e6bd-4e51-985e-2d19dc5aa089" />

