### PR TITLE
fix(netsuite): honor PageSize in restapi and suiteql reads

### DIFF
--- a/providers/netsuite/internal/restapi/read.go
+++ b/providers/netsuite/internal/restapi/read.go
@@ -41,7 +41,12 @@ func (a *Adapter) buildReadRequest(ctx context.Context, params common.ReadParams
 		return nil, err
 	}
 
-	url.WithQueryParam("limit", strconv.Itoa(maxRecordsPerPage))
+	limit := maxRecordsPerPage
+	if params.PageSize > 0 {
+		limit = params.PageSize
+	}
+
+	url.WithQueryParam("limit", strconv.Itoa(limit))
 
 	// Attach Since & Until, if provided.
 	var queries []string

--- a/providers/netsuite/internal/suiteql/read.go
+++ b/providers/netsuite/internal/suiteql/read.go
@@ -36,7 +36,12 @@ func (a *Adapter) buildReadRequest(ctx context.Context, params common.ReadParams
 			return nil, err
 		}
 
-		url.WithQueryParam("limit", strconv.Itoa(maxRecordsPerPage))
+		limit := maxRecordsPerPage
+		if params.PageSize > 0 {
+			limit = params.PageSize
+		}
+
+		url.WithQueryParam("limit", strconv.Itoa(limit))
 		urlStr = url.String()
 	}
 


### PR DESCRIPTION
## What

The NetSuite `restapi` and `suiteql` read adapters hardcoded the list `limit` to `maxRecordsPerPage` (1000) and ignored `params.PageSize`. This change honors `params.PageSize` when set, falling back to 1000 otherwise — mirroring the guard the `restlet` adapter already uses.