### PR TITLE
[ENG-4138] [Attio] Set ReadResultRow.Id in GetRecordsByIds

### DIFF
--- a/docs/subscribe-onboarding/pr-2-verification.md
+++ b/docs/subscribe-onboarding/pr-2-verification.md
@@ -31,6 +31,13 @@ the affected record's **id and event metadata**, not the record body — after t
 server fetches the full record via `GetRecordsByIds`. So your event types only need to expose the object
 name, record id, and event type.
 
+> **Required: populate `ReadResultRow.Id` in `GetRecordsByIds`.** The server correlates each fetched
+> record back to its webhook event by matching the event's record id against `ReadResultRow.Id`
+> (`fetchedByID[row.Id]`). If your parser leaves `Id` empty and only fills `Raw`/`Fields`, the lookup
+> misses, the record is **silently dropped**, and the event is delivered with no record body attached —
+> even though the provider fetch returned `200 OK` with the record. Set `row.Id` to the record id
+> (the same value the event's `RecordId()` returns) for every row you return.
+
 Plus a provider-specific `VerificationParams` struct (the caller fills it in per installation) and one
 or more event types.
 

--- a/providers/attio/parse.go
+++ b/providers/attio/parse.go
@@ -150,6 +150,7 @@ func getRecords(
 			return nil, common.ErrEmptyRecordIdResponse
 		}
 
+		data[i].Id = recordID
 		data[i].Raw = record
 		data[i].Fields = common.ExtractLowercaseFieldsFromRaw(fields, fieldRecord)
 	}

--- a/providers/attio/read_test.go
+++ b/providers/attio/read_test.go
@@ -168,6 +168,7 @@ func TestRead(t *testing.T) { // nolint:funlen,gocognit,cyclop
 				Rows: 1,
 				Data: []common.ReadResultRow{
 					{
+						Id: "2db97cee-6c6b-4486-ae52-db8e4b6f44e9",
 						Fields: map[string]any{
 							"name": []any{
 								map[string]any{

--- a/providers/attio/record_test.go
+++ b/providers/attio/record_test.go
@@ -56,6 +56,7 @@ func TestGetRecordByIds(t *testing.T) {
 
 			Expected: []common.ReadResultRow{
 				{
+					Id: "1bdb55e3-67f4-48d3-829b-45db3039a960",
 					Fields: map[string]any{
 						"name": []any{
 							map[string]any{
@@ -107,6 +108,7 @@ func TestGetRecordByIds(t *testing.T) {
 					},
 				},
 				{
+					Id: "3a95b53c-e7a1-4e53-a4e4-436f72283818",
 					Fields: map[string]any{
 						"name": []any{
 							map[string]any{


### PR DESCRIPTION
## Problem

Attio subscribe webhooks were delivered with **no record body attached**, even though the provider fetch succeeded. Observed live: an Attio `record.created` webhook for a company was verified, object-resolved, and routed to the fetch bucket; `GetRecordsByIds` returned **`200 OK` with the full record** — yet the delivered Ampersand webhook contained only the raw event IDs, no `Fields`/`Raw`.

## Root cause

Attio's `GetRecordsByIds` parser (`providers/attio/parse.go` `getRecords`) populated only `Raw` and `Fields`, leaving **`ReadResultRow.Id` empty**.

The server correlates each fetched record back to its webhook event by matching the event's record id against `ReadResultRow.Id`:

```go
// server messenger/subscribeEventProcessor.go
fetchedByID[fetched[i].Id] = &fetched[i]   // keyed by row.Id (== "")
...
if row, ok := fetchedByID[recordId]; ok { whRes.Record = row } // miss
```

With `Id` empty, `fetchedByID` collapses to a single `""` key, the lookup for the real record id misses, and the record is **silently dropped** — the event is delivered without a record body. Attio events carry only IDs (no inline record), so there's no fallback.

## Fix

- Set `row.Id = recordID` in `getRecords` (one line).
- Update `read_test.go` / `record_test.go` expectations that had encoded the empty-`Id` behavior.
- Document the requirement in `docs/subscribe-onboarding/pr-2-verification.md` so future providers don't hit the same silent drop.

## Testing

`go test ./providers/attio/` passes. Verified live against a real Attio workspace: `GetRecordsByIds` for the affected company returns the full record, and rows now carry the record id in `Id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)