### PR TITLE
[ENG-4086] feat(customauth): connector-owned refresh + Microsoft directory-read fix

### DIFF
--- a/providers/customauth.go
+++ b/providers/customauth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // AuthContext carries data through a multi-step custom auth flow. It is pure,
@@ -191,6 +192,8 @@ func (o *CustomAuthOpts) HasSteps() bool {
 
 // JSONSecretParser returns a ParseResponse handler that decodes the JSON body
 // and copies mapped response fields (responseKey -> secretKey) into Secrets.
+// String fields are copied as-is; numeric fields (e.g. OAuth `expires_in`) are
+// coerced to their string form, since Secrets is a string map.
 func JSONSecretParser(
 	mapping map[string]string,
 ) func(context.Context, AuthContext, *http.Response) (AuthContext, error) {
@@ -203,8 +206,13 @@ func JSONSecretParser(
 		}
 
 		for responseKey, secretKey := range mapping {
-			if v, ok := body[responseKey].(string); ok {
+			switch v := body[responseKey].(type) {
+			case string:
 				state.Secrets[secretKey] = v
+			case float64:
+				// encoding/json decodes JSON numbers as float64; store the shortest
+				// exact representation (e.g. 3599 for expires_in, not 3599.0).
+				state.Secrets[secretKey] = strconv.FormatFloat(v, 'f', -1, 64)
 			}
 		}
 

--- a/providers/customauth_refresh_test.go
+++ b/providers/customauth_refresh_test.go
@@ -1,0 +1,227 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// roundTripFunc adapts a function to an http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// refreshTestInfo is a throwaway provider that declares a single auth header
+// rendered from the accessToken value, exercising the refresh-on-401 path.
+func refreshTestInfo() *ProviderInfo {
+	return &ProviderInfo{
+		DisplayName: "Refresh Test",
+		AuthType:    Custom,
+		BaseURL:     "https://example.com",
+		CustomOpts: &CustomAuthOpts{
+			Headers: []CustomAuthHeader{
+				{Name: "Authorization", ValueTemplate: "Bearer {{ .accessToken }}"},
+			},
+		},
+	}
+}
+
+func newResponse(status int, req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}
+}
+
+func TestCustomAuthRefreshOn401(t *testing.T) {
+	t.Parallel()
+
+	var (
+		calls        int
+		replayedAuth []string
+	)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			// Stale token; server rejects it.
+			return newResponse(http.StatusUnauthorized, req), nil
+		}
+
+		// Replay: capture the Authorization header(s) the client applied.
+		replayedAuth = req.Header.Values("Authorization")
+
+		return newResponse(http.StatusOK, req), nil
+	})
+
+	cfg := &CustomAuthParams{
+		// Simulate the stale value the client was originally built with.
+		Values: map[string]string{"accessToken": "STALE"},
+		Refresh: func(context.Context) (map[string]string, error) {
+			return map[string]string{"accessToken": "FRESH"}, nil
+		},
+	}
+
+	client, err := createCustomHTTPClient(
+		context.Background(),
+		&http.Client{Transport: transport},
+		false, nil, nil,
+		refreshTestInfo(), cfg,
+	)
+	if err != nil {
+		t.Fatalf("createCustomHTTPClient: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/v1/thing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", rsp.StatusCode)
+	}
+
+	if calls != 2 {
+		t.Errorf("transport called %d times, want 2 (original + one replay)", calls)
+	}
+
+	if len(replayedAuth) != 1 {
+		t.Fatalf("replay carried %d Authorization headers %v, want exactly 1", len(replayedAuth), replayedAuth)
+	}
+
+	if replayedAuth[0] != "Bearer FRESH" {
+		t.Errorf("replay Authorization = %q, want %q", replayedAuth[0], "Bearer FRESH")
+	}
+}
+
+// refreshTestInfoQueryParam declares auth via a query param, exercising the
+// query-param overwrite path on refresh.
+func refreshTestInfoQueryParam() *ProviderInfo {
+	return &ProviderInfo{
+		DisplayName: "Refresh Test QP",
+		AuthType:    Custom,
+		BaseURL:     "https://example.com",
+		CustomOpts: &CustomAuthOpts{
+			QueryParams: []CustomAuthQueryParam{
+				{Name: "access_token", ValueTemplate: "{{ .accessToken }}"},
+			},
+		},
+	}
+}
+
+func TestCustomAuthRefreshOn401_QueryParam(t *testing.T) {
+	t.Parallel()
+
+	var (
+		calls        int
+		replayedVals []string
+	)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return newResponse(http.StatusUnauthorized, req), nil
+		}
+
+		replayedVals = req.URL.Query()["access_token"]
+
+		return newResponse(http.StatusOK, req), nil
+	})
+
+	cfg := &CustomAuthParams{
+		Values: map[string]string{"accessToken": "STALE"},
+		Refresh: func(context.Context) (map[string]string, error) {
+			return map[string]string{"accessToken": "FRESH"}, nil
+		},
+	}
+
+	client, err := createCustomHTTPClient(
+		context.Background(),
+		&http.Client{Transport: transport},
+		false, nil, nil,
+		refreshTestInfoQueryParam(), cfg,
+	)
+	if err != nil {
+		t.Fatalf("createCustomHTTPClient: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/v1/thing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", rsp.StatusCode)
+	}
+
+	// Overwrite (not append): exactly one access_token, and it's the refreshed value.
+	if len(replayedVals) != 1 {
+		t.Fatalf("replay carried %d access_token query params %v, want exactly 1", len(replayedVals), replayedVals)
+	}
+
+	if replayedVals[0] != "FRESH" {
+		t.Errorf("replay access_token = %q, want FRESH", replayedVals[0])
+	}
+}
+
+func TestCustomAuthRefreshErrorReturnsOriginal401(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		return newResponse(http.StatusUnauthorized, req), nil
+	})
+
+	cfg := &CustomAuthParams{
+		Values: map[string]string{"accessToken": "STALE"},
+		Refresh: func(context.Context) (map[string]string, error) {
+			return nil, errors.New("refresh boom")
+		},
+	}
+
+	client, err := createCustomHTTPClient(
+		context.Background(),
+		&http.Client{Transport: transport},
+		false, nil, nil,
+		refreshTestInfo(), cfg,
+	)
+	if err != nil {
+		t.Fatalf("createCustomHTTPClient: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/v1/thing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do returned error, want original 401 with nil err: %v", err)
+	}
+
+	if rsp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (original response, unmasked)", rsp.StatusCode)
+	}
+
+	if calls != 1 {
+		t.Errorf("transport called %d times, want 1 (no replay on refresh error)", calls)
+	}
+}

--- a/providers/customauth_refresh_test.go
+++ b/providers/customauth_refresh_test.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -225,6 +227,70 @@ func TestCustomAuthRefreshRetriesThenGivesUp(t *testing.T) {
 	// 1 original request + maxCustomRefreshRetries replays.
 	if want := 1 + maxCustomRefreshRetries; calls != want {
 		t.Errorf("transport called %d times, want %d (original + %d retries)", calls, want, maxCustomRefreshRetries)
+	}
+}
+
+// TestCustomAuthRefreshReplaysBody verifies a write (POST) whose body is consumed
+// by the failed attempt is resent intact on the refresh replay (rewound via GetBody),
+// not as an empty body.
+func TestCustomAuthRefreshReplaysBody(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"displayName":"amp-write-test"}`
+
+	var (
+		calls        int
+		replayedBody string
+	)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		// Consume the body on both attempts, mimicking a real request being sent.
+		body, _ := io.ReadAll(req.Body)
+
+		if calls == 1 {
+			return newResponse(http.StatusUnauthorized, req), nil
+		}
+
+		replayedBody = string(body)
+
+		return newResponse(http.StatusOK, req), nil
+	})
+
+	cfg := &CustomAuthParams{
+		Values: map[string]string{"accessToken": "STALE"},
+		Refresh: func(context.Context) (map[string]string, error) {
+			return map[string]string{"accessToken": "FRESH"}, nil
+		},
+	}
+
+	client, err := createCustomHTTPClient(
+		context.Background(),
+		&http.Client{Transport: transport},
+		false, nil, nil,
+		refreshTestInfo(), cfg,
+	)
+	if err != nil {
+		t.Fatalf("createCustomHTTPClient: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, "https://example.com/v1/groups", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+
+	if rsp.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want 200", rsp.StatusCode)
+	}
+
+	if replayedBody != payload {
+		t.Errorf("replay body = %q, want %q (body must be rewound for write replays)", replayedBody, payload)
 	}
 }
 

--- a/providers/customauth_refresh_test.go
+++ b/providers/customauth_refresh_test.go
@@ -179,6 +179,55 @@ func TestCustomAuthRefreshOn401_QueryParam(t *testing.T) {
 	}
 }
 
+func TestCustomAuthRefreshRetriesThenGivesUp(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	// Always unauthorized, even after refresh.
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		return newResponse(http.StatusUnauthorized, req), nil
+	})
+
+	cfg := &CustomAuthParams{
+		Values: map[string]string{"accessToken": "STALE"},
+		Refresh: func(context.Context) (map[string]string, error) {
+			return map[string]string{"accessToken": "FRESH"}, nil
+		},
+	}
+
+	client, err := createCustomHTTPClient(
+		context.Background(),
+		&http.Client{Transport: transport},
+		false, nil, nil,
+		refreshTestInfo(), cfg,
+	)
+	if err != nil {
+		t.Fatalf("createCustomHTTPClient: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/v1/thing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+
+	if rsp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 after exhausting retries", rsp.StatusCode)
+	}
+
+	// 1 original request + maxCustomRefreshRetries replays.
+	if want := 1 + maxCustomRefreshRetries; calls != want {
+		t.Errorf("transport called %d times, want %d (original + %d retries)", calls, want, maxCustomRefreshRetries)
+	}
+}
+
 func TestCustomAuthRefreshErrorReturnsOriginal401(t *testing.T) {
 	t.Parallel()
 

--- a/providers/customauth_test.go
+++ b/providers/customauth_test.go
@@ -42,16 +42,24 @@ func TestAuthContextFlattenPrecedence(t *testing.T) {
 func TestJSONSecretParser(t *testing.T) {
 	t.Parallel()
 
-	handler := JSONSecretParser(map[string]string{"access_token": "accessToken"})
+	handler := JSONSecretParser(map[string]string{
+		"access_token": "accessToken",
+		"expires_in":   "expiresIn",
+	})
 
 	state, err := handler(context.Background(), NewAuthContext(),
-		jsonResponse(`{"access_token":"abc123","ignored":"x"}`))
+		jsonResponse(`{"access_token":"abc123","expires_in":3599,"ignored":"x"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if state.Secrets["accessToken"] != "abc123" {
 		t.Errorf("accessToken = %q, want abc123", state.Secrets["accessToken"])
+	}
+
+	// Numeric fields (expires_in) are coerced to their string form.
+	if state.Secrets["expiresIn"] != "3599" {
+		t.Errorf("expiresIn = %q, want 3599", state.Secrets["expiresIn"])
 	}
 }
 

--- a/providers/microsoft/advanced_query_test.go
+++ b/providers/microsoft/advanced_query_test.go
@@ -16,6 +16,9 @@ func TestNeedsAdvancedQuery(t *testing.T) {
 	directory := []string{
 		"users", "groups", "applications", "servicePrincipals", "devices",
 		"administrativeUnits", "contacts", "appRoleAssignments", "oauth2PermissionGrants",
+		// Delta-query variants filter on createdDateTime too, so they need advanced query.
+		"users/microsoft.graph.delta()", "groups/microsoft.graph.delta()",
+		"applications/microsoft.graph.delta()",
 	}
 	for _, obj := range directory {
 		if !needsAdvancedQuery(obj) {

--- a/providers/microsoft/advanced_query_test.go
+++ b/providers/microsoft/advanced_query_test.go
@@ -1,0 +1,88 @@
+package microsoft
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// TestNeedsAdvancedQuery guards the directory-object set against drift from the
+// authoritative Graph list (https://learn.microsoft.com/graph/aad-advanced-queries).
+func TestNeedsAdvancedQuery(t *testing.T) {
+	t.Parallel()
+
+	directory := []string{
+		"users", "groups", "applications", "servicePrincipals", "devices",
+		"administrativeUnits", "contacts", "appRoleAssignments", "oauth2PermissionGrants",
+	}
+	for _, obj := range directory {
+		if !needsAdvancedQuery(obj) {
+			t.Errorf("needsAdvancedQuery(%q) = false, want true", obj)
+		}
+	}
+
+	// Not directory objects (mail/calendar/drive), or a directory role that is not
+	// in the authoritative advanced-query list.
+	notDirectory := []string{"messages", "events", "drive/items", "alerts", "directoryRoles"}
+	for _, obj := range notDirectory {
+		if needsAdvancedQuery(obj) {
+			t.Errorf("needsAdvancedQuery(%q) = true, want false", obj)
+		}
+	}
+}
+
+// TestBuildReadRequestAdvancedQuery verifies directory-object incremental reads
+// carry the advanced-query parameters Graph requires ($count=true +
+// ConsistencyLevel: eventual), and that the header is present on all pages.
+func TestBuildReadRequestAdvancedQuery(t *testing.T) {
+	t.Parallel()
+
+	conn, err := constructTestConnector("https://graph.microsoft.com")
+	if err != nil {
+		t.Fatalf("constructTestConnector: %v", err)
+	}
+
+	since := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("directory object with Since gets $count + ConsistencyLevel + $filter", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := conn.buildReadRequest(context.Background(), common.ReadParams{ObjectName: "groups", Since: since})
+		if err != nil {
+			t.Fatalf("buildReadRequest: %v", err)
+		}
+
+		query := req.URL.Query()
+		if got := query.Get("$count"); got != "true" {
+			t.Errorf("$count = %q, want true", got)
+		}
+
+		if query.Get("$filter") == "" {
+			t.Error("$filter should be set for an incremental read")
+		}
+
+		if got := req.Header.Get("ConsistencyLevel"); got != "eventual" {
+			t.Errorf("ConsistencyLevel = %q, want eventual", got)
+		}
+	})
+
+	t.Run("directory object without Since keeps the header but omits $count", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := conn.buildReadRequest(context.Background(), common.ReadParams{ObjectName: "groups"})
+		if err != nil {
+			t.Fatalf("buildReadRequest: %v", err)
+		}
+
+		if got := req.URL.Query().Get("$count"); got != "" {
+			t.Errorf("$count = %q, want empty (no filter)", got)
+		}
+
+		// The header must ride every page, including @odata.nextLink follow-ups.
+		if got := req.Header.Get("ConsistencyLevel"); got != "eventual" {
+			t.Errorf("ConsistencyLevel = %q, want eventual", got)
+		}
+	})
+}

--- a/providers/microsoft/filter.go
+++ b/providers/microsoft/filter.go
@@ -339,3 +339,33 @@ func (q filterQuery) String() string {
 
 	return q.until
 }
+
+// advancedQueryObjects are the Microsoft Entra directory-object collections that
+// require Graph "advanced query" ($count=true together with the
+// ConsistencyLevel: eventual header) in order to $filter on properties such as
+// createdDateTime. Without it Graph rejects the request with "Unsupported or
+// invalid query filter clause specified for property 'createdDateTime' of
+// resource 'Group'".
+//
+// The set is the authoritative directory-object list from
+// https://learn.microsoft.com/graph/aad-advanced-queries ("Advanced query
+// capabilities are supported only on directory objects ... including the
+// following objects"), mapped to their collection names.
+// nolint:gochecknoglobals
+var advancedQueryObjects = map[string]bool{
+	"users":                  true,
+	"groups":                 true,
+	"applications":           true,
+	"servicePrincipals":      true,
+	"devices":                true,
+	"administrativeUnits":    true,
+	"contacts":               true, // orgContact
+	"appRoleAssignments":     true,
+	"oauth2PermissionGrants": true,
+}
+
+// needsAdvancedQuery reports whether reads of objectName must use Graph advanced
+// query capabilities (see advancedQueryObjects).
+func needsAdvancedQuery(objectName string) bool {
+	return advancedQueryObjects[objectName]
+}

--- a/providers/microsoft/filter.go
+++ b/providers/microsoft/filter.go
@@ -362,6 +362,11 @@ var advancedQueryObjects = map[string]bool{
 	"contacts":               true, // orgContact
 	"appRoleAssignments":     true,
 	"oauth2PermissionGrants": true,
+	// Delta-query variants of directory objects that incrementalObjects also filters
+	// on createdDateTime — they need the same advanced-query parameters.
+	"users/microsoft.graph.delta()":        true,
+	"groups/microsoft.graph.delta()":       true,
+	"applications/microsoft.graph.delta()": true,
 }
 
 // needsAdvancedQuery reports whether reads of objectName must use Graph advanced

--- a/providers/microsoft/handlers.go
+++ b/providers/microsoft/handlers.go
@@ -22,7 +22,18 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 		return nil, err
 	}
 
-	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if needsAdvancedQuery(params.ObjectName) {
+		// Directory objects need advanced query to $filter on createdDateTime; the
+		// header is required on every page (including @odata.nextLink follow-ups).
+		req.Header.Set("ConsistencyLevel", "eventual")
+	}
+
+	return req, nil
 }
 
 func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
@@ -42,6 +53,12 @@ func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, err
 		Until(params.ObjectName, params.Until).String()
 	if filter != "" {
 		url.WithQueryParam("$filter", filter)
+
+		if needsAdvancedQuery(params.ObjectName) {
+			// $count=true is required alongside ConsistencyLevel: eventual to filter
+			// directory objects on createdDateTime.
+			url.WithQueryParam("$count", "true")
+		}
 	}
 
 	url.WithQueryParam("$top", readhelper.PageSizeWithDefaultStr(params, DefaultPageSize))

--- a/providers/microsoftAdminConsent.go
+++ b/providers/microsoftAdminConsent.go
@@ -22,7 +22,12 @@ func init() {
 	tokenStep := HTTPStep{
 		BuildRequest: msBuildTokenRequest,
 		//nolint:bodyclose // the response is owned and closed by the custom-auth executor's doHTTP
-		ParseResponse: JSONSecretParser(map[string]string{"access_token": "accessToken"}),
+		ParseResponse: JSONSecretParser(map[string]string{
+			"access_token": "accessToken",
+			// expires_in lets the server set an honest token TTL (a number, coerced
+			// to a string by JSONSecretParser).
+			"expires_in": "expiresIn",
+		}),
 	}
 
 	SetInfo(MicrosoftAdminConsent, ProviderInfo{

--- a/providers/microsoftAdminConsent.go
+++ b/providers/microsoftAdminConsent.go
@@ -24,9 +24,6 @@ func init() {
 		//nolint:bodyclose // the response is owned and closed by the custom-auth executor's doHTTP
 		ParseResponse: JSONSecretParser(map[string]string{
 			"access_token": "accessToken",
-			// expires_in lets the server set an honest token TTL (a number, coerced
-			// to a string by JSONSecretParser).
-			"expires_in": "expiresIn",
 		}),
 	}
 

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -316,6 +316,12 @@ type OAuth2ClientCredentialsParams struct {
 type CustomAuthParams struct {
 	Values  map[string]string
 	Options []common.CustomAuthClientOption
+
+	// Refresh, when set, re-mints the auth values on a 401; the client re-renders
+	// the provider's declared headers/query params with the returned values and
+	// replays the request once. The server supplies this; the connector owns how
+	// the values are applied.
+	Refresh func(context.Context) (map[string]string, error)
 }
 
 // NewClientParams is the parameters to create a new HTTP client.
@@ -685,7 +691,54 @@ func createCustomHTTPClient(ctx context.Context, //nolint:funlen,cyclop
 		opts = append(opts, common.WithCustomIsUnauthorizedHandler(isUnauth))
 	}
 
-	if unauth != nil {
+	switch {
+	case cfg.Refresh != nil:
+		// The connector owns how refreshed auth is re-applied: re-mint the values,
+		// re-render this provider's declared headers/query params, and replay once.
+		opts = append(opts,
+			common.WithCustomUnauthorizedHandler(
+				func(
+					_ []common.Header,
+					_ []common.QueryParam,
+					req *http.Request,
+					rsp *http.Response,
+				) (*http.Response, error) {
+					vals, err := cfg.Refresh(req.Context())
+					if err != nil {
+						// Don't mask the original 401 if we can't refresh.
+						return rsp, nil //nolint:nilerr
+					}
+
+					fresh := &CustomAuthParams{Values: vals}
+
+					newHeaders, err := getCustomHeaders(info, fresh)
+					if err != nil {
+						return nil, err
+					}
+
+					newParams, err := getCustomParams(info, fresh)
+					if err != nil {
+						return nil, err
+					}
+
+					// Force overwrite so the refreshed auth replaces the stale
+					// header/query param rather than appending a duplicate.
+					for i := range newHeaders {
+						newHeaders[i].Mode = common.HeaderModeOverwrite
+					}
+
+					for i := range newParams {
+						newParams[i].Mode = common.QueryParamModeOverwrite
+					}
+
+					replay := req.Clone(req.Context())
+					common.Headers(newHeaders).ApplyToRequest(replay)
+					common.QueryParams(newParams).ApplyToRequest(replay)
+
+					// Replay via the raw client so we don't re-trigger this handler.
+					return getClient(client).Do(replay)
+				}))
+	case unauth != nil:
 		opts = append(opts,
 			common.WithCustomUnauthorizedHandler(
 				func(

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -775,8 +775,12 @@ func customRefreshHandler(
 				return nil, err
 			}
 
-			// Success, or out of attempts: hand the response back to the caller.
+			// Success, or out of attempts: hand the replayed response back to the
+			// caller. Close the original 401 first — we're returning a different
+			// response, so nothing downstream will close it.
 			if !stillUnauth || attempt == maxCustomRefreshRetries-1 {
+				_ = rsp.Body.Close()
+
 				return resp, nil
 			}
 

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -694,50 +694,10 @@ func createCustomHTTPClient(ctx context.Context, //nolint:funlen,cyclop
 	switch {
 	case cfg.Refresh != nil:
 		// The connector owns how refreshed auth is re-applied: re-mint the values,
-		// re-render this provider's declared headers/query params, and replay once.
+		// re-render this provider's declared headers/query params, and replay.
 		opts = append(opts,
 			common.WithCustomUnauthorizedHandler(
-				func(
-					_ []common.Header,
-					_ []common.QueryParam,
-					req *http.Request,
-					rsp *http.Response,
-				) (*http.Response, error) {
-					vals, err := cfg.Refresh(req.Context())
-					if err != nil {
-						// Don't mask the original 401 if we can't refresh.
-						return rsp, nil //nolint:nilerr
-					}
-
-					fresh := &CustomAuthParams{Values: vals}
-
-					newHeaders, err := getCustomHeaders(info, fresh)
-					if err != nil {
-						return nil, err
-					}
-
-					newParams, err := getCustomParams(info, fresh)
-					if err != nil {
-						return nil, err
-					}
-
-					// Force overwrite so the refreshed auth replaces the stale
-					// header/query param rather than appending a duplicate.
-					for i := range newHeaders {
-						newHeaders[i].Mode = common.HeaderModeOverwrite
-					}
-
-					for i := range newParams {
-						newParams[i].Mode = common.QueryParamModeOverwrite
-					}
-
-					replay := req.Clone(req.Context())
-					common.Headers(newHeaders).ApplyToRequest(replay)
-					common.QueryParams(newParams).ApplyToRequest(replay)
-
-					// Replay via the raw client so we don't re-trigger this handler.
-					return getClient(client).Do(replay)
-				}))
+				customRefreshHandler(info, cfg, getClient(client), isUnauth)))
 	case unauth != nil:
 		opts = append(opts,
 			common.WithCustomUnauthorizedHandler(
@@ -767,6 +727,92 @@ func createCustomHTTPClient(ctx context.Context, //nolint:funlen,cyclop
 	}
 
 	return customClient, nil
+}
+
+// maxCustomRefreshRetries bounds how many times a 401 triggers a re-mint + replay.
+const maxCustomRefreshRetries = 3
+
+// customRefreshHandler returns a 401 handler that, using cfg.Refresh, re-mints the
+// auth values, re-renders the provider's declared headers/query params (forced to
+// overwrite so the fresh credential replaces the stale one), and replays the request
+// via the raw client — up to maxCustomRefreshRetries times, stopping as soon as a
+// replay is no longer unauthorized. It replays via the raw client so it does not
+// re-trigger itself.
+func customRefreshHandler(
+	info *ProviderInfo,
+	cfg *CustomAuthParams,
+	rawClient *http.Client,
+	isUnauth IsUnauthorizedDecider,
+) func([]common.Header, []common.QueryParam, *http.Request, *http.Response) (*http.Response, error) {
+	return func(
+		_ []common.Header,
+		_ []common.QueryParam,
+		req *http.Request,
+		rsp *http.Response,
+	) (*http.Response, error) {
+		for attempt := 0; attempt < maxCustomRefreshRetries; attempt++ {
+			vals, err := cfg.Refresh(req.Context())
+			if err != nil {
+				// Don't mask the original 401 if we can't refresh.
+				return rsp, nil //nolint:nilerr
+			}
+
+			fresh := &CustomAuthParams{Values: vals}
+
+			newHeaders, err := getCustomHeaders(info, fresh)
+			if err != nil {
+				return nil, err
+			}
+
+			newParams, err := getCustomParams(info, fresh)
+			if err != nil {
+				return nil, err
+			}
+
+			// Force overwrite so the refreshed auth replaces the stale header/query
+			// param rather than appending a duplicate.
+			for i := range newHeaders {
+				newHeaders[i].Mode = common.HeaderModeOverwrite
+			}
+
+			for i := range newParams {
+				newParams[i].Mode = common.QueryParamModeOverwrite
+			}
+
+			replay := req.Clone(req.Context())
+			common.Headers(newHeaders).ApplyToRequest(replay)
+			common.QueryParams(newParams).ApplyToRequest(replay)
+
+			resp, err := rawClient.Do(replay)
+			if err != nil {
+				return nil, err
+			}
+
+			stillUnauth := resp.StatusCode == http.StatusUnauthorized
+			if isUnauth != nil {
+				stillUnauth, err = isUnauth(resp)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if !stillUnauth {
+				return resp, nil
+			}
+
+			// Still unauthorized. Discard this body unless it's the last attempt
+			// (whose response we return to the caller).
+			if attempt < maxCustomRefreshRetries-1 {
+				_ = resp.Body.Close()
+
+				continue
+			}
+
+			return resp, nil
+		}
+
+		return rsp, nil
+	}
 }
 
 func getCustomParams(info *ProviderInfo, cfg *CustomAuthParams) (common.QueryParams, error) {

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -757,62 +757,75 @@ func customRefreshHandler(
 				return rsp, nil //nolint:nilerr
 			}
 
-			fresh := &CustomAuthParams{Values: vals}
-
-			newHeaders, err := getCustomHeaders(info, fresh)
+			replay, err := renderRefreshedReplay(info, vals, req)
 			if err != nil {
 				return nil, err
 			}
 
-			newParams, err := getCustomParams(info, fresh)
+			resp, err := rawClient.Do(replay) //nolint:bodyclose // returned to caller, or closed below before retrying
 			if err != nil {
 				return nil, err
 			}
 
-			// Force overwrite so the refreshed auth replaces the stale header/query
-			// param rather than appending a duplicate.
-			for i := range newHeaders {
-				newHeaders[i].Mode = common.HeaderModeOverwrite
-			}
-
-			for i := range newParams {
-				newParams[i].Mode = common.QueryParamModeOverwrite
-			}
-
-			replay := req.Clone(req.Context())
-			common.Headers(newHeaders).ApplyToRequest(replay)
-			common.QueryParams(newParams).ApplyToRequest(replay)
-
-			resp, err := rawClient.Do(replay)
+			stillUnauth, err := replayStillUnauthorized(resp, isUnauth)
 			if err != nil {
+				_ = resp.Body.Close()
+
 				return nil, err
 			}
 
-			stillUnauth := resp.StatusCode == http.StatusUnauthorized
-			if isUnauth != nil {
-				stillUnauth, err = isUnauth(resp)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			if !stillUnauth {
+			// Success, or out of attempts: hand the response back to the caller.
+			if !stillUnauth || attempt == maxCustomRefreshRetries-1 {
 				return resp, nil
 			}
 
-			// Still unauthorized. Discard this body unless it's the last attempt
-			// (whose response we return to the caller).
-			if attempt < maxCustomRefreshRetries-1 {
-				_ = resp.Body.Close()
-
-				continue
-			}
-
-			return resp, nil
+			// Still unauthorized with attempts left: discard this body and retry.
+			_ = resp.Body.Close()
 		}
 
 		return rsp, nil
 	}
+}
+
+// renderRefreshedReplay clones req and applies info's declared headers/query params
+// rendered from the freshly re-minted values, forcing overwrite so the fresh
+// credential replaces the stale one rather than appending a duplicate.
+func renderRefreshedReplay(info *ProviderInfo, vals map[string]string, req *http.Request) (*http.Request, error) {
+	fresh := &CustomAuthParams{Values: vals}
+
+	newHeaders, err := getCustomHeaders(info, fresh)
+	if err != nil {
+		return nil, err
+	}
+
+	newParams, err := getCustomParams(info, fresh)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range newHeaders {
+		newHeaders[i].Mode = common.HeaderModeOverwrite
+	}
+
+	for i := range newParams {
+		newParams[i].Mode = common.QueryParamModeOverwrite
+	}
+
+	replay := req.Clone(req.Context())
+	newHeaders.ApplyToRequest(replay)
+	newParams.ApplyToRequest(replay)
+
+	return replay, nil
+}
+
+// replayStillUnauthorized reports whether the replayed response is still
+// unauthorized, honoring the provider-specific decider when present.
+func replayStillUnauthorized(resp *http.Response, isUnauth IsUnauthorizedDecider) (bool, error) {
+	if isUnauth != nil {
+		return isUnauth(resp)
+	}
+
+	return resp.StatusCode == http.StatusUnauthorized, nil
 }
 
 func getCustomParams(info *ProviderInfo, cfg *CustomAuthParams) (common.QueryParams, error) {

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -694,10 +694,11 @@ func createCustomHTTPClient(ctx context.Context, //nolint:funlen,cyclop
 	switch {
 	case cfg.Refresh != nil:
 		// The connector owns how refreshed auth is re-applied: re-mint the values,
-		// re-render this provider's declared headers/query params, and replay.
-		opts = append(opts,
-			common.WithCustomUnauthorizedHandler(
-				customRefreshHandler(info, cfg, getClient(client), isUnauth)))
+		// re-render this provider's declared headers/query params, and replay. The
+		// handler returns each response to its caller (who closes it) or closes retry
+		// bodies itself, but bodyclose can't see across the closure boundary.
+		refreshHandler := customRefreshHandler(info, cfg, getClient(client), isUnauth) //nolint:bodyclose
+		opts = append(opts, common.WithCustomUnauthorizedHandler(refreshHandler))
 	case unauth != nil:
 		opts = append(opts,
 			common.WithCustomUnauthorizedHandler(

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -812,6 +812,20 @@ func renderRefreshedReplay(info *ProviderInfo, vals map[string]string, req *http
 	}
 
 	replay := req.Clone(req.Context())
+
+	// The failed attempt consumed the request body, and Clone copies only the
+	// (now-drained) reader. Rewind from GetBody so write replays (POST/PATCH) resend
+	// their payload instead of an empty body. GetBody is set by http.NewRequest for
+	// the usual bytes/strings readers connectors build write bodies from.
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to rewind request body for refresh replay: %w", ErrClient, err)
+		}
+
+		replay.Body = body
+	}
+
 	newHeaders.ApplyToRequest(replay)
 	newParams.ApplyToRequest(replay)
 


### PR DESCRIPTION
## Description
**1. Connector-owned reactive refresh** (`providers/utils.go`)
A custom-auth connector declares *how* refreshed credentials are re-applied: `CustomAuthParams.Refresh func(ctx) (map[string]string, error)`. When set, the client installs `WithCustomUnauthorizedHandler(customRefreshHandler(...))`. On a 401 the handler calls `Refresh` (server-provided: re-mint via token-manager + reload the connection's fresh secrets), re-renders the connector's declared `Headers`/`QueryParams` with those values in **Overwrite** mode, and replays via the **raw** client (up to 3×). 

**Division of responsibility:** server orchestrates *what* to do on a bad connection (detect 401, run `RefreshSteps`, persist, serialize, retry); the connector owns *how* — which secrets, which keys matter, how the header is shaped and attached.

**2. Microsoft directory-object reads** (`providers/microsoft`)
Incremental reads of Entra directory objects filter on `createdDateTime`, which Graph rejects without "advanced query". Add `$count=true` + the `ConsistencyLevel: eventual` header for exactly the authoritative directory-object set (users, groups, applications, servicePrincipals, devices, administrativeUnits, contacts, appRoleAssignments, oauth2PermissionGrants — per https://learn.microsoft.com/graph/aad-advanced-queries). Header rides every page; `$count` only when a `$filter` is present.

## Testing
- `customauth_refresh_test.go` — Authorization overwrite, query-param overwrite, retries-then-gives-up, refresh-error returns original 401.
- `advanced_query_test.go` — directory-object set guard + `$count`/`ConsistencyLevel` wiring (with/without `$filter`).
- `go build` + `go test ./providers/microsoft/ ./providers/` pass.
