### PR TITLE
[CON-3243] fix(google): stop classifying recent calendar edits as creates

### DIFF
--- a/providers/google/internal/calendar/subscriptionEvent.go
+++ b/providers/google/internal/calendar/subscriptionEvent.go
@@ -13,22 +13,33 @@ import (
 // which is how GetRecordsByIds queries.
 const statusCancelled = "cancelled"
 
+// createdUpdatedEpsilon is how close an event's updated time must be to its created time to
+// classify as a create. On a genuine create the two are near-identical, but not equal: created
+// is truncated to whole seconds while updated keeps milliseconds (live-observed delta: 318ms).
+// 2s absorbs that skew while excluding human edits-after-create. Trade-off: an async
+// post-create touch by Google that bumps updated past 2s (e.g. Meet link resolution) would
+// deliver that create as an update.
+const createdUpdatedEpsilon = 2 * time.Second
+
 // SubscriptionEvent is one Calendar event to be classified, built from a GetRecordsByIds row.
 //
 // Calendar pushes have an empty body, so the subscribe pipeline fetches the changed events
 // first and classifies them afterwards. Keeping that split, GetRecordsByIds is a plain read
 // and EventType does the classification here. A Calendar event has no event-type field (Gmail
-// gets one from its history categories), so the type is inferred from the status and the
-// created time relative to the fetch window (UpdatedMin, the checkpoint GetRecordsByIds used).
+// gets one from its history categories), so the type is inferred from the status, the created
+// time relative to the fetch window (UpdatedMin, the checkpoint GetRecordsByIds used), and how
+// closely updated trails created.
 type SubscriptionEvent struct {
 	// RecordID is the Calendar event ID.
 	RecordID string
 	// Status is the event status; "cancelled" means the event was deleted.
 	Status string
-	// Created is the event creation time (RFC3339), compared against UpdatedMin to tell a
-	// new event from an edit to an existing one.
+	// Created is the event creation time (RFC3339). EventType compares it against UpdatedMin
+	// and Updated to tell a new event from an edit to an existing one.
 	Created string
-	// Updated is the last-modification time (RFC3339), used as the event timestamp.
+	// Updated is the last-modification time (RFC3339), used as the event timestamp and, with
+	// Created, to classify creates (a genuine create has updated within a few seconds of
+	// created).
 	Updated string
 	// UpdatedMin is the fetch window checkpoint (recordIds[0] passed to GetRecordsByIds).
 	UpdatedMin string
@@ -39,10 +50,19 @@ type SubscriptionEvent struct {
 var _ common.SubscriptionEvent = SubscriptionEvent{}
 
 // EventType infers the event type from the row. A cancelled event is a delete; otherwise an
-// event created within the fetch window is a create, and an older one is an update.
+// event is a create only when it was created within the fetch window AND its updated time sits
+// within createdUpdatedEpsilon of its created time. Everything else is an update.
+//
+// The window check alone is not enough: the server's updatedMin checkpoint lags real time by a
+// couple of minutes (lookback buffer plus time between pushes), so an event edited shortly
+// after creation still has created >= updatedMin and would re-classify as a create. On a
+// genuine create updated barely trails created, while any edit pushes updated well past it, so
+// the epsilon is what separates the two. The window check stays as a guard against backfills
+// that rewrite an old event's updated time to near its created time.
 //
 // updatedMin defines the window and must parse, or we error. A non-cancelled event with no
-// usable created time falls back to update.
+// usable created time falls back to update; one created in the window with no usable updated
+// time falls back to create (the pre-epsilon behavior).
 func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 	if strings.EqualFold(e.Status, statusCancelled) {
 		return common.SubscriptionEventTypeDelete, nil
@@ -60,8 +80,18 @@ func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 		return common.SubscriptionEventTypeUpdate, nil // nolint: nilerr
 	}
 
-	// Created at or after the window start means it's new within this fetch.
-	if !created.Before(window) {
+	// Created before the window start means it existed before this fetch: an edit.
+	if created.Before(window) {
+		return common.SubscriptionEventTypeUpdate, nil
+	}
+
+	updated, err := time.Parse(time.RFC3339, e.Updated)
+	if err != nil {
+		// Created in the window but nothing to measure the edit gap with; call it a create.
+		return common.SubscriptionEventTypeCreate, nil // nolint: nilerr
+	}
+
+	if updated.Sub(created) <= createdUpdatedEpsilon {
 		return common.SubscriptionEventTypeCreate, nil
 	}
 

--- a/providers/google/internal/calendar/subscriptionEvent_test.go
+++ b/providers/google/internal/calendar/subscriptionEvent_test.go
@@ -29,19 +29,63 @@ func TestSubscriptionEventEventType(t *testing.T) {
 			want:  common.SubscriptionEventTypeDelete,
 		},
 		{
-			name:  "created within the window is a create",
-			event: SubscriptionEvent{Status: "confirmed", Created: "2026-06-18T09:00:00.000Z", UpdatedMin: updatedMin},
-			want:  common.SubscriptionEventTypeCreate,
+			name: "created within the window with updated close behind is a create",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-18T09:00:00.000Z",
+				Updated: "2026-06-18T09:00:00.318Z", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeCreate,
 		},
 		{
-			name:  "created exactly at the window boundary is a create",
-			event: SubscriptionEvent{Status: "confirmed", Created: updatedMin, UpdatedMin: updatedMin},
-			want:  common.SubscriptionEventTypeCreate,
+			name: "created within the window but edited later is an update",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-18T09:00:00.000Z",
+				Updated: "2026-06-18T09:02:47.000Z", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name: "updated exactly epsilon after created is still a create",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-18T09:00:00.000Z",
+				Updated: "2026-06-18T09:00:02.000Z", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeCreate,
+		},
+		{
+			name: "updated just past epsilon is an update",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-18T09:00:00.000Z",
+				Updated: "2026-06-18T09:00:02.001Z", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name: "created exactly at the window boundary is a create",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: updatedMin, Updated: updatedMin, UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeCreate,
+		},
+		{
+			name: "created before the window is an update even when updated trails created closely",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-01T09:00:00.000Z",
+				Updated: "2026-06-01T09:00:00.500Z", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeUpdate,
 		},
 		{
 			name:  "created before the window is an update",
 			event: SubscriptionEvent{Status: "confirmed", Created: "2026-06-01T09:00:00.000Z", UpdatedMin: updatedMin},
 			want:  common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name: "created in the window with missing updated falls back to create",
+			event: SubscriptionEvent{
+				Status: "confirmed", Created: "2026-06-18T09:00:00.000Z", Updated: "", UpdatedMin: updatedMin,
+			},
+			want: common.SubscriptionEventTypeCreate,
 		},
 		{
 			name:  "missing created falls back to update",
@@ -64,6 +108,62 @@ func TestSubscriptionEventEventType(t *testing.T) {
 
 			assert.Equal(t, got, tt.want)
 			assert.Equal(t, err != nil, tt.wantErr)
+		})
+	}
+}
+
+// TestSubscriptionEventEventTypeLiveSamples replays the timestamps of three live webhook
+// deliveries for one Calendar event (created, edited ~3 minutes later, edited again ~17
+// minutes later). The middle delivery is the regression: its checkpoint still predated the
+// event's creation, so the window check alone classified the edit as a create.
+func TestSubscriptionEventEventTypeLiveSamples(t *testing.T) {
+	t.Parallel()
+
+	const (
+		created = "2026-07-27T18:46:10.000Z"
+		status  = "confirmed"
+	)
+
+	tests := []struct {
+		name       string
+		updated    string
+		updatedMin string
+		want       common.SubscriptionEventType
+	}{
+		{
+			name:       "initial creation delivers as create",
+			updated:    "2026-07-27T18:46:10.318Z",
+			updatedMin: "2026-07-27T18:41:55Z",
+			want:       common.SubscriptionEventTypeCreate,
+		},
+		{
+			name:       "edit before the checkpoint catches up delivers as update",
+			updated:    "2026-07-27T18:48:57.232Z",
+			updatedMin: "2026-07-27T18:44:11Z", // still before created: window check alone said create
+			want:       common.SubscriptionEventTypeUpdate,
+		},
+		{
+			name:       "edit after the checkpoint catches up delivers as update",
+			updated:    "2026-07-27T19:03:20.633Z",
+			updatedMin: "2026-07-27T18:46:58Z",
+			want:       common.SubscriptionEventTypeUpdate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := SubscriptionEvent{
+				Status:     status,
+				Created:    created,
+				Updated:    tt.updated,
+				UpdatedMin: tt.updatedMin,
+			}
+
+			got, err := event.EventType()
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }
@@ -93,11 +193,12 @@ func TestSubscriptionEventsFromRecords(t *testing.T) {
 			},
 		},
 		{
-			// id/status/created only in the marshaled Fields (lowercased keys), not Raw.
+			// id/status/created/updated only in the marshaled Fields (lowercased keys), not Raw.
 			Fields: map[string]any{
 				"id":      "evt-new-1",
 				"status":  "confirmed",
-				"created": "2026-06-18T11:00:00.000Z", // created inside the window: a create
+				"created": "2026-06-18T11:00:00.000Z", // created inside the window with
+				"updated": "2026-06-18T11:00:00.421Z", // updated close behind: a create
 			},
 		},
 	}


### PR DESCRIPTION
Fix:
Tighten the create rule in an event classification as create only when created >= updatedMin and updated − created ≤ 2s (createdUpdatedEpsilon). On a genuine create the gap is milliseconds (318ms observed; created is second-truncated, updated keeps millis), while any real edit pushes updated minutes past.

Checklist
- [x] Scope limited to one concern (event classification)
- [x] Unit tests added/updated — epsilon boundary cases plus a regression test replaying the three live deliveries above
- [x] Manual sandbox verification
- [ ] Live-test Meet-link creation to confirm the trade-off bound (optional pre-merge)