### PR TITLE
[ENG-4138] [Attio] Subscribe follow-up fixes (event parsing, filter key, exports)

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -870,6 +870,19 @@ type SubscriptionEventWithRecord interface {
 	Record(fields []string) (ReadResultRow, error)
 }
 
+// SubscriptionEventWithMetadata is an optional interface implemented by providers
+// whose event identifies its object only by an id that must be resolved against
+// object metadata (e.g. Attio record.* events carry id.object_id, a per-workspace
+// UUID, rather than an object name). When implemented, callers can resolve the
+// object name by passing metadata from the same provider.
+type SubscriptionEventWithMetadata interface {
+	SubscriptionUpdateEvent
+
+	// ObjectNameFromMetadata resolves the object's name for the event using object
+	// metadata from the same provider.
+	ObjectNameFromMetadata(metadata *ListObjectMetadataResult) (string, error)
+}
+
 // CollapsedSubscriptionEvent some providers send multiple events in a single webhook payload.
 // This interface is used to extract individual events to SubscriptionEvent type
 // from a collapsed event for webhook parsing and processing.

--- a/common/types.go
+++ b/common/types.go
@@ -870,19 +870,6 @@ type SubscriptionEventWithRecord interface {
 	Record(fields []string) (ReadResultRow, error)
 }
 
-// SubscriptionEventWithMetadata is an optional interface implemented by providers
-// whose event identifies its object only by an id that must be resolved against
-// object metadata (e.g. Attio record.* events carry id.object_id, a per-workspace
-// UUID, rather than an object name). When implemented, callers can resolve the
-// object name by passing metadata from the same provider.
-type SubscriptionEventWithMetadata interface {
-	SubscriptionUpdateEvent
-
-	// ObjectNameFromMetadata resolves the object's name for the event using object
-	// metadata from the same provider.
-	ObjectNameFromMetadata(metadata *ListObjectMetadataResult) (string, error)
-}
-
 // CollapsedSubscriptionEvent some providers send multiple events in a single webhook payload.
 // This interface is used to extract individual events to SubscriptionEvent type
 // from a collapsed event for webhook parsing and processing.

--- a/connectors.go
+++ b/connectors.go
@@ -241,6 +241,23 @@ type WebhookVerifierConnector interface {
 	) (bool, error)
 }
 
+// SubscriptionEventObjectNameConnector resolves the object name for a subscription
+// event whose payload identifies the object only by a provider type id rather than
+// a name (e.g. Attio record.* events carry an id.object_id, a per-workspace UUID).
+//
+// It exists because a plain SubscriptionEvent cannot resolve such an id on its own:
+// the mapping from type id to name is provider state that must be fetched (and may
+// be cached). Callers should prefer this method when a connector implements it, and
+// fall back to SubscriptionEvent.ObjectName() otherwise.
+type SubscriptionEventObjectNameConnector interface {
+	Connector
+
+	// GetObjectNameFromTypeId resolves the object name for the given subscription
+	// event by mapping the event's object type id to an object name, fetching from
+	// the provider (and caching) when necessary.
+	GetObjectNameFromTypeId(ctx context.Context, event common.SubscriptionEvent) (string, error)
+}
+
 // SubscribeConnector defines the interface for connectors that manage webhook subscriptions.
 //
 // Connectors implementing this interface are responsible for creating, updating, and deleting

--- a/providers/attio/connector.go
+++ b/providers/attio/connector.go
@@ -14,6 +14,11 @@ const (
 type Connector struct {
 	BaseURL string
 	Client  *common.JSONHTTPClient
+
+	// objectNameCache memoizes object_id -> api_slug lookups used by
+	// GetObjectNameFromTypeId. The connector is always used via *Connector, so the
+	// embedded lock is never copied.
+	objectNameCache objectNameCache
 }
 
 func NewConnector(opts ...Option) (conn *Connector, outErr error) {

--- a/providers/attio/record.go
+++ b/providers/attio/record.go
@@ -33,8 +33,10 @@ func (c *Connector) GetRecordsByIds( //nolint:revive
 		return nil, err
 	}
 
+	// Attio's list-records query expects a singular "filter" key.
+	// Ref: https://docs.attio.com/rest-api/guides/filtering-and-sorting
 	payload := map[string]any{
-		"filters": map[string]any{
+		"filter": map[string]any{
 			"record_id": map[string]any{
 				"$in": ids,
 			},

--- a/providers/attio/record_test.go
+++ b/providers/attio/record_test.go
@@ -40,8 +40,18 @@ func TestGetRecordByIds(t *testing.T) {
 
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
-				If:    mockcond.Path("/v2/objects/companies/records/query"),
-				Then:  mockserver.Response(http.StatusOK, responseGetRecordsByIds),
+				If: mockcond.And{
+					mockcond.Path("/v2/objects/companies/records/query"),
+					// Attio expects a singular "filter" key with record_id $in.
+					mockcond.Body(`{
+						"filter": {
+							"record_id": {
+								"$in": ["1bdb55e3-67f4-48d3-829b-45db3039a960", "3a95b53c-e7a1-4e53-a4e4-436f72283818"]
+							}
+						}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseGetRecordsByIds),
 			}.Server(),
 
 			Expected: []common.ReadResultRow{

--- a/providers/attio/subscribe.go
+++ b/providers/attio/subscribe.go
@@ -120,11 +120,11 @@ func (c *Connector) DeleteSubscription(
 		return fmt.Errorf("%w: subscription is empty", errMissingParams)
 	}
 
-	err := c.deleteSubscription(ctx, subscriptionData.Data.ID.WebhookID)
+	err := c.deleteSubscription(ctx, subscriptionData.Data.Id.WebhookId)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to delete subscription (ID: %s): %w",
-			subscriptionData.Data.ID.WebhookID,
+			"failed to delete subscription (id: %s): %w",
+			subscriptionData.Data.Id.WebhookId,
 			err,
 		)
 	}

--- a/providers/attio/subscribe.go
+++ b/providers/attio/subscribe.go
@@ -9,7 +9,10 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-var _ connectors.SubscribeConnector = &Connector{}
+var (
+	_ connectors.SubscribeConnector                   = &Connector{}
+	_ connectors.SubscriptionEventObjectNameConnector = &Connector{}
+)
 
 func (c *Connector) EmptySubscriptionParams() *common.SubscribeParams {
 	return &common.SubscribeParams{}

--- a/providers/attio/subscribe.go
+++ b/providers/attio/subscribe.go
@@ -135,7 +135,7 @@ func (c *Connector) DeleteSubscription(
 func (c *Connector) createSubscriptions(ctx context.Context,
 	payload *subscriptionPayload,
 	updater common.WriteMethod,
-) (*createSubscriptionsResponse, error) {
+) (*CreateSubscriptionsResponse, error) {
 	url, err := c.getSubscribeURL()
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (c *Connector) createSubscriptions(ctx context.Context,
 		return nil, fmt.Errorf("failed to create subscription: %w", err)
 	}
 
-	result, err := common.UnmarshalJSON[createSubscriptionsResponse](resp)
+	result, err := common.UnmarshalJSON[CreateSubscriptionsResponse](resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal subscription response: %w", err)
 	}
@@ -172,7 +172,7 @@ func buildPayload(
 	standardObjects map[common.ObjectName]string,
 	webhookURL string,
 ) (*subscriptionPayload, error) {
-	subscriptions := make([]subscription, 0)
+	subscriptions := make([]Subscription, 0)
 
 	for objectName, events := range subscriptionEvents {
 		for _, event := range events.Events {

--- a/providers/attio/subscribe_test.go
+++ b/providers/attio/subscribe_test.go
@@ -174,9 +174,9 @@ func TestCreateSubscribe(t *testing.T) {
 						TargetURL: "https://example.com/webhook",
 						Status:    "active",
 						CreatedAt: "2026-01-30T10:06:11.304000000Z",
-						ID: CreateSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "c570dd25-5ded-44f6-b94a-84250956455d",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "c570dd25-5ded-44f6-b94a-84250956455d",
 						},
 						Subscriptions: []Subscription{
 							{
@@ -273,9 +273,9 @@ func TestCreateSubscribe(t *testing.T) {
 				Result: &SubscriptionResult{
 					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: CreateSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
@@ -341,9 +341,9 @@ func TestDeleteSubscribe(t *testing.T) {
 				Result: &SubscriptionResult{
 					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: CreateSubscriptionsResponseID{
-							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
-							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
+						Id: CreateSubscriptionsResponseId{
+							WorkspaceId: "e8d74639-96e5-41be-af46-ced812aef5c5",
+							WebhookId:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",

--- a/providers/attio/subscribe_test.go
+++ b/providers/attio/subscribe_test.go
@@ -170,15 +170,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
 						Status:    "active",
 						CreatedAt: "2026-01-30T10:06:11.304000000Z",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "c570dd25-5ded-44f6-b94a-84250956455d",
 						},
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.deleted",
 								Filter: map[string]any{
@@ -271,15 +271,15 @@ func TestCreateSubscribe(t *testing.T) {
 					},
 				},
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{
@@ -339,15 +339,15 @@ func TestDeleteSubscribe(t *testing.T) {
 			Name: "Unsubscribe successfully",
 			Input: common.SubscriptionResult{
 				Result: &SubscriptionResult{
-					Data: createSubscriptionsResponseData{
+					Data: CreateSubscriptionsResponseData{
 						TargetURL: "https://example.com/webhook",
-						ID: createSubscriptionsResponseID{
+						ID: CreateSubscriptionsResponseID{
 							WorkspaceID: "e8d74639-96e5-41be-af46-ced812aef5c5",
 							WebhookID:   "d1c60c7a-c895-4a4a-ba2f-249aeb359d17",
 						},
 						Status:    "active",
 						CreatedAt: "2026-01-30T13:04:22.051000000Z",
-						Subscriptions: []subscription{
+						Subscriptions: []Subscription{
 							{
 								EventType: "record.updated",
 								Filter: map[string]any{

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -24,9 +24,10 @@ type (
 )
 
 var (
-	_ common.SubscriptionEvent          = SubscriptionEvent{}
-	_ common.SubscriptionUpdateEvent    = SubscriptionEvent{}
-	_ common.CollapsedSubscriptionEvent = CollapsedSubscriptionEvent{}
+	_ common.SubscriptionEvent             = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent       = SubscriptionEvent{}
+	_ common.SubscriptionEventWithMetadata = SubscriptionEvent{}
+	_ common.CollapsedSubscriptionEvent    = CollapsedSubscriptionEvent{}
 
 	errTypeMismatch = errors.New("type mismatch")
 )
@@ -134,7 +135,7 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 //
 // The metadata must come from the same provider and be keyed by object_id (the
 // same contract as GetObjectNameFromObjectMetadata).
-func (evt SubscriptionEvent) ObjectNameWithMetadata(
+func (evt SubscriptionEvent) ObjectNameFromMetadata(
 	metadata *common.ListObjectMetadataResult,
 ) (string, error) {
 	idMap, err := evt.idMap()

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -395,27 +395,6 @@ func (c *Connector) fetchObjectIdToName(ctx context.Context) (map[string]string,
 	return idToName, nil
 }
 
-// GetFieldNameFromObjectMetadata looks up a field's api_slug from metadata using the object_id and attribute_id.
-// It returns an error if the object or attribute is not found.
-func GetFieldNameFromObjectMetadata(
-	metadata *common.ListObjectMetadataResult,
-	objectID string,
-	attributeID string,
-) (string, error) {
-	obj, ok := metadata.Result[objectID]
-	if !ok {
-		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
-	}
-
-	for fieldName, field := range obj.Fields {
-		if field.FieldId != nil && *field.FieldId == attributeID {
-			return fieldName, nil
-		}
-	}
-
-	return "", fmt.Errorf("%w: attribute %q in object %q", common.ErrNotFound, attributeID, objectID)
-}
-
 // Example: Webhook response
 /*
 {

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -123,9 +123,41 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 	return objectName, nil
 }
 
+// ObjectNameWithMetadata resolves the object's name for the event using object
+// metadata from the same provider.
+//
+// Standard and custom object changes arrive as generic record.* events that
+// identify the object only by its id.object_id — a per-workspace UUID, not a name.
+// This method looks that object_id up in the provided metadata. For core-object
+// events (note, task, list, workspace-member) the object is already encoded in the
+// event_type, so it falls back to ObjectName() without consulting metadata.
+//
+// The metadata must come from the same provider and be keyed by object_id (the
+// same contract as GetObjectNameFromObjectMetadata).
+func (evt SubscriptionEvent) ObjectNameWithMetadata(
+	metadata *common.ListObjectMetadataResult,
+) (string, error) {
+	idMap, err := evt.idMap()
+	if err != nil {
+		return "", err
+	}
+
+	objectID, ok := idMap["object_id"].(string)
+	if !ok {
+		// No object_id: this is a core-object event whose object is in event_type.
+		return evt.ObjectName()
+	}
+
+	if metadata == nil {
+		return "", fmt.Errorf("%w: metadata is nil", errTypeMismatch)
+	}
+
+	return GetObjectNameFromObjectMetadata(metadata, objectID)
+}
+
 func (evt SubscriptionEvent) RawEventName() (string, error) {
-	// asMap returns the single event object ({event_type, id, ...}) extracted
-	// from the top-level events array, so event_type is read directly off it.
+	// asMap returns the single event object ({event_type, id, ...}), so event_type
+	// is read directly off it.
 	event := evt.asMap()
 
 	eventName, ok := event["event_type"].(string)

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -145,9 +145,14 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 //
 // A naive objectName+"_id" is wrong for some events: note-content events carry a
 // "note_id" (not "note-content_id"), and workspace-member events carry a
-// "workspace_member_id" (underscore, not the hyphenated object name).
+// "workspace_member_id" (underscore, not the hyphenated object name). Example
+// "id" objects from the docs for these two non-obvious cases:
 //
-// Keys verified against Attio's webhook reference (see each event's "id" schema):
+//	note-content.updated:     {"workspace_id": "...", "note_id": "..."}
+//	workspace-member.created: {"workspace_id": "...", "workspace_member_id": "..."}
+//
+// Keys verified against Attio's webhook reference (see each event's "id" schema
+// and example):
 //   - source of truth: https://api.attio.com/openapi/webhooks
 //   - record.*:           https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
 //   - list.*:             https://docs.attio.com/rest-api/webhook-reference/list-events/listcreated

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -139,18 +139,52 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 	return maps.Clone(evt), nil
 }
 
+// recordIDKeyByEventObject maps the object portion of an Attio webhook event_type
+// (the part before the ".", e.g. "note-content" in "note-content.updated") to the
+// key that holds the affected record's identifier inside the event "id" object.
+//
+// A naive objectName+"_id" is wrong for some events: note-content events carry a
+// "note_id" (not "note-content_id"), and workspace-member events carry a
+// "workspace_member_id" (underscore, not the hyphenated object name).
+//
+// Keys verified against Attio's webhook reference (see each event's "id" schema):
+//   - source of truth: https://api.attio.com/openapi/webhooks
+//   - record.*:           https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
+//   - list.*:             https://docs.attio.com/rest-api/webhook-reference/list-events/listcreated
+//   - task.*:             https://docs.attio.com/rest-api/webhook-reference/task-events/taskcreated
+//   - note.*:             https://docs.attio.com/rest-api/webhook-reference/note-events/notecreated
+//   - note-content.*:     https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
+//   - workspace-member.*: https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
+//
+//nolint:gochecknoglobals
+var recordIDKeyByEventObject = map[string]string{
+	"record":           "record_id",
+	"list":             "list_id",
+	"task":             "task_id",
+	"note":             "note_id",
+	"note-content":     "note_id",
+	"workspace-member": "workspace_member_id",
+}
+
 func (evt SubscriptionEvent) RecordId() (string, error) {
 	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
 	}
 
-	objectName, err := evt.ObjectName()
+	eventName, err := evt.RawEventName()
 	if err != nil {
 		return "", err
 	}
 
-	idKey := objectName + "_id"
+	// event_type has the form "{object}.{action}"; the object portion determines
+	// which key inside the "id" object holds the record identifier.
+	eventObject := strings.Split(eventName, ".")[0]
+
+	idKey, ok := recordIDKeyByEventObject[eventObject]
+	if !ok {
+		return "", fmt.Errorf("%w: no record id key mapping for event %q", errTypeMismatch, eventName)
+	}
 
 	return lookupID(idMap, idKey)
 }

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -24,8 +24,9 @@ type (
 )
 
 var (
-	_ common.SubscriptionEvent       = SubscriptionEvent{}
-	_ common.SubscriptionUpdateEvent = SubscriptionEvent{}
+	_ common.SubscriptionEvent          = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent    = SubscriptionEvent{}
+	_ common.CollapsedSubscriptionEvent = CollapsedSubscriptionEvent{}
 
 	errTypeMismatch = errors.New("type mismatch")
 )
@@ -228,21 +229,47 @@ func lookupID(idMap map[string]any, key string) (string, error) {
 	return id, nil
 }
 
-// asMap returns the event as a StringMap.
+// asMap returns the single event as a StringMap. A SubscriptionEvent is one
+// event object ({event_type, id, actor}) produced by
+// CollapsedSubscriptionEvent.SubscriptionEventList, so no unwrapping is needed.
 func (evt SubscriptionEvent) asMap() common.StringMap {
-	// extract first event from events array
-	// Attio sends an array of events, but it only contains one event per webhook call.
-	// So we extract the first event for processing.
-	evtsArray, ok := evt["events"].([]any)
-	if ok && len(evtsArray) > 0 {
-		firstEvt, ok := evtsArray[0].(map[string]any)
-		if ok {
-			return common.StringMap(firstEvt)
-		}
+	return common.StringMap(evt)
+}
+
+// CollapsedSubscriptionEvent is the raw Attio webhook payload. Attio delivers a
+// top-level object with an "events" array; each element is an individual event.
+// Currently each delivery carries exactly one event, but the schema notes this
+// may change to support batching, so we fan out every element.
+// Ref: https://api.attio.com/openapi/webhooks
+type CollapsedSubscriptionEvent map[string]any
+
+// RawMap returns a copy of the raw payload.
+func (e CollapsedSubscriptionEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(e), nil
+}
+
+// SubscriptionEventList fans the top-level "events" array out into one
+// SubscriptionEvent per event.
+func (e CollapsedSubscriptionEvent) SubscriptionEventList() ([]common.SubscriptionEvent, error) {
+	rawEvents, ok := e["events"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected events to be []any, got %T",
+			common.ErrSubscriptionEventList, e["events"])
 	}
 
-	// Fallback to returning the whole event if extraction fails
-	return common.StringMap(evt)
+	events := make([]common.SubscriptionEvent, 0, len(rawEvents))
+
+	for _, raw := range rawEvents {
+		eventMap, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: expected event to be map[string]any, got %T",
+				common.ErrSubscriptionEventList, raw)
+		}
+
+		events = append(events, SubscriptionEvent(eventMap))
+	}
+
+	return events, nil
 }
 
 func computeSignature(secret string, body []byte) []byte {

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/amp-labs/connectors/common"
 )
@@ -24,10 +25,9 @@ type (
 )
 
 var (
-	_ common.SubscriptionEvent             = SubscriptionEvent{}
-	_ common.SubscriptionUpdateEvent       = SubscriptionEvent{}
-	_ common.SubscriptionEventWithMetadata = SubscriptionEvent{}
-	_ common.CollapsedSubscriptionEvent    = CollapsedSubscriptionEvent{}
+	_ common.SubscriptionEvent          = SubscriptionEvent{}
+	_ common.SubscriptionUpdateEvent    = SubscriptionEvent{}
+	_ common.CollapsedSubscriptionEvent = CollapsedSubscriptionEvent{}
 
 	errTypeMismatch = errors.New("type mismatch")
 )
@@ -122,38 +122,6 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 	objectName := strings.Split(name, ".")[0]
 
 	return objectName, nil
-}
-
-// ObjectNameWithMetadata resolves the object's name for the event using object
-// metadata from the same provider.
-//
-// Standard and custom object changes arrive as generic record.* events that
-// identify the object only by its id.object_id — a per-workspace UUID, not a name.
-// This method looks that object_id up in the provided metadata. For core-object
-// events (note, task, list, workspace-member) the object is already encoded in the
-// event_type, so it falls back to ObjectName() without consulting metadata.
-//
-// The metadata must come from the same provider and be keyed by object_id (the
-// same contract as GetObjectNameFromObjectMetadata).
-func (evt SubscriptionEvent) ObjectNameFromMetadata(
-	metadata *common.ListObjectMetadataResult,
-) (string, error) {
-	idMap, err := evt.idMap()
-	if err != nil {
-		return "", err
-	}
-
-	objectID, ok := idMap["object_id"].(string)
-	if !ok {
-		// No object_id: this is a core-object event whose object is in event_type.
-		return evt.ObjectName()
-	}
-
-	if metadata == nil {
-		return "", fmt.Errorf("%w: metadata is nil", errTypeMismatch)
-	}
-
-	return GetObjectNameFromObjectMetadata(metadata, objectID)
 }
 
 func (evt SubscriptionEvent) RawEventName() (string, error) {
@@ -312,6 +280,121 @@ func computeSignature(secret string, body []byte) []byte {
 	return h.Sum(nil)
 }
 
+// objectNameCacheKey is the context key under which GetObjectNameFromTypeId stores
+// its object_id -> object name cache.
+type objectNameCacheKey struct{}
+
+// objectNameCache maps an Attio object_id to its object name (api_slug). It is kept
+// in the context so a batch of events resolves the object list at most once.
+type objectNameCache struct {
+	mu sync.RWMutex
+	m  map[string]string
+}
+
+// WithObjectNameCache returns a context carrying an object_id -> name cache used by
+// GetObjectNameFromTypeId. Callers that process multiple events should set this up
+// once so the object list is fetched at most once per batch. Without it,
+// GetObjectNameFromTypeId still works but fetches the object list on every call.
+func WithObjectNameCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, objectNameCacheKey{}, &objectNameCache{m: make(map[string]string)})
+}
+
+func objectNameCacheFromContext(ctx context.Context) *objectNameCache {
+	cache, _ := ctx.Value(objectNameCacheKey{}).(*objectNameCache)
+
+	return cache
+}
+
+func (o *objectNameCache) get(objectID string) (string, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	name, ok := o.m[objectID]
+
+	return name, ok
+}
+
+func (o *objectNameCache) store(idToName map[string]string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for id, name := range idToName {
+		o.m[id] = name
+	}
+}
+
+// GetObjectNameFromTypeId resolves the object name for a subscription event.
+//
+// Standard and custom object changes arrive as generic record.* events that
+// identify the object only by its id.object_id (a per-workspace UUID). This maps
+// that id to the object's api_slug: it first checks the object_id -> name cache in
+// the context (see WithObjectNameCache), and on a miss fetches the workspace's
+// objects directly from GET /v2/objects and caches the result.
+// Ref: https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects
+//
+// For core-object events (note, task, list, workspace-member) there is no
+// object_id — the object is already in the event_type — so ObjectName() is returned
+// without any lookup.
+func (c *Connector) GetObjectNameFromTypeId(
+	ctx context.Context, event common.SubscriptionEvent,
+) (string, error) {
+	attioEvent, ok := event.(SubscriptionEvent)
+	if !ok {
+		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, SubscriptionEvent{}, event)
+	}
+
+	idMap, err := attioEvent.idMap()
+	if err != nil {
+		return "", err
+	}
+
+	objectID, ok := idMap["object_id"].(string)
+	if !ok {
+		// No object_id: a core-object event whose object is in the event_type.
+		return attioEvent.ObjectName()
+	}
+
+	cache := objectNameCacheFromContext(ctx)
+	if cache != nil {
+		if name, found := cache.get(objectID); found {
+			return name, nil
+		}
+	}
+
+	idToName, err := c.fetchObjectIdToName(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if cache != nil {
+		cache.store(idToName)
+	}
+
+	name, found := idToName[objectID]
+	if !found {
+		return "", fmt.Errorf("%w: object type %q", common.ErrNotFound, objectID)
+	}
+
+	return name, nil
+}
+
+// fetchObjectIdToName fetches the workspace's objects directly and returns an
+// object_id -> api_slug map.
+// Ref: https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects
+func (c *Connector) fetchObjectIdToName(ctx context.Context) (map[string]string, error) {
+	objects, err := c.readStandardOrCustomObjectsList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list objects: %w", err)
+	}
+
+	idToName := make(map[string]string, len(objects))
+	for _, obj := range objects {
+		idToName[obj.Id.ObjectId] = obj.ApiSlug
+	}
+
+	return idToName, nil
+}
+
 // GetFieldNameFromObjectMetadata looks up a field's api_slug from metadata using the object_id and attribute_id.
 // It returns an error if the object or attribute is not found.
 func GetFieldNameFromObjectMetadata(
@@ -331,20 +414,6 @@ func GetFieldNameFromObjectMetadata(
 	}
 
 	return "", fmt.Errorf("%w: attribute %q in object %q", common.ErrNotFound, attributeID, objectID)
-}
-
-// GetObjectNameFromObjectMetadata looks up an object's display name from metadata using the object_id.
-// It returns an error if the object is not found.
-func GetObjectNameFromObjectMetadata(
-	metadata *common.ListObjectMetadataResult,
-	objectID string,
-) (string, error) {
-	obj, ok := metadata.Result[objectID]
-	if !ok {
-		return "", fmt.Errorf("%w: object %q", common.ErrNotFound, objectID)
-	}
-
-	return obj.DisplayName, nil
 }
 
 // Example: Webhook response

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -76,7 +76,9 @@ func (evt SubscriptionEvent) PreLoadData(data *common.SubscriptionEventPreLoadDa
 }
 
 func (evt SubscriptionEvent) UpdatedFields() ([]string, error) {
-	return nil, errors.New("attio webhooks do not provide updated field information") //nolint:err113
+	// Attio webhooks do not provide updated field information, so we return an
+	// empty list without an error.
+	return []string{}, nil
 }
 
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -145,21 +145,17 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 //
 // A naive objectName+"_id" is wrong for some events: note-content events carry a
 // "note_id" (not "note-content_id"), and workspace-member events carry a
-// "workspace_member_id" (underscore, not the hyphenated object name). Example
-// "id" objects from the docs for these two non-obvious cases:
+// "workspace_member_id" (underscore, not the hyphenated object name).
 //
-//	note-content.updated:     {"workspace_id": "...", "note_id": "..."}
-//	workspace-member.created: {"workspace_id": "...", "workspace_member_id": "..."}
+// Every mapping below is confirmed against the concrete example "id" object in
+// Attio's webhook reference (source of truth: https://api.attio.com/openapi/webhooks):
 //
-// Keys verified against Attio's webhook reference (see each event's "id" schema
-// and example):
-//   - source of truth: https://api.attio.com/openapi/webhooks
-//   - record.*:           https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
-//   - list.*:             https://docs.attio.com/rest-api/webhook-reference/list-events/listcreated
-//   - task.*:             https://docs.attio.com/rest-api/webhook-reference/task-events/taskcreated
-//   - note.*:             https://docs.attio.com/rest-api/webhook-reference/note-events/notecreated
-//   - note-content.*:     https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
-//   - workspace-member.*: https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
+//	record.*           id: {"workspace_id","object_id","record_id"}   https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
+//	list.*             id: {"workspace_id","list_id"}                 https://docs.attio.com/rest-api/webhook-reference/list-events/listcreated
+//	task.*             id: {"workspace_id","task_id"}                 https://docs.attio.com/rest-api/webhook-reference/task-events/taskcreated
+//	note.*             id: {"workspace_id","note_id"}                 https://docs.attio.com/rest-api/webhook-reference/note-events/notecreated
+//	note-content.*     id: {"workspace_id","note_id"}                 https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
+//	workspace-member.* id: {"workspace_id","workspace_member_id"}     https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
 //
 //nolint:gochecknoglobals
 var recordIDKeyByEventObject = map[string]string{

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -280,29 +280,13 @@ func computeSignature(secret string, body []byte) []byte {
 	return h.Sum(nil)
 }
 
-// objectNameCacheKey is the context key under which GetObjectNameFromTypeId stores
-// its object_id -> object name cache.
-type objectNameCacheKey struct{}
-
-// objectNameCache maps an Attio object_id to its object name (api_slug). It is kept
-// in the context so a batch of events resolves the object list at most once.
+// objectNameCache maps an Attio object_id to its object name (api_slug). It lives
+// on the Connector so a connector instance resolves the object list at most once
+// (and picks up newly created objects on a cache miss). It is safe for concurrent
+// use.
 type objectNameCache struct {
 	mu sync.RWMutex
 	m  map[string]string
-}
-
-// WithObjectNameCache returns a context carrying an object_id -> name cache used by
-// GetObjectNameFromTypeId. Callers that process multiple events should set this up
-// once so the object list is fetched at most once per batch. Without it,
-// GetObjectNameFromTypeId still works but fetches the object list on every call.
-func WithObjectNameCache(ctx context.Context) context.Context {
-	return context.WithValue(ctx, objectNameCacheKey{}, &objectNameCache{m: make(map[string]string)})
-}
-
-func objectNameCacheFromContext(ctx context.Context) *objectNameCache {
-	cache, _ := ctx.Value(objectNameCacheKey{}).(*objectNameCache)
-
-	return cache
 }
 
 func (o *objectNameCache) get(objectID string) (string, bool) {
@@ -318,6 +302,10 @@ func (o *objectNameCache) store(idToName map[string]string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
+	if o.m == nil {
+		o.m = make(map[string]string, len(idToName))
+	}
+
 	for id, name := range idToName {
 		o.m[id] = name
 	}
@@ -327,9 +315,9 @@ func (o *objectNameCache) store(idToName map[string]string) {
 //
 // Standard and custom object changes arrive as generic record.* events that
 // identify the object only by its id.object_id (a per-workspace UUID). This maps
-// that id to the object's api_slug: it first checks the object_id -> name cache in
-// the context (see WithObjectNameCache), and on a miss fetches the workspace's
-// objects directly from GET /v2/objects and caches the result.
+// that id to the object's api_slug: it first checks the connector's object_id ->
+// name cache, and on a miss fetches the workspace's objects directly from
+// GET /v2/objects and caches the result.
 // Ref: https://docs.attio.com/rest-api/endpoint-reference/objects/list-objects
 //
 // For core-object events (note, task, list, workspace-member) there is no
@@ -354,11 +342,8 @@ func (c *Connector) GetObjectNameFromTypeId(
 		return attioEvent.ObjectName()
 	}
 
-	cache := objectNameCacheFromContext(ctx)
-	if cache != nil {
-		if name, found := cache.get(objectID); found {
-			return name, nil
-		}
+	if name, found := c.objectNameCache.get(objectID); found {
+		return name, nil
 	}
 
 	idToName, err := c.fetchObjectIdToName(ctx)
@@ -366,9 +351,7 @@ func (c *Connector) GetObjectNameFromTypeId(
 		return "", err
 	}
 
-	if cache != nil {
-		cache.store(idToName)
-	}
+	c.objectNameCache.store(idToName)
 
 	name, found := idToName[objectID]
 	if !found {

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -149,15 +149,18 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 // "note_id" (not "note-content_id"), and workspace-member events carry a
 // "workspace_member_id" (underscore, not the hyphenated object name).
 //
-// Every mapping below is confirmed against the concrete example "id" object in
-// Attio's webhook reference (source of truth: https://api.attio.com/openapi/webhooks):
+// Each mapping is confirmed against the concrete example "id" object in Attio's
+// webhook reference (source of truth: https://api.attio.com/openapi/webhooks):
 //
-//	record.*           id: {"workspace_id","object_id","record_id"}   https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
-//	list.*             id: {"workspace_id","list_id"}                 https://docs.attio.com/rest-api/webhook-reference/list-events/listcreated
-//	task.*             id: {"workspace_id","task_id"}                 https://docs.attio.com/rest-api/webhook-reference/task-events/taskcreated
-//	note.*             id: {"workspace_id","note_id"}                 https://docs.attio.com/rest-api/webhook-reference/note-events/notecreated
-//	note-content.*     id: {"workspace_id","note_id"}                 https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
-//	workspace-member.* id: {"workspace_id","workspace_member_id"}     https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
+//	record.*             id: {workspace_id, object_id, record_id}
+//	list.*               id: {workspace_id, list_id}
+//	task.*               id: {workspace_id, task_id}
+//	note.* / note-content id: {workspace_id, note_id}
+//	workspace-member.*   id: {workspace_id, workspace_member_id}
+//
+// Per-event reference pages live under
+// https://docs.attio.com/rest-api/webhook-reference (e.g. record-events/recordcreated,
+// note-content-events/note-contentupdated, workspace-member-events/workspace-membercreated).
 //
 //nolint:gochecknoglobals
 var recordIDKeyByEventObject = map[string]string{
@@ -306,9 +309,7 @@ func (o *objectNameCache) store(idToName map[string]string) {
 		o.m = make(map[string]string, len(idToName))
 	}
 
-	for id, name := range idToName {
-		o.m[id] = name
-	}
+	maps.Copy(o.m, idToName)
 }
 
 // GetObjectNameFromTypeId resolves the object name for a subscription event.
@@ -326,8 +327,8 @@ func (o *objectNameCache) store(idToName map[string]string) {
 func (c *Connector) GetObjectNameFromTypeId(
 	ctx context.Context, event common.SubscriptionEvent,
 ) (string, error) {
-	attioEvent, ok := event.(SubscriptionEvent)
-	if !ok {
+	attioEvent, isAttioEvent := event.(SubscriptionEvent)
+	if !isAttioEvent {
 		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, SubscriptionEvent{}, event)
 	}
 

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -112,21 +112,9 @@ func (evt SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 }
 
 func (evt SubscriptionEvent) ObjectName() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	name, err := evt.RawEventName()
 	if err != nil {
 		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	name, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, name, eventsMap["event_type"])
 	}
 
 	objectName := strings.Split(name, ".")[0]
@@ -135,21 +123,13 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 }
 
 func (evt SubscriptionEvent) RawEventName() (string, error) {
-	m := evt.asMap()
+	// asMap returns the single event object ({event_type, id, ...}) extracted
+	// from the top-level events array, so event_type is read directly off it.
+	event := evt.asMap()
 
-	events, err := m.Get("events")
-	if err != nil {
-		return "", err
-	}
-
-	eventsMap, ok := events.(map[string]any)
+	eventName, ok := event["event_type"].(string)
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	eventName, ok := eventsMap["event_type"].(string)
-	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, eventName, eventsMap["event_type"])
+		return "", fmt.Errorf("%w: expected string event_type, got %T", errTypeMismatch, event["event_type"])
 	}
 
 	return eventName, nil
@@ -160,21 +140,9 @@ func (evt SubscriptionEvent) RawMap() (map[string]any, error) {
 }
 
 func (evt SubscriptionEvent) RecordId() (string, error) {
-	m := evt.asMap()
-
-	events, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
-	}
-
-	eventsMap, exist := events.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, eventsMap, events)
-	}
-
-	idMap, exist := eventsMap["id"].(map[string]string)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, eventsMap["id"])
 	}
 
 	objectName, err := evt.ObjectName()
@@ -184,35 +152,42 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 
 	idKey := objectName + "_id"
 
-	id, ok := idMap[idKey]
-	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", idKey) //nolint:err113
-	}
-
-	return id, nil
+	return lookupID(idMap, idKey)
 }
 
 func (evt SubscriptionEvent) Workspace() (string, error) {
-	m := evt.asMap()
-
-	data, err := m.Get("events")
+	idMap, err := evt.idMap()
 	if err != nil {
 		return "", err
 	}
 
-	dataMap, exist := data.(map[string]any)
-	if !exist {
-		return "", fmt.Errorf("%w: expected %T got %T", errTypeMismatch, dataMap, data)
+	return lookupID(idMap, "workspace_id")
+}
+
+// idMap returns the "id" object of the event as a map[string]any.
+// Attio's webhook id object holds the workspace_id and object-specific
+// identifiers (e.g. note_id, record_id).
+func (evt SubscriptionEvent) idMap() (map[string]any, error) {
+	event := evt.asMap()
+
+	idMap, ok := event["id"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: expected id to be map[string]any, got %T", errTypeMismatch, event["id"])
 	}
 
-	idMap, ok := dataMap["id"].(map[string]string)
+	return idMap, nil
+}
+
+// lookupID returns the string value stored under key in the event's id map.
+func lookupID(idMap map[string]any, key string) (string, error) {
+	value, ok := idMap[key]
 	if !ok {
-		return "", fmt.Errorf("%w: expected %T, got %T", errTypeMismatch, idMap, dataMap["id"])
+		return "", fmt.Errorf("%w: id map does not contain %q", errTypeMismatch, key)
 	}
 
-	id, ok := idMap["workspace_id"]
+	id, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("idMap does not contain id %s", "workspace_id") //nolint:err113
+		return "", fmt.Errorf("%w: expected %q to be string, got %T", errTypeMismatch, key, value)
 	}
 
 	return id, nil

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// newTestEvent creates a SubscriptionEvent that mirrors a real Attio webhook
-// payload: a top-level "events" array whose single element holds the event_type
-// and an "id" object. The id values are stored as map[string]any because that is
-// what encoding/json produces when decoding a real webhook body.
+// newTestEvent creates a single SubscriptionEvent as produced by
+// CollapsedSubscriptionEvent.SubscriptionEventList: one event object holding the
+// event_type and an "id" object. The id values are stored as map[string]any
+// because that is what encoding/json produces when decoding a real webhook body.
 func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
-	event := map[string]any{
+	event := SubscriptionEvent{
 		"event_type": eventType,
 	}
 
@@ -27,9 +27,7 @@ func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
 		event["id"] = id
 	}
 
-	return SubscriptionEvent{
-		"events": []any{event},
-	}
+	return event
 }
 
 func TestSubscriptionEvent_EventType(t *testing.T) {
@@ -62,7 +60,7 @@ func TestSubscriptionEvent_EventType(t *testing.T) {
 			expected: common.SubscriptionEventTypeOther,
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -117,7 +115,7 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 			expected: "record",
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -167,7 +165,7 @@ func TestSubscriptionEvent_RawEventName(t *testing.T) {
 			expected: "record.created",
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -260,7 +258,7 @@ func TestSubscriptionEvent_RecordId(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -315,7 +313,7 @@ func TestSubscriptionEvent_Workspace(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "Missing events key",
+			name:        "Empty event",
 			event:       SubscriptionEvent{},
 			expectedErr: true,
 		},
@@ -392,11 +390,13 @@ func TestSubscriptionEvent_EventTimeStampNano(t *testing.T) {
 	}
 }
 
-// TestSubscriptionEvent_RealWebhookPayload decodes a real Attio webhook body
-// (via encoding/json, the way the server does) and verifies the parsing methods
-// work end to end. This guards against the events-as-array / id map[string]any
+// TestCollapsedSubscriptionEvent_RealWebhookPayload decodes a real Attio webhook
+// body (via encoding/json, the way the server does), fans it out through
+// SubscriptionEventList, and verifies the parsing methods work end to end on the
+// resulting per-event SubscriptionEvents. It uses two events to also exercise the
+// array fan-out (batching), guarding against the events-array / id map[string]any
 // shape being mishandled.
-func TestSubscriptionEvent_RealWebhookPayload(t *testing.T) {
+func TestCollapsedSubscriptionEvent_RealWebhookPayload(t *testing.T) {
 	t.Parallel()
 
 	body := []byte(`{
@@ -404,53 +404,108 @@ func TestSubscriptionEvent_RealWebhookPayload(t *testing.T) {
 		"events": [
 			{
 				"event_type": "note.updated",
-				"id": {
-					"workspace_id": "ws-1",
-					"note_id": "note-9"
-				}
+				"id": { "workspace_id": "ws-1", "note_id": "note-9" }
+			},
+			{
+				"event_type": "record.created",
+				"id": { "workspace_id": "ws-1", "object_id": "obj-1", "record_id": "rec-2" }
 			}
 		]
 	}`)
 
-	var evt SubscriptionEvent
-	if err := json.Unmarshal(body, &evt); err != nil {
+	var collapsed CollapsedSubscriptionEvent
+	if err := json.Unmarshal(body, &collapsed); err != nil {
 		t.Fatalf("failed to unmarshal payload: %v", err)
 	}
 
-	eventType, err := evt.EventType()
+	events, err := collapsed.SubscriptionEventList()
 	if err != nil {
-		t.Fatalf("EventType() error: %v", err)
+		t.Fatalf("SubscriptionEventList() error: %v", err)
 	}
 
-	if eventType != common.SubscriptionEventTypeUpdate {
-		t.Fatalf("EventType() = %v, want %v", eventType, common.SubscriptionEventTypeUpdate)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
 	}
 
-	objectName, err := evt.ObjectName()
-	if err != nil {
-		t.Fatalf("ObjectName() error: %v", err)
+	cases := []struct {
+		eventType  common.SubscriptionEventType
+		objectName string
+		recordID   string
+	}{
+		{common.SubscriptionEventTypeUpdate, "note", "note-9"},
+		{common.SubscriptionEventTypeCreate, "record", "rec-2"},
 	}
 
-	if objectName != "note" {
-		t.Fatalf("ObjectName() = %q, want %q", objectName, "note")
+	for i, want := range cases {
+		evt := events[i]
+
+		eventType, err := evt.EventType()
+		if err != nil {
+			t.Fatalf("event %d EventType() error: %v", i, err)
+		}
+
+		if eventType != want.eventType {
+			t.Fatalf("event %d EventType() = %v, want %v", i, eventType, want.eventType)
+		}
+
+		objectName, err := evt.ObjectName()
+		if err != nil {
+			t.Fatalf("event %d ObjectName() error: %v", i, err)
+		}
+
+		if objectName != want.objectName {
+			t.Fatalf("event %d ObjectName() = %q, want %q", i, objectName, want.objectName)
+		}
+
+		recordID, err := evt.RecordId()
+		if err != nil {
+			t.Fatalf("event %d RecordId() error: %v", i, err)
+		}
+
+		if recordID != want.recordID {
+			t.Fatalf("event %d RecordId() = %q, want %q", i, recordID, want.recordID)
+		}
+
+		workspace, err := evt.Workspace()
+		if err != nil {
+			t.Fatalf("event %d Workspace() error: %v", i, err)
+		}
+
+		if workspace != "ws-1" {
+			t.Fatalf("event %d Workspace() = %q, want %q", i, workspace, "ws-1")
+		}
+	}
+}
+
+func TestCollapsedSubscriptionEvent_SubscriptionEventList_Errors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event CollapsedSubscriptionEvent
+	}{
+		{
+			name:  "missing events key",
+			event: CollapsedSubscriptionEvent{"webhook_id": "wh-1"},
+		},
+		{
+			name:  "events is not an array",
+			event: CollapsedSubscriptionEvent{"events": map[string]any{"event_type": "note.updated"}},
+		},
+		{
+			name:  "event element is not an object",
+			event: CollapsedSubscriptionEvent{"events": []any{"not-an-object"}},
+		},
 	}
 
-	recordID, err := evt.RecordId()
-	if err != nil {
-		t.Fatalf("RecordId() error: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if recordID != "note-9" {
-		t.Fatalf("RecordId() = %q, want %q", recordID, "note-9")
-	}
-
-	workspace, err := evt.Workspace()
-	if err != nil {
-		t.Fatalf("Workspace() error: %v", err)
-	}
-
-	if workspace != "ws-1" {
-		t.Fatalf("Workspace() = %q, want %q", workspace, "ws-1")
+			if _, err := tt.event.SubscriptionEventList(); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
 	}
 }
 

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -207,7 +207,7 @@ func TestSubscriptionEvent_RecordId(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			name: "Extracts record ID using object name as key",
+			name: "note event uses note_id",
 			event: newTestEvent("note.updated", map[string]string{
 				"workspace_id": "ws-123",
 				"note_id":      "note-456",
@@ -215,8 +215,46 @@ func TestSubscriptionEvent_RecordId(t *testing.T) {
 			expected: "note-456",
 		},
 		{
+			// note-content events carry note_id, not "note-content_id".
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated
+			name: "note-content event uses note_id",
+			event: newTestEvent("note-content.updated", map[string]string{
+				"workspace_id": "ws-123",
+				"note_id":      "note-789",
+			}),
+			expected: "note-789",
+		},
+		{
+			// workspace-member events carry workspace_member_id (underscore).
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/workspace-member-events/workspace-membercreated
+			name: "workspace-member event uses workspace_member_id",
+			event: newTestEvent("workspace-member.created", map[string]string{
+				"workspace_id":        "ws-123",
+				"workspace_member_id": "wm-001",
+			}),
+			expected: "wm-001",
+		},
+		{
+			// record events carry record_id (alongside object_id).
+			// Ref: https://docs.attio.com/rest-api/webhook-reference/record-events/recordcreated
+			name: "record event uses record_id",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-123",
+				"object_id":    "obj-1",
+				"record_id":    "rec-001",
+			}),
+			expected: "rec-001",
+		},
+		{
 			name: "Missing ID key for object",
 			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-123",
+			}),
+			expectedErr: true,
+		},
+		{
+			name: "Unmapped event object returns error",
+			event: newTestEvent("unknown-object.created", map[string]string{
 				"workspace_id": "ws-123",
 			}),
 			expectedErr: true,

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -145,7 +145,7 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 	}
 }
 
-func TestSubscriptionEvent_ObjectNameWithMetadata(t *testing.T) {
+func TestSubscriptionEvent_ObjectNameFromMetadata(t *testing.T) {
 	t.Parallel()
 
 	// Metadata is keyed by object_id (the contract shared with
@@ -214,7 +214,7 @@ func TestSubscriptionEvent_ObjectNameWithMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := tt.event.ObjectNameWithMetadata(tt.metadata)
+			result, err := tt.event.ObjectNameFromMetadata(tt.metadata)
 			if tt.expectedErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -3,10 +3,16 @@ package attio
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
 // newTestEvent creates a single SubscriptionEvent as produced by
@@ -126,95 +132,6 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 			t.Parallel()
 
 			result, err := tt.event.ObjectName()
-			if tt.expectedErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if result != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestSubscriptionEvent_ObjectNameFromMetadata(t *testing.T) {
-	t.Parallel()
-
-	// Metadata is keyed by object_id (the contract shared with
-	// GetObjectNameFromObjectMetadata), and DisplayName holds the object name.
-	metadata := &common.ListObjectMetadataResult{
-		Result: map[string]common.ObjectMetadata{
-			"obj-people-uuid": {DisplayName: "people"},
-		},
-	}
-
-	tests := []struct {
-		name        string
-		event       SubscriptionEvent
-		metadata    *common.ListObjectMetadataResult
-		expected    string
-		expectedErr bool
-	}{
-		{
-			name: "record event resolves object_id via metadata",
-			event: newTestEvent("record.created", map[string]string{
-				"workspace_id": "ws-1",
-				"object_id":    "obj-people-uuid",
-				"record_id":    "rec-1",
-			}),
-			metadata: metadata,
-			expected: "people",
-		},
-		{
-			name: "core event falls back to event_type object",
-			event: newTestEvent("note.updated", map[string]string{
-				"workspace_id": "ws-1",
-				"note_id":      "note-1",
-			}),
-			metadata: metadata,
-			expected: "note",
-		},
-		{
-			name: "unknown object_id returns error",
-			event: newTestEvent("record.created", map[string]string{
-				"workspace_id": "ws-1",
-				"object_id":    "obj-unknown",
-				"record_id":    "rec-1",
-			}),
-			metadata:    metadata,
-			expectedErr: true,
-		},
-		{
-			name: "nil metadata with record event returns error",
-			event: newTestEvent("record.created", map[string]string{
-				"workspace_id": "ws-1",
-				"object_id":    "obj-people-uuid",
-				"record_id":    "rec-1",
-			}),
-			metadata:    nil,
-			expectedErr: true,
-		},
-		{
-			name:        "empty event returns error",
-			event:       SubscriptionEvent{},
-			metadata:    metadata,
-			expectedErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result, err := tt.event.ObjectNameFromMetadata(tt.metadata)
 			if tt.expectedErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -696,41 +613,56 @@ func TestGetFieldNameFromObjectMetadata(t *testing.T) {
 	}
 }
 
-func TestGetObjectNameFromObjectMetadata(t *testing.T) {
+func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
 	t.Parallel()
 
-	metadata := &common.ListObjectMetadataResult{
-		Result: map[string]common.ObjectMetadata{
-			"obj-uuid-1": {
-				DisplayName: "Companies",
-			},
-			"obj-uuid-2": {
-				DisplayName: "People",
-			},
-		},
-		Errors: map[string]error{},
+	objectsResponse := testutils.DataFromFile(t, "objects.json")
+
+	server := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If:    mockcond.Path("/v2/objects"),
+		Then:  mockserver.Response(http.StatusOK, objectsResponse),
+	}.Server()
+	t.Cleanup(server.Close)
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("failed to construct test connector: %v", err)
 	}
 
 	tests := []struct {
 		name        string
-		objectID    string
+		event       SubscriptionEvent
 		expected    string
-		expectedErr error
+		expectedErr bool
 	}{
 		{
-			name:     "Found object display name",
-			objectID: "obj-uuid-1",
-			expected: "Companies",
+			// record.* event: object_id resolved via GET /v2/objects.
+			name: "record event resolves object_id to api_slug",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "0e80364d-70b1-44d3-b7ba-0a6a564a7152",
+				"record_id":    "rec-1",
+			}),
+			expected: "people",
 		},
 		{
-			name:     "Found second object display name",
-			objectID: "obj-uuid-2",
-			expected: "People",
+			// core-object event: no object_id, falls back to ObjectName() (no fetch).
+			name: "core event falls back to event_type object",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-1",
+				"note_id":      "note-1",
+			}),
+			expected: "note",
 		},
 		{
-			name:        "Object not found",
-			objectID:    "unknown-obj",
-			expectedErr: common.ErrNotFound,
+			name: "unknown object_id returns error",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "does-not-exist",
+				"record_id":    "rec-1",
+			}),
+			expectedErr: true,
 		},
 	}
 
@@ -738,14 +670,10 @@ func TestGetObjectNameFromObjectMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := GetObjectNameFromObjectMetadata(metadata, tt.objectID)
-			if tt.expectedErr != nil {
+			result, err := conn.GetObjectNameFromTypeId(t.Context(), tt.event)
+			if tt.expectedErr {
 				if err == nil {
-					t.Fatalf("expected error %v, got nil", tt.expectedErr)
-				}
-
-				if !errors.Is(err, tt.expectedErr) {
-					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
+					t.Fatal("expected error, got nil")
 				}
 
 				return
@@ -759,5 +687,48 @@ func TestGetObjectNameFromObjectMetadata(t *testing.T) {
 				t.Fatalf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestConnector_GetObjectNameFromTypeId_CachesInContext(t *testing.T) {
+	t.Parallel()
+
+	objectsResponse := testutils.DataFromFile(t, "objects.json")
+
+	var calls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/objects" {
+			atomic.AddInt32(&calls, 1)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(objectsResponse)
+	}))
+	t.Cleanup(server.Close)
+
+	conn, err := constructTestConnector(server.URL)
+	if err != nil {
+		t.Fatalf("failed to construct test connector: %v", err)
+	}
+
+	ctx := WithObjectNameCache(t.Context())
+
+	for range 3 {
+		name, err := conn.GetObjectNameFromTypeId(ctx, newTestEvent("record.created", map[string]string{
+			"object_id": "bb3380d7-06a7-4948-9d62-3e735e782c5c",
+			"record_id": "rec-1",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if name != "companies" {
+			t.Fatalf("expected %q, got %q", "companies", name)
+		}
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected objects to be fetched once with cache, got %d", got)
 	}
 }

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -2,7 +2,6 @@ package attio
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -510,104 +509,6 @@ func TestCollapsedSubscriptionEvent_SubscriptionEventList_Errors(t *testing.T) {
 
 			if _, err := tt.event.SubscriptionEventList(); err == nil {
 				t.Fatal("expected error, got nil")
-			}
-		})
-	}
-}
-
-func TestGetFieldNameFromObjectMetadata(t *testing.T) {
-	t.Parallel()
-
-	metadata := &common.ListObjectMetadataResult{
-		Result: map[string]common.ObjectMetadata{
-			"obj-uuid-1": {
-				DisplayName: "Companies",
-				Fields: map[string]common.FieldMetadata{
-					"name": {
-						DisplayName: "name",
-						FieldId:     new("attr-uuid-1"),
-					},
-					"domains": {
-						DisplayName: "domains",
-						FieldId:     new("attr-uuid-2"),
-					},
-				},
-			},
-			"obj-uuid-2": {
-				DisplayName: "People",
-				Fields: map[string]common.FieldMetadata{
-					"email": {
-						DisplayName: "email",
-						FieldId:     nil,
-					},
-				},
-			},
-		},
-		Errors: map[string]error{},
-	}
-
-	tests := []struct {
-		name        string
-		objectID    string
-		attributeID string
-		expected    string
-		expectedErr error
-	}{
-		{
-			name:        "Found field by attribute ID",
-			objectID:    "obj-uuid-1",
-			attributeID: "attr-uuid-1",
-			expected:    "name",
-		},
-		{
-			name:        "Found second field by attribute ID",
-			objectID:    "obj-uuid-1",
-			attributeID: "attr-uuid-2",
-			expected:    "domains",
-		},
-		{
-			name:        "Object not found",
-			objectID:    "unknown-obj",
-			attributeID: "attr-uuid-1",
-			expectedErr: common.ErrNotFound,
-		},
-		{
-			name:        "Attribute not found in object",
-			objectID:    "obj-uuid-1",
-			attributeID: "unknown-attr",
-			expectedErr: common.ErrNotFound,
-		},
-		{
-			name:        "Nil FieldId is skipped",
-			objectID:    "obj-uuid-2",
-			attributeID: "any-attr",
-			expectedErr: common.ErrNotFound,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result, err := GetFieldNameFromObjectMetadata(metadata, tt.objectID, tt.attributeID)
-			if tt.expectedErr != nil {
-				if err == nil {
-					t.Fatalf("expected error %v, got nil", tt.expectedErr)
-				}
-
-				if !errors.Is(err, tt.expectedErr) {
-					t.Fatalf("expected error %v, got %v", tt.expectedErr, err)
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if result != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, result)
 			}
 		})
 	}

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -591,7 +591,7 @@ func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
 	}
 }
 
-func TestConnector_GetObjectNameFromTypeId_CachesInContext(t *testing.T) {
+func TestConnector_GetObjectNameFromTypeId_CachesOnConnector(t *testing.T) {
 	t.Parallel()
 
 	objectsResponse := testutils.DataFromFile(t, "objects.json")
@@ -613,10 +613,9 @@ func TestConnector_GetObjectNameFromTypeId_CachesInContext(t *testing.T) {
 		t.Fatalf("failed to construct test connector: %v", err)
 	}
 
-	ctx := WithObjectNameCache(t.Context())
-
+	// The same connector caches the object list, so repeated resolutions fetch once.
 	for range 3 {
-		name, err := conn.GetObjectNameFromTypeId(ctx, newTestEvent("record.created", map[string]string{
+		name, err := conn.GetObjectNameFromTypeId(t.Context(), newTestEvent("record.created", map[string]string{
 			"object_id": "bb3380d7-06a7-4948-9d62-3e735e782c5c",
 			"record_id": "rec-1",
 		}))

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -145,6 +145,95 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 	}
 }
 
+func TestSubscriptionEvent_ObjectNameWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Metadata is keyed by object_id (the contract shared with
+	// GetObjectNameFromObjectMetadata), and DisplayName holds the object name.
+	metadata := &common.ListObjectMetadataResult{
+		Result: map[string]common.ObjectMetadata{
+			"obj-people-uuid": {DisplayName: "people"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		event       SubscriptionEvent
+		metadata    *common.ListObjectMetadataResult
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name: "record event resolves object_id via metadata",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "obj-people-uuid",
+				"record_id":    "rec-1",
+			}),
+			metadata: metadata,
+			expected: "people",
+		},
+		{
+			name: "core event falls back to event_type object",
+			event: newTestEvent("note.updated", map[string]string{
+				"workspace_id": "ws-1",
+				"note_id":      "note-1",
+			}),
+			metadata: metadata,
+			expected: "note",
+		},
+		{
+			name: "unknown object_id returns error",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "obj-unknown",
+				"record_id":    "rec-1",
+			}),
+			metadata:    metadata,
+			expectedErr: true,
+		},
+		{
+			name: "nil metadata with record event returns error",
+			event: newTestEvent("record.created", map[string]string{
+				"workspace_id": "ws-1",
+				"object_id":    "obj-people-uuid",
+				"record_id":    "rec-1",
+			}),
+			metadata:    nil,
+			expectedErr: true,
+		},
+		{
+			name:        "empty event returns error",
+			event:       SubscriptionEvent{},
+			metadata:    metadata,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tt.event.ObjectNameWithMetadata(tt.metadata)
+			if tt.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestSubscriptionEvent_RawEventName(t *testing.T) {
 	t.Parallel()
 

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -327,9 +327,13 @@ func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
 
 	evt := newTestEvent("note.updated", nil)
 
-	_, err := evt.UpdatedFields()
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	fields, err := evt.UpdatedFields()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(fields) != 0 {
+		t.Fatalf("expected empty fields, got %v", fields)
 	}
 }
 

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -1,6 +1,7 @@
 package attio
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -8,21 +9,26 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// newTestEvent creates a SubscriptionEvent for testing.
-// The "events" value is a map (not an array) so that asMap() falls back
-// to returning the raw SubscriptionEvent, which is what the methods expect
-// when they call m.Get("events").
+// newTestEvent creates a SubscriptionEvent that mirrors a real Attio webhook
+// payload: a top-level "events" array whose single element holds the event_type
+// and an "id" object. The id values are stored as map[string]any because that is
+// what encoding/json produces when decoding a real webhook body.
 func newTestEvent(eventType string, idMap map[string]string) SubscriptionEvent {
-	inner := map[string]any{
+	event := map[string]any{
 		"event_type": eventType,
 	}
 
 	if idMap != nil {
-		inner["id"] = idMap
+		id := make(map[string]any, len(idMap))
+		for k, v := range idMap {
+			id[k] = v
+		}
+
+		event["id"] = id
 	}
 
 	return SubscriptionEvent{
-		"events": inner,
+		"events": []any{event},
 	}
 }
 
@@ -345,6 +351,68 @@ func TestSubscriptionEvent_EventTimeStampNano(t *testing.T) {
 	_, err := evt.EventTimeStampNano()
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+// TestSubscriptionEvent_RealWebhookPayload decodes a real Attio webhook body
+// (via encoding/json, the way the server does) and verifies the parsing methods
+// work end to end. This guards against the events-as-array / id map[string]any
+// shape being mishandled.
+func TestSubscriptionEvent_RealWebhookPayload(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"webhook_id": "wh-1",
+		"events": [
+			{
+				"event_type": "note.updated",
+				"id": {
+					"workspace_id": "ws-1",
+					"note_id": "note-9"
+				}
+			}
+		]
+	}`)
+
+	var evt SubscriptionEvent
+	if err := json.Unmarshal(body, &evt); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	eventType, err := evt.EventType()
+	if err != nil {
+		t.Fatalf("EventType() error: %v", err)
+	}
+
+	if eventType != common.SubscriptionEventTypeUpdate {
+		t.Fatalf("EventType() = %v, want %v", eventType, common.SubscriptionEventTypeUpdate)
+	}
+
+	objectName, err := evt.ObjectName()
+	if err != nil {
+		t.Fatalf("ObjectName() error: %v", err)
+	}
+
+	if objectName != "note" {
+		t.Fatalf("ObjectName() = %q, want %q", objectName, "note")
+	}
+
+	recordID, err := evt.RecordId()
+	if err != nil {
+		t.Fatalf("RecordId() error: %v", err)
+	}
+
+	if recordID != "note-9" {
+		t.Fatalf("RecordId() = %q, want %q", recordID, "note-9")
+	}
+
+	workspace, err := evt.Workspace()
+	if err != nil {
+		t.Fatalf("Workspace() error: %v", err)
+	}
+
+	if workspace != "ws-1" {
+		t.Fatalf("Workspace() = %q, want %q", workspace, "ws-1")
 	}
 }
 

--- a/providers/attio/types.go
+++ b/providers/attio/types.go
@@ -38,10 +38,11 @@ type subscriptionPayload struct {
 
 type subscriptionData struct {
 	TargetURL     string         `json:"target_url"    validate:"required"`
-	Subscriptions []subscription `json:"subscriptions" validate:"required"`
+	Subscriptions []Subscription `json:"subscriptions" validate:"required"`
 }
 
-type subscription struct {
+// Subscription is a single webhook subscription entry (event type + optional filter).
+type Subscription struct {
 	EventType providerEvent `json:"event_type" validate:"required"`
 	// Filter is an object used to limit which webhook events are delivered.
 	// Filters can target specific records (by list_id, entry_id) or specific object (by object_id).
@@ -51,21 +52,24 @@ type subscription struct {
 	Filter any `json:"filter"`
 }
 
-// // createSubscriptionsResponse is the response returned by Attio when a webhook is created.
+// CreateSubscriptionsResponse is the response returned by Attio when a webhook is created.
 // Reference: https://docs.attio.com/rest-api/endpoint-reference/webhooks/create-a-webhook#response-data
-type createSubscriptionsResponse struct {
-	Data createSubscriptionsResponseData `json:"data"`
+type CreateSubscriptionsResponse struct {
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
-type createSubscriptionsResponseID struct {
+// CreateSubscriptionsResponseID holds the workspace and webhook identifiers of a created webhook.
+type CreateSubscriptionsResponseID struct {
 	WorkspaceID string `json:"workspace_id"`
 	WebhookID   string `json:"webhook_id"`
 }
 
-type createSubscriptionsResponseData struct {
+// CreateSubscriptionsResponseData is the data payload of a created webhook subscription.
+// It is nested in common.SubscriptionResult.Result, so it is exported.
+type CreateSubscriptionsResponseData struct {
 	TargetURL     string                        `json:"target_url"`
-	Subscriptions []subscription                `json:"subscriptions" validate:"required"`
-	ID            createSubscriptionsResponseID `json:"id"`
+	Subscriptions []Subscription                `json:"subscriptions" validate:"required"`
+	ID            CreateSubscriptionsResponseID `json:"id"`
 	Status        string                        `json:"status"`
 	CreatedAt     string                        `json:"created_at"`
 	// Secret used for webhook signature verification.
@@ -82,7 +86,7 @@ type SuccessfulSubscription struct {
 }
 
 type SubscriptionResult struct {
-	Data createSubscriptionsResponseData `json:"data"`
+	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
 // providerEvent represents the combined event type string used by Attio.

--- a/providers/attio/types.go
+++ b/providers/attio/types.go
@@ -58,10 +58,10 @@ type CreateSubscriptionsResponse struct {
 	Data CreateSubscriptionsResponseData `json:"data"`
 }
 
-// CreateSubscriptionsResponseID holds the workspace and webhook identifiers of a created webhook.
-type CreateSubscriptionsResponseID struct {
-	WorkspaceID string `json:"workspace_id"`
-	WebhookID   string `json:"webhook_id"`
+// CreateSubscriptionsResponseId holds the workspace and webhook identifiers of a created webhook.
+type CreateSubscriptionsResponseId struct {
+	WorkspaceId string `json:"workspace_id"`
+	WebhookId   string `json:"webhook_id"`
 }
 
 // CreateSubscriptionsResponseData is the data payload of a created webhook subscription.
@@ -69,7 +69,7 @@ type CreateSubscriptionsResponseID struct {
 type CreateSubscriptionsResponseData struct {
 	TargetURL     string                        `json:"target_url"`
 	Subscriptions []Subscription                `json:"subscriptions" validate:"required"`
-	ID            CreateSubscriptionsResponseID `json:"id"`
+	Id            CreateSubscriptionsResponseId `json:"id"`
 	Status        string                        `json:"status"`
 	CreatedAt     string                        `json:"created_at"`
 	// Secret used for webhook signature verification.
@@ -80,7 +80,7 @@ type CreateSubscriptionsResponseData struct {
 
 // SuccessfulSubscription is used internally for rollback tracking.
 type SuccessfulSubscription struct {
-	ID         string
+	Id         string
 	ObjectName string
 	EventName  string
 }

--- a/providers/attio/utils.go
+++ b/providers/attio/utils.go
@@ -65,7 +65,7 @@ func buildSubscriptionPayloadForCoreObj(
 	objEvents objectEvents,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	providerEvents := objEvents.toProviderEvents(event)
 	if len(providerEvents) == 0 {
 		return nil, fmt.Errorf("%w: object '%s' with event '%s'",
@@ -73,7 +73,7 @@ func buildSubscriptionPayloadForCoreObj(
 	}
 
 	for _, e := range providerEvents {
-		sub = append(sub, subscription{
+		sub = append(sub, Subscription{
 			EventType: e,
 			Filter:    nil,
 		})
@@ -86,7 +86,7 @@ func buildSubscriptionPayloadForStandardObj(
 	standardObjects map[common.ObjectName]string,
 	objectName common.ObjectName,
 	event common.SubscriptionEventType,
-) (sub []subscription, err error) {
+) (sub []Subscription, err error) {
 	// Handle building subscriptions for standard/custom objects
 	objectId, exists := standardObjects[objectName]
 	if !exists {
@@ -112,7 +112,7 @@ func buildSubscriptionPayloadForStandardObj(
 		},
 	}
 	sub = append(sub,
-		subscription{
+		Subscription{
 			EventType: recordEvent,
 			Filter:    filter,
 		},


### PR DESCRIPTION
Consolidates the Attio subscribe follow-up work into a single PR (previously split across #3215/#3216/#3217/#3218, now closed). Stacked on #2668.

Addresses review comments from #2387 that were marked resolved but weren't, plus the `UpdatedFields` behavior change.

### Fixes
1. **`UpdatedFields` returns empty, not an error** — Attio webhooks carry no updated-field info, so `UpdatedFields()` now returns `[]string{}, nil` instead of an error.

2. **Event parsing worked only on fabricated data** 🔴 — `asMap()` already extracts the single event from the top-level `events` **array**, but `ObjectName`/`RawEventName`/`RecordId`/`Workspace` then called `m.Get("events")` again on the unwrapped event (fails with `key not found: events`), and `id` was asserted as `map[string]string` when `encoding/json` yields `map[string]any`. Both failed on real payloads. The methods now read `event_type`/`id` directly and assert `map[string]any`. The test helper built a fake map/`map[string]string` shape to pass; it now builds the real array/`any` shape, and a new `TestSubscriptionEvent_RealWebhookPayload` decodes a real JSON body end to end.

3. **`GetRecordsByIds` used the wrong filter key** 🔴 — sent `"filters"` (plural); the List-records endpoint (`POST /v2/objects/{object}/records/query`) expects a singular **`"filter"`** with `record_id`/`$in` (verified against the endpoint reference and filtering guide). With the plural key the filter was ignored and Attio returned unfiltered records. The mock now also asserts the request body.

4. **Exported result types nested in `SubscriptionResult`** — `subscription`→`Subscription`, `createSubscriptionsResponse{,Data,ID}`→exported, with godoc, per review feedback.

Builds, `go test ./providers/attio/...` passes, gofumpt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)