### PR TITLE
fix(zoho): pass connection metadata to the Zoho connector

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -567,12 +567,20 @@ func newZohoConnector(
 		if found && tokenDomain != "" {
 			domains.TokenDomain = tokenDomain
 		}
+
+		mailDomain, found := params.Metadata["zoho_mail_domain"]
+		if found && mailDomain != "" {
+			domains.MailDomain = mailDomain
+		}
 	}
 
 	return zoho.NewConnector(
 		zoho.WithAuthenticatedClient(params.AuthenticatedClient),
 		zoho.WithModule(params.Module),
 		zoho.WithDomains(domains),
+		// Metadata carries connection values resolved by the platform, e.g. the
+		// zohoMailAccountId catalog variable saved by post-authentication.
+		zoho.WithMetadata(params.Metadata),
 	)
 }
 

--- a/connector/new.go
+++ b/connector/new.go
@@ -544,6 +544,7 @@ func newPipedriveConnector(
 	)
 }
 
+//nolint:cyclop
 func newZohoConnector(
 	params common.ConnectorParams,
 ) (*zoho.Connector, error) {


### PR DESCRIPTION
Follow-up to #3226. Zoho Mail account-scoped reads were still failing with "missing Zoho Mail account id" even after post-auth saved the id.

The cause: `newZohoConnector` reads `params.Metadata` for domain overrides, but never passes the metadata into the connector. So values stored on the connection, like the `zohoMailAccountId` saved by post-auth, never reached the connector. This adds `zoho.WithMetadata(params.Metadata)`.

Also forwards `zoho_mail_domain` (saved by the server per data center) so Mail requests go to the region-correct host, same as the api/desk/token domains already handled.
