### PR TITLE
[Attio] Return empty updated fields without error

### DIFF
--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -76,7 +76,9 @@ func (evt SubscriptionEvent) PreLoadData(data *common.SubscriptionEventPreLoadDa
 }
 
 func (evt SubscriptionEvent) UpdatedFields() ([]string, error) {
-	return nil, errors.New("attio webhooks do not provide updated field information") //nolint:err113
+	// Attio webhooks do not provide updated field information, so we return an
+	// empty list without an error.
+	return []string{}, nil
 }
 
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -327,9 +327,13 @@ func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
 
 	evt := newTestEvent("note.updated", nil)
 
-	_, err := evt.UpdatedFields()
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	fields, err := evt.UpdatedFields()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(fields) != 0 {
+		t.Fatalf("expected empty fields, got %v", fields)
 	}
 }
 


### PR DESCRIPTION
Stacked on #2668.

`SubscriptionEvent.UpdatedFields` previously returned an error because Attio webhooks do not carry updated-field information. This changes it to return an empty `[]string` with no error, so callers can treat it as "no updated fields" rather than an error condition.

- Updated the unit test to expect no error and an empty slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)