### PR TITLE
[Attio] Use singular "filter" key in GetRecordsByIds

### DIFF
--- a/providers/attio/record.go
+++ b/providers/attio/record.go
@@ -33,8 +33,10 @@ func (c *Connector) GetRecordsByIds( //nolint:revive
 		return nil, err
 	}
 
+	// Attio's list-records query expects a singular "filter" key.
+	// Ref: https://docs.attio.com/rest-api/guides/filtering-and-sorting
 	payload := map[string]any{
-		"filters": map[string]any{
+		"filter": map[string]any{
 			"record_id": map[string]any{
 				"$in": ids,
 			},

--- a/providers/attio/record_test.go
+++ b/providers/attio/record_test.go
@@ -40,8 +40,18 @@ func TestGetRecordByIds(t *testing.T) {
 
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.Path("/v2/objects/companies/records/query"),
-				Then:  mockserver.Response(http.StatusOK, responseGetRecordsByIds),
+				If: mockcond.And{
+					mockcond.Path("/v2/objects/companies/records/query"),
+					// Attio expects a singular "filter" key with record_id $in.
+					mockcond.Body(`{
+						"filter": {
+							"record_id": {
+								"$in": ["1bdb55e3-67f4-48d3-829b-45db3039a960", "3a95b53c-e7a1-4e53-a4e4-436f72283818"]
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseGetRecordsByIds),
 			}.Server(),
 
 			Expected: []common.ReadResultRow{


### PR DESCRIPTION
Stacked on #3216.

Follow-up to review on #2387. `GetRecordsByIds` sent the list-records query body with a `"filters"` (plural) key, but Attio expects a singular **`"filter"`** ([docs](https://docs.attio.com/rest-api/guides/filtering-and-sorting)):

```json
{ "filter": { "record_id": { "$in": ["..."] } } }
```

With the plural key the filter is ignored/rejected, so Attio returns unfiltered records instead of the requested IDs.

The existing test didn't catch this because the mock matched only on the URL path. The mock now also asserts the request body — verified by reverting the fix (the test then fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)