### PR TITLE
fix(connectwise): List custom fields are singleSelect, not multiSelect

### DIFF
--- a/providers/connectwise/custom.go
+++ b/providers/connectwise/custom.go
@@ -249,23 +249,23 @@ func (f modelCustomField) getValueType() common.ValueType {
 	case "TextArea":
 		return common.ValueTypeString
 	case "Number":
-		return multiValueOrDefault(f, common.ValueTypeFloat)
+		return selectValueOrDefault(f, common.ValueTypeFloat)
 	case "Percent":
-		return multiValueOrDefault(f, common.ValueTypeFloat)
+		return selectValueOrDefault(f, common.ValueTypeFloat)
 	case "Text":
-		return multiValueOrDefault(f, common.ValueTypeString)
+		return selectValueOrDefault(f, common.ValueTypeString)
 	default:
 		return common.ValueTypeOther
 	}
 }
 
-// multiValueOrDefault returns MultiSelect or SingleSelect for list-style fields, and defaultValue otherwise.
-// Number, Percent, Text can all be either primitive data type or Multi/Single Select.
-func multiValueOrDefault(field modelCustomField, defaultValue common.ValueType) common.ValueType {
+// selectValueOrDefault returns SingleSelect for list-style fields, and defaultValue otherwise.
+// Number, Percent, Text can all be either primitive data type or Single Select.
+// Both entry methods hold exactly one value: "List" is a dropdown pick-list, "Option" is radio buttons.
+// ConnectWise user-defined fields have no multi-select entry method; values are always scalar.
+func selectValueOrDefault(field modelCustomField, defaultValue common.ValueType) common.ValueType {
 	switch field.EntryTypeIdentifier {
-	case "List":
-		return common.ValueTypeMultiSelect
-	case "Option":
+	case "List", "Option":
 		return common.ValueTypeSingleSelect
 	default:
 		return defaultValue

--- a/providers/connectwise/custom_test.go
+++ b/providers/connectwise/custom_test.go
@@ -1,0 +1,109 @@
+package connectwise
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestGetValueType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fieldType string
+		entryType string
+		expected  common.ValueType
+	}{
+		// Regression: ConnectWise "List" entry method is a single-select dropdown, not multi-select.
+		// Values in read responses are always scalar (e.g. "false"), never arrays.
+		{
+			name:      "List Text is single select",
+			fieldType: "Text",
+			entryType: "List",
+			expected:  common.ValueTypeSingleSelect,
+		},
+		{
+			name:      "List Number is single select",
+			fieldType: "Number",
+			entryType: "List",
+			expected:  common.ValueTypeSingleSelect,
+		},
+		{
+			name:      "List Percent is single select",
+			fieldType: "Percent",
+			entryType: "List",
+			expected:  common.ValueTypeSingleSelect,
+		},
+		{
+			name:      "Option Text is single select",
+			fieldType: "Text",
+			entryType: "Option",
+			expected:  common.ValueTypeSingleSelect,
+		},
+		{
+			name:      "EntryField Text is string",
+			fieldType: "Text",
+			entryType: "EntryField",
+			expected:  common.ValueTypeString,
+		},
+		{
+			name:      "EntryField Number is float",
+			fieldType: "Number",
+			entryType: "EntryField",
+			expected:  common.ValueTypeFloat,
+		},
+		{
+			name:      "EntryField Percent is float",
+			fieldType: "Percent",
+			entryType: "EntryField",
+			expected:  common.ValueTypeFloat,
+		},
+		{
+			name:      "Checkbox is boolean",
+			fieldType: "Checkbox",
+			entryType: "EntryField",
+			expected:  common.ValueTypeBoolean,
+		},
+		{
+			name:      "Date is date",
+			fieldType: "Date",
+			entryType: "Date",
+			expected:  common.ValueTypeDate,
+		},
+		{
+			name:      "Hyperlink is string",
+			fieldType: "Hyperlink",
+			entryType: "EntryField",
+			expected:  common.ValueTypeString,
+		},
+		{
+			name:      "TextArea is string",
+			fieldType: "TextArea",
+			entryType: "EntryField",
+			expected:  common.ValueTypeString,
+		},
+		{
+			name:      "Button is other",
+			fieldType: "Button",
+			entryType: "Button",
+			expected:  common.ValueTypeOther,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			field := modelCustomField{
+				FieldTypeIdentifier: tt.fieldType,
+				EntryTypeIdentifier: tt.entryType,
+			}
+
+			if got := field.getValueType(); got != tt.expected {
+				t.Errorf("getValueType() with fieldType=%q entryType=%q: got %q, want %q",
+					tt.fieldType, tt.entryType, got, tt.expected)
+			}
+		})
+	}
+}

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -132,7 +132,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							},
 							"customField16": {
 								DisplayName:  "is_synced",
-								ValueType:    "multiSelect",
+								ValueType:    "singleSelect",
 								ProviderType: "List_Text",
 								ReadOnly:     new(false),
 								IsCustom:     new(true),
@@ -147,7 +147,7 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							},
 							"customField83": {
 								DisplayName:  "Hobby",
-								ValueType:    "multiSelect",
+								ValueType:    "singleSelect",
 								ProviderType: "List_Text",
 								ReadOnly:     new(false),
 								IsCustom:     new(true),


### PR DESCRIPTION
## Problem

ConnectWise `List` custom fields (e.g. `contacts.customField16` / `is_synced`) were reported by metadata as `valueType: multiSelect`. Consumers then array-wrapped the scalar values on read (`"false"` → `["false"]`) and sent writes back as arrays — the wrong shape for ConnectWise's `customFields[].value`.

## Root cause

`multiValueOrDefault` mapped `entryTypeIdentifier == "List"` to `multiSelect`. But in ConnectWise, the distinction between `List` (dropdown pick-list) and `Option` (radio buttons) is presentation, not cardinality — both hold exactly one scalar value.

Per the official ConnectWise OpenAPI spec (vendored in this repo at `scripts/openapi/connectwise/internal/files/All.json`, obtained from the [ConnectWise Developer Network](https://developer.connectwise.com)):

- `UserDefinedField.entryTypeIdentifier` enum: `["Date", "EntryField", "List", "Option"]` — there is **no multi-select entry method**.
- `UserDefinedFieldValueModel.value` is typed `string` (scalar) — multiple selections are unrepresentable at the wire level.

## Fix

- `List` now maps to `singleSelect` (same as `Option`); function renamed to `selectValueOrDefault`.
- Updated metadata golden expectations (`customField16`, `customField83`).
- Added `TestGetValueType` regression test covering the entry-method × field-type matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)