### PR TITLE
[ENG-4138] [Attio] Rename GetObjectNameFromTypeId to GetObjectNameFromEvent

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -252,10 +252,10 @@ type WebhookVerifierConnector interface {
 type SubscriptionEventObjectNameConnector interface {
 	Connector
 
-	// GetObjectNameFromTypeId resolves the object name for the given subscription
+	// GetObjectNameFromEvent resolves the object name for the given subscription
 	// event by mapping the event's object type id to an object name, fetching from
 	// the provider (and caching) when necessary.
-	GetObjectNameFromTypeId(ctx context.Context, event common.SubscriptionEvent) (string, error)
+	GetObjectNameFromEvent(ctx context.Context, event common.SubscriptionEvent) (string, error)
 }
 
 // SubscribeConnector defines the interface for connectors that manage webhook subscriptions.

--- a/providers/attio/connector.go
+++ b/providers/attio/connector.go
@@ -16,7 +16,7 @@ type Connector struct {
 	Client  *common.JSONHTTPClient
 
 	// objectNameCache memoizes object_id -> api_slug lookups used by
-	// GetObjectNameFromTypeId. The connector is always used via *Connector, so the
+	// GetObjectNameFromEvent. The connector is always used via *Connector, so the
 	// embedded lock is never copied.
 	objectNameCache objectNameCache
 }

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -312,7 +312,7 @@ func (o *objectNameCache) store(idToName map[string]string) {
 	maps.Copy(o.m, idToName)
 }
 
-// GetObjectNameFromTypeId resolves the object name for a subscription event.
+// GetObjectNameFromEvent resolves the object name for a subscription event.
 //
 // Standard and custom object changes arrive as generic record.* events that
 // identify the object only by its id.object_id (a per-workspace UUID). This maps
@@ -324,7 +324,7 @@ func (o *objectNameCache) store(idToName map[string]string) {
 // For core-object events (note, task, list, workspace-member) there is no
 // object_id — the object is already in the event_type — so ObjectName() is returned
 // without any lookup.
-func (c *Connector) GetObjectNameFromTypeId(
+func (c *Connector) GetObjectNameFromEvent(
 	ctx context.Context, event common.SubscriptionEvent,
 ) (string, error) {
 	attioEvent, isAttioEvent := event.(SubscriptionEvent)

--- a/providers/attio/subscriptionEvent_test.go
+++ b/providers/attio/subscriptionEvent_test.go
@@ -514,7 +514,7 @@ func TestCollapsedSubscriptionEvent_SubscriptionEventList_Errors(t *testing.T) {
 	}
 }
 
-func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
+func TestConnector_GetObjectNameFromEvent(t *testing.T) {
 	t.Parallel()
 
 	objectsResponse := testutils.DataFromFile(t, "objects.json")
@@ -571,7 +571,7 @@ func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := conn.GetObjectNameFromTypeId(t.Context(), tt.event)
+			result, err := conn.GetObjectNameFromEvent(t.Context(), tt.event)
 			if tt.expectedErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -591,7 +591,7 @@ func TestConnector_GetObjectNameFromTypeId(t *testing.T) {
 	}
 }
 
-func TestConnector_GetObjectNameFromTypeId_CachesOnConnector(t *testing.T) {
+func TestConnector_GetObjectNameFromEvent_CachesOnConnector(t *testing.T) {
 	t.Parallel()
 
 	objectsResponse := testutils.DataFromFile(t, "objects.json")
@@ -615,7 +615,7 @@ func TestConnector_GetObjectNameFromTypeId_CachesOnConnector(t *testing.T) {
 
 	// The same connector caches the object list, so repeated resolutions fetch once.
 	for range 3 {
-		name, err := conn.GetObjectNameFromTypeId(t.Context(), newTestEvent("record.created", map[string]string{
+		name, err := conn.GetObjectNameFromEvent(t.Context(), newTestEvent("record.created", map[string]string{
 			"object_id": "bb3380d7-06a7-4948-9d62-3e735e782c5c",
 			"record_id": "rec-1",
 		}))


### PR DESCRIPTION
Renames the `connectors.SubscriptionEventObjectNameConnector` interface method `GetObjectNameFromTypeId` → `GetObjectNameFromEvent` (and Attio's implementation). The method takes the whole subscription event, so the new name reads more accurately.

Server call site updated in the corresponding server PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)