### PR TITLE
fix(salesforce): raise apex deploy poll timeout 5m -> 15m

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -81,7 +81,7 @@ type DeployResult = metadata.DeployResult
 
 const (
 	deployPollInterval = 10 * time.Second
-	deployPollTimeout  = 5 * time.Minute
+	deployPollTimeout  = 15 * time.Minute
 
 	// apexDeployMaxAttempts is the maximum number of attempts for deploying an apex trigger.
 	// Retries handle the race condition where a custom field was just created via Metadata API


### PR DESCRIPTION
## What

Raises `deployPollTimeout` in `providers/salesforce/apex.go` from **5m → 15m**.

## Why

Large Salesforce orgs exceed the 5-minute metadata-deploy poll window when deploying CDC quota-optimization Apex triggers. Production deploys run the companion Apex test class (75% coverage gate), which on a big org (e.g. AuraSell's `edb`, whose `account` object has 27 watch fields) takes longer than 5 minutes. The connector stops polling at 5m and the subscribe activity errors:

```
failed to redeploy apex trigger for object account: failed to poll deploy status for account:
deploy poll timeout after 5m0s for deployId 0AfPP0000023zyf0AA
```

Result: the deploy is still running in Salesforce, but Ampersand gives up, the subscription result is never persisted (no channel filter), and rollback then also fails — so the optimization never takes effect and orphaned checkbox fields are left behind.

## Change

- `deployPollTimeout: 5 * time.Minute` → `15 * time.Minute`

## Notes / follow-ups (separate)

- Making this configurable (per-call/env) would be better long-term than a larger constant.
- The failed-rollback path uses an AllOrNone delete that fails on partial success — separate bug worth fixing.

## Rollout

After merge: cut a connectors release, bump the server's connectors pin, deploy, then retry the AuraSell edb enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)