### PR TITLE
[ENG-4142] feat(acculynx): add Appointment->Job and Appointment->User associations

### DIFF
--- a/providers/acculynx/associations.go
+++ b/providers/acculynx/associations.go
@@ -1,6 +1,70 @@
 package acculynx
 
-import "github.com/amp-labs/connectors/common"
+import (
+	"slices"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// appointmentJobAssociation and appointmentUserAssociation are the association
+// keys Hatch's config requests for calendars/appointments (see the server's
+// getHatchAssociations, which returns ["jobs", "users"]). They match the target
+// object names the server hydrates.
+const (
+	appointmentJobAssociation  = objectJobs
+	appointmentUserAssociation = objectUsers
+)
+
+// attachAppointmentAssociations attaches the Appointment->Job and
+// Appointment->User edges to appointment rows produced by the calendars/
+// appointments fan-out. Both are reference-shape associations (ObjectId only,
+// the server hydrates via GetRecordsByIds) — the same shape as outreach's
+// collectAssociations, and unlike the embedded Job<->Contact edge above.
+//
+//   - Appointment->Job: the job id rides on the appointment body (jobId). It is
+//     empty for non-job calendar events (e.g. Personal), so the edge is emitted
+//     only when present.
+//   - Appointment->User: the appointment body carries no calendar/user id — the
+//     calendarId is the fan-out path parent, so it is threaded in. A calendar's
+//     id equals its user's id in AccuLynx; company/crew calendars are not users
+//     and are dropped downstream when hydration 404s (see GetRecordsByIds).
+//
+// It is a no-op for any object other than calendars/appointments, so the nested
+// fan-out can call it unconditionally.
+func attachAppointmentAssociations(params common.ReadParams, calendarID string, rows []common.ReadResultRow) {
+	if params.ObjectName != "calendars/appointments" {
+		return
+	}
+
+	wantJob := slices.Contains(params.AssociatedObjects, appointmentJobAssociation)
+	wantUser := slices.Contains(params.AssociatedObjects, appointmentUserAssociation)
+
+	if !wantJob && !wantUser {
+		return
+	}
+
+	for idx := range rows {
+		if wantJob {
+			if jobID, _ := rows[idx].Raw["jobId"].(string); jobID != "" {
+				addAssociation(&rows[idx], appointmentJobAssociation, jobID)
+			}
+		}
+
+		if wantUser && calendarID != "" {
+			addAssociation(&rows[idx], appointmentUserAssociation, calendarID)
+		}
+	}
+}
+
+// addAssociation appends a reference-shape association (ObjectId only) under the
+// given key, initialising the row's association map on first use.
+func addAssociation(row *common.ReadResultRow, key, objectID string) {
+	if row.Associations == nil {
+		row.Associations = make(map[string][]common.Association)
+	}
+
+	row.Associations[key] = append(row.Associations[key], common.Association{ObjectId: objectID})
+}
 
 // jobContactsAssociation is the association key Hatch's config requests (see the
 // server's getHatchAssociations). It matches the embedded "contacts" array that

--- a/providers/acculynx/batchRecordReader.go
+++ b/providers/acculynx/batchRecordReader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -18,8 +19,14 @@ import (
 
 var errBatchReadEmptyResponse = errors.New("acculynx: empty response body for record fetch")
 
+// batchReadableObjects lists objects the connector can hydrate by id via a
+// single-record GET. Users were added for the appointment->user association:
+// an appointment's calendar id equals its user id, so the server hydrates the
+// user directly. Not every calendar is a user (company/crew calendars 404), so
+// GetRecordsByIds skips ids that are not found — see isNotFound below.
+//
 //nolint:gochecknoglobals
-var batchReadableObjects = datautils.NewStringSet(objectContacts, objectJobs)
+var batchReadableObjects = datautils.NewStringSet(objectContacts, objectJobs, objectUsers)
 
 //nolint:revive
 func (c *Connector) GetRecordsByIds(
@@ -32,7 +39,7 @@ func (c *Connector) GetRecordsByIds(
 	objectName = strings.ToLower(objectName)
 
 	if !batchReadableObjects.Has(objectName) {
-		return nil, fmt.Errorf("%w: %s (only contacts and jobs supported)",
+		return nil, fmt.Errorf("%w: %s (only contacts, jobs and users supported)",
 			common.ErrGetRecordNotSupportedForObject, objectName)
 	}
 
@@ -43,18 +50,29 @@ func (c *Connector) GetRecordsByIds(
 	fieldSet := datautils.NewSetFromList(fields)
 
 	rows := make([]common.ReadResultRow, len(recordIds))
+	found := make([]bool, len(recordIds))
 	jobs := make([]simultaneously.Job, len(recordIds))
 
 	for i, recordID := range recordIds {
-		idx, id := i, recordID
+		idx, currentID := i, recordID
 
 		jobs[idx] = func(ctx context.Context) error {
-			row, err := c.fetchSingleRecord(ctx, objectName, id, fieldSet)
+			row, err := c.fetchSingleRecord(ctx, objectName, currentID, fieldSet)
 			if err != nil {
-				return fmt.Errorf("fetch %s/%s: %w", objectName, id, err)
+				// A record that no longer exists — or, for the appointment->user
+				// edge, a calendar id that is not a user — must not sink the whole
+				// batch. Skip the missing id and let the caller receive the ids
+				// that do resolve, matching the "missing ids simply don't come
+				// back" semantics of the bulk-by-id connectors.
+				if isNotFound(err) {
+					return nil
+				}
+
+				return fmt.Errorf("fetch %s/%s: %w", objectName, currentID, err)
 			}
 
 			rows[idx] = row
+			found[idx] = true
 
 			return nil
 		}
@@ -64,7 +82,36 @@ func (c *Connector) GetRecordsByIds(
 		return nil, err
 	}
 
-	return rows, nil
+	return compactFound(rows, found), nil
+}
+
+// isNotFound reports whether err represents a 404 from AccuLynx. The base JSON
+// HTTP client maps a 404 to a retryable *common.HTTPError rather than
+// common.ErrNotFound, so the HTTP status is inspected directly — mirroring the
+// google calendar connector's handling.
+func isNotFound(err error) bool {
+	if errors.Is(err, common.ErrNotFound) {
+		return true
+	}
+
+	if httpErr, ok := errors.AsType[*common.HTTPError](err); ok {
+		return httpErr.Status == http.StatusNotFound
+	}
+
+	return false
+}
+
+// compactFound returns only the rows whose id resolved, preserving input order.
+func compactFound(rows []common.ReadResultRow, found []bool) []common.ReadResultRow {
+	out := make([]common.ReadResultRow, 0, len(rows))
+
+	for i, ok := range found {
+		if ok {
+			out = append(out, rows[i])
+		}
+	}
+
+	return out
 }
 
 func (c *Connector) fetchSingleRecord(

--- a/providers/acculynx/batchRecordReader_test.go
+++ b/providers/acculynx/batchRecordReader_test.go
@@ -121,23 +121,93 @@ func TestGetRecordsByIds_RawPreservedUntouched(t *testing.T) {
 	assert.Equal(t, rows[0].Raw["_link"], "https://api.acculynx.com/api/v2/contacts/contact-1")
 }
 
-func TestGetRecordsByIds_FailingFetchPropagatesError(t *testing.T) {
+func TestGetRecordsByIds_NotFoundIsSkippedNotErrored(t *testing.T) {
 	t.Parallel()
 
+	// A 404 for one id must not fail the whole batch: the batch returns the ids
+	// that resolve and silently omits the missing one. This is required for the
+	// appointment->user edge (company/crew calendar ids are not users and 404),
+	// and also hardens hydration for a since-deleted job/contact.
+	srv := mockserver.Switch{
+		Setup: mockserver.ContentJSON(),
+		Cases: []mockserver.Case{
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/job-1"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{"id":"job-1","jobName":"First"}`),
+			},
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/missing-job"),
+				},
+				Then: mockserver.ResponseString(http.StatusNotFound, `{"detail":"NotFound"}`),
+			},
+		},
+		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-1", "missing-job"}, []string{"id", "jobName"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, rows[0].Id, "job-1")
+	assert.Equal(t, rows[0].Fields["jobName"], "First")
+}
+
+func TestGetRecordsByIds_NonNotFoundStillErrors(t *testing.T) {
+	t.Parallel()
+
+	// A non-404 failure (e.g. 500) must still fail the batch — only genuine
+	// not-found ids are skipped.
 	srv := mockserver.Conditional{
 		Setup: mockserver.ContentJSON(),
 		If: mockcond.And{
 			mockcond.MethodGET(),
-			mockcond.Path("/api/v2/jobs/missing-job"),
+			mockcond.Path("/api/v2/jobs/boom-job"),
 		},
-		Then: mockserver.ResponseString(http.StatusNotFound, `{"detail":"NotFound"}`),
+		Then: mockserver.ResponseString(http.StatusInternalServerError, `{"detail":"boom"}`),
 	}.Server()
 
 	conn, err := constructTestReadConnector(srv.URL)
 	assert.NilError(t, err)
 
 	_, err = conn.GetRecordsByIds(context.Background(), objectJobs,
-		[]string{"missing-job"}, []string{"id"}, nil)
+		[]string{"boom-job"}, []string{"id"}, nil)
 
-	assert.Assert(t, err != nil, "404 from upstream should surface as an error")
+	assert.Assert(t, err != nil, "a 500 from upstream should still surface as an error")
+}
+
+func TestGetRecordsByIds_HydratesUsers(t *testing.T) {
+	t.Parallel()
+
+	// Users were added to the batch-readable set for the appointment->user edge;
+	// a calendar id equals its user id, so hydration resolves the full user
+	// (including role, which Hatch filters on).
+	srv := mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/v2/users/794f06f5"),
+		},
+		Then: mockserver.ResponseString(http.StatusOK,
+			`{"id":"794f06f5","displayName":"Diane Hatch","role":{"id":"r1","name":"CompanyAdmin"}}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectUsers,
+		[]string{"794f06f5"}, []string{"id", "displayName", "role"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, rows[0].Id, "794f06f5")
+	assert.Equal(t, rows[0].Fields["displayName"], "Diane Hatch")
 }

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -58,6 +58,7 @@ const (
 	objectEstimates   = "estimates"
 	objectSupplements = "supplements"
 	objectCalendars   = "calendars"
+	objectUsers       = "users"
 )
 
 // includesByObject lists the AccuLynx ?includes= expansions applied
@@ -443,6 +444,7 @@ func (c *Connector) fetchChildPages(
 			return nil, err
 		}
 
+		attachAppointmentAssociations(params, parentID, result.Data)
 		allRows = append(allRows, result.Data...)
 
 		if result.NextPage == "" {

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -31,6 +31,9 @@ var jobContacts002Response []byte
 //go:embed test/read/calendar-appointments.json
 var calendarAppointmentsResponse []byte
 
+//go:embed test/read/calendar-appointments-assoc.json
+var calendarAppointmentsAssocResponse []byte
+
 //go:embed test/read/calendars-list.json
 var calendarsListResponse []byte
 
@@ -572,6 +575,97 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Comparator: testconn.ComparatorPagination,
 			Expected: &common.ReadResult{
 				Rows: 1,
+				Done: true,
+			},
+		},
+		{
+			Name: "Read calendars/appointments attaches job and user associations",
+			Input: common.ReadParams{
+				ObjectName:        "calendars/appointments",
+				Fields:            connectors.Fields("id", "title"),
+				PageSize:          100,
+				AssociatedObjects: []string{"jobs", "users"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/calendars"),
+						},
+						Then: mockserver.Response(http.StatusOK, calendarsListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/calendars/cal-001/appointments"),
+						},
+						Then: mockserver.Response(http.StatusOK, calendarAppointmentsAssocResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						// Job-linked event: both edges. calendarId (cal-001) is the
+						// fan-out parent -> user; jobId rides on the body -> job.
+						Fields: map[string]any{"id": "appt-1", "title": "Site visit"},
+						Raw:    map[string]any{"id": "appt-1", "jobId": "job-777"},
+						Associations: map[string][]common.Association{
+							"jobs":  {{ObjectId: "job-777"}},
+							"users": {{ObjectId: "cal-001"}},
+						},
+					},
+					{
+						// Personal event: no jobId, so only the user edge is emitted.
+						Fields: map[string]any{"id": "appt-2", "title": "Lunch"},
+						Raw:    map[string]any{"id": "appt-2"},
+						Associations: map[string][]common.Association{
+							"users": {{ObjectId: "cal-001"}},
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read calendars/appointments without association request attaches nothing",
+			Input: common.ReadParams{
+				ObjectName: "calendars/appointments",
+				Fields:     connectors.Fields("id", "title"),
+				PageSize:   100,
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/calendars"),
+						},
+						Then: mockserver.Response(http.StatusOK, calendarsListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/calendars/cal-001/appointments"),
+						},
+						Then: mockserver.Response(http.StatusOK, calendarAppointmentsAssocResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{Fields: map[string]any{"id": "appt-1"}, Raw: map[string]any{"id": "appt-1"}},
+					{Fields: map[string]any{"id": "appt-2"}, Raw: map[string]any{"id": "appt-2"}},
+				},
 				Done: true,
 			},
 		},

--- a/providers/acculynx/test/read/calendar-appointments-assoc.json
+++ b/providers/acculynx/test/read/calendar-appointments-assoc.json
@@ -1,0 +1,19 @@
+{
+  "count": 2,
+  "pageSize": 100,
+  "pageStartIndex": 0,
+  "items": [
+    {
+      "id": "appt-1",
+      "title": "Site visit",
+      "jobId": "job-777",
+      "jobName": "Roof Replace",
+      "eventType": "Appointment"
+    },
+    {
+      "id": "appt-2",
+      "title": "Lunch",
+      "eventType": "Personal"
+    }
+  ]
+}

--- a/test/acculynx/read-by-ids/main.go
+++ b/test/acculynx/read-by-ids/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	testAccuLynx "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// Live validation for the appointment associations work:
+//
+//  1. Read calendars/appointments with AssociatedObjects=[jobs,users] and show
+//     each appointment carries a "jobs" edge (jobId, when present) and a "users"
+//     edge (the calendarId fan-out parent).
+//  2. GetRecordsByIds("users", [realUser, companyCalendar]) proves skip-on-404:
+//     the real user hydrates (with role), the company calendar id — which is not
+//     a user and returns 404 — is silently omitted, and the call does NOT error.
+//  3. GetRecordsByIds("jobs", [realJob]) confirms job hydration still works.
+//
+// IDs below are from the Hatch test tenant (see acculynx-creds.json); adjust if
+// the tenant data changes.
+const (
+	realUserID        = "794f06f5-b10e-4ceb-88e2-d597b03c301a" // "Diane Hatch" — a person calendar == user
+	companyCalendarID = "faba30e4-10bc-4c10-a266-29a45d572ca4" // "Hatch Homes Services" — a calendar that is NOT a user (404)
+	realJobID         = "6c0b61d3-ca9e-4593-91bf-fa4df85485e6" // a jobId taken off a live appointment
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testAccuLynx.GetAccuLynxConnector(ctx)
+
+	slog.Info("=== 1) Read calendars/appointments with job+user associations ===")
+
+	if err := readAppointmentsWithAssociations(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	slog.Info("=== 2) GetRecordsByIds(users) skips a non-user calendar id (404) ===")
+
+	if err := hydrateUsersWithMissing(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	slog.Info("=== 3) GetRecordsByIds(jobs) hydrates a real job ===")
+
+	if err := hydrateJob(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func readAppointmentsWithAssociations(ctx context.Context, conn *acculynx.Connector) error {
+	params := common.ReadParams{
+		ObjectName:        "calendars/appointments",
+		Fields:            connectors.Fields("id", "title", "jobId", "jobName", "eventType"),
+		AssociatedObjects: []string{"jobs", "users"},
+		Since:             time.Now().AddDate(0, 0, -60),
+		Until:             time.Now(),
+	}
+
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		return fmt.Errorf("reading appointments with associations: %w", err)
+	}
+
+	slog.Info("appointments read", "rows", res.Rows)
+
+	withJob, withUser := 0, 0
+
+	for _, row := range res.Data {
+		if len(row.Associations["jobs"]) > 0 {
+			withJob++
+		}
+
+		if len(row.Associations["users"]) > 0 {
+			withUser++
+		}
+	}
+
+	slog.Info("association coverage",
+		"rows", res.Rows,
+		"withJobEdge", withJob,
+		"withUserEdge", withUser)
+
+	// Dump the first few rows so the Associations map is visible.
+	max := 3
+	if len(res.Data) < max {
+		max = len(res.Data)
+	}
+
+	utils.DumpJSON(res.Data[:max], os.Stdout)
+
+	return nil
+}
+
+func hydrateUsersWithMissing(ctx context.Context, conn *acculynx.Connector) error {
+	ids := []string{realUserID, companyCalendarID}
+
+	rows, err := conn.GetRecordsByIds(ctx, "users", ids,
+		[]string{"id", "displayName", "role"}, nil)
+	if err != nil {
+		return fmt.Errorf("GetRecordsByIds(users) errored — skip-on-404 is broken: %w", err)
+	}
+
+	slog.Info("users hydrated",
+		"requested", len(ids),
+		"returned", len(rows),
+		"expected", "1 (company calendar id skipped)")
+
+	utils.DumpJSON(rows, os.Stdout)
+
+	return nil
+}
+
+func hydrateJob(ctx context.Context, conn *acculynx.Connector) error {
+	rows, err := conn.GetRecordsByIds(ctx, "jobs", []string{realJobID},
+		[]string{"id", "jobName"}, nil)
+	if err != nil {
+		return fmt.Errorf("GetRecordsByIds(jobs): %w", err)
+	}
+
+	slog.Info("job hydrated", "returned", len(rows))
+	utils.DumpJSON(rows, os.Stdout)
+
+	return nil
+}


### PR DESCRIPTION
## Appointment→Job and Appointment→User associations.

### What changed

  - Both edges attached in the calendars/appointments fan-out (fetchChildPages, not the top-level marshaller, appointments short-circuit before it):
  - Appointment→Job: from appointment.jobId, emitted only when non-empty (Personal events have none).
  - Appointment→User: from the calendarId fan-out parent, a calendar's id equals its user's id (verified live).
  - users added to batch-read + GetRecordsByIds now skips 404s, so the User edge hydrates the full user (incl. role), and a non-user calendar id (company/crew calendars) no longer fails the whole batch. This also hardens the Job edge.

### Resolved open question

calendarId == userId for person calendars (live: /users/{id} → 200) company/crew calendars are not users (→ 404, skipped). No lookup/name-match needed.

## Testing

### Unit: go test ./providers/acculynx/...

<img width="1466" height="742" alt="image" src="https://github.com/user-attachments/assets/d9ed4b34-8fcd-47c2-981a-75b72162e324" />

<img width="1466" height="164" alt="image" src="https://github.com/user-attachments/assets/fae8eb89-bdec-4081-890c-c79c57bdfc3b" />


### Live: go run ./test/acculynx/read-by-ids/main.go (needs acculynx-creds.json)

<img width="1466" height="894" alt="image" src="https://github.com/user-attachments/assets/e2887245-8d64-4669-ba11-49b7621c6c60" />

<img width="1466" height="913" alt="image" src="https://github.com/user-attachments/assets/3420a460-991c-4c93-9459-9502766d0276" />








