### PR TITLE
[ENG-4127] feat(connectwise): Change Contacts PUT to PATCH

### DIFF
--- a/providers/connectwise/communication-types.go
+++ b/providers/connectwise/communication-types.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/naming"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/spyzhov/ajson"
 )
@@ -79,7 +81,7 @@ func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // 
 	return nil
 }
 
-// payloadWithCommunicationItems rewrites the write payload for a contact record
+// postPayloadWithCommunicationItems rewrites the write payload for a contact record
 // so that virtual communication-item fields are translated into a proper
 // `communicationItems` array for ConnectWise.
 //
@@ -92,7 +94,7 @@ func attachCommunicationItems(node *ajson.Node, root map[string]any) error { // 
 //
 // If the record is nil or the intent is empty (no communication fields set),
 // the function returns without modifying the record.
-func (c *Connector) payloadWithCommunicationItems(ctx context.Context, record common.Record) error {
+func (c *Connector) postPayloadWithCommunicationItems(ctx context.Context, record common.Record) error {
 	if record == nil {
 		// No record to modify; nothing to do.
 		return nil
@@ -148,7 +150,224 @@ func (c *Connector) payloadWithCommunicationItems(ctx context.Context, record co
 	return nil
 }
 
-// patchPayloadWithCommunicationItems transforms a list of JSON Patch operations
+// contactsFullUpdatePayload builds a JSON Patch payload that emulates a full
+// PUT for a contact record, while avoiding ConnectWise's known issues with
+// native PUT.
+//
+// ConnectWise's PUT for contacts is problematic:
+//   - Including `communicationItems` in a PUT can trigger spurious validation
+//     errors even when the items are correct.
+//   - PUT does not truly replace the object: custom fields property is left untouched,
+//     and communication items are not fully synchronized.
+//
+// This function implements true full-replacement semantics using PATCH:
+//
+// 1. Clear customFields
+// 2. Remove obsolete top-level field
+// 3. Replace all fields from the incoming record
+// 4. Synchronize communicationItems
+//
+// If the record contains virtual communication-item fields:
+//   - A registry of existing communication items (type ID -> index) is built
+//     from the fetched contact.
+//   - Missing communication type IDs are resolved via the
+//     `/company/communicationTypes` endpoint.
+//   - For each default email/phone/fax:
+//   - If an item with the same type ID exists, its `value` is replaced.
+//   - Otherwise, a new item is appended to `communicationItems`.
+//   - Any existing communication items not present in the intent are removed.
+//     Remove operations are sorted to avoid index instability when deleting
+//     multiple items in a single patch.
+//
+// The resulting patch sequence provides callers with simple "PUT-like"
+// semantics while sidestepping ConnectWise's bugs and limitations around
+// contact updates.
+func (c *Connector) contactsFullUpdatePayload(ctx context.Context, // nolint:cyclop,funlen
+	record common.Record,
+	contactId string,
+) ([]patchOperationPayload, error) {
+	// Start by clearing customFields; ConnectWise requires this for PATCH to work.
+	operations := []patchOperationPayload{
+		{
+			Op:    operationReplace,
+			Path:  "customFields",
+			Value: []any{},
+		},
+	}
+
+	if record == nil {
+		return operations, nil
+	}
+
+	contact, err := fetchContact[map[string]any](ctx, c, contactId)
+	if err != nil {
+		return nil, err
+	}
+
+	var registry map[string]int
+
+	keys := datautils.Map[string, any](*contact).Keys()
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if datautils.NewSet(
+			"firstName",        // required field
+			"customFields",     // already clearing above; required for PATCH to work
+			"ignoreDuplicates", // unremovable flag
+			"_info",            // metadata; ignore
+			"id",               // read-only field
+		).Has(key) {
+			continue
+		}
+
+		// Handle communicationItems separately via per-element add/replace/remove.
+		if key == "communicationItems" {
+			registry, err = makeCommunicationItemsRegistry((*contact)[key])
+			if err != nil {
+				return nil, err
+			}
+
+			continue
+		}
+
+		// Remove all other fields; they will be replaced from the new record.
+		operations = append(operations, patchOperationPayload{
+			Op:   operationRemove,
+			Path: key,
+		})
+	}
+
+	intent, err := createCommunicationItemsIntent(record)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace all fields from the incoming record (core + custom fields).
+	keys = datautils.Map[string, any](record).Keys()
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		operations = append(operations, patchOperationPayload{
+			Op:    operationReplace,
+			Path:  key,
+			Value: record[key],
+		})
+	}
+
+	if intent.isEmpty() {
+		// No communication-item fields present; patch is complete.
+		return operations, nil
+	}
+
+	if intent.needIds() {
+		if err = c.fetchMissingCommunicationItemIds(ctx, intent); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add or replace default email/phone/fax items.
+	if intent.DefaultEmail != "" {
+		operations = append(operations,
+			makeOperationAddOrReplace(registry, intent.DefaultEmailId, intent.DefaultEmail, communicationTypeEmail)...,
+		)
+	}
+
+	if intent.DefaultPhone != "" {
+		operations = append(operations,
+			makeOperationAddOrReplace(registry, intent.DefaultPhoneId, intent.DefaultPhone, communicationTypePhone)...,
+		)
+	}
+
+	if intent.DefaultFax != "" {
+		operations = append(operations,
+			makeOperationAddOrReplace(registry, intent.DefaultFaxId, intent.DefaultFax, communicationTypeFax)...,
+		)
+	}
+
+	// Remove any existing communication items not present in the intent.
+	// First, exclude the items we are keeping (defaults).
+	delete(registry, intent.DefaultEmailId)
+	delete(registry, intent.DefaultPhoneId)
+	delete(registry, intent.DefaultFaxId)
+
+	opRemove := make([]patchOperationPayload, 0, len(registry))
+	for _, index := range registry {
+		opRemove = append(opRemove, patchOperationPayload{
+			Op:          operationRemove,
+			Path:        fmt.Sprintf("/communicationItems/%v", index),
+			removeIndex: index,
+		})
+	}
+
+	// Sort remove operations to maintain stable indices during patch application.
+	sortRemovePayloads(opRemove)
+	operations = append(operations, opRemove...)
+
+	return operations, nil
+}
+
+// makeOperationAddOrReplace generates JSON Patch operations to add or replace
+// a single default communication item (email/phone/fax) based on the existing
+// registry.
+func makeOperationAddOrReplace(registry map[string]int,
+	identifier string,
+	value string,
+	communicationType string,
+) []patchOperationPayload {
+	index, found := registry[identifier]
+	if !found {
+		// No existing item with this type ID; append a new one.
+		return []patchOperationPayload{{
+			Op:   "add",
+			Path: fmt.Sprintf("/communicationItems/%v", len(registry)),
+			Value: createCommunicationItemPayload{
+				Type:              communicationItemTypePayload{identifier},
+				Value:             value,
+				DefaultFlag:       true,
+				CommunicationType: communicationType,
+			},
+		}}
+	}
+
+	// Existing item with this type ID; update its value.
+	return []patchOperationPayload{{
+		Op:    "replace",
+		Path:  fmt.Sprintf("/communicationItems/%v/value", index),
+		Value: value,
+	}}
+}
+
+func makeCommunicationItemsRegistry(value any) (map[string]int, error) {
+	registry := make(map[string]int)
+
+	communicationItems, ok := value.([]any)
+	if !ok {
+		return nil, jsonquery.ErrNotArray
+	}
+
+	for index, communicationItem := range communicationItems {
+		item, ok := communicationItem.(map[string]any)
+		if !ok {
+			return nil, jsonquery.ErrNotObject
+		}
+
+		node, err := jsonquery.Convertor.NodeFromMap(item)
+		if err != nil {
+			return nil, err
+		}
+
+		typeId, err := jsonquery.New(node, "type").IntegerRequired("id")
+		if err != nil {
+			return nil, err
+		}
+
+		registry[strconv.FormatInt(typeId, 10)] = index
+	}
+
+	return registry, nil
+}
+
+// contactsPartialUpdatePayload transforms a list of JSON Patch operations
 // that may include virtual communication-item fields into a list of operations
 // that target ConnectWise's actual `communicationItems` array.
 //
@@ -170,7 +389,7 @@ func (c *Connector) payloadWithCommunicationItems(ctx context.Context, record co
 //
 // This function is ConnectWise logic-specific because it relies on ConnectWise's
 // behavior around defaultFlag and array indexing when constructing patches.
-func (c *Connector) patchPayloadWithCommunicationItems(ctx context.Context, // nolint:cyclop
+func (c *Connector) contactsPartialUpdatePayload(ctx context.Context, // nolint:cyclop
 	input []patchOperationPayload,
 	contactId string,
 ) ([]patchOperationPayload, error) {
@@ -185,7 +404,7 @@ func (c *Connector) patchPayloadWithCommunicationItems(ctx context.Context, // n
 		return operations, nil
 	}
 
-	contact, err := c.fetchContact(ctx, contactId)
+	contact, err := fetchContact[readContactResponse](ctx, c, contactId)
 	if err != nil {
 		return nil, err
 	}
@@ -289,20 +508,20 @@ func createCommunicationItemsIntentForPatch( // nolint:cyclop
 }
 
 // fetchContact retrieves a single contact record from ConnectWise by ID.
-func (c *Connector) fetchContact(ctx context.Context, contactId string) (*readContactResponse, error) {
-	url, err := c.getURL(objectNameContacts)
+func fetchContact[T any](ctx context.Context, connector *Connector, contactId string) (*T, error) {
+	url, err := connector.getURL(objectNameContacts)
 	if err != nil {
 		return nil, err
 	}
 
 	url.AddPath(contactId)
 
-	res, err := c.JSONHTTPClient().Get(ctx, url.String(), c.clientIdHeader())
+	res, err := connector.JSONHTTPClient().Get(ctx, url.String(), connector.clientIdHeader())
 	if err != nil {
 		return nil, err
 	}
 
-	return common.UnmarshalJSON[readContactResponse](res)
+	return common.UnmarshalJSON[T](res)
 }
 
 // fetchMissingCommunicationItemIds populates missing communication type IDs in
@@ -411,13 +630,7 @@ func allJsonPatchOperations(intent *communicationItemsIntent,
 	opRemove = append(opRemove, removePhone...)
 	opRemove = append(opRemove, removeFax...)
 
-	sort.Slice(opRemove, func(i, j int) bool {
-		// Remove from the highest index to the lowest. Removing a later item
-		// shifts only indexes after it, so it cannot change the index of an
-		// earlier item that is still scheduled for removal. Removing in the
-		// opposite order would shift all subsequent removeIndex values.
-		return opRemove[i].removeIndex > opRemove[j].removeIndex
-	})
+	sortRemovePayloads(opRemove)
 
 	output = append(output, opRemove...)
 

--- a/providers/connectwise/test/write/contacts/scenario3/put-as-patch.json
+++ b/providers/connectwise/test/write/contacts/scenario3/put-as-patch.json
@@ -1,0 +1,112 @@
+[
+  {
+    "op": "replace",
+    "path": "customFields",
+    "value": []
+  },
+  {
+    "op": "remove",
+    "path": "lastName"
+  },
+  {
+    "op": "remove",
+    "path": "inactiveFlag"
+  },
+  {
+    "op": "remove",
+    "path": "disablePortalLoginFlag"
+  },
+  {
+    "op": "remove",
+    "path": "unsubscribeFlag"
+  },
+  {
+    "op": "remove",
+    "path": "mobileGuid"
+  },
+  {
+    "op": "remove",
+    "path": "defaultFlag"
+  },
+  {
+    "op": "remove",
+    "path": "marriedFlag"
+  },
+  {
+    "op": "remove",
+    "path": "portalSecurityLevel"
+  },
+  {
+    "op": "remove",
+    "path": "defaultBillingFlag"
+  },
+  {
+    "op": "remove",
+    "path": "childrenFlag"
+  },
+  {
+    "op": "remove",
+    "path": "types"
+  },
+  {
+    "op": "replace",
+    "path": "firstName",
+    "value": "Maurice Emard"
+  },
+  {
+    "op": "replace",
+    "path": "lastName",
+    "value": "Andrew Schmeler"
+  },
+  {
+    "op": "replace",
+    "path": "customFields",
+    "value": [
+      {
+        "id": 59,
+        "value": false
+      },
+      {
+        "id": 83,
+        "value": "Skiing"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/communicationItems/3",
+    "value": {
+      "type": {
+        "id": "1"
+      },
+      "value": "professional.bob.updated@test.com",
+      "defaultFlag": true,
+      "communicationType": "Email"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/communicationItems/1/value",
+    "value": "+380111358"
+  },
+  {
+    "op": "add",
+    "path": "/communicationItems/3",
+    "value": {
+      "type": {
+        "id": "26"
+      },
+      "value": "+77767",
+      "defaultFlag": true,
+      "communicationType": "Fax"
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/communicationItems/2"
+  },
+  {
+    "op": "remove",
+    "path": "/communicationItems/0"
+  }
+]

--- a/providers/connectwise/write.go
+++ b/providers/connectwise/write.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -77,7 +78,7 @@ func (c *Connector) makeWriteCreatePayload(ctx context.Context, params common.Wr
 	payloadWithCustomFields(record)
 
 	if params.ObjectName == objectNameContacts {
-		if err = c.payloadWithCommunicationItems(ctx, record); err != nil {
+		if err = c.postPayloadWithCommunicationItems(ctx, record); err != nil {
 			return nil, "", err
 		}
 	}
@@ -85,40 +86,24 @@ func (c *Connector) makeWriteCreatePayload(ctx context.Context, params common.Wr
 	return record, http.MethodPost, nil
 }
 
-// makeWriteUpdatePayload builds an update payload for the given object.
+// makeWriteUpdatePayload builds the update payload and HTTP method for the
+// given object.
 //
-// By contract, params.RecordData holds the JSON payload for the update.
-// For updates, we may:
-//   - Use HTTP PATCH with a JSON Patch array when the caller provides a
-//     patch-style payload.
-//   - Use HTTP PUT (full replacement) for regular object payloads.
+// params.RecordData holds the update payload. Depending on its shape:
+//   - JSON Patch array -> HTTP PATCH (with custom-field normalization).
+//   - Regular object -> HTTP PUT, except for contacts.
 //
-// Behavior:
-//   - If the payload is detected as a JSON Patch (via extractPatchPayload),
-//     the function:
-//   - Normalizes custom fields for the patch (payloadPatchWithCustomFields).
-//   - For contacts, translates virtual communication-item fields into
-//     concrete JSON Patch operations targeting `communicationItems`.
-//   - Returns the resulting patch array and http.MethodPatch.
-//   - Otherwise, it:
-//   - Extracts the record, applies custom-field normalization.
-//   - For contacts with `communicationItems`, works around a ConnectWise
-//     validation bug by clearing `communicationItems` via a preliminary
-//     PATCH before performing the PUT.
-//   - Returns the record and http.MethodPut.
-//
-// ConnectWise-specific notes:
-//   - PATCH body must be a bare JSON array of operations, not wrapped in an
-//     object.
-//   - Contacts: including `communicationItems` in a PUT can trigger spurious
-//     validation errors; we clear them out first via PATCH.
+// ConnectWise specifics:
+//   - PATCH body must be a bare JSON array of operations.
+//   - For contacts, full replacement is implemented via PATCH instead of PUT
+//     to avoid known bugs with `communicationItems` validation.
 func (c *Connector) makeWriteUpdatePayload(ctx context.Context, params common.WriteParams) (any, string, error) {
-	// Detect JSON Patch payloads and use HTTP PATCH if present.
+	// Detect JSON Patch payloads and use HTTP PATCH.
 	if payload, ok := extractPatchPayload(params); ok {
 		data := payloadPatchWithCustomFields(params.ObjectName, payload.Patch)
 
 		if params.ObjectName == objectNameContacts {
-			items, err := c.patchPayloadWithCommunicationItems(ctx, data, params.RecordId)
+			items, err := c.contactsPartialUpdatePayload(ctx, data, params.RecordId)
 
 			return items, http.MethodPatch, err
 		}
@@ -126,7 +111,7 @@ func (c *Connector) makeWriteUpdatePayload(ctx context.Context, params common.Wr
 		return data, http.MethodPatch, nil
 	}
 
-	// Regular object payload: use PUT.
+	// Regular object payload.
 	record, err := params.GetRecord()
 	if err != nil {
 		return nil, "", err
@@ -135,60 +120,13 @@ func (c *Connector) makeWriteUpdatePayload(ctx context.Context, params common.Wr
 	payloadWithCustomFields(record)
 
 	if params.ObjectName == objectNameContacts {
-		if err = c.payloadWithCommunicationItems(ctx, record); err != nil {
-			return nil, "", err
-		}
+		// For contacts, emulate full PUT via PATCH to avoid ConnectWise bugs.
+		items, err := c.contactsFullUpdatePayload(ctx, record, params.RecordId)
 
-		if _, ok := record["communicationItems"]; ok {
-			// Work around ConnectWise validation bug for contacts:
-			// Including communicationItems in a PUT may cause a 400 even when
-			// the items are valid. Since PUT is a full replacement, we clear
-			// communicationItems first via PATCH, then proceed with the PUT.
-			if err = c.clearContactCommunicationItems(ctx, params); err != nil {
-				return nil, "", err
-			}
-		}
+		return items, http.MethodPatch, err
 	}
 
 	return record, http.MethodPut, nil
-}
-
-// clearContactCommunicationItems removes all communication items from a contact
-// via a preliminary PATCH before a full PUT update.
-//
-// This is required due to a ConnectWise validation bug: when `communicationItems`
-// are present in a PUT request for a contact, the API may reject the payload as
-// invalid even if the items are correct. Clearing them first avoids this issue.
-//
-// The function performs a single PATCH with:
-//   - "remove" operation for `/communicationItems`.
-//   - "replace" operation for `/customFields` with an empty array to satisfy
-//     ConnectWise's validation requirements for custom fields.
-func (c *Connector) clearContactCommunicationItems(ctx context.Context,
-	params common.WriteParams,
-) error {
-	url, err := c.getURL(objectNameContacts)
-	if err != nil {
-		return err
-	}
-
-	url.AddPath(params.RecordId)
-
-	if _, err = c.JSONHTTPClient().Patch(ctx, url.String(), []map[string]any{
-		{
-			"op":   "remove",
-			"path": "/communicationItems",
-		},
-		{
-			"op":    "replace",
-			"path":  "/customFields",
-			"value": []any{},
-		},
-	}, c.clientIdHeader()); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // payloadPatchWithCustomFields normalizes JSON Patch payloads for objects that
@@ -349,4 +287,14 @@ type patchOperationPayload struct {
 	Path        string `json:"path"`
 	Value       any    `json:"value,omitempty"`
 	removeIndex int
+}
+
+func sortRemovePayloads(payloads []patchOperationPayload) {
+	// Remove from the highest index to the lowest. Removing a later item
+	// shifts only indexes after it, so it cannot change the index of an
+	// earlier item that is still scheduled for removal. Removing in the
+	// opposite order would shift all subsequent removeIndex values.
+	sort.Slice(payloads, func(i, j int) bool {
+		return payloads[i].removeIndex > payloads[j].removeIndex
+	})
 }

--- a/providers/connectwise/write_test.go
+++ b/providers/connectwise/write_test.go
@@ -85,7 +85,7 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 			ExpectedErrs: nil,
 		},
 		{
-			Name: "Update contact via PUT",
+			Name: "Update contact via PUT translated into PATCH",
 			Input: common.WriteParams{
 				ObjectName: "contacts",
 				RecordId:   "57919",
@@ -94,15 +94,31 @@ func TestWrite(t *testing.T) { // nolint:funlen,gocognit,cyclop
 					"customField83": "Skiing",
 				},
 			},
-			Server: mockserver.Conditional{
+			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
-				If: mockcond.And{
-					mockcond.MethodPUT(),
-					mockcond.Path("/v4_6_release/apis/3.0/company/contacts/57919"),
-					mockcond.Body(`{"customFields":[{"id":83,"value":"Skiing"}],"lastName":"Sims"}`),
-					mockcond.Header(http.Header{"ClientId": []string{"dummy-client-id"}}),
-				},
-				Then: mockserver.Response(http.StatusOK, responseContact),
+				Cases: []mockserver.Case{{
+					If: mockcond.And{
+						mockcond.MethodGET(),
+						mockcond.Path("/v4_6_release/apis/3.0/company/contacts/57919"),
+					},
+					Then: mockserver.ResponseString(http.StatusOK, `{
+						"firstName": "Estella",
+						"lastName": "Mcdowell"
+					}`),
+				}, {
+					If: mockcond.And{
+						mockcond.MethodPATCH(),
+						mockcond.Path("/v4_6_release/apis/3.0/company/contacts/57919"),
+						mockcond.Body(`[
+							{"op":"replace","path":"customFields","value":[]},
+							{"op":"remove","path":"lastName"},
+							{"op":"replace","path":"customFields","value":[{"id":83,"value":"Skiing"}]},
+							{"op":"replace","path":"lastName","value":"Sims"}
+						]`),
+						mockcond.Header(http.Header{"ClientId": []string{"dummy-client-id"}}),
+					},
+					Then: mockserver.Response(http.StatusOK, responseContact),
+				}},
 			}.Server(),
 			Comparator: testconn.ComparatorSubsetWrite,
 			Expected: &common.WriteResult{

--- a/test/connectwise/write-delete/contacts-patch/main.go
+++ b/test/connectwise/write-delete/contacts-patch/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/amp-labs/connectors/internal/datautils"
 	connTest "github.com/amp-labs/connectors/test/connectwise"
-	"github.com/amp-labs/connectors/test/utils"
 	"github.com/amp-labs/connectors/test/utils/testscenario"
 	"github.com/brianvoe/gofakeit/v6"
 )
@@ -42,9 +41,6 @@ func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
 
-	// Set up slog logging.
-	utils.SetupLogging()
-
 	conn := connTest.GetConnectWiseConnector(ctx)
 
 	firstName := gofakeit.Name()
@@ -52,68 +48,6 @@ func main() {
 	lastName := gofakeit.Name()
 	updatedLastName := gofakeit.Name()
 
-	fmt.Println(">>> Using PUT")
-
-	// PUT operation does a complete replacement.
-	testscenario.ValidateCreateUpdateDelete(ctx, conn,
-		"contacts",
-		payload{
-			FirstName:            firstName,
-			LastName:             lastName,
-			CustomFieldMarketing: true,
-			CustomFieldHobby:     "Traveling",
-			Email:                "professional.bob@test.com",
-			EmailId:              "13",
-			Phone:                "+380001000",
-			PhoneId:              "",
-			Fax:                  "+99969",
-			FaxId:                "",
-		},
-		payload{
-			FirstName:            updatedFirstName,
-			LastName:             updatedLastName,
-			CustomFieldMarketing: false,
-			CustomFieldHobby:     "Skiing",
-			Email:                "professional.bob.updated@test.com",
-			EmailId:              "",
-			Phone:                "+380111358",
-			PhoneId:              "",
-			Fax:                  "+77767",
-			FaxId:                "26",
-		},
-		testscenario.CRUDTestSuite{
-			ReadFields: datautils.NewSet("id", "firstName", "lastName",
-				"customField83",
-				"customField59",
-				"AMPERSAND-defaultEmail",
-				"AMPERSAND-defaultEmailId",
-				"AMPERSAND-defaultPhone",
-				"AMPERSAND-defaultPhoneId",
-				"AMPERSAND-defaultFax",
-				"AMPERSAND-defaultFaxId",
-			),
-			SearchBy: testscenario.Property{
-				Key:   "firstname",
-				Value: firstName,
-				Since: time.Now().Add(-10 * time.Second),
-			},
-			RecordIdentifierKey: "id",
-			UpdatedFields: map[string]string{
-				"firstname":                updatedFirstName,
-				"lastname":                 updatedLastName,
-				"customfield83":            "Skiing",
-				"customfield59":            "false",
-				"ampersand-defaultemail":   "professional.bob.updated@test.com",
-				"ampersand-defaultemailid": "1",
-				"ampersand-defaultphone":   "+380111358",
-				"ampersand-defaultphoneid": "2",
-				"ampersand-defaultfax":     "+77767",
-				"ampersand-defaultfaxid":   "26",
-			},
-		},
-	)
-
-	fmt.Println()
 	fmt.Println(">>> Using PATCH")
 
 	testscenario.ValidateCreateUpdateDelete(ctx, conn,

--- a/test/connectwise/write-delete/contacts-put/main.go
+++ b/test/connectwise/write-delete/contacts-put/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type payload struct {
+	FirstName            string `json:"firstName"`
+	LastName             string `json:"lastName"`
+	CustomFieldMarketing bool   `json:"customField59"`
+	CustomFieldHobby     string `json:"customField83"`
+	Email                string `json:"AMPERSAND-defaultEmail,omitempty"`
+	EmailId              string `json:"AMPERSAND-defaultEmailId,omitempty"`
+	Phone                string `json:"AMPERSAND-defaultPhone,omitempty"`
+	PhoneId              string `json:"AMPERSAND-defaultPhoneId,omitempty"`
+	Fax                  string `json:"AMPERSAND-defaultFax,omitempty"`
+	FaxId                string `json:"AMPERSAND-defaultFaxId,omitempty"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	firstName := gofakeit.Name()
+	updatedFirstName := gofakeit.Name()
+	lastName := gofakeit.Name()
+	updatedLastName := gofakeit.Name()
+
+	fmt.Println(">>> Using PUT")
+
+	// PUT operation does a complete replacement.
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"contacts",
+		payload{
+			FirstName:            firstName,
+			LastName:             lastName,
+			CustomFieldMarketing: true,
+			CustomFieldHobby:     "Traveling",
+			Email:                "professional.bob@test.com",
+			EmailId:              "13",
+			Phone:                "+380001000",
+			PhoneId:              "",
+			Fax:                  "+99969",
+			FaxId:                "",
+		},
+		payload{
+			FirstName:            updatedFirstName,
+			LastName:             updatedLastName,
+			CustomFieldMarketing: false,
+			CustomFieldHobby:     "Skiing",
+			Email:                "professional.bob.updated@test.com",
+			EmailId:              "",
+			Phone:                "+380111358",
+			PhoneId:              "",
+			Fax:                  "+77767",
+			FaxId:                "26",
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("id", "firstName", "lastName",
+				"customField83",
+				"customField59",
+				"AMPERSAND-defaultEmail",
+				"AMPERSAND-defaultEmailId",
+				"AMPERSAND-defaultPhone",
+				"AMPERSAND-defaultPhoneId",
+				"AMPERSAND-defaultFax",
+				"AMPERSAND-defaultFaxId",
+			),
+			SearchBy: testscenario.Property{
+				Key:   "firstname",
+				Value: firstName,
+				Since: time.Now().Add(-10 * time.Second),
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"firstname":                updatedFirstName,
+				"lastname":                 updatedLastName,
+				"customfield83":            "Skiing",
+				"customfield59":            "false",
+				"ampersand-defaultemail":   "professional.bob.updated@test.com",
+				"ampersand-defaultemailid": "1",
+				"ampersand-defaultphone":   "+380111358",
+				"ampersand-defaultphoneid": "2",
+				"ampersand-defaultfax":     "+77767",
+				"ampersand-defaultfaxid":   "26",
+			},
+		},
+	)
+}


### PR DESCRIPTION
# Description

To bypass validation bugs of ConnectWise API this PR replaces the use of PUT method on contacts with an equivalent PATCH.

# Live Tests

Update contacts via PUT (under the hood a PATCH equivalent)
<img width="336" height="264" alt="image" src="https://github.com/user-attachments/assets/88464d0d-7cb6-46ef-ab84-613f7eca47db" />

Update contacts via PATCH
<img width="342" height="271" alt="image" src="https://github.com/user-attachments/assets/85d694ff-3579-4d87-bd83-d63d07bbbad0" />

