### PR TITLE
[CON-3433] fix(pylon): issues incremental read

### DIFF
--- a/providers/pylon/handlers.go
+++ b/providers/pylon/handlers.go
@@ -14,7 +14,13 @@ import (
 	"github.com/amp-labs/connectors/internal/jsonquery"
 )
 
-var limit = "999" //nolint:gochecknoglobals
+const (
+	// limit is the page size for the GET endpoints, which take it as a query param.
+	limit = "999"
+	// searchLimit is the page size for POST /issues/search, which takes limit as a
+	// JSON number rather than a query param. The endpoint caps it at 1000.
+	searchLimit = 999
+)
 
 func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, objectName string) (*http.Request, error) {
 	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, objectName)
@@ -91,13 +97,22 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 	}
 
 	if params.ObjectName == "issues" {
-		// issues required start_time and end_time query params.
-		// The time window cannot exceed 30 days.
-		// addIssuesTimeWindowQuery adds start_time and end_time query params for the "issues" object
-		// and validates the time window does not exceed 30 days.
-		if err := addIssuesTimeWindowQuery(url, params); err != nil {
+		// Issues are read via POST /issues/search rather than GET /issues, because the
+		// latter filters on created_at and so never re-reads issues updated after the
+		// watermark. Note that POST /issues (without /search) creates an issue.
+		url.AddPath("search")
+
+		body, err := buildIssueBody(params)
+		if err != nil {
 			return nil, err
 		}
+
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+
+		return http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(jsonData))
 	}
 
 	url.WithQueryParam("limit", limit)

--- a/providers/pylon/read_test.go
+++ b/providers/pylon/read_test.go
@@ -3,6 +3,7 @@ package pylon
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -72,8 +73,11 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id", "title")},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.Path("/issues"),
-				Then:  mockserver.Response(http.StatusOK, responseIssuesEmpty),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
 			}.Server(),
 			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
@@ -81,6 +85,79 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 				NextPage: "",
 				Done:     true,
 			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:  "Issues are read via POST to the search endpoint",
+			Input: common.ReadParams{ObjectName: "issues", Fields: connectors.Fields("id", "title")},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+					// filter is optional, and is omitted when no window is requested.
+					mockcond.Body(`{"limit":999}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Since alone filters on updated_at with a lower bound",
+			Input: common.ReadParams{
+				ObjectName: "issues",
+				Fields:     connectors.Fields("id", "title"),
+				Since:      time.Unix(1754518014, 0),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+					mockcond.Body(`{
+						"limit":999,
+						"filter":{
+							"operator":"and",
+							"subfilters":[
+								{"field":"updated_at","operator":"time_is_after","value":"2025-08-06T22:06:54Z"}
+							]
+						}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Since and Until filter on updated_at with both bounds",
+			Input: common.ReadParams{
+				ObjectName: "issues",
+				Fields:     connectors.Fields("id", "title"),
+				Since:      time.Unix(1754518014, 0),
+				Until:      time.Unix(1754518016, 0),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+					mockcond.Body(`{
+						"limit":999,
+						"filter":{
+							"operator":"and",
+							"subfilters":[
+								{"field":"updated_at","operator":"time_is_after","value":"2025-08-06T22:06:54Z"},
+								{"field":"updated_at","operator":"time_is_before","value":"2025-08-06T22:06:56Z"}
+							]
+						}}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/pylon/read_test.go
+++ b/providers/pylon/read_test.go
@@ -161,6 +161,47 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
+			Name: "PageSize sets the limit, and is clamped to the endpoint maximum",
+			Input: common.ReadParams{
+				ObjectName: "issues",
+				Fields:     connectors.Fields("id", "title"),
+				PageSize:   5000,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+					// 5000 is above what search accepts, so it falls back to the maximum.
+					mockcond.Body(`{"limit":999}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "PageSize below the maximum is passed through",
+			Input: common.ReadParams{
+				ObjectName: "issues",
+				Fields:     connectors.Fields("id", "title"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/issues/search"),
+					mockcond.MethodPOST(),
+					mockcond.Body(`{"limit":2}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseIssuesEmpty),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "Next page is the last page",
 			Input: common.ReadParams{
 				ObjectName: "accounts",

--- a/providers/pylon/utils.go
+++ b/providers/pylon/utils.go
@@ -23,19 +23,24 @@ func inferValueTypeFromData(value any) common.ValueType {
 	}
 }
 
-// buildIssueBody constructs the POST /issues/search payload. The search endpoint has no
-// start_time/end_time parameters; a time window is instead expressed as a filter over
-// updated_at, so that issues modified after the watermark are re-read rather than only
-// newly created ones.
-//
+// buildIssueBody constructs the POST /issues/search.
+// We use a POST request because the GET /issues endpoint filters on created_at, which means
+// issues updated after the watermark are never re-read. The POST /issues/search endpoint
+// instead filters on updated_at, which is what we want.
+
 // filter is optional, and is omitted entirely when neither Since nor Until is set, which
 // reads every issue.
 func buildIssueBody(params common.ReadParams) (map[string]any, error) {
-	body := map[string]any{
-		"limit": searchLimit,
+	pageSize := searchLimit
+	if params.PageSize > 0 && params.PageSize <= searchLimit {
+		pageSize = params.PageSize
 	}
 
-	subfilters := make([]map[string]any, 0, 2) //nolint:gomnd
+	body := map[string]any{
+		"limit": pageSize,
+	}
+
+	subfilters := make([]map[string]any, 0, 2) //nolint:gomnd,mnd
 
 	if !params.Since.IsZero() {
 		subfilters = append(subfilters, map[string]any{

--- a/providers/pylon/utils.go
+++ b/providers/pylon/utils.go
@@ -1,11 +1,9 @@
 package pylon
 
 import (
-	"errors"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/common/urlbuilder"
 )
 
 func inferValueTypeFromData(value any) common.ValueType {
@@ -25,30 +23,46 @@ func inferValueTypeFromData(value any) common.ValueType {
 	}
 }
 
-func addIssuesTimeWindowQuery(url *urlbuilder.URL, params common.ReadParams) error {
-	var startTime, endTime time.Time
-
-	if params.Since.IsZero() {
-		// Default to last 29 days instead of 30 to account for potential
-		// timezone transitions and microsecond precision differences that
-		// could cause the API to reject requests exceeding 30 days exactly.
-		startTime = time.Now().UTC().AddDate(0, 0, -29)
-	} else {
-		startTime = params.Since.UTC()
+// buildIssueBody constructs the POST /issues/search payload. The search endpoint has no
+// start_time/end_time parameters; a time window is instead expressed as a filter over
+// updated_at, so that issues modified after the watermark are re-read rather than only
+// newly created ones.
+//
+// filter is optional, and is omitted entirely when neither Since nor Until is set, which
+// reads every issue.
+func buildIssueBody(params common.ReadParams) (map[string]any, error) {
+	body := map[string]any{
+		"limit": searchLimit,
 	}
 
-	if params.Until.IsZero() {
-		endTime = time.Now().UTC()
-	} else {
-		endTime = params.Until.UTC()
+	subfilters := make([]map[string]any, 0, 2) //nolint:gomnd
+
+	if !params.Since.IsZero() {
+		subfilters = append(subfilters, map[string]any{
+			"field":    "updated_at",
+			"operator": "time_is_after",
+			"value":    params.Since.UTC().Format(time.RFC3339),
+		})
 	}
 
-	if endTime.Sub(startTime) > 30*24*time.Hour {
-		return errors.New("time window exceeds 30 days") // nolint:err113
+	if !params.Until.IsZero() {
+		subfilters = append(subfilters, map[string]any{
+			"field":    "updated_at",
+			"operator": "time_is_before",
+			"value":    params.Until.UTC().Format(time.RFC3339),
+		})
 	}
 
-	url.WithQueryParam("start_time", startTime.Format(time.RFC3339))
-	url.WithQueryParam("end_time", endTime.Format(time.RFC3339))
+	if len(subfilters) > 0 {
+		body["filter"] = map[string]any{
+			"operator":   "and",
+			"subfilters": subfilters,
+		}
+	}
 
-	return nil
+	if params.NextPage != "" {
+		body["cursor"] = params.NextPage.String()
+	}
+
+	return body, nil
 }

--- a/test/pylon/read/main.go
+++ b/test/pylon/read/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -49,7 +50,137 @@ func main() {
 
 	readIssueScenarios(ctx, conn)
 
+	verifyIncrementalRead(ctx, conn)
+
 	slog.Info("Read operation completed successfully.")
+}
+
+func verifyIncrementalRead(ctx context.Context, conn *pylon.Connector) {
+	// A narrow window used only to locate the freshly created issue quickly.
+	recentWindow := time.Now().UTC().Add(-2 * time.Minute)
+	title := "Ampersand incremental-read test " + time.Now().UTC().Format("20060102T150405Z")
+
+	// 1. Create an issue.
+	createRes, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "issues",
+		RecordData: map[string]any{
+			"title":           title,
+			"body_html":       "<p>Created by the Ampersand incremental-read test.</p>",
+			"requester_email": "ampersand-incremental-test@example.com",
+		},
+	})
+	if err != nil {
+		utils.Fail("could not create test issue", "error", err)
+	}
+
+	issueID, _ := createRes.Data["id"].(string)
+	slog.Info("step 1: created test issue", "id", issueID, "title", title)
+
+	// 2. Read it back to confirm the freshly created issue is returned
+	created, found := findIssue(ctx, conn, issueID, recentWindow)
+	if !found {
+		deleteIssue(ctx, conn, issueID)
+		utils.Fail("step 2: created issue was not returned by the first read", "id", issueID)
+	}
+
+	createdAt := mustParseTime(created["created_at"])
+	slog.Info("step 2: first read OK, created issue is present", "id", issueID, "created_at", createdAt)
+
+	// 3. Update the issue by closing it. The row changes but created_at does not.
+	time.Sleep(3 * time.Second)
+
+	if _, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "issues",
+		RecordId:   issueID,
+		RecordData: map[string]any{"state": "closed"},
+	}); err != nil {
+		deleteIssue(ctx, conn, issueID)
+		utils.Fail("step 3: could not close test issue", "id", issueID, "error", err)
+	}
+
+	slog.Info("step 3: closed test issue", "id", issueID)
+
+	// 4. Read it back again to capture the new updated_at.
+	updated, found := findIssue(ctx, conn, issueID, recentWindow)
+	if !found {
+		deleteIssue(ctx, conn, issueID)
+		utils.Fail("step 4: updated issue was not returned when reading the recent window", "id", issueID)
+	}
+
+	updatedAt := mustParseTime(updated["updated_at"])
+	if !updatedAt.After(createdAt) {
+		deleteIssue(ctx, conn, issueID)
+		utils.Fail("step 4: updated_at did not advance past created_at; cannot demonstrate the fix",
+			"created_at", createdAt, "updated_at", updatedAt)
+	}
+
+	// 5. Re-read with a watermark strictly between created_at and updated_at.
+	watermark := createdAt.Add(updatedAt.Sub(createdAt) / 2)
+	_, foundAfterUpdate := findIssue(ctx, conn, issueID, watermark)
+
+	// Delete the test issue before asserting.
+	deleteIssue(ctx, conn, issueID)
+
+	if !foundAfterUpdate {
+		utils.Fail("step 5: INCREMENTAL READ REGRESSION: issue updated after the watermark was not re-read",
+			"id", issueID, "watermark", watermark, "created_at", createdAt, "updated_at", updatedAt)
+	}
+
+	slog.Info("step 5: incremental read verified, issue updated after the watermark was re-read",
+		"id", issueID, "watermark", watermark, "created_at", createdAt, "updated_at", updatedAt)
+}
+
+func deleteIssue(ctx context.Context, conn *pylon.Connector, id string) {
+	url := fmt.Sprintf("%s/issues/%s", conn.ProviderInfo().BaseURL, id)
+
+	if _, err := conn.JSONHTTPClient().Delete(ctx, url); err != nil {
+		slog.Warn("could not delete test issue", "id", id, "error", err)
+
+		return
+	}
+
+	slog.Info("cleaned up test issue", "id", id)
+}
+
+// findIssue reads issues page by page, filtered to updates since the given time, and returns the
+// raw record whose id matches, if any.
+func findIssue(ctx context.Context, conn *pylon.Connector, id string, since time.Time) (map[string]any, bool) {
+	var nextPage common.NextPageToken
+
+	for {
+		res, err := conn.Read(ctx, common.ReadParams{
+			ObjectName: "issues",
+			Fields:     connectors.Fields("id", "created_at", "updated_at", "state"),
+			Since:      since,
+			NextPage:   nextPage,
+		})
+		if err != nil {
+			utils.Fail("error reading issues", "error", err)
+		}
+
+		for _, row := range res.Data {
+			if row.Raw["id"] == id {
+				return row.Raw, true
+			}
+		}
+
+		if res.Done || res.NextPage == "" {
+			return nil, false
+		}
+
+		nextPage = res.NextPage
+	}
+}
+
+func mustParseTime(value any) time.Time {
+	str, _ := value.(string)
+
+	parsed, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		utils.Fail("could not parse timestamp", "value", value, "error", err)
+	}
+
+	return parsed.UTC()
 }
 
 // readIssueScenarios exercises every filter shape buildIssueBody can emit against live

--- a/test/pylon/read/main.go
+++ b/test/pylon/read/main.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
-	"github.com/amp-labs/connectors/test/pylon"
+	"github.com/amp-labs/connectors/providers/pylon"
+	connTest "github.com/amp-labs/connectors/test/pylon"
 	"github.com/amp-labs/connectors/test/utils"
 )
 
@@ -21,7 +23,7 @@ func main() {
 	// Set up slog logging.
 	utils.SetupLogging()
 
-	conn := pylon.GetConnector(ctx)
+	conn := connTest.GetConnector(ctx)
 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "accounts",
@@ -45,16 +47,81 @@ func main() {
 	slog.Info("Reading contacts..")
 	utils.DumpJSON(res, os.Stdout)
 
-	res, err = conn.Read(ctx, common.ReadParams{
-		ObjectName: "issues",
-		Fields:     connectors.Fields("id", "created_at", "body_html"),
-	})
-	if err != nil {
-		utils.Fail("error reading from pylon", "error", err)
-	}
-
-	slog.Info("Reading issues..")
-	utils.DumpJSON(res, os.Stdout)
+	readIssueScenarios(ctx, conn)
 
 	slog.Info("Read operation completed successfully.")
+}
+
+// readIssueScenarios exercises every filter shape buildIssueBody can emit against live
+// Pylon. Row counts rising across the widening windows show that the updated_at filter
+// is not capped at 30 days the way GET /issues caps start_time/end_time.
+//
+// Failures are logged rather than fatal, so one run reports on every shape.
+func readIssueScenarios(ctx context.Context, conn *pylon.Connector) {
+	now := time.Now().UTC()
+
+	scenarios := []struct {
+		name     string
+		verifies string
+		since    time.Time
+		until    time.Time
+	}{
+		{
+			name:     "no window",
+			verifies: "filter omitted entirely; full backfill reads all issues",
+		},
+		{
+			name:     "since only",
+			verifies: "lone lower bound; Pylon accepts an 'and' wrapping a single subfilter",
+			since:    now.AddDate(0, 0, -7),
+		},
+		{
+			name:     "until only",
+			verifies: "lone upper bound; same single-subfilter shape",
+			until:    now,
+		},
+		{
+			name:     "since and until, 7 days",
+			verifies: "ordinary incremental read; two subfilters under 'and'",
+			since:    now.AddDate(0, 0, -7),
+			until:    now,
+		},
+		{
+			name:     "since and until, 60 days",
+			verifies: "window wider than the 30 day cap GET /issues enforces",
+			since:    now.AddDate(0, 0, -60),
+			until:    now,
+		},
+		{
+			name:     "since and until, 120 days",
+			verifies: "window far past the cap; confirms no silent truncation at 30 days",
+			since:    now.AddDate(0, 0, -120),
+			until:    now,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		res, err := conn.Read(ctx, common.ReadParams{
+			ObjectName: "issues",
+			Fields:     connectors.Fields("id", "created_at", "updated_at", "state"),
+			Since:      scenario.since,
+			Until:      scenario.until,
+		})
+		if err != nil {
+			slog.Error("issues read FAILED",
+				"scenario", scenario.name,
+				"verifies", scenario.verifies,
+				"error", err,
+			)
+
+			continue
+		}
+
+		slog.Info("issues read OK",
+			"scenario", scenario.name,
+			"verifies", scenario.verifies,
+			"rows", res.Rows,
+			"done", res.Done,
+		)
+	}
 }


### PR DESCRIPTION
Read issues with `POST /issues/search`, filtered on `updated_at`.

* Verified : Search endpoint does not have  30 days window cap for date filter. 
* Accounts and contacts: cannot be made incremental Neither search endpoint supports a time filter.


## Test Result

```
time=2026-07-15T14:16:41.143+05:45 level=INFO msg="issues read OK" scenario="no window" verifies="filter omitted entirely; full backfill reads all issues" rows=2 done=false
time=2026-07-15T14:16:41.635+05:45 level=INFO msg="issues read OK" scenario="since only" verifies="lone lower bound; Pylon accepts an 'and' wrapping a single subfilter" rows=2 done=false
time=2026-07-15T14:16:42.309+05:45 level=INFO msg="issues read OK" scenario="until only" verifies="lone upper bound; same single-subfilter shape" rows=2 done=false
time=2026-07-15T14:16:42.882+05:45 level=INFO msg="issues read OK" scenario="since and until, 7 days" verifies="ordinary incremental read; two subfilters under 'and'" rows=2 done=false
{
  "data": [
    {
      "fields": {
        "created_at": "2026-07-15T00:24:34Z",
        "id": "b5eb9159-9c67-627d-aef9-11aac8d25f6f",
        "state": "waiting_on_you",
        "updated_at": "2026-07-15T01:14:35Z"
      },
      "raw": {
        "account": {
          "external_ids": null,
          "id": "b4e92d81-1199-adf2-7a42-0d229d75652a"
        },
        "assignee": {
          "id": "6fbe363e-0ad8-b6af-477c-cc587f4de496"
        },
        "author_unverified": false,
        "body_html": "<redacted body_html>",
        "business_hours_first_response_seconds": 2127,
        "business_hours_time_in_status_seconds": {
          "in_progress": 0,
          "on_hold": 0,
          "open": 2125
        },
        "created_at": "2026-07-15T00:24:34Z",
        "custom_fields": {
          "question_type": {
            "value": "",
            "values": [
              "<redacted values>"
            ]
          }
        },
        "customer_portal_visible": false,
        "first_response_seconds": 2881,
        "first_response_time": "2026-07-15T01:12:33Z",
        "id": "b5eb9159-9c67-627d-aef9-11aac8d25f6f",
        "latest_message_time": "2026-07-15T01:14:28Z",
        "link": "<redacted link>",
        "number": 1675,
        "number_of_touches": 1,
        "requester": {
          "id": "1e2bd820-3f76-3651-fb8a-89aa84308dcc"
        },
        "resolution_time": null,
        "slack": {
          "channel_id": "<redacted channel_id>",
          "message_ts": "<redacted message_ts>",
          "workspace_id": "<redacted workspace_id>"
        },
        "source": "slack",
        "state": "waiting_on_you",
        "tags": null,
        "team": {
          "id": "9bd7155c-33ca-9f83-f29e-9d1e221a4110"
        },
        "team_slas": [
          {
            "first_response": {
              "business_hours_seconds": 2119,
              "seconds": 2873,
              "time": "2026-07-15T01:12:33Z"
            },
            "team_id": "9bd7155c-33ca-9f83-f29e-9d1e221a4110"
          }
        ],
        "time_in_status_seconds": {
          "in_progress": 25076,
          "on_hold": 117,
          "open": 2882
        },
        "title": "<redacted title>",
        "type": "conversation",
        "updated_at": "2026-07-15T01:14:35Z"
      }
    },
    {
      "fields": {
        "created_at": "2026-07-15T00:11:53Z",
        "id": "00eaf622-cd48-0358-243f-a6e807322df6",
        "state": "closed",
        "updated_at": "2026-07-15T00:16:40Z"
      },
      "raw": {
        "account": {
          "external_ids": null,
          "id": "b3e561af-4bb7-ff60-d414-a8a32f62176c"
        },
        "assignee": {
          "id": "a37f0a94-fd0c-3807-3fcc-f5560c17c769"
        },
        "author_unverified": false,
        "body_html": "<redacted body_html>",
        "business_hours_resolution_seconds": 0,
        "business_hours_time_in_status_seconds": {
          "on_hold": 182,
          "open": 104
        },
        "created_at": "2026-07-15T00:11:53Z",
        "custom_fields": {
          "question_type": {
            "value": "",
            "values": [
              "<redacted values>"
            ]
          }
        },
        "customer_portal_visible": false,
        "first_response_time": null,
        "id": "00eaf622-cd48-0358-243f-a6e807322df6",
        "latest_message_time": "2026-07-15T00:11:53Z",
        "link": "<redacted link>",
        "number": 1674,
        "number_of_touches": 1,
        "requester": {
          "id": "f5c90ce6-7bca-24d6-8f15-a18c8de06500"
        },
        "resolution_seconds": 0,
        "resolution_time": "2026-07-15T00:10:36Z",
        "slack": {
          "channel_id": "<redacted channel_id>",
          "message_ts": "<redacted message_ts>",
          "workspace_id": "<redacted workspace_id>"
        },
        "source": "slack",
        "state": "closed",
        "tags": null,
        "team": {
          "id": "9bd7155c-33ca-9f83-f29e-9d1e221a4110"
        },
        "team_slas": [
          {
            "resolution": {
              "business_hours_seconds": 282,
              "seconds": 282,
              "time": "2026-07-15T00:16:40Z"
            },
            "team_id": "9bd7155c-33ca-9f83-f29e-9d1e221a4110"
          }
        ],
        "time_in_status_seconds": {
          "on_hold": 182,
          "open": 104
        },
        "title": "<redacted title>",
        "type": "conversation",
        "updated_at": "2026-07-15T00:16:40Z"
      }
    }
  ],
  "done": false,
  "nextPage": "<cursor>",
  "rows": 2
}
time=2026-07-16T15:38:58.425+05:45 level=INFO msg="issues read OK" scenario="no window" verifies="filter omitted entirely; full backfill reads all issues" rows=999 done=false
time=2026-07-16T15:39:00.577+05:45 level=INFO msg="issues read OK" scenario="since only" verifies="lone lower bound; Pylon accepts an 'and' wrapping a single subfilter" rows=45 done=true
time=2026-07-16T15:39:17.135+05:45 level=INFO msg="issues read OK" scenario="until only" verifies="lone upper bound; same single-subfilter shape" rows=999 done=false
time=2026-07-16T15:39:17.801+05:45 level=INFO msg="issues read OK" scenario="since and until, 7 days" verifies="ordinary incremental read; two subfilters under 'and'" rows=45 done=true
time=2026-07-16T15:39:18.775+05:45 level=INFO msg="issues read OK" scenario="since and until, 60 days" verifies="window wider than the 30 day cap GET /issues enforces" rows=266 done=true
time=2026-07-16T15:39:36.609+05:45 level=INFO msg="issues read OK" scenario="since and until, 120 days" verifies="window far past the cap; confirms no silent truncation at 30 days" rows=881 done=true
time=2026-07-16T15:39:39.060+05:45 level=INFO msg="step 1: created test issue" id=7d1e1cb8-6a57-400f-8cf4-924dbfef5ded title="Ampersand incremental-read test 20260716T095436Z"
time=2026-07-16T15:39:39.559+05:45 level=INFO msg="step 2: first read OK, created issue is present" id=7d1e1cb8-6a57-400f-8cf4-924dbfef5ded created_at=2026-07-16T09:54:36.000Z
time=2026-07-16T15:39:43.160+05:45 level=INFO msg="step 3: closed test issue" id=7d1e1cb8-6a57-400f-8cf4-924dbfef5ded
time=2026-07-16T15:39:43.962+05:45 level=DEBUG msg="HTTP request" method=DELETE url=https://api.usepylon.com/issues/7d1e1cb8-6a57-400f-8cf4-924dbfef5ded correlationId=80fbea37-51f7-4783-8d3b-853538bc761e headers.Accept=application/json
time=2026-07-16T15:39:44.740+05:45 level=DEBUG msg="HTTP response" details="map[correlationId:80fbea37-51f7-4783-8d3b-853538bc761e headers:[Content-Type: application/json Access-Control-Expose-Headers: X-Pylon-Request-ID Vary: Accept-Encoding Vary: Origin X-Pylon-Request-Id: 59ab5689-9846-471e-a174-008c636ba426 Content-Length: 53 Strict-Transport-Security: max-age=31536000; includeSubDomains; preload X-Content-Type-Options: nosniff X-Frame-Options: DENY X-Rate-Limit-Remaining: 19 Date: Thu, 16 Jul 2026 09:54:44 GMT] method:DELETE status:200 url:https://api.usepylon.com/issues/7d1e1cb8-6a57-400f-8cf4-924dbfef5ded]"
time=2026-07-16T15:39:44.740+05:45 level=INFO msg="cleaned up test issue" id=7d1e1cb8-6a57-400f-8cf4-924dbfef5ded
time=2026-07-16T15:39:44.740+05:45 level=INFO msg="step 5: incremental read verified, issue updated after the watermark was re-read" id=7d1e1cb8-6a57-400f-8cf4-924dbfef5ded watermark=2026-07-16T09:54:39.000Z created_at=2026-07-16T09:54:36.000Z updated_at=2026-07-16T09:54:42.000Z
time=2026-07-16T15:39:44.740+05:45 level=INFO msg="Read operation completed successfully."


``
