### PR TITLE
[ENG-4127] feat(connectwise): Write contact communication items

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -171,6 +171,9 @@ var (
 	// from previous SubscriptionResult. This should not happen and it points to issues with implementation.
 	// Likely the result was not created properly by previous Create/Update step.
 	ErrPrevSubscriptionResultInvalid = errors.New("previous SubscriptionResult does not match expectations")
+
+	// ErrInvalidVirtualField is returned when Write cannot happen due to invalid virtual field.
+	ErrInvalidVirtualField = errors.New("virtual field is invalid")
 )
 
 // ReadParams defines how we are reading data from a SaaS API.

--- a/providers/connectwise/communication-types.go
+++ b/providers/connectwise/communication-types.go
@@ -1,8 +1,13 @@
 package connectwise
 
 import (
+	"context"
+	"fmt"
 	"maps"
+	"sort"
+	"strings"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
@@ -12,8 +17,25 @@ const (
 	communicationTypeEmail = "Email"
 	communicationTypePhone = "Phone"
 	communicationTypeFax   = "Fax"
+
+	operationAdd     = "add"
+	operationReplace = "replace"
+	operationRemove  = "remove"
 )
 
+// attachCommunicationItems attaches default communication items from a contact's
+// `communicationItems` array to the top-level `root` map as virtual fields.
+//
+// It:
+//   - Reads the optional `communicationItems` array from the provided JSON node.
+//   - Iterates over items and selects only those marked as default (DefaultFlag=true).
+//   - For each default item, writes the corresponding virtual fields for value and ID
+//     (e.g. email, emailId, phone, phoneId, fax, faxId) into `root`.
+//
+// Non-default communication items are ignored because only the default item per
+// type is exposed via the connector's Read/Metadata surfaces.
+//
+// If `communicationItems` is missing or empty, no fields are added and no error is returned.
 func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // nolint:cyclop
 	communicationItems, err := jsonquery.New(node).ArrayOptional("communicationItems")
 	if err != nil {
@@ -21,8 +43,7 @@ func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // 
 	}
 
 	if len(communicationItems) == 0 {
-		// This contact doesn't have communication items.
-		// Nothing to attach.
+		// Contact has no communicationItems; nothing to attach.
 		return nil
 	}
 
@@ -35,8 +56,7 @@ func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // 
 		}
 
 		if !item.DefaultFlag {
-			// Only the default communication items in each category matter.
-			// Other items can be skipped as they don't participate in Read/Metadata.
+			// Only default communication items are exposed as virtual fields.
 			continue
 		}
 
@@ -53,13 +73,618 @@ func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // 
 		}
 	}
 
-	// Move communication items to the top root level.
+	// Merge extracted fields into the top-level record.
 	maps.Copy(root, fields)
 
 	return nil
 }
 
-// readCommunicationItem is returned by contact as elements of `communicationItems` array.
+// payloadWithCommunicationItems rewrites the write payload for a contact record
+// so that virtual communication-item fields are translated into a proper
+// `communicationItems` array for ConnectWise.
+//
+// It:
+//   - Builds a communicationItemsIntent from the incoming record.
+//   - Fetches any missing communication type IDs if required.
+//   - Constructs a `communicationItems` array containing only the default
+//     email/phone/fax items specified in the intent.
+//   - Sets this array on record["communicationItems"].
+//
+// If the record is nil or the intent is empty (no communication fields set),
+// the function returns without modifying the record.
+func (c *Connector) payloadWithCommunicationItems(ctx context.Context, record common.Record) error {
+	if record == nil {
+		// No record to modify; nothing to do.
+		return nil
+	}
+
+	intent, err := createCommunicationItemsIntent(record)
+	if err != nil {
+		return err
+	}
+
+	if intent.isEmpty() {
+		// No communication-item fields present in the record; no-op.
+		return nil
+	}
+
+	if intent.needIds() {
+		if err = c.fetchMissingCommunicationItemIds(ctx, intent); err != nil {
+			return err
+		}
+	}
+
+	communicationItems := make([]createCommunicationItemPayload, 0)
+
+	if intent.DefaultEmail != "" {
+		communicationItems = append(communicationItems, createCommunicationItemPayload{
+			Type:              communicationItemTypePayload{Id: intent.DefaultEmailId},
+			Value:             intent.DefaultEmail,
+			DefaultFlag:       true,
+			CommunicationType: communicationTypeEmail,
+		})
+	}
+
+	if intent.DefaultPhone != "" {
+		communicationItems = append(communicationItems, createCommunicationItemPayload{
+			Type:              communicationItemTypePayload{Id: intent.DefaultPhoneId},
+			Value:             intent.DefaultPhone,
+			DefaultFlag:       true,
+			CommunicationType: communicationTypePhone,
+		})
+	}
+
+	if intent.DefaultFax != "" {
+		communicationItems = append(communicationItems, createCommunicationItemPayload{
+			Type:              communicationItemTypePayload{Id: intent.DefaultFaxId},
+			Value:             intent.DefaultFax,
+			DefaultFlag:       true,
+			CommunicationType: communicationTypeFax,
+		})
+	}
+
+	record["communicationItems"] = communicationItems
+
+	return nil
+}
+
+// patchPayloadWithCommunicationItems transforms a list of JSON Patch operations
+// that may include virtual communication-item fields into a list of operations
+// that target ConnectWise's actual `communicationItems` array.
+//
+// It:
+//   - Separates virtual-field operations from real-field operations using
+//     createCommunicationItemsIntentForPatch.
+//   - Fetches the current contact to inspect existing communicationItems.
+//   - Builds a registry (type ID -> index) for existing items and attempts to
+//     resolve default item IDs per type from the contact response.
+//   - Fetches any still-missing communication type IDs from the company's
+//     communication types endpoint.
+//   - Generates concrete JSON Patch operations (add/replace/remove) for
+//     email/phone/fax based on the intent and current state.
+//
+// The returned slice contains:
+//   - All non-communication operations from the original input.
+//   - Additional JSON Patch operations targeting `/communicationItems` and its
+//     children to realize the desired email/phone/fax changes.
+//
+// This function is ConnectWise logic-specific because it relies on ConnectWise's
+// behavior around defaultFlag and array indexing when constructing patches.
+func (c *Connector) patchPayloadWithCommunicationItems(ctx context.Context, // nolint:cyclop
+	input []patchOperationPayload,
+	contactId string,
+) ([]patchOperationPayload, error) {
+	// Separate virtual-field ops from real ops and build the intent.
+	operations, intent, err := createCommunicationItemsIntentForPatch(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if intent.isEmpty() {
+		// No communication-item changes requested; return original operations.
+		return operations, nil
+	}
+
+	contact, err := c.fetchContact(ctx, contactId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a registry: communication type ID -> index in contact.Items.
+	// This lets us generate replace/remove operations by index.
+	itemsRegistry := make(map[string]int)
+
+	for index, item := range contact.Items {
+		identifier := item.Type.Id.String()
+		itemsRegistry[identifier] = index
+
+		if item.DefaultFlag {
+			switch item.CommunicationType {
+			case communicationTypeEmail:
+				if intent.needEmailId() || intent.RemoveEmail {
+					intent.DefaultEmailId = identifier
+				}
+			case communicationTypePhone:
+				if intent.needPhoneId() || intent.RemovePhone {
+					intent.DefaultPhoneId = identifier
+				}
+			case communicationTypeFax:
+				if intent.needFaxId() || intent.RemoveFax {
+					intent.DefaultFaxId = identifier
+				}
+			}
+		}
+	}
+
+	// Fetch any still-missing communication type IDs from /company/communicationTypes.
+	if intent.needIds() {
+		if err = c.fetchMissingCommunicationItemIds(ctx, intent); err != nil {
+			return nil, err
+		}
+	}
+
+	// Generate concrete JSON Patch operations for communicationItems.
+	operations = append(operations, allJsonPatchOperations(intent, contact, itemsRegistry)...)
+
+	return operations, nil
+}
+
+// createCommunicationItemsIntentForParse extracts communication-item intent from
+// a list of JSON Patch operations that may reference virtual fields.
+//
+// It scans each operation's Path for known virtual-fields
+// For each recognized virtual field:
+//   - It updates the corresponding field in communicationItemsIntent.
+//   - For "remove" operations on value fields, it sets the Remove* flags.
+//
+// Recognized operations are removed from the returned slice; unrecognized
+// operations are returned as-is in `filtered`.
+//
+// Returns:
+//   - filtered: operations that do not pertain to communication items.
+//   - intent: populated communicationItemsIntent describing desired changes.
+//   - err: any error encountered while parsing virtual field values.
+func createCommunicationItemsIntentForPatch( // nolint:cyclop
+	input []patchOperationPayload,
+) ([]patchOperationPayload, *communicationItemsIntent, error) {
+	intent := &communicationItemsIntent{}
+	filtered := make([]patchOperationPayload, 0, len(input))
+
+	var err error
+
+	for _, item := range input {
+		path, _ := strings.CutPrefix(item.Path, "/")
+		switch path {
+		case virtualFieldContactEmail:
+			intent.DefaultEmail, err = virtualFieldStringValue(item.Value, path)
+			if item.Op == operationRemove {
+				intent.RemoveEmail = true
+			}
+		case virtualFieldContactEmailId:
+			intent.DefaultEmailId, err = virtualFieldStringValue(item.Value, path)
+		case virtualFieldContactFax:
+			intent.DefaultFax, err = virtualFieldStringValue(item.Value, path)
+			if item.Op == operationRemove {
+				intent.RemoveFax = true
+			}
+		case virtualFieldContactFaxId:
+			intent.DefaultFaxId, err = virtualFieldStringValue(item.Value, path)
+		case virtualFieldContactPhone:
+			intent.DefaultPhone, err = virtualFieldStringValue(item.Value, path)
+			if item.Op == operationRemove {
+				intent.RemovePhone = true
+			}
+		case virtualFieldContactPhoneId:
+			intent.DefaultPhoneId, err = virtualFieldStringValue(item.Value, path)
+		default:
+			filtered = append(filtered, item)
+		}
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return filtered, intent, nil
+}
+
+// fetchContact retrieves a single contact record from ConnectWise by ID.
+func (c *Connector) fetchContact(ctx context.Context, contactId string) (*readContactResponse, error) {
+	url, err := c.getURL(objectNameContacts)
+	if err != nil {
+		return nil, err
+	}
+
+	url.AddPath(contactId)
+
+	res, err := c.JSONHTTPClient().Get(ctx, url.String(), c.clientIdHeader())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.UnmarshalJSON[readContactResponse](res)
+}
+
+// fetchMissingCommunicationItemIds populates missing communication type IDs in
+// the intent by querying /company/communicationTypes with defaultFlag=true.
+//
+// For each communication type (email/phone/fax) where:
+//   - The intent has a value but no ID, and
+//   - The communication type response indicates that type is default,
+//
+// the corresponding Default*Id field in intent is set.
+//
+// This is used when the caller provides only the value (e.g. email address)
+// but not the ConnectWise-specific type ID.
+func (c *Connector) fetchMissingCommunicationItemIds(ctx context.Context, //nolint:cyclop
+	intent *communicationItemsIntent,
+) error {
+	url, err := c.getCommunicationTypesURL()
+	if err != nil {
+		return err
+	}
+
+	url.WithQueryParam("conditions", "defaultFlag=true")
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String(), c.clientIdHeader())
+	if err != nil {
+		return err
+	}
+
+	types, err := common.UnmarshalJSON[communicationTypesResponse](resp)
+	if err != nil {
+		return err
+	}
+
+	// Assign IDs for fields that have a value but are missing an ID.
+	for _, item := range *types {
+		if item.EmailFlag && intent.needEmailId() {
+			intent.DefaultEmailId = item.Id.String()
+
+			continue
+		}
+
+		if item.PhoneFlag && intent.needPhoneId() {
+			intent.DefaultPhoneId = item.Id.String()
+
+			continue
+		}
+
+		if item.FaxFlag && intent.needFaxId() {
+			intent.DefaultFaxId = item.Id.String()
+
+			continue
+		}
+	}
+
+	return nil
+}
+
+// allJsonPatchOperations builds the JSON Patch operations needed to transform
+// contact communication items to match intent.
+//
+// Operation ordering is important because removing an item shifts the indexes
+// of all subsequent items in communicationItems:
+//   - Add/replace operations are emitted first, while the original item indexes
+//     are still valid.
+//   - Remove operations are emitted last, so their index shifts cannot affect
+//     any add/replace operations.
+//   - Remove operations are sorted by descending removeIndex, so removing an
+//     item does not change the index of any item that is still scheduled for
+//     removal. Removing from the beginning would shift the indexes of all
+//     subsequent items and invalidate their removeIndex values.
+//
+// ConnectWise-specific behavior also affects where additions are placed:
+//   - ConnectWise appends an item even when the operation specifies index 0.
+//   - Targeting an addition at index 0 does not respect DefaultFlag.
+//   - To ensure DefaultFlag is respected, new items must explicitly be added
+//     at the end of communicationItems.
+//
+// Returns a single ordered slice of patch operations for the PATCH request.
+func allJsonPatchOperations(intent *communicationItemsIntent,
+	contact *readContactResponse,
+	itemsRegistry map[string]int,
+) (output []patchOperationPayload) {
+	// Generate operations for each communication type.
+	opEmail, removeEmail := makeJsonPatchOperations(intent.DefaultEmailId, intent.DefaultEmail,
+		intent.RemoveEmail, communicationTypeEmail, contact.Items, itemsRegistry)
+	opPhone, removePhone := makeJsonPatchOperations(intent.DefaultPhoneId, intent.DefaultPhone,
+		intent.RemovePhone, communicationTypePhone, contact.Items, itemsRegistry)
+	opFax, removeFax := makeJsonPatchOperations(intent.DefaultFaxId, intent.DefaultFax,
+		intent.RemoveFax, communicationTypeFax, contact.Items, itemsRegistry)
+
+	// Execute "add/replace" operations before removals. Removing an item is the
+	// only operation here that shifts the indexes of existing items, so all
+	// index-dependent replace operations must be completed first.
+	//
+	// ConnectWise-specific behavior:
+	//   - Specifying index 0 still causes the item to be appended to the end.
+	//   - However, DefaultFlag is not respected when index 0 is specified.
+	//   - Therefore, new items are explicitly added at the end of the array.
+	output = append(output, opEmail...)
+	output = append(output, opPhone...)
+	output = append(output, opFax...)
+
+	var opRemove []patchOperationPayload
+
+	opRemove = append(opRemove, removeEmail...)
+	opRemove = append(opRemove, removePhone...)
+	opRemove = append(opRemove, removeFax...)
+
+	sort.Slice(opRemove, func(i, j int) bool {
+		// Remove from the highest index to the lowest. Removing a later item
+		// shifts only indexes after it, so it cannot change the index of an
+		// earlier item that is still scheduled for removal. Removing in the
+		// opposite order would shift all subsequent removeIndex values.
+		return opRemove[i].removeIndex > opRemove[j].removeIndex
+	})
+
+	output = append(output, opRemove...)
+
+	return output
+}
+
+// makeJsonPatchOperations generates JSON Patch operations for a single
+// communication type (email/phone/fax) based on the desired value and current state.
+//
+// Parameters:
+//   - identifier: communication type ID (e.g. "4" for a specific phone type).
+//   - value: desired value (email address, phone number, etc.).
+//   - isRemove: true if the caller wants to remove this communication item.
+//   - communicationType: one of Email/Phone/Fax.
+//   - items: current communicationItems from the contact.
+//   - itemsRegistry: map from "type ID" -> to "index in items".
+//
+// Returns:
+//   - ops: add/replace operations for this communication type (it may be empty).
+//   - removes: remove operations for this communication type (it may be empty).
+//
+// Behavior:
+//   - If the identifier is not found in itemsRegistry:
+//   - For remove: no operations (nothing to remove).
+//   - For add/update: generate an "add" operation that appends a new item
+//     to the end of communicationItems (index = len(items)).
+//   - If the identifier exists:
+//   - For remove: generate a "remove" operation for that index.
+//   - For update:
+//   - Generate a "replace" for /value if identifier is non-empty.
+//   - If the existing item is not marked as default, generate a "replace"
+//     for /defaultFlag to mark it as default.
+//
+// ConnectWise-specific note:
+//   - New items must be appended (not inserted at index 0) for DefaultFlag
+//     to be respected by the provider.
+func makeJsonPatchOperations(identifier string,
+	value string,
+	isRemove bool,
+	communicationType string,
+	items []readCommunicationItem,
+	itemsRegistry map[string]int,
+) ([]patchOperationPayload, []patchOperationPayload) {
+	index, exists := itemsRegistry[identifier]
+	if !exists {
+		if isRemove {
+			// Identifier not present; nothing to remove.
+			return nil, nil
+		}
+
+		// Create a new communication item by appending to the end of the array.
+		// This is required for ConnectWise to honor DefaultFlag.
+		return []patchOperationPayload{{
+			Op:   operationAdd,
+			Path: fmt.Sprintf("/communicationItems/%v", len(items)),
+			Value: createCommunicationItemPayload{
+				Type: communicationItemTypePayload{
+					Id: identifier,
+				},
+				Value:             value,
+				DefaultFlag:       true,
+				CommunicationType: communicationType,
+			},
+		}}, nil
+	}
+
+	// Existing item found; decide between remove or update.
+	if isRemove {
+		// Remove the entire communication item at this index.
+		return nil, []patchOperationPayload{{
+			Op:          operationRemove,
+			Path:        fmt.Sprintf("/communicationItems/%v", index),
+			removeIndex: index,
+		}}
+	}
+
+	// Update existing item.
+	output := make([]patchOperationPayload, 0)
+	if identifier != "" {
+		output = append(output, patchOperationPayload{
+			Op:    operationReplace,
+			Path:  fmt.Sprintf("/communicationItems/%v/value", index),
+			Value: value,
+		})
+	}
+
+	if !items[index].DefaultFlag {
+		// Mark this item as the default for its type.
+		output = append(output, patchOperationPayload{
+			Op:    operationReplace,
+			Path:  fmt.Sprintf("/communicationItems/%v/defaultFlag", index),
+			Value: true,
+		})
+	}
+
+	return output, nil
+}
+
+// communicationItemsIntent represents the desired changes to a contact's
+// communication items (email, phone, fax) expressed via virtual fields.
+//
+// It captures:
+//   - Desired default values and their type IDs for each communication type.
+//   - Flags indicating whether a particular type should be removed.
+//
+// This struct is used internally to translate virtual-field-based writes
+// into concrete JSON Patch operations against ConnectWise's contact endpoint
+// as well as for POST/PUT REST methods.
+type communicationItemsIntent struct {
+	DefaultPhone   string
+	DefaultPhoneId string
+	DefaultEmail   string
+	DefaultEmailId string
+	DefaultFax     string
+	DefaultFaxId   string
+	RemovePhone    bool
+	RemoveEmail    bool
+	RemoveFax      bool
+}
+
+// createCommunicationItemsIntent builds a communicationItemsIntent from a record
+// by extracting virtual communication-item fields.
+//
+// It extracts:
+//   - Default email, phone, and fax values and their type IDs.
+//
+// Recognized virtual fields are removed from the record as they are processed.
+// If a virtual field has an invalid type or format, an error is returned.
+func createCommunicationItemsIntent(record common.Record) (*communicationItemsIntent, error) { // nolint:cyclop,funlen
+	intent := &communicationItemsIntent{}
+
+	// Extract default communication fields and their IDs.
+	var err error
+
+	intent.DefaultEmail, err = extractAndRemoveVirtualField(record, virtualFieldContactEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	intent.DefaultEmailId, err = extractAndRemoveVirtualField(record, virtualFieldContactEmailId)
+	if err != nil {
+		return nil, err
+	}
+
+	intent.DefaultPhone, err = extractAndRemoveVirtualField(record, virtualFieldContactPhone)
+	if err != nil {
+		return nil, err
+	}
+
+	intent.DefaultPhoneId, err = extractAndRemoveVirtualField(record, virtualFieldContactPhoneId)
+	if err != nil {
+		return nil, err
+	}
+
+	intent.DefaultFax, err = extractAndRemoveVirtualField(record, virtualFieldContactFax)
+	if err != nil {
+		return nil, err
+	}
+
+	intent.DefaultFaxId, err = extractAndRemoveVirtualField(record, virtualFieldContactFaxId)
+	if err != nil {
+		return nil, err
+	}
+
+	return intent, nil
+}
+
+// extractAndRemoveVirtualField extracts a virtual field value from the record
+// as a string and then removes the field from the record.
+//
+// This ensures that virtual fields do not leak into the final payload sent to
+// ConnectWise; they are only used to drive intent generation.
+func extractAndRemoveVirtualField(record common.Record, virtualFieldName string) (string, error) {
+	value, found := record[virtualFieldName]
+	if !found {
+		return "", nil
+	}
+
+	output, err := virtualFieldStringValue(value, virtualFieldName)
+	if err != nil {
+		return "", err
+	}
+
+	// Remove the virtual field from the record so it doesn't appear in the payload.
+	delete(record, virtualFieldName)
+
+	return output, nil
+}
+
+// virtualFieldStringValue converts a virtual field value to a string, allowing nil.
+//
+// If value is nil, it returns ("", nil) to represent a removed or unset field.
+// If value is a string, it returns that string.
+// Otherwise, it returns an error indicating an invalid virtual field type.
+func virtualFieldStringValue(value any, virtualFieldName string) (string, error) {
+	if value == nil {
+		// Nil is allowed for remove operations; treat as empty.
+		return "", nil
+	}
+
+	output, ok := value.(string)
+	if ok {
+		return output, nil
+	}
+
+	return "", fmt.Errorf("%w: field %v is not a string",
+		common.ErrInvalidVirtualField, virtualFieldName)
+}
+
+// isEmpty reports whether the intent specifies any communication-item changes.
+//
+// It returns true if all value and ID fields are empty.
+// In practice, callers check isEmpty before proceeding with communication-item logic.
+func (i communicationItemsIntent) isEmpty() bool {
+	return i.DefaultPhoneId == "" &&
+		i.DefaultEmailId == "" &&
+		i.DefaultFaxId == "" &&
+		i.DefaultPhone == "" &&
+		i.DefaultEmail == "" &&
+		i.DefaultFax == ""
+}
+
+// needIds reports whether any communication type has a value but is missing its
+// corresponding type ID.
+//
+// This is used to decide whether to call fetchMissingCommunicationItemIds.
+func (i communicationItemsIntent) needIds() bool {
+	return i.needEmailId() || i.needPhoneId() || i.needFaxId()
+}
+
+// needEmailId reports whether email value is set but email type ID is missing.
+func (i communicationItemsIntent) needEmailId() bool {
+	return i.DefaultEmail != "" && i.DefaultEmailId == ""
+}
+
+// needPhoneId reports whether phone value is set but phone type ID is missing.
+func (i communicationItemsIntent) needPhoneId() bool {
+	return i.DefaultPhone != "" && i.DefaultPhoneId == ""
+}
+
+// needFaxId reports whether fax value is set but fax type ID is missing.
+func (i communicationItemsIntent) needFaxId() bool {
+	return i.DefaultFax != "" && i.DefaultFaxId == ""
+}
+
+// communicationTypesResponse is the response from the `/company/communicationTypes`
+// endpoint. It is a list of communication type definitions, each indicating which
+// channels (email/phone/fax) it applies to and whether it is the default type.
+type communicationTypesResponse []communicationTypeResponse
+
+type communicationTypeResponse struct {
+	Id          naming.Text `json:"id"`
+	Description string      `json:"description"`
+	PhoneFlag   bool        `json:"phoneFlag"`
+	FaxFlag     bool        `json:"faxFlag"`
+	EmailFlag   bool        `json:"emailFlag"`
+	DefaultFlag bool        `json:"defaultFlag"`
+}
+
+// readContactResponse represents the subset of the contact read response that
+// includes the `communicationItems` array.
+type readContactResponse struct {
+	Items []readCommunicationItem `json:"communicationItems"`
+}
+
+// readCommunicationItem represents a single element of the `communicationItems`
+// array returned when reading a contact from ConnectWise.
 type readCommunicationItem struct {
 	Id   int `json:"id"`
 	Type struct {
@@ -70,4 +695,22 @@ type readCommunicationItem struct {
 	Value             any    `json:"value"`
 	DefaultFlag       bool   `json:"defaultFlag"`
 	CommunicationType string `json:"communicationType"`
+}
+
+// createCommunicationItemPayload represents a communication item as it should
+// be sent when creating or updating a contact's communicationItems via PATCH/POST.
+type createCommunicationItemPayload struct {
+	Type              communicationItemTypePayload `json:"type"`
+	Value             string                       `json:"value"`
+	DefaultFlag       bool                         `json:"defaultFlag"`
+	CommunicationType string                       `json:"communicationType"`
+}
+
+// communicationItemTypePayload describes the communication type for a
+// create/update payload. The ID is sent as a string, even though read responses
+// may return it as an integer.
+type communicationItemTypePayload struct {
+	// Id is sent as a string in write payloads.
+	// Read responses may return it as an int.
+	Id string `json:"id"`
 }

--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -115,6 +115,10 @@ func (c *Connector) getURL(objectName string) (*urlbuilder.URL, error) {
 	return urlbuilder.New(c.ModuleInfo().BaseURL, apiVersion, objectPath)
 }
 
+func (c *Connector) getCommunicationTypesURL() (*urlbuilder.URL, error) {
+	return urlbuilder.New(c.ModuleInfo().BaseURL, apiVersion, "company/communicationTypes")
+}
+
 func (c *Connector) clientIdHeader() common.Header {
 	return common.Header{
 		Key:   "ClientId",

--- a/providers/connectwise/custom.go
+++ b/providers/connectwise/custom.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -76,6 +77,40 @@ func (c *Connector) requestCustomFields(
 	}
 
 	return fields, nil
+}
+
+func payloadWithCustomFields(record common.Record) {
+	if record == nil {
+		// No-op. Nothing to modify.
+		return
+	}
+
+	customFields := make([]map[string]any, 0)
+
+	for key, value := range record {
+		if key == "customFields" {
+			continue
+		}
+
+		if fieldIdStr, ok := strings.CutPrefix(key, "customField"); ok {
+			fieldId, err := strconv.Atoi(fieldIdStr)
+			if err != nil {
+				continue
+			}
+
+			// This is in-house field, shouldn't be part of actual payload.
+			delete(record, key)
+
+			customFields = append(customFields, map[string]any{
+				"id":    fieldId,
+				"value": value,
+			})
+		}
+	}
+
+	if len(customFields) != 0 {
+		record["customFields"] = customFields
+	}
 }
 
 // objectsSupportingCustomFields lists ConnectWise object names that can include customFields in read responses.

--- a/providers/connectwise/test/write/contacts/payload-post.json
+++ b/providers/connectwise/test/write/contacts/payload-post.json
@@ -1,0 +1,30 @@
+{
+  "firstName": "Estella",
+  "lastName": "Mcdowell",
+  "communicationItems": [
+    {
+      "type": {
+        "id": "13"
+      },
+      "value": "professional.bob@test.com",
+      "defaultFlag": true,
+      "communicationType": "Email"
+    },
+    {
+      "type": {
+        "id": "2"
+      },
+      "value": "+380001000",
+      "defaultFlag": true,
+      "communicationType": "Phone"
+    },
+    {
+      "type": {
+        "id": "3"
+      },
+      "value": "+99969",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  ]
+}

--- a/providers/connectwise/test/write/contacts/payload-put.json
+++ b/providers/connectwise/test/write/contacts/payload-put.json
@@ -1,0 +1,30 @@
+{
+  "firstName": "Estella",
+  "lastName": "Mcdowell",
+  "communicationItems": [
+    {
+      "type": {
+        "id": "1"
+      },
+      "value": "professional.bob.updated@test.com",
+      "defaultFlag": true,
+      "communicationType": "Email"
+    },
+    {
+      "type": {
+        "id": "2"
+      },
+      "value": "+380111358",
+      "defaultFlag": true,
+      "communicationType": "Phone"
+    },
+    {
+      "type": {
+        "id": "26"
+      },
+      "value": "+77767",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  ]
+}

--- a/providers/connectwise/test/write/contacts/scenario1/1-before.json
+++ b/providers/connectwise/test/write/contacts/scenario1/1-before.json
@@ -1,0 +1,44 @@
+{
+  "communicationItems": [
+    {
+      "id": 99820,
+      "type": {
+        "id": 13,
+        "name": "Individual Professional",
+        "_info": {
+          "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/13"
+        }
+      },
+      "value": "professional.bob@test.com",
+      "defaultFlag": true,
+      "domain": "@test.com",
+      "communicationType": "Email"
+    },
+    {
+      "id": 99821,
+      "type": {
+        "id": 2,
+        "name": "Phone - Direct",
+        "_info": {
+          "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/2"
+        }
+      },
+      "value": "+380001000",
+      "defaultFlag": true,
+      "communicationType": "Phone"
+    },
+    {
+      "id": 99822,
+      "type": {
+        "id": 3,
+        "name": "Fax - Work",
+        "_info": {
+          "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/3"
+        }
+      },
+      "value": "+99969",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  ]
+}

--- a/providers/connectwise/test/write/contacts/scenario1/2-patch.json
+++ b/providers/connectwise/test/write/contacts/scenario1/2-patch.json
@@ -1,0 +1,19 @@
+[
+  {
+    "op": "replace",
+    "path": "/communicationItems/1/value",
+    "value": "+380111358"
+  },
+  {
+    "op": "add",
+    "path": "/communicationItems/3",
+    "value": {
+      "type": {
+        "id": "26"
+      },
+      "value": "+77767",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  }
+]

--- a/providers/connectwise/test/write/contacts/scenario1/3-after.json
+++ b/providers/connectwise/test/write/contacts/scenario1/3-after.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": 99820,
+    "type": {
+      "id": 13,
+      "name": "Individual Professional",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/13"
+      }
+    },
+    "value": "professional.bob@test.com",
+    "defaultFlag": true,
+    "domain": "@test.com",
+    "communicationType": "Email"
+  },
+  {
+    "id": 99821,
+    "type": {
+      "id": 2,
+      "name": "Phone - Direct",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/2"
+      }
+    },
+    "value": "+380111358",
+    "defaultFlag": true,
+    "communicationType": "Phone"
+  },
+  {
+    "id": 99822,
+    "type": {
+      "id": 3,
+      "name": "Fax - Work",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/3"
+      }
+    },
+    "value": "+99969",
+    "defaultFlag": false,
+    "communicationType": "Fax"
+  },
+  {
+    "id": 99823,
+    "type": {
+      "id": 26,
+      "name": "Work Fax",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/26"
+      }
+    },
+    "value": "+77767",
+    "defaultFlag": true,
+    "communicationType": "Fax"
+  }
+]

--- a/providers/connectwise/test/write/contacts/scenario2/1-before.json
+++ b/providers/connectwise/test/write/contacts/scenario2/1-before.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": 99855,
+    "type": {
+      "id": 13,
+      "name": "Individual Professional",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/13"
+      }
+    },
+    "value": "professional.bob@test.com",
+    "defaultFlag": true,
+    "domain": "@test.com",
+    "communicationType": "Email"
+  },
+  {
+    "id": 99856,
+    "type": {
+      "id": 2,
+      "name": "Phone - Direct",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/2"
+      }
+    },
+    "value": "+380001000",
+    "defaultFlag": true,
+    "communicationType": "Phone"
+  },
+  {
+    "id": 99857,
+    "type": {
+      "id": 3,
+      "name": "Fax - Work",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/3"
+      }
+    },
+    "value": "+99969",
+    "defaultFlag": true,
+    "communicationType": "Fax"
+  }
+]

--- a/providers/connectwise/test/write/contacts/scenario2/2-patch.json
+++ b/providers/connectwise/test/write/contacts/scenario2/2-patch.json
@@ -1,0 +1,23 @@
+[
+  {
+    "op": "replace",
+    "path": "/communicationItems/1/value",
+    "value": "+380111358"
+  },
+  {
+    "op": "add",
+    "path": "/communicationItems/3",
+    "value": {
+      "type": {
+        "id": "26"
+      },
+      "value": "+77767",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/communicationItems/0"
+  }
+]

--- a/providers/connectwise/test/write/contacts/scenario2/3-after.json
+++ b/providers/connectwise/test/write/contacts/scenario2/3-after.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": 99856,
+    "type": {
+      "id": 2,
+      "name": "Phone - Direct",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/2"
+      }
+    },
+    "value": "+380111358",
+    "defaultFlag": true,
+    "communicationType": "Phone"
+  },
+  {
+    "id": 99857,
+    "type": {
+      "id": 3,
+      "name": "Fax - Work",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/3"
+      }
+    },
+    "value": "+99969",
+    "defaultFlag": false,
+    "communicationType": "Fax"
+  },
+  {
+    "id": 99858,
+    "type": {
+      "id": 26,
+      "name": "Work Fax",
+      "_info": {
+        "type_href": "https://sandbox-na.myconnectwise.net/v4_6_release/apis/3.0//company/communicationTypes/26"
+      }
+    },
+    "value": "+77767",
+    "defaultFlag": true,
+    "communicationType": "Fax"
+  }
+]

--- a/providers/connectwise/write.go
+++ b/providers/connectwise/write.go
@@ -1,3 +1,6 @@
+// Package connectwise implements the ConnectWise provider connector, handling
+// object reads, writes, and provider-specific quirks (custom fields,
+// communication items, JSON Patch behavior, etc.).
 package connectwise
 
 import (
@@ -14,13 +17,14 @@ import (
 	"github.com/amp-labs/connectors/internal/jsonquery"
 )
 
+// buildWriteRequest constructs an HTTP request for a write operation (create or update) against a ConnectWise object.
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
 	url, err := c.getURL(params.ObjectName)
 	if err != nil {
 		return nil, err
 	}
 
-	data, method, err := makeWritePayload(params, url)
+	data, method, err := c.makeWritePayload(ctx, params, url)
 	if err != nil {
 		return nil, err
 	}
@@ -40,94 +44,177 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 	return req, nil
 }
 
-// Returns payload, http method and modifies URL to include the record id in its path for update write case.
-func makeWritePayload(params common.WriteParams, url *urlbuilder.URL) (any, string, error) {
+// makeWritePayload builds the write payload and HTTP method for a create or
+// update operation, and adjusts the URL as needed.
+func (c *Connector) makeWritePayload(ctx context.Context,
+	params common.WriteParams,
+	url *urlbuilder.URL,
+) (any, string, error) {
 	if params.IsUpdate() {
 		url.AddPath(params.RecordId)
 
-		return makeWriteUpdatePayload(params)
+		return c.makeWriteUpdatePayload(ctx, params)
 	}
 
-	return makeWriteCreatePayload(params)
+	return c.makeWriteCreatePayload(ctx, params)
 }
 
-func makeWriteCreatePayload(params common.WriteParams) (any, string, error) {
+// makeWriteCreatePayload builds a create (POST) payload for the given object.
+//
+// It:
+//   - Extracts the record from params.
+//   - Applies custom-field normalization via payloadWithCustomFields.
+//   - For contacts, enriches the record with communication items by translating
+//     virtual fields into a proper `communicationItems` array.
+//
+// Returns the record, http.MethodPost, and any error encountered.
+func (c *Connector) makeWriteCreatePayload(ctx context.Context, params common.WriteParams) (any, string, error) {
 	record, err := params.GetRecord()
+	if err != nil {
+		return nil, "", err
+	}
+
 	payloadWithCustomFields(record)
 
-	return record, http.MethodPost, err
-}
-
-func payloadWithCustomFields(record common.Record) {
-	if record == nil {
-		// No-op. Nothing to modify.
-		return
-	}
-
-	customFields := make([]map[string]any, 0)
-
-	for key, value := range record {
-		if key == "customFields" {
-			continue
-		}
-
-		if fieldIdStr, ok := strings.CutPrefix(key, "customField"); ok {
-			fieldId, err := strconv.Atoi(fieldIdStr)
-			if err != nil {
-				continue
-			}
-
-			// This is in-house field, shouldn't be part of actual payload.
-			delete(record, key)
-
-			customFields = append(customFields, map[string]any{
-				"id":    fieldId,
-				"value": value,
-			})
+	if params.ObjectName == objectNameContacts {
+		if err = c.payloadWithCommunicationItems(ctx, record); err != nil {
+			return nil, "", err
 		}
 	}
 
-	if len(customFields) != 0 {
-		record["customFields"] = customFields
-	}
+	return record, http.MethodPost, nil
 }
 
-// By contract, WriteParams.RecordData holds the JSON payload.
-// For updates, we may need to switch to PATCH (JSON Patch) or use PUT (replace).
-func makeWriteUpdatePayload(params common.WriteParams) (any, string, error) {
-	// If the incoming WriteParams.RecordData represents a JSON Patch payload, we must use HTTP PATCH.
-	// Important: the connector's internal contract requires RecordData
-	// to be a JSON object, not a top-level JSON array.
-	// However, ConnectWise provider expects a PATCH body as a bare JSON array.
+// makeWriteUpdatePayload builds an update payload for the given object.
+//
+// By contract, params.RecordData holds the JSON payload for the update.
+// For updates, we may:
+//   - Use HTTP PATCH with a JSON Patch array when the caller provides a
+//     patch-style payload.
+//   - Use HTTP PUT (full replacement) for regular object payloads.
+//
+// Behavior:
+//   - If the payload is detected as a JSON Patch (via extractPatchPayload),
+//     the function:
+//   - Normalizes custom fields for the patch (payloadPatchWithCustomFields).
+//   - For contacts, translates virtual communication-item fields into
+//     concrete JSON Patch operations targeting `communicationItems`.
+//   - Returns the resulting patch array and http.MethodPatch.
+//   - Otherwise, it:
+//   - Extracts the record, applies custom-field normalization.
+//   - For contacts with `communicationItems`, works around a ConnectWise
+//     validation bug by clearing `communicationItems` via a preliminary
+//     PATCH before performing the PUT.
+//   - Returns the record and http.MethodPut.
+//
+// ConnectWise-specific notes:
+//   - PATCH body must be a bare JSON array of operations, not wrapped in an
+//     object.
+//   - Contacts: including `communicationItems` in a PUT can trigger spurious
+//     validation errors; we clear them out first via PATCH.
+func (c *Connector) makeWriteUpdatePayload(ctx context.Context, params common.WriteParams) (any, string, error) {
+	// Detect JSON Patch payloads and use HTTP PATCH if present.
 	if payload, ok := extractPatchPayload(params); ok {
 		data := payloadPatchWithCustomFields(params.ObjectName, payload.Patch)
+
+		if params.ObjectName == objectNameContacts {
+			items, err := c.patchPayloadWithCommunicationItems(ctx, data, params.RecordId)
+
+			return items, http.MethodPatch, err
+		}
 
 		return data, http.MethodPatch, nil
 	}
 
+	// Regular object payload: use PUT.
 	record, err := params.GetRecord()
+	if err != nil {
+		return nil, "", err
+	}
+
 	payloadWithCustomFields(record)
 
-	return record, http.MethodPut, err
+	if params.ObjectName == objectNameContacts {
+		if err = c.payloadWithCommunicationItems(ctx, record); err != nil {
+			return nil, "", err
+		}
+
+		if _, ok := record["communicationItems"]; ok {
+			// Work around ConnectWise validation bug for contacts:
+			// Including communicationItems in a PUT may cause a 400 even when
+			// the items are valid. Since PUT is a full replacement, we clear
+			// communicationItems first via PATCH, then proceed with the PUT.
+			if err = c.clearContactCommunicationItems(ctx, params); err != nil {
+				return nil, "", err
+			}
+		}
+	}
+
+	return record, http.MethodPut, nil
 }
 
-// payloadPatchWithCustomFields normalizes PATCH payloads for objects that support custom fields.
+// clearContactCommunicationItems removes all communication items from a contact
+// via a preliminary PATCH before a full PUT update.
 //
-// ConnectWise has an unusual requirement for PATCH requests: if an object supports custom fields,
-// the request must include the customFields container, otherwise the API returns 400 Bad Request.
-// To satisfy this requirement, this function always emits a /customFields replace operation for
-// supported objects, even when the caller is only updating non-custom-field properties.
+// This is required due to a ConnectWise validation bug: when `communicationItems`
+// are present in a PUT request for a contact, the API may reject the payload as
+// invalid even if the items are correct. Clearing them first avoids this issue.
 //
-// Individual patch operations targeting custom fields are converted into entries in the
-// /customFields array in the form {id, value}. Only the fields explicitly mentioned are included.
-// Unlike the ConnectWise documentation suggests, omitting a custom field from the array does not
-// wipe it out, and sending an empty array does not clear existing custom field values.
+// The function performs a single PATCH with:
+//   - "remove" operation for `/communicationItems`.
+//   - "replace" operation for `/customFields` with an empty array to satisfy
+//     ConnectWise's validation requirements for custom fields.
+func (c *Connector) clearContactCommunicationItems(ctx context.Context,
+	params common.WriteParams,
+) error {
+	url, err := c.getURL(objectNameContacts)
+	if err != nil {
+		return err
+	}
+
+	url.AddPath(params.RecordId)
+
+	if _, err = c.JSONHTTPClient().Patch(ctx, url.String(), []map[string]any{
+		{
+			"op":   "remove",
+			"path": "/communicationItems",
+		},
+		{
+			"op":    "replace",
+			"path":  "/customFields",
+			"value": []any{},
+		},
+	}, c.clientIdHeader()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// payloadPatchWithCustomFields normalizes JSON Patch payloads for objects that
+// support custom fields.
 //
-// For objects that do not support custom fields, the payload is returned unchanged.
-// Non-custom-field patch operations are preserved as-is.
+// ConnectWise requires that PATCH requests for such objects include a
+// `/customFields` replace operation; otherwise the API may return 400 Bad
+// Request, even if custom fields are not being modified.
+//
+// This function:
+//   - Leaves payloads unchanged for objects that do not support custom fields.
+//   - For supported objects:
+//   - Extracts individual patch operations targeting custom field paths
+//     (e.g. `/customField1`, `/customField2`) and converts them into entries
+//     in a `/customFields` array of the form [{id, value}, ...].
+//   - Preserves all non-custom-field operations as-is.
+//   - Appends a single `/customFields` replace operation with the constructed
+//     array.
+//
+// Notes:
+//   - Only explicitly mentioned custom fields are included in the array.
+//   - Omitting a custom field from the array does not clear its value.
+//   - Sending an empty `customFields` array does not clear existing values.
 func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPayload) []patchOperationPayload {
 	if !objectsSupportingCustomFields.Has(objectName) {
-		// Nothing to do.
+		// Object does not support custom fields; return payload unchanged.
 		return payloads
 	}
 
@@ -135,11 +222,12 @@ func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPa
 	result := make([]patchOperationPayload, 0)
 
 	for _, payload := range payloads {
-		// Path may start with slash. Normalize it.
+		// Normalize path by stripping leading slash.
 		path, _ := strings.CutPrefix(payload.Path, "/")
 
 		fieldIdStr, ok := strings.CutPrefix(path, "customField")
 		if !ok {
+			// Not a custom field operation; preserve as-is.
 			result = append(result, payload)
 
 			continue
@@ -147,6 +235,7 @@ func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPa
 
 		fieldId, err := strconv.Atoi(fieldIdStr)
 		if err != nil {
+			// Malformed custom field ID; preserve operation as-is.
 			result = append(result, payload)
 
 			continue
@@ -158,6 +247,7 @@ func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPa
 		})
 	}
 
+	// Always emit a /customFields replace operation for supported objects.
 	result = append(result, patchOperationPayload{
 		Op:    "replace",
 		Path:  "/customFields",
@@ -167,6 +257,8 @@ func payloadPatchWithCustomFields(objectName string, payloads []patchOperationPa
 	return result
 }
 
+// parseWriteResponse parses the HTTP response from a write operation and
+// constructs a common.WriteResult.
 func (c *Connector) parseWriteResponse(
 	ctx context.Context,
 	params common.WriteParams,
@@ -198,22 +290,32 @@ func (c *Connector) parseWriteResponse(
 	}, nil
 }
 
-// extractPatchPayload determines whether an update operation should use HTTP PATCH
-// instead of PUT by checking if the payload is a JSON Patch array.
-// This means payloads structured with "op", "path", "value"
-// will trigger PATCH, while regular object payloads will use PUT.
+// extractPatchPayload detects whether an update operation should use HTTP PATCH
+// instead of PUT by inspecting the payload structure.
 //
-// Example payload that triggers PATCH (JSON Patch):
+// It interprets the incoming RecordData as a patchPayload:
+//   - If the `patch` field is non-empty and its first element has a non-empty
+//     `Op` (indicating a JSON Patch operation like "add", "replace", "remove"),
+//     the function returns the parsed payload and true.
+//   - Otherwise, it returns nil, false, indicating a regular object payload
+//     suitable for PUT.
 //
-//	"patch": [
-//	  {"op": "replace", "path": "/firstName", "value": "Sims"},
-//	]
+// Expected JSON Patch-style payload (triggers PATCH):
 //
-// Example payload that uses PUT (regular object):
+//	{
+//	  "patch": [
+//	    {"op": "replace", "path": "/firstName", "value": "Sims"}
+//	  ]
+//	}
+//
+// Expected regular object payload (triggers PUT):
 //
 //	{
 //	  "lastName": "Sims"
 //	}
+//
+// This function encapsulates the connector's convention for distinguishing
+// between partial (JSON Patch) and full (PUT) updates.
 func extractPatchPayload(params common.WriteParams) (*patchPayload, bool) {
 	payload, err := common.RecordDataToStruct[patchPayload](params)
 	if err != nil {
@@ -231,12 +333,20 @@ func extractPatchPayload(params common.WriteParams) (*patchPayload, bool) {
 	return nil, false
 }
 
+// patchPayload represents a write payload that contains a JSON Patch array.
+//
+// The `patch` field holds a list of JSON Patch operations (add/replace/remove)
+// targeting specific paths in the ConnectWise object. When this structure is
+// detected, the connector uses HTTP PATCH and sends the inner array as the
+// request body.
 type patchPayload struct {
 	Patch []patchOperationPayload `json:"patch"`
 }
 
+// patchOperationPayload represents a single JSON Patch operation as defined by RFC 6902.
 type patchOperationPayload struct {
-	Op    string `json:"op"`
-	Path  string `json:"path"`
-	Value any    `json:"value"`
+	Op          string `json:"op"`
+	Path        string `json:"path"`
+	Value       any    `json:"value,omitempty"`
+	removeIndex int
 }

--- a/test/connectwise/write-delete/contacts/main.go
+++ b/test/connectwise/write-delete/contacts/main.go
@@ -19,6 +19,12 @@ type payload struct {
 	LastName             string `json:"lastName"`
 	CustomFieldMarketing bool   `json:"customField59"`
 	CustomFieldHobby     string `json:"customField83"`
+	Email                string `json:"AMPERSAND-defaultEmail,omitempty"`
+	EmailId              string `json:"AMPERSAND-defaultEmailId,omitempty"`
+	Phone                string `json:"AMPERSAND-defaultPhone,omitempty"`
+	PhoneId              string `json:"AMPERSAND-defaultPhoneId,omitempty"`
+	Fax                  string `json:"AMPERSAND-defaultFax,omitempty"`
+	FaxId                string `json:"AMPERSAND-defaultFaxId,omitempty"`
 }
 
 type patchPayload struct {
@@ -28,7 +34,7 @@ type patchPayload struct {
 type patchOperation struct {
 	Op    string `json:"op"`
 	Path  string `json:"path"`
-	Value any    `json:"value"`
+	Value any    `json:"value,omitempty"`
 }
 
 func main() {
@@ -48,24 +54,43 @@ func main() {
 
 	fmt.Println(">>> Using PUT")
 
+	// PUT operation does a complete replacement.
 	testscenario.ValidateCreateUpdateDelete(ctx, conn,
 		"contacts",
 		payload{
 			FirstName:            firstName,
 			LastName:             lastName,
-			CustomFieldHobby:     "Traveling",
 			CustomFieldMarketing: true,
+			CustomFieldHobby:     "Traveling",
+			Email:                "professional.bob@test.com",
+			EmailId:              "13",
+			Phone:                "+380001000",
+			PhoneId:              "",
+			Fax:                  "+99969",
+			FaxId:                "",
 		},
 		payload{
 			FirstName:            updatedFirstName,
 			LastName:             updatedLastName,
-			CustomFieldHobby:     "Skiing",
 			CustomFieldMarketing: false,
+			CustomFieldHobby:     "Skiing",
+			Email:                "professional.bob.updated@test.com",
+			EmailId:              "",
+			Phone:                "+380111358",
+			PhoneId:              "",
+			Fax:                  "+77767",
+			FaxId:                "26",
 		},
 		testscenario.CRUDTestSuite{
 			ReadFields: datautils.NewSet("id", "firstName", "lastName",
 				"customField83",
 				"customField59",
+				"AMPERSAND-defaultEmail",
+				"AMPERSAND-defaultEmailId",
+				"AMPERSAND-defaultPhone",
+				"AMPERSAND-defaultPhoneId",
+				"AMPERSAND-defaultFax",
+				"AMPERSAND-defaultFaxId",
 			),
 			SearchBy: testscenario.Property{
 				Key:   "firstname",
@@ -74,10 +99,16 @@ func main() {
 			},
 			RecordIdentifierKey: "id",
 			UpdatedFields: map[string]string{
-				"firstname":     updatedFirstName,
-				"lastname":      updatedLastName,
-				"customfield83": "Skiing",
-				"customfield59": "false",
+				"firstname":                updatedFirstName,
+				"lastname":                 updatedLastName,
+				"customfield83":            "Skiing",
+				"customfield59":            "false",
+				"ampersand-defaultemail":   "professional.bob.updated@test.com",
+				"ampersand-defaultemailid": "1",
+				"ampersand-defaultphone":   "+380111358",
+				"ampersand-defaultphoneid": "2",
+				"ampersand-defaultfax":     "+77767",
+				"ampersand-defaultfaxid":   "26",
 			},
 		},
 	)
@@ -92,6 +123,12 @@ func main() {
 			LastName:             lastName,
 			CustomFieldHobby:     "Traveling",
 			CustomFieldMarketing: true,
+			Email:                "professional.bob@test.com",
+			EmailId:              "13",
+			Phone:                "+380001000",
+			PhoneId:              "",
+			Fax:                  "+99969",
+			FaxId:                "",
 		},
 		patchPayload{Patch: []patchOperation{{
 			Op:    "replace",
@@ -105,11 +142,32 @@ func main() {
 			Op:    "replace",
 			Path:  "/customField83", // Handled and translated by connector.
 			Value: "Hiking",
+		}, {
+			Op:    "replace",
+			Path:  "AMPERSAND-defaultPhone",
+			Value: "+380111358",
+		}, {
+			Op:    "replace",
+			Path:  "AMPERSAND-defaultFax",
+			Value: "+77767",
+		}, {
+			Op:    "replace",
+			Path:  "AMPERSAND-defaultFaxId", // TODO should the order matter? at the moment it doesn't
+			Value: "26",
+		}, {
+			Op:   "remove",
+			Path: "AMPERSAND-defaultEmail", // TODO what if somebody wants to remove id. What if remove id and replace value at the same time.
 		}}},
 		testscenario.CRUDTestSuite{
 			ReadFields: datautils.NewSet("id", "firstName", "lastName",
 				"customField83",
 				"customField59",
+				"AMPERSAND-defaultEmail",
+				"AMPERSAND-defaultEmailId",
+				"AMPERSAND-defaultPhone",
+				"AMPERSAND-defaultPhoneId",
+				"AMPERSAND-defaultFax",
+				"AMPERSAND-defaultFaxId",
 			),
 			SearchBy: testscenario.Property{
 				Key:   "firstname",
@@ -118,10 +176,16 @@ func main() {
 			},
 			RecordIdentifierKey: "id",
 			UpdatedFields: map[string]string{
-				"firstname":     updatedFirstName,
-				"lastname":      updatedLastName,
-				"customfield83": "Hiking",
-				"customfield59": "true",
+				"firstname":                updatedFirstName,
+				"lastname":                 updatedLastName,
+				"customfield83":            "Hiking",
+				"customfield59":            "true",
+				"ampersand-defaultemail":   "",
+				"ampersand-defaultemailid": "",
+				"ampersand-defaultphone":   "+380111358",
+				"ampersand-defaultphoneid": "2",
+				"ampersand-defaultfax":     "+77767",
+				"ampersand-defaultfaxid":   "26",
 			},
 		},
 	)


### PR DESCRIPTION
# Description

Communication items is implemented for:
* Create (POST)
* Update (PUT)
  * Before making a PUT call a special PATCH call is maded to wipe out all the communication items, then it gurnatees that PUT will act as "expected by good provider API design".

Not implemented:
* Update (PATCH)

# Live Tests

<img width="634" height="641" alt="image" src="https://github.com/user-attachments/assets/c60b9b78-2363-4add-aff5-c4809f9b1905" />
