### PR TITLE
fix(zoho): read CRM server_time under float64 and json.Number decodes

### DIFF
--- a/providers/zoho/serverTime_test.go
+++ b/providers/zoho/serverTime_test.go
@@ -1,0 +1,70 @@
+package zoho
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// crmWebhookBody is a Zoho CRM notification payload. server_time is a bare JSON
+// number (epoch millis).
+const crmWebhookBody = `{
+	"server_time": 1750102639787,
+	"affected_values": [
+		{"record_id": "6756839000000575405", "values": {"Company": "Rangoni Of Test"}}
+	],
+	"module": "Leads",
+	"ids": ["6756839000000575405"],
+	"affected_fields": [{"6756839000000575405": ["Company"]}],
+	"operation": "update",
+	"channel_id": "1105420521999070702",
+	"token": "c3504777-db15-4332-8286-478a1b5006bc"
+}`
+
+// TestEventTimeStampNanoDecodeModes verifies the CRM event timestamp is read
+// correctly whether the caller decoded the webhook body with a plain
+// json.Unmarshal (server_time -> float64) or with json.Decoder.UseNumber
+// (server_time -> json.Number). The server decodes Zoho bodies with UseNumber to
+// preserve 64-bit ids in other Zoho modules (e.g. Mail folderId), so the CRM
+// event parser must keep working under both decode modes.
+func TestEventTimeStampNanoDecodeModes(t *testing.T) {
+	t.Parallel()
+
+	const wantNano = int64(1750102639787) * int64(1_000_000)
+
+	firstEventTimestamp := func(t *testing.T, evt CollapsedSubscriptionEvent) int64 {
+		t.Helper()
+
+		events, err := evt.SubscriptionEventList()
+		assert.NilError(t, err)
+		assert.Equal(t, len(events), 1)
+
+		nano, err := events[0].EventTimeStampNano()
+		assert.NilError(t, err)
+
+		return nano
+	}
+
+	t.Run("plain unmarshal (float64)", func(t *testing.T) {
+		t.Parallel()
+
+		var evt CollapsedSubscriptionEvent
+		assert.NilError(t, json.Unmarshal([]byte(crmWebhookBody), &evt))
+
+		assert.Equal(t, firstEventTimestamp(t, evt), wantNano)
+	})
+
+	t.Run("UseNumber (json.Number)", func(t *testing.T) {
+		t.Parallel()
+
+		var evt CollapsedSubscriptionEvent
+
+		decoder := json.NewDecoder(bytes.NewReader([]byte(crmWebhookBody)))
+		decoder.UseNumber()
+		assert.NilError(t, decoder.Decode(&evt))
+
+		assert.Equal(t, firstEventTimestamp(t, evt), wantNano)
+	})
+}

--- a/providers/zoho/subscriptionEvent.go
+++ b/providers/zoho/subscriptionEvent.go
@@ -307,14 +307,39 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 
 // EventTimeStampNano returns the timestamp of the event in nanoseconds.
 func (evt SubscriptionEvent) EventTimeStampNano() (int64, error) {
-	m := evt.asMap()
-
-	serverTime, err := m.AsInt("server_time")
+	serverTime, err := serverTimeMillis(evt.asMap())
 	if err != nil {
 		return 0, err
 	}
 
 	return time.UnixMilli(serverTime).UnixNano(), nil
+}
+
+// serverTimeMillis reads the "server_time" epoch-millis value regardless of how
+// the caller decoded the webhook body. It first tries StringMap.AsInt, which
+// handles the float64 a plain json.Unmarshal produces; if that fails it falls
+// back to parsing a json.Number/string, which is what a caller that decoded with
+// json.Decoder.UseNumber produces. This keeps the timestamp readable under both
+// decode modes (UseNumber is needed by other Zoho modules to preserve 64-bit
+// ids, and AsInt rejects json.Number because its reflect kind is String).
+func serverTimeMillis(m common.StringMap) (int64, error) {
+	if ms, err := m.AsInt("server_time"); err == nil {
+		return ms, nil
+	}
+
+	raw, err := m.Get("server_time")
+	if err != nil {
+		return 0, err
+	}
+
+	switch v := raw.(type) {
+	case json.Number:
+		return v.Int64()
+	case string:
+		return json.Number(v).Int64()
+	default:
+		return 0, fmt.Errorf("%w: server_time expected a number, got %T", errTypeMismatch, raw)
+	}
 }
 
 // UpdatedFields returns the fields that were updated in the event.


### PR DESCRIPTION
This is blocking Zoho mail https://github.com/amp-labs/connectors/pull/3196

EventTimeStampNano read server_time via StringMap.AsInt, which only
handles the float64 that a plain json.Unmarshal produces. When the caller
decodes the webhook body with json.Decoder.UseNumber (as the server does
for Zoho to preserve 64-bit ids in the Mail module — folderId exceeds
2^53 with no string twin), server_time arrives as a json.Number, whose
reflect kind is String, so AsInt errors and the CRM event loses its
timestamp (breaking event-collapse dedup downstream).

Add serverTimeMillis: try AsInt first (the existing float64 path), then
fall back to parsing a json.Number/string. This makes the CRM event
parser tolerant of both decode modes, so enabling UseNumber for Zoho is
fully backward compatible for CRM.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>