### PR TITLE
feat(openapi): capture schema $ref names and plumb referenceTo through static schemas

### DIFF
--- a/internal/metadatadef/definition.go
+++ b/internal/metadatadef/definition.go
@@ -22,6 +22,12 @@ type ExtendedSchema[C any] struct {
 	ResponseKey string
 	Problem     error
 	Custom      C
+
+	// ItemSchemaName is the OpenAPI component name of the schema describing a single item
+	// of this object, if the response referenced one. Empty when the response schema is inlined.
+	// Ex: GET /company/contacts responds with {"items": {"$ref": "#/components/schemas/Contact"}},
+	// so the contacts object has ItemSchemaName "Contact".
+	ItemSchemaName string
 }
 
 type Schemas[C any] []ExtendedSchema[C]
@@ -30,6 +36,14 @@ type Field struct {
 	Name         string
 	Type         string
 	ValueOptions []string
+
+	// SchemaRefName is the OpenAPI component name this field's schema referenced.
+	// For object fields it is the property's own $ref, for array fields the $ref of its items.
+	// Empty when the property schema is inlined.
+	// Ex: Contact property "company": {"$ref": "#/components/schemas/CompanyReference"}
+	// yields SchemaRefName "CompanyReference", and "types": {"type": "array",
+	// "items": {"$ref": "#/components/schemas/ContactTypeReference"}} yields "ContactTypeReference".
+	SchemaRefName string
 }
 
 type Fields = datautils.Map[string, Field]

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -2,6 +2,7 @@ package staticschema
 
 import (
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -69,6 +70,12 @@ type FieldMetadata struct {
 	ProviderType string           `json:"providerType,omitempty"`
 	ReadOnly     *bool            `json:"readOnly,omitempty"`
 	Values       FieldValues      `json:"values,omitempty"`
+
+	// ReferenceTo is the list of object names this field references.
+	// It is applicable only to lookup fields, otherwise nil.
+	// Ex: ConnectWise Contact.company is a lookup pointing to the companies object,
+	// so its field metadata is {"valueType": "reference", "referenceTo": ["companies"]}.
+	ReferenceTo []string `json:"referenceTo,omitempty"`
 }
 
 type FieldValues []FieldValue
@@ -109,6 +116,7 @@ func (m FieldMetadataMapV2) convertToCommon() map[string]common.FieldMetadata {
 			ProviderType: field.ProviderType,
 			ReadOnly:     field.ReadOnly,
 			Values:       values,
+			ReferenceTo:  slices.Clone(field.ReferenceTo),
 		}
 	}
 

--- a/internal/staticschema/core_test.go
+++ b/internal/staticschema/core_test.go
@@ -1,0 +1,36 @@
+package staticschema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestConvertToCommonCarriesReferenceTo(t *testing.T) {
+	t.Parallel()
+
+	fields := FieldMetadataMapV2{
+		"company": FieldMetadata{
+			DisplayName:  "company",
+			ValueType:    common.ValueTypeReference,
+			ProviderType: "CompanyReference",
+			ReferenceTo:  []string{"companies"},
+		},
+		"firstName": FieldMetadata{
+			DisplayName:  "firstName",
+			ValueType:    common.ValueTypeString,
+			ProviderType: "string",
+		},
+	}
+
+	result := fields.convertToCommon()
+
+	if got := result["company"].ReferenceTo; !reflect.DeepEqual(got, []string{"companies"}) {
+		t.Errorf("company ReferenceTo = %v, want [companies]", got)
+	}
+
+	if got := result["firstName"].ReferenceTo; got != nil {
+		t.Errorf("firstName ReferenceTo = %v, want nil", got)
+	}
+}

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
@@ -72,7 +73,7 @@ func (p PathItem[C]) RetrieveSchemaOperation(
 		displayName = displayProcessor(displayName)
 	}
 
-	fields, responseKey, err := extractObjectFields(
+	fields, responseKey, itemSchemaName, err := extractObjectFields(
 		p.urlPath, p.objectName,
 		schema, locator, propertyFlattener, autoSelectArrayItem,
 	)
@@ -81,13 +82,14 @@ func (p PathItem[C]) RetrieveSchemaOperation(
 	}
 
 	return &metadatadef.ExtendedSchema[C]{
-		ObjectName:  p.objectName,
-		DisplayName: displayName,
-		Fields:      fields,
-		QueryParams: getQueryParameters(operation),
-		URLPath:     p.urlPath,
-		ResponseKey: responseKey,
-		Problem:     err,
+		ObjectName:     p.objectName,
+		DisplayName:    displayName,
+		Fields:         fields,
+		QueryParams:    getQueryParameters(operation),
+		URLPath:        p.urlPath,
+		ResponseKey:    responseKey,
+		Problem:        err,
+		ItemSchemaName: itemSchemaName,
 	}, true, nil
 }
 
@@ -114,7 +116,7 @@ func extractObjectFields(
 	objectName string, schema *openapi3.Schema, locator ObjectArrayLocator,
 	propertyFlattener PropertyFlattener,
 	autoSelectArrayItem bool,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	switch getSchemaType(objectName, schema) {
 	case schemaTypeObject:
 		return extractFieldsFromArrayHolder(urlPath, objectName, schema, locator, propertyFlattener, autoSelectArrayItem)
@@ -126,7 +128,7 @@ func extractObjectFields(
 		// It seems that some OpenAPI files are not that strict about such things. Ex: Pipedrive, Zendesk.
 		return extractFieldsFromArrayHolder(urlPath, objectName, schema, locator, propertyFlattener, autoSelectArrayItem)
 	default:
-		return nil, "", createUnprocessableObjectError(objectName)
+		return nil, "", "", createUnprocessableObjectError(objectName)
 	}
 }
 
@@ -161,7 +163,7 @@ func extractFieldsFromArrayHolder(
 	objectName string, schema *openapi3.Schema, locator ObjectArrayLocator,
 	propertyFlattener PropertyFlattener,
 	autoSelectArrayItem bool,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	arrayOptions := extractPropertiesArrayType(urlPath, schema)
 
 	if len(arrayOptions) == 0 {
@@ -184,20 +186,20 @@ func extractFieldsFromArrayHolder(
 		if approved || locatorWrapper(urlPath, objectName, arrayOptions, locator, option) {
 			fields, err = extractFields(objectName, propertyFlattener, option.Item.Value)
 			if err != nil {
-				return nil, "", err
+				return nil, "", "", err
 			}
 
-			return fields, option.Name, nil
+			return fields, option.Name, schemaRefComponentName(option.Item.Ref), nil
 		}
 	}
 
 	if isBooleanTruthful(schema.AdditionalProperties.Has) {
 		// this schema is dynamic.
 		// the fields cannot be known.
-		return make(metadatadef.Fields), "", nil
+		return make(metadatadef.Fields), "", "", nil
 	}
 
-	return nil, "", createUnprocessableObjectError(objectName)
+	return nil, "", "", createUnprocessableObjectError(objectName)
 }
 
 func locatorWrapper(urlPath string, objectName string, options []Array, locator ObjectArrayLocator, option Array) bool {
@@ -271,16 +273,16 @@ func extractPropertiesArrayType(urlPath string, schema *openapi3.Schema) []Array
 func extractFieldsFromArray(
 	urlPath, objectName string, schema *openapi3.Schema,
 	propertyFlattener PropertyFlattener,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	items, isArray := getItems(urlPath, schema.NewRef())
 	if !isArray {
-		return nil, "", createUnprocessableObjectError(objectName)
+		return nil, "", "", createUnprocessableObjectError(objectName)
 	}
 
 	fields, err = extractFields(objectName, propertyFlattener, items.Value)
 	statsObjectsWithAutoSelectedArrays.Add("", urlPath)
 
-	return fields, "", err
+	return fields, "", schemaRefComponentName(items.Ref), err
 }
 
 func getItems(urlPath string, schema *openapi3.SchemaRef) (itemsSchemaRef *openapi3.SchemaRef, isArray bool) {
@@ -405,14 +407,40 @@ func extractFields(
 			propertyType := extractPropertyType(propertySchema)
 			enumOptions := extractEnumOptions(objectName, propertySchema)
 			combinedFields[property] = metadatadef.Field{
-				Name:         property,
-				Type:         propertyType,
-				ValueOptions: enumOptions,
+				Name:          property,
+				Type:          propertyType,
+				ValueOptions:  enumOptions,
+				SchemaRefName: extractPropertySchemaRefName(propertySchema),
 			}
 		}
 	}
 
 	return combinedFields, nil
+}
+
+// extractPropertySchemaRefName resolves the OpenAPI component name the property schema referenced.
+// For object properties it is the property's own $ref, for array properties the $ref of its items.
+// Empty string when the schema is inlined.
+func extractPropertySchemaRefName(propertySchema *openapi3.SchemaRef) string {
+	if name := schemaRefComponentName(propertySchema.Ref); name != "" {
+		return name
+	}
+
+	if propertySchema.Value != nil && propertySchema.Value.Items != nil {
+		return schemaRefComponentName(propertySchema.Value.Items.Ref)
+	}
+
+	return ""
+}
+
+// schemaRefComponentName converts a $ref URI to the component name.
+// Ex: "#/components/schemas/CompanyReference" -> "CompanyReference".
+func schemaRefComponentName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	return ref[strings.LastIndex(ref, "/")+1:]
 }
 
 func extractPropertyType(propertySchema *openapi3.SchemaRef) string {

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -419,18 +419,55 @@ func extractFields(
 }
 
 // extractPropertySchemaRefName resolves the OpenAPI component name the property schema referenced.
-// For object properties it is the property's own $ref, for array properties the $ref of its items.
+// For object properties it is the property's own $ref, for array properties the $ref of its items,
+// even when the array is declared through a named wrapper schema.
 // Empty string when the schema is inlined.
 func extractPropertySchemaRefName(propertySchema *openapi3.SchemaRef) string {
-	if name := schemaRefComponentName(propertySchema.Ref); name != "" {
-		return name
+	if propertySchema == nil {
+		return ""
 	}
 
 	if propertySchema.Value != nil && propertySchema.Value.Items != nil {
-		return schemaRefComponentName(propertySchema.Value.Items.Ref)
+		return schemaRefNameWithComposites(propertySchema.Value.Items)
 	}
 
-	return ""
+	return schemaRefNameWithComposites(propertySchema)
+}
+
+// schemaRefNameWithComposites resolves the component name of the schema itself, falling back
+// to a lone $ref within allOf/oneOf/anyOf composition, a common idiom to attach extra keywords
+// to a reference, ex: {"allOf": [{"$ref": "#/components/schemas/CompanyReference"}], "nullable": true}.
+// Multiple distinct referenced components make the type ambiguous, resulting in an empty string.
+func schemaRefNameWithComposites(schema *openapi3.SchemaRef) string {
+	if schema == nil {
+		return ""
+	}
+
+	if name := schemaRefComponentName(schema.Ref); name != "" {
+		return name
+	}
+
+	if schema.Value == nil {
+		return ""
+	}
+
+	var result string
+
+	for _, composite := range datautils.MergeSlices(schema.Value.AllOf, schema.Value.OneOf, schema.Value.AnyOf) {
+		if composite == nil {
+			continue
+		}
+
+		if name := schemaRefComponentName(composite.Ref); name != "" {
+			if result != "" && result != name {
+				return ""
+			}
+
+			result = name
+		}
+	}
+
+	return result
 }
 
 // schemaRefComponentName converts a $ref URI to the component name.

--- a/tools/fileconv/api3/models_test.go
+++ b/tools/fileconv/api3/models_test.go
@@ -1,0 +1,91 @@
+package api3
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestSchemaRefComponentName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "OpenAPI 3 component ref",
+			ref:      "#/components/schemas/CompanyReference",
+			expected: "CompanyReference",
+		},
+		{
+			name:     "Swagger 2 definition ref",
+			ref:      "#/definitions/ContactReference",
+			expected: "ContactReference",
+		},
+		{
+			name:     "empty ref",
+			ref:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := schemaRefComponentName(tt.ref); got != tt.expected {
+				t.Errorf("schemaRefComponentName(%q) = %q, want %q", tt.ref, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractPropertySchemaRefName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		schema   *openapi3.SchemaRef
+		expected string
+	}{
+		{
+			name: "object property referencing a component",
+			schema: &openapi3.SchemaRef{
+				Ref:   "#/components/schemas/CompanyReference",
+				Value: &openapi3.Schema{},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "array property with referenced items",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					Items: &openapi3.SchemaRef{
+						Ref:   "#/components/schemas/ContactTypeReference",
+						Value: &openapi3.Schema{},
+					},
+				},
+			},
+			expected: "ContactTypeReference",
+		},
+		{
+			name: "inlined property schema",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := extractPropertySchemaRefName(tt.schema); got != tt.expected {
+				t.Errorf("extractPropertySchemaRefName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/tools/fileconv/api3/models_test.go
+++ b/tools/fileconv/api3/models_test.go
@@ -77,6 +77,46 @@ func TestExtractPropertySchemaRefName(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "object property wrapping a reference in allOf",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					AllOf: openapi3.SchemaRefs{{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					}},
+				},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "array property declared via named wrapper schema",
+			schema: &openapi3.SchemaRef{
+				Ref: "#/components/schemas/CompanyReferenceList",
+				Value: &openapi3.Schema{
+					Items: &openapi3.SchemaRef{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					},
+				},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "ambiguous composition of multiple distinct references",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					OneOf: openapi3.SchemaRefs{{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					}, {
+						Ref:   "#/components/schemas/ContactReference",
+						Value: &openapi3.Schema{},
+					}},
+				},
+			},
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Context

Two ConnectWise metadata issues share one root cause: the OpenAPI extraction pipeline drops the component name a property references (e.g. `CompanyReference`), so generators cannot distinguish lookup fields from ordinary nested objects, and the static-schema format had no way to persist `referenceTo` even if they could.

This PR is the provider-agnostic infrastructure half (part 1 of 2; the ConnectWise consumer is stacked on top):

- `metadatadef.Field.SchemaRefName` — the $ref component name of a property (or of its array items).
- `metadatadef.ExtendedSchema.ItemSchemaName` — the component name of the object's own item schema (e.g. `Contact` for the contacts list endpoint).
- `staticschema.FieldMetadata.ReferenceTo` — optional, serialized as `referenceTo` in schemas.json, and mapped onto `common.FieldMetadata.ReferenceTo` when serving ListObjectMetadata.

No generated schemas change in this PR; generators opt in by populating the new fields. Unit tests cover ref-name extraction and the referenceTo pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)