### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cloud.google.com/go/bigquery v1.79.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260727154549-8d53f77eb37a
+	github.com/amp-labs/amp-common v0.0.0-20260728225358-b144e485a3a0
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
-github.com/amp-labs/amp-common v0.0.0-20260727154549-8d53f77eb37a h1:dRhnr8jvlA8meETkWWzNTNIR9sAwMr3F3Z5lgElqhss=
-github.com/amp-labs/amp-common v0.0.0-20260727154549-8d53f77eb37a/go.mod h1:MfvRXzJXpjTAKOyK12Rtc/Zl8xWJUbU80HNq41dabg4=
+github.com/amp-labs/amp-common v0.0.0-20260728225358-b144e485a3a0 h1:ASSfMhNfq1bN5G4AuV3U5Ig3fb3p+aQugsfEHbjuU48=
+github.com/amp-labs/amp-common v0.0.0-20260728225358-b144e485a3a0/go.mod h1:MfvRXzJXpjTAKOyK12Rtc/Zl8xWJUbU80HNq41dabg4=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [b144e485a3a08c0237efff54098c2b23363259b8](https://github.com/amp-labs/amp-common/commit/b144e485a3a08c0237efff54098c2b23363259b8) from [main](https://github.com/amp-labs/amp-common/tree/main)