### PR TITLE
[ENG-4138] [Attio] Declare subscribe support in ProviderInfo

### DIFF
--- a/providers/attio.go
+++ b/providers/attio.go
@@ -35,8 +35,13 @@ func init() {
 			},
 			Proxy:     true,
 			Read:      true,
-			Subscribe: false,
+			Subscribe: true,
 			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			// Attio supports creating webhook subscriptions via API.
+			// https://docs.attio.com/rest-api/endpoint-reference/webhooks/create-a-webhook
+			SubscribeByAPI: new(true),
 		},
 	})
 }


### PR DESCRIPTION
Stacked on #2668.

Marks Attio as subscribe-capable in the provider catalog:
- `Support.Subscribe = true`
- `SubscribeRequirements{ SubscribeByAPI: true }` — Attio creates webhook subscriptions via the API (`POST /v2/webhooks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)