### PR TITLE
[ENG-4127] tidy(connectwise): Prune secondary custom fields

### DIFF
--- a/providers/connectwise/custom.go
+++ b/providers/connectwise/custom.go
@@ -42,9 +42,7 @@ func flattenCustomFields() common.RecordTransformer {
 				return nil, err
 			}
 
-			// There are 2 formats.
-			fields[field.makeFieldName1()] = field.Value
-			fields[field.makeFieldName2()] = field.Value
+			fields[field.makeFieldName()] = field.Value
 		}
 
 		// Move custom fields to the top root level.
@@ -268,18 +266,10 @@ func (f modelCustomField) getValues() []common.FieldValue {
 	return values
 }
 
-func (f modelCustomField) makeFieldName1() string {
+func (f modelCustomField) makeFieldName() string {
 	return fmt.Sprintf("customField%v", strconv.Itoa(f.Id))
 }
 
-func (f modelCustomField) makeFieldName2() string {
-	return f.Caption
-}
-
-func (f readCustomField) makeFieldName1() string {
+func (f readCustomField) makeFieldName() string {
 	return fmt.Sprintf("customField%v", strconv.Itoa(f.Id))
-}
-
-func (f readCustomField) makeFieldName2() string {
-	return f.Caption
 }

--- a/providers/connectwise/metadata.go
+++ b/providers/connectwise/metadata.go
@@ -42,8 +42,7 @@ func (c *Connector) ListObjectMetadata(
 				Values:       field.getValues(),
 			}
 
-			objectMetadata.AddFieldMetadata(field.makeFieldName1(), fieldMetadata)
-			objectMetadata.AddFieldMetadata(field.makeFieldName2(), fieldMetadata)
+			objectMetadata.AddFieldMetadata(field.makeFieldName(), fieldMetadata)
 		}
 
 		// Write the modified metadata back to the map

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -119,7 +119,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					"contacts": {
 						DisplayName: "Contacts",
 						Fields: map[string]common.FieldMetadata{
-							"Mobile Phone": {
+							"customField80": {
 								DisplayName:  "Mobile Phone",
 								ValueType:    "string",
 								ProviderType: "EntryField_Text",
@@ -127,7 +127,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								IsCustom:     new(true),
 								IsRequired:   new(false),
 							},
-							"is_synced": {
+							"customField16": {
 								DisplayName:  "is_synced",
 								ValueType:    "multiSelect",
 								ProviderType: "List_Text",
@@ -142,7 +142,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 									DisplayValue: "false",
 								}},
 							},
-							"Hobby": {
+							"customField83": {
 								DisplayName:  "Hobby",
 								ValueType:    "multiSelect",
 								ProviderType: "List_Text",
@@ -163,7 +163,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 									DisplayValue: "Hiking",
 								}},
 							},
-							"Chooser": {
+							"customField88": {
 								DisplayName:  "Chooser",
 								ValueType:    "singleSelect",
 								ProviderType: "Option_Text",

--- a/providers/connectwise/read-by-ids_test.go
+++ b/providers/connectwise/read-by-ids_test.go
@@ -29,7 +29,7 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 			Input: testconn.ReadByIdsParams{
 				ObjectName: "contacts",
 				RecordIds:  []string{"57920", "57921", "57922"},
-				Fields:     []string{"firstName", "customField53", "Job Level"},
+				Fields:     []string{"firstName", "customField53"},
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -49,7 +49,6 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				Fields: map[string]any{
 					"firstname":     "Maxime Schaefer [1]",
 					"customfield53": "Software Developer",
-					"job level":     "Software Developer",
 				},
 				Raw: map[string]any{"lastName": "Wayne Blanda"},
 			}, {
@@ -57,7 +56,6 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				Fields: map[string]any{
 					"firstname":     "Roderick Rippin [2]",
 					"customfield53": "Sales Representative",
-					"job level":     "Sales Representative",
 				},
 				Raw: map[string]any{"lastName": "Lemuel Hackett"},
 			}, {
@@ -65,7 +63,6 @@ func TestGetRecordsByIds(t *testing.T) { // nolint:funlen,cyclop
 				Fields: map[string]any{
 					"firstname":     "Randi Haag [3]",
 					"customfield53": "Manager",
-					"job level":     "Manager",
 				},
 				Raw: map[string]any{"lastName": "Ferne Bradtke"},
 			}},

--- a/providers/connectwise/read_test.go
+++ b/providers/connectwise/read_test.go
@@ -158,9 +158,7 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			Input: common.ReadParams{
 				ObjectName: "contacts",
 				Fields: connectors.Fields("firstName", "lastName",
-					"sync_status", // the field uses Caption as the name
-					// The suffix is the constant id of a field.
-					"customField22", // sync_status field can be requested this way too.
+					"customField22", // sync_status.
 				),
 				NextPage: nextPageRelative,
 			},
@@ -182,7 +180,6 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 					Fields: map[string]any{
 						"firstname":     "Alex",
 						"lastname":      "Morgan",
-						"sync_status":   "pending",
 						"customfield22": "pending", // The `Fields` are always lower case
 					},
 					Raw: map[string]any{

--- a/test/connectwise/read/contacts/main.go
+++ b/test/connectwise/read/contacts/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	testscenario.ReadThroughPagesFieldsOnly(ctx, conn, common.ReadParams{
 		ObjectName: "contacts",
-		Fields:     datautils.NewSet("firstName", "lastName", "customField15", "LinkedIn URL"),
+		Fields:     datautils.NewSet("firstName", "lastName", "customField15"),
 		Since:      time.Now().Add(-1 * time.Hour * 24 * 15),
 		PageSize:   1000,
 	})


### PR DESCRIPTION
# Description

Keep custom fields of format `customField<num>`.
The fields that are formed by using Caption (aka display name) are removed. They are not useful for the Write operation and also polute the Installation UI with duplicates.