### PR TITLE
[Attio] Export subscription result types nested in SubscriptionResult

### DIFF
--- a/providers/attio/subscribe.go
+++ b/providers/attio/subscribe.go
@@ -135,7 +135,7 @@ func (c *Connector) DeleteSubscription(
 func (c *Connector) createSubscriptions(ctx context.Context,
 	payload *subscriptionPayload,
 	updater common.WriteMethod,
-) (*createSubscriptionsResponse, error) {
+) (*CreateSubscriptionsResponse, error) {
 	url, err := c.getSubscribeURL()
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (c *Connector) createSubscriptions(ctx context.Context,
 		return nil, fmt.Errorf("failed to create subscription: %w", err)
 	}
 
-	result, err := common.UnmarshalJSON[createSubscriptionsResponse](resp)
+	result, err := common.UnmarshalJSON[CreateSubscriptionsResponse](resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal subscription response: %w", err)
 	}
@@ -172,7 +172,7 @@ func buildPayload(
 	standardObjects map[common.ObjectName]string,
 	webhookURL string,
 ) (*subscriptionPayload, error) {
-	subscriptions := make([]subscription, 0)
+	subscriptions := make([]Subscription, 0)
 
 	for objectName, events := range subscriptionEvents {
 		for _, event := range events.Events {

--- a/providers/attio/subscribe_test.go
+++ b/providers/attio/subscribe_test.go
@@ -170,15 +170,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
 						Status:    "active",
 						CreatedAt: "2026-01-30T10:06:11.304000000Z",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "c570dd25-5ded-44f6-b94a-84250956455d",
 						},
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.deleted",
 								Filter: map[string]any{
@@ -271,15 +271,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{
@@ -339,15 +339,15 @@ func TestDeleteSubscribe(t *testing.T) {
 			Name: "Unsubscribe successfully",
 			Input: common.SubscriptionResult{
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{

--- a/providers/attio/types.go
+++ b/providers/attio/types.go
@@ -38,10 +38,11 @@ type subscriptionPayload struct {
 
 type subscriptionData struct {
 	TargetURL     string         `json:"target_url"    validate:"required"`
-	Subscriptions []subscription `json:"subscriptions" validate:"required"`
+	Subscriptions []Subscription `json:"subscriptions" validate:"required"`
 }
 
-type subscription struct {
+// Subscription is a single webhook subscription entry (event type + optional filter).
+type Subscription struct {
 	EventType providerEvent `json:"event_type" validate:"required"`
 	// Filter is an object used to limit which webhook events are delivered.
 	// Filters can target specific records (by list_id, entry_id) or specific object (by object_id).
@@ -51,21 +52,24 @@ type subscription struct {
 	Filter any `json:"filter"`
 }
 
-// // createSubscriptionsResponse is the response returned by Attio when a webhook is created.
+// CreateSubscriptionsResponse is the response returned by Attio when a webhook is created.
 // Reference: https://docs.attio.com/rest-api/endpoint-reference/webhooks/create-a-webhook#response-data
-type createSubscriptionsResponse struct {
-	Data createSubscriptionsResponseData `json:"data"`
+type CreateSubscriptionsResponse struct {
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
-type createSubscriptionsResponseID struct {
+// CreateSubscriptionsResponseID holds the workspace and webhook identifiers of a created webhook.
+type CreateSubscriptionsResponseID struct {
 	WorkspaceID string `json:"workspace_id"`
 	WebhookID   string `json:"webhook_id"`
 }
 
-type createSubscriptionsResponseData struct {
+// CreateSubscriptionsResponseData is the data payload of a created webhook subscription.
+// It is nested in common.SubscriptionResult.Result, so it is exported.
+type CreateSubscriptionsResponseData struct {
 	TargetURL     string                        `json:"target_url"`
-	Subscriptions []subscription                `json:"subscriptions" validate:"required"`
-	ID            createSubscriptionsResponseID `json:"id"`
+	Subscriptions []Subscription                `json:"subscriptions" validate:"required"`
+	ID            CreateSubscriptionsResponseID `json:"id"`
 	Status        string                        `json:"status"`
 	CreatedAt     string                        `json:"created_at"`
 	// Secret used for webhook signature verification.
@@ -82,7 +86,7 @@ type SuccessfulSubscription struct {
 }
 
 type SubscriptionResult struct {
-	Data createSubscriptionsResponseData `json:"data"`
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
 // providerEvent represents the combined event type string used by Attio.

--- a/providers/attio/utils.go
+++ b/providers/attio/utils.go
@@ -65,7 +65,7 @@ func buildSubscriptionPayloadForCoreObj(
 	objEvents objectEvents,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	providerEvents := objEvents.toProviderEvents(event)
 	if len(providerEvents) == 0 {
 		return nil, fmt.Errorf("%w: object '%s' with event '%s'",
@@ -73,7 +73,7 @@ func buildSubscriptionPayloadForCoreObj(
 	}
 
 	for _, e := range providerEvents {
-		sub = append(sub, subscription{
+		sub = append(sub, Subscription{
 			EventType: e,
 			Filter:    nil,
 		})
@@ -86,7 +86,7 @@ func buildSubscriptionPayloadForStandardObj(
 	standardObjects map[common.ObjectName]string,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	// Handle building subscriptions for standard/custom objects
 	objectId, exists := standardObjects[objectName]
 	if !exists {
@@ -112,7 +112,7 @@ func buildSubscriptionPayloadForStandardObj(
 		},
 	}
 	sub = append(sub,
-		subscription{
+		Subscription{
 			EventType: recordEvent,
 			Filter:    filter,
 		},


### PR DESCRIPTION
Stacked on #3217.

Addresses the review comment on #2387 asking that all types nested under `common.SubscriptionResult.Result` be exported.

Renames:
- `subscription` → `Subscription`
- `createSubscriptionsResponse` → `CreateSubscriptionsResponse`
- `createSubscriptionsResponseData` → `CreateSubscriptionsResponseData`
- `createSubscriptionsResponseID` → `CreateSubscriptionsResponseID`

Plus godoc comments on the exported types. No behavior change — purely visibility/convention (the server JSON round-trips `Result`, so this wasn't functionally required, but it matches the maintainer convention for provider result types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)