### PR TITLE
fix(connectwise): Communication item removal

### DIFF
--- a/providers/connectwise/communication-types.go
+++ b/providers/connectwise/communication-types.go
@@ -420,15 +420,15 @@ func (c *Connector) contactsPartialUpdatePayload(ctx context.Context, // nolint:
 		if item.DefaultFlag {
 			switch item.CommunicationType {
 			case communicationTypeEmail:
-				if intent.needEmailId() || intent.RemoveEmail {
+				if intent.needEmailId() {
 					intent.DefaultEmailId = identifier
 				}
 			case communicationTypePhone:
-				if intent.needPhoneId() || intent.RemovePhone {
+				if intent.needPhoneId() {
 					intent.DefaultPhoneId = identifier
 				}
 			case communicationTypeFax:
-				if intent.needFaxId() || intent.RemoveFax {
+				if intent.needFaxId() {
 					intent.DefaultFaxId = identifier
 				}
 			}
@@ -862,7 +862,8 @@ func (i communicationItemsIntent) isEmpty() bool {
 		i.DefaultFaxId == "" &&
 		i.DefaultPhone == "" &&
 		i.DefaultEmail == "" &&
-		i.DefaultFax == ""
+		i.DefaultFax == "" &&
+		!i.RemovePhone && !i.RemoveFax && !i.RemoveEmail
 }
 
 // needIds reports whether any communication type has a value but is missing its
@@ -875,17 +876,17 @@ func (i communicationItemsIntent) needIds() bool {
 
 // needEmailId reports whether email value is set but email type ID is missing.
 func (i communicationItemsIntent) needEmailId() bool {
-	return i.DefaultEmail != "" && i.DefaultEmailId == ""
+	return i.DefaultEmailId == "" && (i.DefaultEmail != "" || i.RemoveEmail)
 }
 
 // needPhoneId reports whether phone value is set but phone type ID is missing.
 func (i communicationItemsIntent) needPhoneId() bool {
-	return i.DefaultPhone != "" && i.DefaultPhoneId == ""
+	return i.DefaultPhoneId == "" && (i.DefaultPhone != "" || i.RemovePhone)
 }
 
 // needFaxId reports whether fax value is set but fax type ID is missing.
 func (i communicationItemsIntent) needFaxId() bool {
-	return i.DefaultFax != "" && i.DefaultFaxId == ""
+	return i.DefaultFaxId == "" && (i.DefaultFax != "" || i.RemoveFax)
 }
 
 // communicationTypesResponse is the response from the `/company/communicationTypes`

--- a/test/connectwise/write-delete/contacts-patch/3/main.go
+++ b/test/connectwise/write-delete/contacts-patch/3/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors/internal/datautils"
+	connTest "github.com/amp-labs/connectors/test/connectwise"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type payload struct {
+	FirstName            string `json:"firstName"`
+	LastName             string `json:"lastName"`
+	CustomFieldMarketing bool   `json:"customField59"`
+	CustomFieldHobby     string `json:"customField83"`
+	Email                string `json:"AMPERSAND-defaultEmail,omitempty"`
+	EmailId              string `json:"AMPERSAND-defaultEmailId,omitempty"`
+	Phone                string `json:"AMPERSAND-defaultPhone,omitempty"`
+	PhoneId              string `json:"AMPERSAND-defaultPhoneId,omitempty"`
+	Fax                  string `json:"AMPERSAND-defaultFax,omitempty"`
+	FaxId                string `json:"AMPERSAND-defaultFaxId,omitempty"`
+}
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	conn := connTest.GetConnectWiseConnector(ctx)
+
+	firstName := gofakeit.Name()
+	lastName := gofakeit.Name()
+
+	fmt.Println(">>> Using PATCH")
+
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"contacts",
+		payload{
+			FirstName:            firstName,
+			LastName:             lastName,
+			CustomFieldHobby:     "Traveling",
+			CustomFieldMarketing: true,
+			Email:                "professional.bob@test.com",
+			EmailId:              "13",
+			Phone:                "+380001000",
+			PhoneId:              "",
+			Fax:                  "+99969",
+			FaxId:                "",
+		},
+		map[string]any{
+			"patch": []map[string]any{{
+				"op":   "remove",
+				"path": "/AMPERSAND-defaultEmail",
+			}},
+		},
+		testscenario.CRUDTestSuite{
+			ReadFields: datautils.NewSet("id", "firstName", "lastName",
+				"customField83",
+				"customField59",
+				"AMPERSAND-defaultEmail",
+				"AMPERSAND-defaultEmailId",
+				"AMPERSAND-defaultPhone",
+				"AMPERSAND-defaultPhoneId",
+				"AMPERSAND-defaultFax",
+				"AMPERSAND-defaultFaxId",
+			),
+			SearchBy: testscenario.Property{
+				Key:   "firstname",
+				Value: firstName,
+				Since: time.Now().Add(-10 * time.Second),
+			},
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"firstname":                firstName,
+				"lastname":                 lastName,
+				"customfield83":            "Traveling",
+				"customfield59":            "true",
+				"ampersand-defaultemail":   "",
+				"ampersand-defaultemailid": "",
+				"ampersand-defaultphone":   "+380001000",
+				"ampersand-defaultphoneid": "2",
+				"ampersand-defaultfax":     "+99969",
+				"ampersand-defaultfaxid":   "3",
+			},
+		},
+	)
+}


### PR DESCRIPTION
# Bug

Removal of a default field did not trigger id lookup.

# FIx

Changed the definition of needEmailId and alike. The id is needed when id is empty and either the value is set (add/replace requested) or the remove flag is set to true (remove requested)

# Live Tests

<img width="773" height="607" alt="image" src="https://github.com/user-attachments/assets/37a97c09-a9d2-4983-be4a-df02586fdabe" />

<img width="777" height="639" alt="image" src="https://github.com/user-attachments/assets/aceffe02-fce2-46a2-a998-f382147bf812" />

<img width="768" height="662" alt="image" src="https://github.com/user-attachments/assets/c1e9a484-ad26-4565-91bd-cac5bf9b0fbe" />

