### PR TITLE
[ENG-4125] feat(connectwise): Write with Custom Fields

### DIFF
--- a/providers/connectwise/write.go
+++ b/providers/connectwise/write.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 )
 
@@ -17,24 +20,9 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	method := http.MethodPost
-
-	// By contract, WriteParams.RecordData holds the JSON payload.
-	// For updates, we may need to switch to PATCH (JSON Patch) or use PUT (replace).
-	data := params.RecordData
-	if params.IsUpdate() {
-		url.AddPath(params.RecordId)
-
-		// If the incoming WriteParams.RecordData represents a JSON Patch payload, we must use HTTP PATCH.
-		// Important: the connector's internal contract requires RecordData
-		// to be a JSON object, not a top-level JSON array.
-		// However, ConnectWise provider expects a PATCH body as a bare JSON array.
-		if payload, ok := extractPatchPayload(params); ok {
-			method = http.MethodPatch
-			data = payload.Patch
-		} else {
-			method = http.MethodPut
-		}
+	data, method, err := makeWritePayload(params, url)
+	if err != nil {
+		return nil, err
 	}
 
 	jsonData, err := json.Marshal(data)
@@ -50,6 +38,133 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 	c.clientIdHeader().ApplyToRequest(req)
 
 	return req, nil
+}
+
+// Returns payload, http method and modifies URL to include the record id in its path for update write case.
+func makeWritePayload(params common.WriteParams, url *urlbuilder.URL) (any, string, error) {
+	if params.IsUpdate() {
+		url.AddPath(params.RecordId)
+
+		return makeWriteUpdatePayload(params)
+	}
+
+	return makeWriteCreatePayload(params)
+}
+
+func makeWriteCreatePayload(params common.WriteParams) (any, string, error) {
+	record, err := params.GetRecord()
+	payloadWithCustomFields(record)
+
+	return record, http.MethodPost, err
+}
+
+func payloadWithCustomFields(record common.Record) {
+	if record == nil {
+		// No-op. Nothing to modify.
+		return
+	}
+
+	customFields := make([]map[string]any, 0)
+
+	for key, value := range record {
+		if key == "customFields" {
+			continue
+		}
+
+		if fieldIdStr, ok := strings.CutPrefix(key, "customField"); ok {
+			fieldId, err := strconv.Atoi(fieldIdStr)
+			if err != nil {
+				continue
+			}
+
+			// This is in-house field, shouldn't be part of actual payload.
+			delete(record, key)
+
+			customFields = append(customFields, map[string]any{
+				"id":    fieldId,
+				"value": value,
+			})
+		}
+	}
+
+	if len(customFields) != 0 {
+		record["customFields"] = customFields
+	}
+}
+
+// By contract, WriteParams.RecordData holds the JSON payload.
+// For updates, we may need to switch to PATCH (JSON Patch) or use PUT (replace).
+func makeWriteUpdatePayload(params common.WriteParams) (any, string, error) {
+	// If the incoming WriteParams.RecordData represents a JSON Patch payload, we must use HTTP PATCH.
+	// Important: the connector's internal contract requires RecordData
+	// to be a JSON object, not a top-level JSON array.
+	// However, ConnectWise provider expects a PATCH body as a bare JSON array.
+	if payload, ok := extractPatchPayload(params); ok {
+		data := payloadPatchWithCustomFields(params.ObjectName, payload.Patch)
+
+		return data, http.MethodPatch, nil
+	}
+
+	record, err := params.GetRecord()
+	payloadWithCustomFields(record)
+
+	return record, http.MethodPut, err
+}
+
+// payloadPatchWithCustomFields normalizes PATCH payloads for objects that support custom fields.
+//
+// ConnectWise has an unusual requirement for PATCH requests: if an object supports custom fields,
+// the request must include the customFields container, otherwise the API returns 400 Bad Request.
+// To satisfy this requirement, this function always emits a /customFields replace operation for
+// supported objects, even when the caller is only updating non-custom-field properties.
+//
+// Individual patch operations targeting custom fields are converted into entries in the
+// /customFields array in the form {id, value}. Only the fields explicitly mentioned are included.
+// Unlike the ConnectWise documentation suggests, omitting a custom field from the array does not
+// wipe it out, and sending an empty array does not clear existing custom field values.
+//
+// For objects that do not support custom fields, the payload is returned unchanged.
+// Non-custom-field patch operations are preserved as-is.
+func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPayload) []patchOperationPayload {
+	if !objectsSupportingCustomFields.Has(objectName) {
+		// Nothing to do.
+		return payloads
+	}
+
+	customFields := make([]map[string]any, 0)
+	result := make([]patchOperationPayload, 0)
+
+	for _, payload := range payloads {
+		// Path may start with slash. Normalize it.
+		path, _ := strings.CutPrefix(payload.Path, "/")
+
+		fieldIdStr, ok := strings.CutPrefix(path, "customField")
+		if !ok {
+			result = append(result, payload)
+
+			continue
+		}
+
+		fieldId, err := strconv.Atoi(fieldIdStr)
+		if err != nil {
+			result = append(result, payload)
+
+			continue
+		}
+
+		customFields = append(customFields, map[string]any{
+			"id":    fieldId,
+			"value": payload.Value,
+		})
+	}
+
+	result = append(result, patchOperationPayload{
+		Op:    "replace",
+		Path:  "/customFields",
+		Value: customFields,
+	})
+
+	return result
 }
 
 func (c *Connector) parseWriteResponse(

--- a/providers/connectwise/write_test.go
+++ b/providers/connectwise/write_test.go
@@ -58,13 +58,16 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			},
 		},
 		{
-			Name:  "Create task via POST",
-			Input: common.WriteParams{ObjectName: "contacts", RecordData: "dummy"},
+			Name: "Create task via POST",
+			Input: common.WriteParams{ObjectName: "contacts", RecordData: map[string]any{
+				"customField83": "Traveling",
+			}},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.MethodPOST(),
 					mockcond.Path("/v4_6_release/apis/3.0/company/contacts"),
+					mockcond.Body(`{"customFields":[{"id":83,"value":"Traveling"}]}`),
 					mockcond.Header(http.Header{"ClientId": []string{"dummy-client-id"}}),
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
@@ -87,7 +90,8 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				ObjectName: "contacts",
 				RecordId:   "57919",
 				RecordData: map[string]any{
-					"lastName": "Sims",
+					"lastName":      "Sims",
+					"customField83": "Skiing",
 				},
 			},
 			Server: mockserver.Conditional{
@@ -95,7 +99,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				If: mockcond.And{
 					mockcond.MethodPUT(),
 					mockcond.Path("/v4_6_release/apis/3.0/company/contacts/57919"),
-					mockcond.Body(`{"lastName": "Sims"}`),
+					mockcond.Body(`{"customFields":[{"id":83,"value":"Skiing"}],"lastName":"Sims"}`),
 					mockcond.Header(http.Header{"ClientId": []string{"dummy-client-id"}}),
 				},
 				Then: mockserver.Response(http.StatusOK, responseContact),
@@ -120,7 +124,8 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				RecordData: map[string]any{
 					"patch": []any{
 						map[string]any{"op": "replace", "path": "/firstName", "value": "Sims"},
-						map[string]any{"op": "replace", "path": "/customFields/1/value", "value": true},
+						map[string]any{"op": "replace", "path": "/customField53", "value": "Software Developer"},
+						map[string]any{"op": "replace", "path": "/customField83", "value": "Hiking"},
 					},
 				},
 			},
@@ -131,7 +136,10 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					mockcond.Path("/v4_6_release/apis/3.0/company/contacts/57919"),
 					mockcond.Body(`[
 						{"op":"replace","path":"/firstName","value":"Sims"},
-						{"op":"replace","path":"/customFields/1/value","value":true}
+						{"op":"replace","path":"/customFields","value": [
+							{"id":53,"value":"Software Developer"},
+							{"id":83,"value":"Hiking"}
+						]}
 					]`),
 					mockcond.Header(http.Header{"ClientId": []string{"dummy-client-id"}}),
 				},

--- a/test/connectwise/write-delete/contacts/main.go
+++ b/test/connectwise/write-delete/contacts/main.go
@@ -15,8 +15,10 @@ import (
 )
 
 type payload struct {
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
+	FirstName            string `json:"firstName"`
+	LastName             string `json:"lastName"`
+	CustomFieldMarketing bool   `json:"customField59"`
+	CustomFieldHobby     string `json:"customField83"`
 }
 
 type patchPayload struct {
@@ -49,15 +51,22 @@ func main() {
 	testscenario.ValidateCreateUpdateDelete(ctx, conn,
 		"contacts",
 		payload{
-			FirstName: firstName,
-			LastName:  lastName,
+			FirstName:            firstName,
+			LastName:             lastName,
+			CustomFieldHobby:     "Traveling",
+			CustomFieldMarketing: true,
 		},
 		payload{
-			FirstName: updatedFirstName,
-			LastName:  updatedLastName,
+			FirstName:            updatedFirstName,
+			LastName:             updatedLastName,
+			CustomFieldHobby:     "Skiing",
+			CustomFieldMarketing: false,
 		},
 		testscenario.CRUDTestSuite{
-			ReadFields: datautils.NewSet("id", "firstName", "lastName"),
+			ReadFields: datautils.NewSet("id", "firstName", "lastName",
+				"customField83",
+				"customField59",
+			),
 			SearchBy: testscenario.Property{
 				Key:   "firstname",
 				Value: firstName,
@@ -65,8 +74,10 @@ func main() {
 			},
 			RecordIdentifierKey: "id",
 			UpdatedFields: map[string]string{
-				"firstname": updatedFirstName,
-				"lastname":  updatedLastName,
+				"firstname":     updatedFirstName,
+				"lastname":      updatedLastName,
+				"customfield83": "Skiing",
+				"customfield59": "false",
 			},
 		},
 	)
@@ -77,15 +88,12 @@ func main() {
 	testscenario.ValidateCreateUpdateDelete(ctx, conn,
 		"contacts",
 		payload{
-			FirstName: firstName,
-			LastName:  lastName,
+			FirstName:            firstName,
+			LastName:             lastName,
+			CustomFieldHobby:     "Traveling",
+			CustomFieldMarketing: true,
 		},
 		patchPayload{Patch: []patchOperation{{
-			// Not clear why this is needed. This was discovered by trial and error.
-			Op:    "replace",
-			Path:  "/customFields/1/value",
-			Value: true,
-		}, {
 			Op:    "replace",
 			Path:  "firstName",
 			Value: updatedFirstName,
@@ -93,9 +101,16 @@ func main() {
 			Op:    "replace",
 			Path:  "/lastName",
 			Value: updatedLastName,
+		}, {
+			Op:    "replace",
+			Path:  "/customField83", // Handled and translated by connector.
+			Value: "Hiking",
 		}}},
 		testscenario.CRUDTestSuite{
-			ReadFields: datautils.NewSet("id", "firstName", "lastName"),
+			ReadFields: datautils.NewSet("id", "firstName", "lastName",
+				"customField83",
+				"customField59",
+			),
 			SearchBy: testscenario.Property{
 				Key:   "firstname",
 				Value: firstName,
@@ -103,8 +118,10 @@ func main() {
 			},
 			RecordIdentifierKey: "id",
 			UpdatedFields: map[string]string{
-				"firstname": updatedFirstName,
-				"lastname":  updatedLastName,
+				"firstname":     updatedFirstName,
+				"lastname":      updatedLastName,
+				"customfield83": "Hiking",
+				"customfield59": "true",
 			},
 		},
 	)

--- a/test/utils/mockutils/mockcond/body.go
+++ b/test/utils/mockutils/mockcond/body.go
@@ -54,9 +54,10 @@ func Body(expected string, rules ...FieldIgnoreRule) Check {
 
 		textEquals := textBodyMatch(body, expected)
 		jsonEquals := jsonBodyMatch(body, expected, rules)
+		arrayJsonEquals := jsonBodyArrayMatch(body, expected, rules)
 		xmlEquals := xmlBodyMatch(body, expected)
 
-		return textEquals || jsonEquals || xmlEquals
+		return textEquals || jsonEquals || arrayJsonEquals || xmlEquals
 	}
 }
 
@@ -123,6 +124,35 @@ func jsonBodyMatch(actual []byte, expected string, rules []FieldIgnoreRule) bool
 	secondObj := applyIgnoreRules(second, rules)
 
 	return reflect.DeepEqual(firstObj, secondObj)
+}
+
+func jsonBodyArrayMatch(actual []byte, expected string, rules []FieldIgnoreRule) bool {
+	first := make([]map[string]any, 0)
+	if err := json.Unmarshal(actual, &first); err != nil {
+		return false
+	}
+
+	second := make([]map[string]any, 0)
+	if err := json.Unmarshal([]byte(expected), &second); err != nil {
+		return false
+	}
+
+	if len(first) != len(second) {
+		return false
+	}
+
+	for index, firstItem := range first {
+		secondItem := second[index]
+
+		firstObj := applyIgnoreRules(firstItem, rules)
+		secondObj := applyIgnoreRules(secondItem, rules)
+
+		if !reflect.DeepEqual(firstObj, secondObj) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func applyIgnoreRules(entity any, rules []FieldIgnoreRule) any {


### PR DESCRIPTION
# Description

Custom fields are now supported as native fields for the following write cases:
* Create
<img width="339" height="155" alt="image" src="https://github.com/user-attachments/assets/832a33b6-2b9b-4a6b-9f3a-ed04288f186a" />

* Update
<img width="409" height="156" alt="image" src="https://github.com/user-attachments/assets/eb8409c0-2a15-4e5d-ae71-74cc85506eff" />

* Update with operations
<img width="617" height="339" alt="image" src="https://github.com/user-attachments/assets/0c94a40b-46f2-4ae9-9cd5-d5c8423e85ea" />


Custom Field must be of format `customField<num>`:
<img width="515" height="162" alt="image" src="https://github.com/user-attachments/assets/7bd7b09d-00f2-4a0b-b192-7654d6db8c92" />

# Live Tests

### Write/Delete [Contacts](https://github.com/amp-labs/connectors/blob/3fee124b14ec6241ee6e2b0567f97ac3c98e84cc/test/connectwise/write-delete/contacts/main.go#L34)
<img width="374" height="504" alt="image" src="https://github.com/user-attachments/assets/5090b298-f7ab-4116-9a74-1ce5e82fd9c6" />
