### PR TITLE
fix(zoho): resolve Zoho Mail account id during post-auth

### DIFF
--- a/providers/zoho/authmetadata.go
+++ b/providers/zoho/authmetadata.go
@@ -30,10 +30,6 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 		return &common.PostAuthInfo{}, nil
 	}
 
-	// The account id travels as a catalog variable, which is what the connector
-	// reads back when building account-scoped paths. The workspace reference is
-	// deliberately left alone: it is a single field shared by every Zoho module
-	// that OAuth already fills from api_domain, and nothing in Zoho reads it.
 	return &common.PostAuthInfo{
 		RawResponse: resp,
 		CatalogVars: AuthMetadataVars{

--- a/providers/zoho/authmetadata.go
+++ b/providers/zoho/authmetadata.go
@@ -30,22 +30,16 @@ func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, 
 		return &common.PostAuthInfo{}, nil
 	}
 
-	info := &common.PostAuthInfo{
+	// The account id travels as a catalog variable, which is what the connector
+	// reads back when building account-scoped paths. The workspace reference is
+	// deliberately left alone: it is a single field shared by every Zoho module
+	// that OAuth already fills from api_domain, and nothing in Zoho reads it.
+	return &common.PostAuthInfo{
 		RawResponse: resp,
 		CatalogVars: AuthMetadataVars{
 			MailAccountID: accountID,
 		}.AsMap(),
-	}
-
-	// The workspace reference is shared by every Zoho module, so it is only
-	// claimed when this connector actually represents Mail. Reporting it from
-	// a CRM or Desk connection would overwrite that connection's workspace
-	// reference with an unrelated mailbox id.
-	if c.isMailModule() {
-		info.ProviderWorkspaceRef = accountID
-	}
-
-	return info, nil
+	}, nil
 }
 
 // mailAdapterForPostAuth returns an adapter bound to the Zoho Mail API.

--- a/providers/zoho/authmetadata.go
+++ b/providers/zoho/authmetadata.go
@@ -2,33 +2,62 @@ package zoho
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/zoho/internal/mail"
 )
 
 func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
-	switch c.moduleID {
-	case providers.ModuleZohoMail:
-		return c.mailPostAuthInfo(ctx)
-	default:
+	adapter, err := c.mailAdapterForPostAuth()
+	if err != nil {
+		slog.Warn("skipping Zoho Mail post-authentication metadata",
+			"provider", c.Provider(), "module", c.moduleID, "error", err)
+
 		return &common.PostAuthInfo{}, nil
 	}
-}
 
-// mailPostAuthInfo resolves the Zoho Mail account id (delegated to the mail
-// adapter) and returns it as a catalog variable for account-scoped API paths.
-func (c *Connector) mailPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
-	resp, accountID, err := c.mailAdapter.GetAccountID(ctx)
+	resp, accountID, err := adapter.GetAccountID(ctx)
 	if err != nil {
-		return nil, err
+		// Expected whenever the connection has no access to Zoho Mail, either
+		// because the account has no mailbox or because the Mail scopes were
+		// not granted. Account-scoped Mail objects stay unavailable, every
+		// other module keeps working.
+		slog.Warn("could not resolve Zoho Mail account id, account-scoped Mail objects will be unavailable",
+			"provider", c.Provider(), "module", c.moduleID, "error", err)
+
+		return &common.PostAuthInfo{}, nil
 	}
 
-	return &common.PostAuthInfo{
-		ProviderWorkspaceRef: accountID,
-		RawResponse:          resp,
+	info := &common.PostAuthInfo{
+		RawResponse: resp,
 		CatalogVars: AuthMetadataVars{
 			MailAccountID: accountID,
 		}.AsMap(),
-	}, nil
+	}
+
+	// The workspace reference is shared by every Zoho module, so it is only
+	// claimed when this connector actually represents Mail. Reporting it from
+	// a CRM or Desk connection would overwrite that connection's workspace
+	// reference with an unrelated mailbox id.
+	if c.isMailModule() {
+		info.ProviderWorkspaceRef = accountID
+	}
+
+	return info, nil
+}
+
+// mailAdapterForPostAuth returns an adapter bound to the Zoho Mail API.
+//
+// The connector only builds mailAdapter when it was constructed for the Mail
+// module. For every other module that field is nil and moduleInfo describes a
+// different host, so a dedicated adapter pointed at the Mail base URL is built
+// here.
+func (c *Connector) mailAdapterForPostAuth() (*mail.Adapter, error) {
+	if c.mailAdapter != nil {
+		return c.mailAdapter, nil
+	}
+
+	return mail.NewAdapter(c.Client, c.providerInfo.ReadModuleInfo(providers.ModuleZohoMail), "")
 }

--- a/providers/zoho/internal/mail/adapter.go
+++ b/providers/zoho/internal/mail/adapter.go
@@ -8,7 +8,12 @@ import (
 	"github.com/amp-labs/connectors/providers"
 )
 
-var ErrMissingAccountID = errors.New("missing Zoho Mail account id; post-authentication has not run")
+// ErrMissingAccountID reports that no Zoho Mail account id is attached to the
+// connection. Post-authentication resolves the id on a best effort basis, so
+// this also covers connections whose account has no mailbox or whose
+// integration was never granted the Zoho Mail scopes.
+var ErrMissingAccountID = errors.New(
+	"missing Zoho Mail account id; the connection has no Zoho Mail access or post-authentication has not run")
 
 type Adapter struct {
 	Client  *common.JSONHTTPClient


### PR DESCRIPTION
Zoho Mail objects that live under `api/accounts/{accountId}/...` were failing with "missing Zoho Mail account id".

The server fetches post-auth metadata using the provider's default module (CRM), but `GetPostAuthInfo` only resolved the account id when the module was Mail. So `zohoMailAccountId` was never fetched and never saved.

Now the account id is resolved for every module. Not every Zoho customer uses Mail, so the lookup is best effort: if it fails (no mailbox, or the Mail scopes were not granted) it returns empty post-auth info and connection creation is unaffected.
