### PR TITLE
[Attio] Fix webhook event parsing for real payloads

### DIFF
--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -112,21 +112,9 @@ func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 }
 
 func (evt SubscriptionEvent) ObjectName() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	name, err := evt.RawEventName()
 	if err != nil {
 		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	name, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, name, eventsMap["event_type"])
 	}
 
 	objectName := strings.Split(name, ".")[0]
@@ -135,21 +123,13 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 }
 
 func (evt SubscriptionEvent) RawEventName() (string, error) {
-	m := evt.asMap()
+	// asMap returns the single event object ({event_type, id, ...}) extracted
+	// from the top-level events array, so event_type is read directly off it.
+	event := evt.asMap()
 
-	events, err := m.Get("events")
-	if err != nil {
-		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
+	eventName, ok := event["event_type"].(string)
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	eventName, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, eventName, eventsMap["event_type"])
+		return "", fmt.Errorf("%w: expected string event_type, got %T", errTypeMismatch, event["event_type"])
 	}
 
 	return eventName, nil
@@ -160,21 +140,9 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 }
 
 func (evt SubscriptionEvent) RecordId() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
-	}
-
-	eventsMap, exist := events.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	idMap, exist := eventsMap["id"].(map[string]string)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, eventsMap["id"])
 	}
 
 	objectName, err := evt.ObjectName()
@@ -184,35 +152,42 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 
 	idKey := objectName + "_id"
 
-	id, ok := idMap[idKey]
-	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", idKey) //nolint:err113
-	}
-
-	return id, nil
+	return lookupID(idMap, idKey)
 }
 
 func (evt SubscriptionEvent) Workspace() (string, error) {
-	m := evt.asMap()
-
-	data, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
 	}
 
-	dataMap, exist := data.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, dataMap, data)
+	return lookupID(idMap, "workspace_id")
+}
+
+// idMap returns the "id" object of the event as a map[string]any.
+// Attio's webhook id object holds the workspace_id and object-specific
+// identifiers (e.g. note_id, record_id).
+func (evt SubscriptionEvent) idMap() (map[string]any, error) {
+	event := evt.asMap()
+
+	idMap, ok := event["id"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected id to be map[string]any, got %T", errTypeMismatch, event["id"])
 	}
 
-	idMap, ok := dataMap["id"].(map[string]string)
+	return idMap, nil
+}
+
+// lookupID returns the string value stored under key in the event's id map.
+func lookupID(idMap map[string]any, key string) (string, error) {
+	value, ok := idMap[key]
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, dataMap["id"])
+		return "", fmt.Errorf("%w: id map does not contain %q", errTypeMismatch, key)
 	}
 
-	id, ok := idMap["workspace_id"]
+	id, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", "workspace_id") //nolint:err113
+		return "", fmt.Errorf("%w: expected %q to be string, got %T", errTypeMismatch, key, value)
 	}
 
 	return id, nil

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -1,6 +1,7 @@
 package attio
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -8,21 +9,26 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// newTestEvent creates a SubscriptionEvent for testing.
-// The "events" value is a map (not an array) so that asMap() falls back
-// to returning the raw SubscriptionEvent, which is what the methods expect
-// when they call m.Get("events").
+// newTestEvent creates a SubscriptionEvent that mirrors a real Attio webhook
+// payload: a top-level "events" array whose single element holds the event_type
+// and an "id" object. The id values are stored as map[string]any because that is
+// what encoding/json produces when decoding a real webhook body.
 func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
-	inner := map[string]any{
+	event := map[string]any{
 		"event_type": eventType,
 	}
 
 	if idMap != nil {
-		inner["id"] = idMap
+		id := make(map[string]any, len(idMap))
+		for k, v := range idMap {
+			id[k] = v
+		}
+
+		event["id"] = id
 	}
 
 	return SubscriptionEvent{
-		"events": inner,
+		"events": []any{event},
 	}
 }
 
@@ -345,6 +351,68 @@ func TestSubscriptionEvent_EventTimeStampNano(t *testing.T) {
 	_, err := evt.EventTimeStampNano()
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+// TestSubscriptionEvent_RealWebhookPayload decodes a real Attio webhook body
+// (via encoding/json, the way the server does) and verifies the parsing methods
+// work end to end. This guards against the events-as-array / id map[string]any
+// shape being mishandled.
+func TestSubscriptionEvent_RealWebhookPayload(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"webhook_id": "wh-1",
+		"events": [
+			{
+				"event_type": "note.updated",
+				"id": {
+					"workspace_id": "ws-1",
+					"note_id": "note-9"
+				}
+			}
+		]
+	}`)
+
+	var evt SubscriptionEvent
+	if err := json.Unmarshal(body, &evt); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	eventType, err := evt.EventType()
+	if err != nil {
+		t.Fatalf("EventType() error: %v", err)
+	}
+
+	if eventType != common.SubscriptionEventTypeUpdate {
+		t.Fatalf("EventType() = %v, want %v", eventType, common.SubscriptionEventTypeUpdate)
+	}
+
+	objectName, err := evt.ObjectName()
+	if err != nil {
+		t.Fatalf("ObjectName() error: %v", err)
+	}
+
+	if objectName != "note" {
+		t.Fatalf("ObjectName() = %q, want %q", objectName, "note")
+	}
+
+	recordID, err := evt.RecordId()
+	if err != nil {
+		t.Fatalf("RecordId() error: %v", err)
+	}
+
+	if recordID != "note-9" {
+		t.Fatalf("RecordId() = %q, want %q", recordID, "note-9")
+	}
+
+	workspace, err := evt.Workspace()
+	if err != nil {
+		t.Fatalf("Workspace() error: %v", err)
+	}
+
+	if workspace != "ws-1" {
+		t.Fatalf("Workspace() = %q, want %q", workspace, "ws-1")
 	}
 }
 


### PR DESCRIPTION
Stacked on #3215 (which is stacked on #2668).

Follow-up to review comments on #2387 that were marked resolved but still broke on real Attio webhook payloads.

### Bugs
- `asMap()` extracts the single event from the top-level `events` **array**, but `ObjectName`/`RawEventName`/`RecordId`/`Workspace` then called `m.Get("events")` again on the already-unwrapped event → every method failed with `key not found: events`.
- The `id` object was asserted as `map[string]string`, but `encoding/json` decodes nested objects to `map[string]any` → `RecordId`/`Workspace` always failed on real data.

Server-side, `Workspace`/`ObjectName`/`RecordId` errors are hard aborts on the webhook path, so this would have broken Attio event processing once wired in.

### Fix
- Read `event_type`/`id` directly off the unwrapped event; assert `id` as `map[string]any`.
- The old tests passed only because the helper fabricated `events` as a map and `id` as `map[string]string`. The helper now builds the real array/`any` shape, and a new `TestSubscriptionEvent_RealWebhookPayload` decodes a real JSON body end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)