### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cloud.google.com/go/bigquery v1.77.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260722183224-4cca1fb65bfe
+	github.com/amp-labs/amp-common v0.0.0-20260723042450-78c214ed40af
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
-github.com/amp-labs/amp-common v0.0.0-20260722183224-4cca1fb65bfe h1:F4HN8Jyh8Uz+DRi46XHjOrjF+Rgld118Xl1hJJIU4dg=
-github.com/amp-labs/amp-common v0.0.0-20260722183224-4cca1fb65bfe/go.mod h1:csP+rBfgpO/KHTqd4myuKmLzLr69OnPM05wF6VnvF3E=
+github.com/amp-labs/amp-common v0.0.0-20260723042450-78c214ed40af h1:4halVOct7m+9yMdJIkR/BAUVSTNs2khmd7NvHUp8WUw=
+github.com/amp-labs/amp-common v0.0.0-20260723042450-78c214ed40af/go.mod h1:JXC5io5PFITL1xTgZCLRDU66atZqMuRTlSwlYCzLRoo=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [78c214ed40afb208852b1509b536b5121ac41804](https://github.com/amp-labs/amp-common/commit/78c214ed40afb208852b1509b536b5121ac41804) from [main](https://github.com/amp-labs/amp-common/tree/main)