### PR TITLE
feat(connectwise): classify lookup fields as reference with referenceTo

### DIFF
--- a/internal/metadatadef/definition.go
+++ b/internal/metadatadef/definition.go
@@ -22,6 +22,12 @@ type ExtendedSchema[C any] struct {
 	ResponseKey string
 	Problem     error
 	Custom      C
+
+	// ItemSchemaName is the OpenAPI component name of the schema describing a single item
+	// of this object, if the response referenced one. Empty when the response schema is inlined.
+	// Ex: GET /company/contacts responds with {"items": {"$ref": "#/components/schemas/Contact"}},
+	// so the contacts object has ItemSchemaName "Contact".
+	ItemSchemaName string
 }
 
 type Schemas[C any] []ExtendedSchema[C]
@@ -30,6 +36,14 @@ type Field struct {
 	Name         string
 	Type         string
 	ValueOptions []string
+
+	// SchemaRefName is the OpenAPI component name this field's schema referenced.
+	// For object fields it is the property's own $ref, for array fields the $ref of its items.
+	// Empty when the property schema is inlined.
+	// Ex: Contact property "company": {"$ref": "#/components/schemas/CompanyReference"}
+	// yields SchemaRefName "CompanyReference", and "types": {"type": "array",
+	// "items": {"$ref": "#/components/schemas/ContactTypeReference"}} yields "ContactTypeReference".
+	SchemaRefName string
 }
 
 type Fields = datautils.Map[string, Field]

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -2,6 +2,7 @@ package staticschema
 
 import (
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -69,6 +70,12 @@ type FieldMetadata struct {
 	ProviderType string           `json:"providerType,omitempty"`
 	ReadOnly     *bool            `json:"readOnly,omitempty"`
 	Values       FieldValues      `json:"values,omitempty"`
+
+	// ReferenceTo is the list of object names this field references.
+	// It is applicable only to lookup fields, otherwise nil.
+	// Ex: ConnectWise Contact.company is a lookup pointing to the companies object,
+	// so its field metadata is {"valueType": "reference", "referenceTo": ["companies"]}.
+	ReferenceTo []string `json:"referenceTo,omitempty"`
 }
 
 type FieldValues []FieldValue
@@ -109,6 +116,7 @@ func (m FieldMetadataMapV2) convertToCommon() map[string]common.FieldMetadata {
 			ProviderType: field.ProviderType,
 			ReadOnly:     field.ReadOnly,
 			Values:       values,
+			ReferenceTo:  slices.Clone(field.ReferenceTo),
 		}
 	}
 

--- a/internal/staticschema/core_test.go
+++ b/internal/staticschema/core_test.go
@@ -1,0 +1,36 @@
+package staticschema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestConvertToCommonCarriesReferenceTo(t *testing.T) {
+	t.Parallel()
+
+	fields := FieldMetadataMapV2{
+		"company": FieldMetadata{
+			DisplayName:  "company",
+			ValueType:    common.ValueTypeReference,
+			ProviderType: "CompanyReference",
+			ReferenceTo:  []string{"companies"},
+		},
+		"firstName": FieldMetadata{
+			DisplayName:  "firstName",
+			ValueType:    common.ValueTypeString,
+			ProviderType: "string",
+		},
+	}
+
+	result := fields.convertToCommon()
+
+	if got := result["company"].ReferenceTo; !reflect.DeepEqual(got, []string{"companies"}) {
+		t.Errorf("company ReferenceTo = %v, want [companies]", got)
+	}
+
+	if got := result["firstName"].ReferenceTo; got != nil {
+		t.Errorf("firstName ReferenceTo = %v, want nil", got)
+	}
+}

--- a/providers/connectwise/internal/metadata/schemas.json
+++ b/providers/connectwise/internal/metadata/schemas.json
@@ -425,7 +425,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "ptoAvailableType": {
               "displayName": "ptoAvailableType",
@@ -646,7 +649,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -676,7 +682,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -786,7 +795,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -1402,7 +1414,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "bottomComment": {
               "displayName": "bottomComment",
@@ -1445,7 +1460,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "contact": {
               "displayName": "contact",
@@ -1478,7 +1496,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -1498,7 +1519,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "employeeCompNotExceed": {
               "displayName": "employeeCompNotExceed",
@@ -1600,7 +1624,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -1863,12 +1890,18 @@
             "defaultDepartment": {
               "displayName": "defaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "emailAddress": {
               "displayName": "emailAddress",
@@ -1913,12 +1946,18 @@
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityLocation": {
               "displayName": "securityLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityRole": {
               "displayName": "securityRole",
@@ -2374,7 +2413,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customLabel": {
               "displayName": "customLabel",
@@ -2460,7 +2502,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "miscInvoice": {
               "displayName": "miscInvoice",
@@ -2984,7 +3029,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -3014,7 +3062,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "duration": {
               "displayName": "duration",
@@ -3209,7 +3260,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "mergedParentTicket": {
               "displayName": "mergedParentTicket",
@@ -3897,7 +3951,10 @@
             "subType": {
               "displayName": "subType",
               "valueType": "reference",
-              "providerType": "CampaignSubTypeReference"
+              "providerType": "CampaignSubTypeReference",
+              "referenceTo": [
+                "subTypes"
+              ]
             },
             "type": {
               "displayName": "type",
@@ -4449,7 +4506,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "expenseEntryFlag": {
               "displayName": "expenseEntryFlag",
@@ -4474,7 +4534,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -4737,7 +4800,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -4767,7 +4833,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "member": {
               "displayName": "member",
@@ -4849,7 +4918,10 @@
             "territory": {
               "displayName": "territory",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "ticket": {
               "displayName": "ticket",
@@ -4992,7 +5064,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "calendar": {
               "displayName": "calendar",
@@ -5031,7 +5106,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -5240,7 +5318,10 @@
             "territory": {
               "displayName": "territory",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "territoryManager": {
               "displayName": "territoryManager",
@@ -5458,7 +5539,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "city": {
               "displayName": "city",
@@ -5476,7 +5560,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "defaultContact": {
               "displayName": "defaultContact",
@@ -5575,7 +5662,10 @@
             "territory": {
               "displayName": "territory",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "twitterUrl": {
               "displayName": "twitterUrl",
@@ -5939,7 +6029,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "country": {
               "displayName": "country",
@@ -6136,7 +6229,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -6386,7 +6482,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "companySite": {
               "displayName": "companySite",
@@ -6571,7 +6670,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "deviceIdentifier": {
               "displayName": "deviceIdentifier",
@@ -6624,7 +6726,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "locationId": {
               "displayName": "locationId",
@@ -7060,7 +7165,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "country": {
               "displayName": "country",
@@ -7368,7 +7476,10 @@
             "baseCurrency": {
               "displayName": "baseCurrency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "chiefOperatingOfficer": {
               "displayName": "chiefOperatingOfficer",
@@ -8610,7 +8721,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -9575,7 +9689,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -9585,7 +9702,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             }
           }
         },
@@ -9664,7 +9784,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "encryptionKey": {
               "displayName": "encryptionKey",
@@ -9684,7 +9807,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "storeIdentifier": {
               "displayName": "storeIdentifier",
@@ -9750,7 +9876,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "discardDuplicatesFlag": {
               "displayName": "discardDuplicatesFlag",
@@ -9821,7 +9950,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "neverRespondFlag": {
               "displayName": "neverRespondFlag",
@@ -10594,7 +10726,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -11291,7 +11426,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "bottomCommentFlag": {
               "displayName": "bottomCommentFlag",
@@ -11361,7 +11499,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
@@ -11483,7 +11624,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -11621,7 +11765,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -11680,7 +11827,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -11690,7 +11840,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "remitName": {
               "displayName": "remitName",
@@ -12624,7 +12777,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "path": {
               "displayName": "path",
@@ -14573,7 +14729,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "bottomComment": {
               "displayName": "bottomComment",
@@ -14601,7 +14760,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -14681,7 +14843,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "locationId": {
               "displayName": "locationId",
@@ -14843,7 +15008,10 @@
             "territory": {
               "displayName": "territory",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "territoryId": {
               "displayName": "territoryId",
@@ -15006,7 +15174,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -15016,7 +15187,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -15048,7 +15222,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -15058,7 +15235,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -15313,12 +15493,18 @@
             "defaultDepartment": {
               "displayName": "defaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "disableNewCrossReferencesFlag": {
               "displayName": "disableNewCrossReferencesFlag",
@@ -16537,7 +16723,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "bottomCommentFlag": {
               "displayName": "bottomCommentFlag",
@@ -16555,7 +16744,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "configIds": {
               "displayName": "configIds",
@@ -16573,7 +16765,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -16583,7 +16778,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "description": {
               "displayName": "description",
@@ -16618,7 +16816,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "notes": {
               "displayName": "notes",
@@ -17550,7 +17751,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -18030,7 +18234,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -18787,7 +18994,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "locationId": {
               "displayName": "locationId",
@@ -19533,7 +19743,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -19548,7 +19761,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "duration": {
               "displayName": "duration",
@@ -19649,7 +19865,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -20336,7 +20555,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "board": {
               "displayName": "board",
@@ -20384,7 +20606,10 @@
             "companyLocation": {
               "displayName": "companyLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "contact": {
               "displayName": "contact",
@@ -20397,7 +20622,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -20412,7 +20640,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "description": {
               "displayName": "description",
@@ -20500,7 +20731,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "manager": {
               "displayName": "manager",
@@ -20666,7 +20900,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -20790,7 +21027,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "locationId": {
               "displayName": "locationId",
@@ -20864,7 +21104,10 @@
             "terms": {
               "displayName": "terms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "total": {
               "displayName": "total",
@@ -21040,7 +21283,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "decemberMargin": {
               "displayName": "decemberMargin",
@@ -21055,7 +21301,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "februaryMargin": {
               "displayName": "februaryMargin",
@@ -21110,7 +21359,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "marchMargin": {
               "displayName": "marchMargin",
@@ -21215,7 +21467,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "newWindowFlag": {
               "displayName": "newWindowFlag",
@@ -21607,7 +21862,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -21622,7 +21880,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "dropShipFlag": {
               "displayName": "dropShipFlag",
@@ -21660,7 +21921,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "mfgItemID": {
               "displayName": "mfgItemID",
@@ -22308,7 +22572,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "businessUnitId": {
               "displayName": "businessUnitId",
@@ -22360,7 +22627,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -22875,7 +23145,10 @@
             "salesTeamLocation": {
               "displayName": "salesTeamLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             }
           }
         },
@@ -23744,7 +24017,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "discussionsLockedFlag": {
               "displayName": "discussionsLockedFlag",
@@ -23835,7 +24111,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "markFirstNoteIssueFlag": {
               "displayName": "markFirstNoteIssueFlag",
@@ -24157,7 +24436,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -24187,7 +24469,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -24960,7 +25245,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -24990,7 +25278,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "duration": {
               "displayName": "duration",
@@ -25185,7 +25476,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "mergedParentTicket": {
               "displayName": "mergedParentTicket",
@@ -27406,7 +27700,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -27416,7 +27713,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -27627,7 +27927,10 @@
             "reportsTo": {
               "displayName": "reportsTo",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "salesRep": {
               "displayName": "salesRep",
@@ -27827,7 +28130,10 @@
             "defaultDepartment": {
               "displayName": "defaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "defaultEmail": {
               "displayName": "defaultEmail",
@@ -27851,7 +28157,10 @@
             "defaultLocation": {
               "displayName": "defaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "defaultPhone": {
               "displayName": "defaultPhone",
@@ -28260,12 +28569,18 @@
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "reportCard": {
               "displayName": "reportCard",
@@ -28351,7 +28666,10 @@
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -28361,17 +28679,26 @@
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityLocation": {
               "displayName": "securityLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityRole": {
               "displayName": "securityRole",
@@ -28397,12 +28724,18 @@
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
@@ -28705,12 +29038,18 @@
             "defaultDepartment": {
               "displayName": "defaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "enableMobileFlag": {
               "displayName": "enableMobileFlag",
@@ -28899,12 +29238,18 @@
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "reportCard": {
               "displayName": "reportCard",
@@ -28990,7 +29335,10 @@
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -29000,17 +29348,26 @@
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityLocation": {
               "displayName": "securityLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "serviceBoardTeamIds": {
               "displayName": "serviceBoardTeamIds",
@@ -29028,12 +29385,18 @@
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
@@ -29154,7 +29517,10 @@
             "baseCurrency": {
               "displayName": "baseCurrency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "groupCaption": {
               "displayName": "groupCaption",
@@ -29755,7 +30121,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -29765,7 +30134,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -31184,7 +31556,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -31202,7 +31577,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -31386,7 +31764,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "emailCC": {
               "displayName": "emailCC",
@@ -31495,7 +31876,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -32439,7 +32823,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "expenseEntryFlag": {
               "displayName": "expenseEntryFlag",
@@ -32459,7 +32846,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -33272,7 +33662,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -33324,7 +33717,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "openInNewWindow": {
               "displayName": "openInNewWindow",
@@ -33628,7 +34024,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "dateClosed": {
               "displayName": "dateClosed",
@@ -33899,7 +34298,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "cityTaxAmount": {
               "displayName": "cityTaxAmount",
@@ -33977,7 +34379,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "dateClosed": {
               "displayName": "dateClosed",
@@ -33987,7 +34392,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "departmentId": {
               "displayName": "departmentId",
@@ -34265,7 +34673,10 @@
             "billingTerms": {
               "displayName": "billingTerms",
               "valueType": "reference",
-              "providerType": "BillingTermsReference"
+              "providerType": "BillingTermsReference",
+              "referenceTo": [
+                "billingTerms"
+              ]
             },
             "cityTaxAmount": {
               "displayName": "cityTaxAmount",
@@ -34330,7 +34741,10 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "customer": {
               "displayName": "customer",
@@ -34731,7 +35145,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "height": {
               "displayName": "height",
@@ -34756,7 +35173,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "manager": {
               "displayName": "manager",
@@ -34856,12 +35276,18 @@
             "currency": {
               "displayName": "currency",
               "valueType": "reference",
-              "providerType": "CurrencyReference"
+              "providerType": "CurrencyReference",
+              "referenceTo": [
+                "currencies"
+              ]
             },
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -34876,7 +35302,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "locationDefaultFlag": {
               "displayName": "locationDefaultFlag",
@@ -35066,7 +35495,10 @@
             "defaultDepartment": {
               "displayName": "defaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "defaultEmail": {
               "displayName": "defaultEmail",
@@ -35090,7 +35522,10 @@
             "defaultLocation": {
               "displayName": "defaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "defaultPhone": {
               "displayName": "defaultPhone",
@@ -35499,12 +35934,18 @@
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "reportCard": {
               "displayName": "reportCard",
@@ -35590,7 +36031,10 @@
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -35600,17 +36044,26 @@
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityLocation": {
               "displayName": "securityLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "securityRole": {
               "displayName": "securityRole",
@@ -35636,12 +36089,18 @@
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
@@ -36058,7 +36517,10 @@
             "department": {
               "displayName": "department",
               "valueType": "reference",
-              "providerType": "SystemDepartmentReference"
+              "providerType": "SystemDepartmentReference",
+              "referenceTo": [
+                "system/departments"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -36068,7 +36530,10 @@
             "location": {
               "displayName": "location",
               "valueType": "reference",
-              "providerType": "SystemLocationReference"
+              "providerType": "SystemLocationReference",
+              "referenceTo": [
+                "system/locations"
+              ]
             },
             "name": {
               "displayName": "name",

--- a/providers/connectwise/internal/metadata/schemas.json
+++ b/providers/connectwise/internal/metadata/schemas.json
@@ -81,8 +81,11 @@
             },
             "customCalendar": {
               "displayName": "customCalendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -91,18 +94,27 @@
             },
             "hiImpactHiUrgency": {
               "displayName": "hiImpactHiUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "hiImpactLowUrgency": {
               "displayName": "hiImpactLowUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "hiImpactMedUrgency": {
               "displayName": "hiImpactMedUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -111,33 +123,51 @@
             },
             "lowImpactHiUrgency": {
               "displayName": "lowImpactHiUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "lowImpactLowUrgency": {
               "displayName": "lowImpactLowUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "lowImpactMedUrgency": {
               "displayName": "lowImpactMedUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "medImpactHiUrgency": {
               "displayName": "medImpactHiUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "medImpactLowUrgency": {
               "displayName": "medImpactLowUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "medImpactMedUrgency": {
               "displayName": "medImpactMedUrgency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -188,8 +218,11 @@
             },
             "accountingPackage": {
               "displayName": "accountingPackage",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AccountingPackageReference",
+              "referenceTo": [
+                "accountingPackages"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -391,8 +424,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "ptoAvailableType": {
               "displayName": "ptoAvailableType",
@@ -612,8 +645,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -642,8 +675,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -704,38 +737,56 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "assignTo": {
               "displayName": "assignTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "assignedBy": {
               "displayName": "assignedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "campaign": {
               "displayName": "campaign",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignReference",
+              "referenceTo": [
+                "campaigns"
+              ]
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -784,8 +835,11 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "phoneNumber": {
               "displayName": "phoneNumber",
@@ -794,33 +848,48 @@
             },
             "reminder": {
               "displayName": "reminder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ReminderReference"
             },
             "scheduleStatus": {
               "displayName": "scheduleStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ScheduleStatusReference",
+              "referenceTo": [
+                "schedule/statuses"
+              ]
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityStatusReference",
+              "referenceTo": [
+                "sales/activities/statuses"
+              ]
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityTypeReference",
+              "referenceTo": [
+                "sales/activities/types"
+              ]
             },
             "where": {
               "displayName": "where",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             }
           }
         },
@@ -846,8 +915,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "billableOption": {
               "displayName": "billableOption",
@@ -904,8 +976,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -952,13 +1027,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -1071,8 +1152,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AdjustmentTypeReference",
+              "referenceTo": [
+                "procurement/adjustments/types"
+              ]
             }
           }
         },
@@ -1273,18 +1357,24 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billToContact": {
               "displayName": "billToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billToSite": {
               "displayName": "billToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billableExpenseInvoice": {
               "displayName": "billableExpenseInvoice",
@@ -1303,13 +1393,16 @@
             },
             "billingCycle": {
               "displayName": "billingCycle",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingCycleReference",
+              "referenceTo": [
+                "billingCycles"
+              ]
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "bottomComment": {
               "displayName": "bottomComment",
@@ -1343,18 +1436,24 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "coverAgreementExpense": {
               "displayName": "coverAgreementExpense",
@@ -1378,8 +1477,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -1398,8 +1497,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "employeeCompNotExceed": {
               "displayName": "employeeCompNotExceed",
@@ -1472,8 +1571,11 @@
             },
             "invoiceTemplate": {
               "displayName": "invoiceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "invoicingCycle": {
               "displayName": "invoicingCycle",
@@ -1497,8 +1599,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -1522,13 +1624,19 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "parentAgreement": {
               "displayName": "parentAgreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "periodType": {
               "displayName": "periodType",
@@ -1555,8 +1663,11 @@
             },
             "projectType": {
               "displayName": "projectType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectTypeReference",
+              "referenceTo": [
+                "projectTypes"
+              ]
             },
             "prorateFirstBill": {
               "displayName": "prorateFirstBill",
@@ -1590,28 +1701,37 @@
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shipToContact": {
               "displayName": "shipToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "shipToSite": {
               "displayName": "shipToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "startDate": {
               "displayName": "startDate",
@@ -1620,18 +1740,27 @@
             },
             "subContractCompany": {
               "displayName": "subContractCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "subContractContact": {
               "displayName": "subContractContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxable": {
               "displayName": "taxable",
@@ -1645,8 +1774,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementTypeReference",
+              "referenceTo": [
+                "finance/agreements/types"
+              ]
             },
             "workOrder": {
               "displayName": "workOrder",
@@ -1655,13 +1787,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -1724,13 +1862,13 @@
             },
             "defaultDepartment": {
               "displayName": "defaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "emailAddress": {
               "displayName": "emailAddress",
@@ -1774,33 +1912,42 @@
             },
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityLocation": {
               "displayName": "securityLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityRole": {
               "displayName": "securityRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SecurityRoleReference",
+              "referenceTo": [
+                "securityroles"
+              ]
             },
             "serviceDefaultBoard": {
               "displayName": "serviceDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StructureReference"
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             }
           }
         },
@@ -1895,8 +2042,11 @@
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             }
           }
         },
@@ -2114,8 +2264,11 @@
             },
             "agreementInvoice": {
               "displayName": "agreementInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "allowRestrictedDeptOnRoutingFlag": {
               "displayName": "allowRestrictedDeptOnRoutingFlag",
@@ -2204,18 +2357,24 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "creditMemoInvoice": {
               "displayName": "creditMemoInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customLabel": {
               "displayName": "customLabel",
@@ -2244,13 +2403,16 @@
             },
             "downPaymentInvoice": {
               "displayName": "downPaymentInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailTemplateReference"
             },
             "excludeAvalaraFlag": {
               "displayName": "excludeAvalaraFlag",
@@ -2289,18 +2451,24 @@
             },
             "localizedCountry": {
               "displayName": "localizedCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "miscInvoice": {
               "displayName": "miscInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "noWatermarkFlag": {
               "displayName": "noWatermarkFlag",
@@ -2309,8 +2477,11 @@
             },
             "overallInvoiceDefault": {
               "displayName": "overallInvoiceDefault",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "payableName": {
               "displayName": "payableName",
@@ -2349,8 +2520,11 @@
             },
             "progressInvoice": {
               "displayName": "progressInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "progressTimeFlag": {
               "displayName": "progressTimeFlag",
@@ -2384,23 +2558,35 @@
             },
             "salesOrderInvoice": {
               "displayName": "salesOrderInvoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "standardInvoiceActual": {
               "displayName": "standardInvoiceActual",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "standardInvoiceFixed": {
               "displayName": "standardInvoiceFixed",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "state": {
               "displayName": "state",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StateReference",
+              "referenceTo": [
+                "states"
+              ]
             },
             "topcomment": {
               "displayName": "topcomment",
@@ -2520,8 +2706,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -2572,8 +2761,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementType": {
               "displayName": "agreementType",
@@ -2709,8 +2901,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "budgetHours": {
               "displayName": "budgetHours",
@@ -2739,13 +2934,19 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "contactEmailAddress": {
               "displayName": "contactEmailAddress",
@@ -2774,13 +2975,16 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -2809,8 +3013,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "duration": {
               "displayName": "duration",
@@ -2943,8 +3147,8 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "knowledgeBaseCategoryId": {
               "displayName": "knowledgeBaseCategoryId",
@@ -3004,13 +3208,16 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "mergedParentTicket": {
               "displayName": "mergedParentTicket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "minutesBeforeWaiting": {
               "displayName": "minutesBeforeWaiting",
@@ -3029,13 +3236,19 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "owner": {
               "displayName": "owner",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "parentTicketId": {
               "displayName": "parentTicketId",
@@ -3074,8 +3287,11 @@
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "processNotifications": {
               "displayName": "processNotifications",
@@ -3188,8 +3404,11 @@
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "severity": {
               "displayName": "severity",
@@ -3212,8 +3431,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "siteName": {
               "displayName": "siteName",
@@ -3227,8 +3446,11 @@
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "slaStatus": {
               "displayName": "slaStatus",
@@ -3237,8 +3459,8 @@
             },
             "source": {
               "displayName": "source",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "stateIdentifier": {
               "displayName": "stateIdentifier",
@@ -3247,8 +3469,8 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "subBillingAmount": {
               "displayName": "subBillingAmount",
@@ -3285,8 +3507,8 @@
             },
             "subType": {
               "displayName": "subType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "summary": {
               "displayName": "summary",
@@ -3295,23 +3517,32 @@
             },
             "team": {
               "displayName": "team",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTeamReference",
+              "referenceTo": [
+                "teams"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             },
             "zip": {
               "displayName": "zip",
@@ -3347,8 +3578,11 @@
             },
             "holidayList": {
               "displayName": "holidayList",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "HolidayListReference",
+              "referenceTo": [
+                "holidayLists"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -3578,8 +3812,11 @@
             },
             "defaultGroup": {
               "displayName": "defaultGroup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "GroupReference",
+              "referenceTo": [
+                "groups"
+              ]
             },
             "emailsSent": {
               "displayName": "emailsSent",
@@ -3623,8 +3860,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -3648,18 +3888,24 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignStatusReference",
+              "referenceTo": [
+                "marketing/campaigns/statuses"
+              ]
             },
             "subType": {
               "displayName": "subType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignSubTypeReference"
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignTypeReference",
+              "referenceTo": [
+                "marketing/campaigns/types"
+              ]
             }
           }
         },
@@ -3675,8 +3921,11 @@
             },
             "agreementType": {
               "displayName": "agreementType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementTypeReference",
+              "referenceTo": [
+                "finance/agreements/types"
+              ]
             },
             "autoUpdateUnitCostFlag": {
               "displayName": "autoUpdateUnitCostFlag",
@@ -3733,8 +3982,8 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductCategoryReference"
             },
             "connectWiseID": {
               "displayName": "connectWiseID",
@@ -3768,8 +4017,11 @@
             },
             "entityType": {
               "displayName": "entityType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EntityTypeReference",
+              "referenceTo": [
+                "entityTypes"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -3793,8 +4045,11 @@
             },
             "manufacturer": {
               "displayName": "manufacturer",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ManufacturerReference",
+              "referenceTo": [
+                "manufacturers"
+              ]
             },
             "manufacturerPartNumber": {
               "displayName": "manufacturerPartNumber",
@@ -3883,8 +4138,11 @@
             },
             "recurringBillCycle": {
               "displayName": "recurringBillCycle",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingCycleReference",
+              "referenceTo": [
+                "billingCycles"
+              ]
             },
             "recurringCost": {
               "displayName": "recurringCost",
@@ -3933,8 +4191,11 @@
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "specialOrderFlag": {
               "displayName": "specialOrderFlag",
@@ -3943,8 +4204,8 @@
             },
             "subcategory": {
               "displayName": "subcategory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductSubCategoryReference"
             },
             "taxableFlag": {
               "displayName": "taxableFlag",
@@ -3953,18 +4214,27 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductTypeReference",
+              "referenceTo": [
+                "procurement/types"
+              ]
             },
             "unitOfMeasure": {
               "displayName": "unitOfMeasure",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "UnitOfMeasureReference",
+              "referenceTo": [
+                "unitOfMeasures"
+              ]
             },
             "vendor": {
               "displayName": "vendor",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "vendorSku": {
               "displayName": "vendorSku",
@@ -4047,8 +4317,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -4101,8 +4374,11 @@
             },
             "chargeCode": {
               "displayName": "chargeCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ChargeCodeReference",
+              "referenceTo": [
+                "chargeCodes"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -4111,8 +4387,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ExpenseTypeReference",
+              "referenceTo": [
+                "expense/types"
+              ]
             }
           }
         },
@@ -4156,8 +4435,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -4166,8 +4448,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "expenseEntryFlag": {
               "displayName": "expenseEntryFlag",
@@ -4191,8 +4473,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -4206,13 +4488,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -4349,13 +4637,19 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementType": {
               "displayName": "agreementType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementTypeReference",
+              "referenceTo": [
+                "finance/agreements/types"
+              ]
             },
             "agreementsFlag": {
               "displayName": "agreementsFlag",
@@ -4419,8 +4713,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -4439,8 +4736,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -4464,18 +4761,21 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "IvItemReference"
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "myOpportunitiesFlag": {
               "displayName": "myOpportunitiesFlag",
@@ -4489,13 +4789,13 @@
             },
             "productCategory": {
               "displayName": "productCategory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductCategoryReference"
             },
             "productSubCategory": {
               "displayName": "productSubCategory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductSubCategoryReference"
             },
             "productsFlag": {
               "displayName": "productsFlag",
@@ -4504,28 +4804,37 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "projectBoard": {
               "displayName": "projectBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectBoardReference"
             },
             "projectType": {
               "displayName": "projectType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectTypeReference",
+              "referenceTo": [
+                "projectTypes"
+              ]
             },
             "serviceBoard": {
               "displayName": "serviceBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "serviceType": {
               "displayName": "serviceType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "servicesFlag": {
               "displayName": "servicesFlag",
@@ -4534,18 +4843,21 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "territory": {
               "displayName": "territory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             }
           }
         },
@@ -4658,28 +4970,37 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billingContact": {
               "displayName": "billingContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billingSite": {
               "displayName": "billingSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "calendar": {
               "displayName": "calendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "city": {
               "displayName": "city",
@@ -4688,13 +5009,19 @@
             },
             "companyEntityType": {
               "displayName": "companyEntityType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EntityTypeReference",
+              "referenceTo": [
+                "entityTypes"
+              ]
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "creditLimit": {
               "displayName": "creditLimit",
@@ -4703,8 +5030,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -4723,8 +5050,11 @@
             },
             "defaultContact": {
               "displayName": "defaultContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "deletedBy": {
               "displayName": "deletedBy",
@@ -4738,8 +5068,8 @@
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailTemplateReference"
             },
             "facebookUrl": {
               "displayName": "facebookUrl",
@@ -4773,13 +5103,16 @@
             },
             "invoiceDeliveryMethod": {
               "displayName": "invoiceDeliveryMethod",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingDeliveryReference"
             },
             "invoiceTemplate": {
               "displayName": "invoiceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "invoiceToEmailAddress": {
               "displayName": "invoiceToEmailAddress",
@@ -4808,8 +5141,11 @@
             },
             "market": {
               "displayName": "market",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MarketDescriptionReference",
+              "referenceTo": [
+                "marketDescriptions"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -4828,13 +5164,19 @@
             },
             "ownershipType": {
               "displayName": "ownershipType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OwnershipTypeReference",
+              "referenceTo": [
+                "ownershipTypes"
+              ]
             },
             "parentCompany": {
               "displayName": "parentCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "phoneNumber": {
               "displayName": "phoneNumber",
@@ -4843,8 +5185,11 @@
             },
             "pricingSchedule": {
               "displayName": "pricingSchedule",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PricingScheduleReference",
+              "referenceTo": [
+                "pricingschedules"
+              ]
             },
             "resellerIdentifier": {
               "displayName": "resellerIdentifier",
@@ -4858,13 +5203,13 @@
             },
             "sicCode": {
               "displayName": "sicCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SicCodeReference"
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "state": {
               "displayName": "state",
@@ -4873,13 +5218,19 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyStatusReference",
+              "referenceTo": [
+                "company/companies/statuses"
+              ]
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxIdentifier": {
               "displayName": "taxIdentifier",
@@ -4888,18 +5239,24 @@
             },
             "territory": {
               "displayName": "territory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "territoryManager": {
               "displayName": "territoryManager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "timeZoneSetup": {
               "displayName": "timeZoneSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "twitterUrl": {
               "displayName": "twitterUrl",
@@ -5079,23 +5436,29 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billingContact": {
               "displayName": "billingContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billingSite": {
               "displayName": "billingSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "city": {
               "displayName": "city",
@@ -5104,18 +5467,24 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "defaultContact": {
               "displayName": "defaultContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "deletedFlag": {
               "displayName": "deletedFlag",
@@ -5174,8 +5543,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "state": {
               "displayName": "state",
@@ -5184,13 +5553,19 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyStatusReference",
+              "referenceTo": [
+                "company/companies/statuses"
+              ]
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxIdentifier": {
               "displayName": "taxIdentifier",
@@ -5199,8 +5574,8 @@
             },
             "territory": {
               "displayName": "territory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "twitterUrl": {
               "displayName": "twitterUrl",
@@ -5313,8 +5688,11 @@
             },
             "track": {
               "displayName": "track",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TrackReference",
+              "referenceTo": [
+                "tracks"
+              ]
             }
           }
         },
@@ -5552,18 +5930,24 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "defaultBillingFlag": {
               "displayName": "defaultBillingFlag",
@@ -5587,8 +5971,11 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactDepartmentReference",
+              "referenceTo": [
+                "company/contacts/departments"
+              ]
             },
             "facebookUrl": {
               "displayName": "facebookUrl",
@@ -5622,8 +6009,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "state": {
               "displayName": "state",
@@ -5748,8 +6135,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -5925,8 +6312,11 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -5979,33 +6369,45 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyCountry": {
               "displayName": "companyCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "companySite": {
               "displayName": "companySite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "companyStatus": {
               "displayName": "companyStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyStatusReference",
+              "referenceTo": [
+                "company/companies/statuses"
+              ]
             },
             "companyType": {
               "displayName": "companyType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyTypeReference",
+              "referenceTo": [
+                "company/companies/types"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -6014,8 +6416,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "vendorPickerFlag": {
               "displayName": "vendorPickerFlag",
@@ -6036,8 +6441,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -6046,8 +6454,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyTypeReference",
+              "referenceTo": [
+                "company/companies/types"
+              ]
             }
           }
         },
@@ -6123,8 +6534,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocationId": {
               "displayName": "companyLocationId",
@@ -6133,8 +6547,11 @@
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "cpuSpeed": {
               "displayName": "cpuSpeed",
@@ -6153,8 +6570,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "deviceIdentifier": {
               "displayName": "deviceIdentifier",
@@ -6178,8 +6595,11 @@
             },
             "installedBy": {
               "displayName": "installedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "ipAddress": {
               "displayName": "ipAddress",
@@ -6203,8 +6623,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -6223,8 +6643,11 @@
             },
             "manufacturer": {
               "displayName": "manufacturer",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ManufacturerReference",
+              "referenceTo": [
+                "manufacturers"
+              ]
             },
             "manufacturerPartNumber": {
               "displayName": "manufacturerPartNumber",
@@ -6308,18 +6731,24 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationStatusReference",
+              "referenceTo": [
+                "company/configurations/statuses"
+              ]
             },
             "tagNumber": {
               "displayName": "tagNumber",
@@ -6328,13 +6757,19 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationTypeReference",
+              "referenceTo": [
+                "company/configurations/types"
+              ]
             },
             "vendor": {
               "displayName": "vendor",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "vendorNotes": {
               "displayName": "vendorNotes",
@@ -6535,8 +6970,11 @@
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -6545,8 +6983,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactTypeReference",
+              "referenceTo": [
+                "company/contacts/types"
+              ]
             }
           }
         },
@@ -6577,8 +7018,11 @@
             },
             "assistantContact": {
               "displayName": "assistantContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "birthDay": {
               "displayName": "birthDay",
@@ -6607,18 +7051,24 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -6657,8 +7107,11 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactDepartmentReference",
+              "referenceTo": [
+                "company/contacts/departments"
+              ]
             },
             "disablePortalLoginFlag": {
               "displayName": "disablePortalLoginFlag",
@@ -6722,8 +7175,11 @@
             },
             "managerContact": {
               "displayName": "managerContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "marriedFlag": {
               "displayName": "marriedFlag",
@@ -6742,8 +7198,8 @@
             },
             "photo": {
               "displayName": "photo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentReference"
             },
             "portalPassword": {
               "displayName": "portalPassword",
@@ -6784,8 +7240,8 @@
             },
             "relationship": {
               "displayName": "relationship",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "RelationshipReference"
             },
             "relationshipOverride": {
               "displayName": "relationshipOverride",
@@ -6809,8 +7265,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "state": {
               "displayName": "state",
@@ -6911,28 +7367,40 @@
             },
             "baseCurrency": {
               "displayName": "baseCurrency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "chiefOperatingOfficer": {
               "displayName": "chiefOperatingOfficer",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "controller": {
               "displayName": "controller",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "dispatcher": {
               "displayName": "dispatcher",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "dutyManager": {
               "displayName": "dutyManager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "fiscalYearStart": {
               "displayName": "fiscalYearStart",
@@ -7058,13 +7526,19 @@
             },
             "president": {
               "displayName": "president",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "serviceManager": {
               "displayName": "serviceManager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             }
           }
         },
@@ -7097,8 +7571,11 @@
             },
             "addressFormat": {
               "displayName": "addressFormat",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AddressFormatReference",
+              "referenceTo": [
+                "addressFormats"
+              ]
             },
             "cityCaption": {
               "displayName": "cityCaption",
@@ -8132,8 +8609,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -8199,8 +8676,11 @@
             },
             "accountManagerRole": {
               "displayName": "accountManagerRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             },
             "companyIdGenerationFlag": {
               "displayName": "companyIdGenerationFlag",
@@ -8299,8 +8779,11 @@
             },
             "salesRepRole": {
               "displayName": "salesRepRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             },
             "secondaryRepCaption": {
               "displayName": "secondaryRepCaption",
@@ -8309,8 +8792,11 @@
             },
             "technicalContactRole": {
               "displayName": "technicalContactRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             }
           }
         },
@@ -8331,8 +8817,11 @@
             },
             "currencyCode": {
               "displayName": "currencyCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyCodeReference",
+              "referenceTo": [
+                "currencyCodes"
+              ]
             },
             "currencyIdentifier": {
               "displayName": "currencyIdentifier",
@@ -9085,8 +9574,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -9095,8 +9584,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             }
           }
         },
@@ -9132,8 +9621,11 @@
             },
             "scheduleEntry": {
               "displayName": "scheduleEntry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ScheduleEntryReference",
+              "referenceTo": [
+                "schedule/entries"
+              ]
             }
           }
         },
@@ -9171,8 +9663,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "encryptionKey": {
               "displayName": "encryptionKey",
@@ -9191,8 +9683,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "storeIdentifier": {
               "displayName": "storeIdentifier",
@@ -9223,8 +9715,11 @@
             },
             "asio365EmailSetup": {
               "displayName": "asio365EmailSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "Office365EmailSetupReference",
+              "referenceTo": [
+                "emailSetups"
+              ]
             },
             "bccEmailTo": {
               "displayName": "bccEmailTo",
@@ -9238,18 +9733,24 @@
             },
             "defaultCompany": {
               "displayName": "defaultCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "defaultMember": {
               "displayName": "defaultMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "discardDuplicatesFlag": {
               "displayName": "discardDuplicatesFlag",
@@ -9291,8 +9792,11 @@
             },
             "googleEmailSetup": {
               "displayName": "googleEmailSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "GoogleEmailSetupReference",
+              "referenceTo": [
+                "system/googleemailsetup"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -9301,8 +9805,8 @@
             },
             "imapSetup": {
               "displayName": "imapSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ImapSetupReference"
             },
             "inboundTicketMailboxId": {
               "displayName": "inboundTicketMailboxId",
@@ -9311,13 +9815,13 @@
             },
             "itemOverride": {
               "displayName": "itemOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "neverRespondFlag": {
               "displayName": "neverRespondFlag",
@@ -9331,8 +9835,11 @@
             },
             "office365EmailSetup": {
               "displayName": "office365EmailSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "Office365EmailSetupReference",
+              "referenceTo": [
+                "emailSetups"
+              ]
             },
             "postRepliesToTicketFlag": {
               "displayName": "postRepliesToTicketFlag",
@@ -9341,8 +9848,11 @@
             },
             "priorityOverride": {
               "displayName": "priorityOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "responseEmailForExisting": {
               "displayName": "responseEmailForExisting",
@@ -9356,8 +9866,11 @@
             },
             "serviceBoard": {
               "displayName": "serviceBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "setEmailToDefaultContactFlag": {
               "displayName": "setEmailToDefaultContactFlag",
@@ -9366,23 +9879,23 @@
             },
             "sourceOverride": {
               "displayName": "sourceOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "statusOverride": {
               "displayName": "statusOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "subTypeOverride": {
               "displayName": "subTypeOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "typeOverride": {
               "displayName": "typeOverride",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "useEmailMessageIdFlag": {
               "displayName": "useEmailMessageIdFlag",
@@ -9445,13 +9958,16 @@
             },
             "emailConnector": {
               "displayName": "emailConnector",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailConnectorReference",
+              "referenceTo": [
+                "emailConnectors"
+              ]
             },
             "existingTenant": {
               "displayName": "existingTenant",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ExistingTenantReference"
             },
             "failedFolder": {
               "displayName": "failedFolder",
@@ -9567,18 +10083,24 @@
             },
             "serviceBoard": {
               "displayName": "serviceBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "serviceStatus": {
               "displayName": "serviceStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "serviceSurvey": {
               "displayName": "serviceSurvey",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSurveyReference",
+              "referenceTo": [
+                "service/surveys"
+              ]
             },
             "subject": {
               "displayName": "subject",
@@ -9972,8 +10494,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAmount": {
               "displayName": "agreementAmount",
@@ -10052,18 +10577,24 @@
             },
             "classification": {
               "displayName": "classification",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ClassificationReference",
+              "referenceTo": [
+                "classifications"
+              ]
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -10077,8 +10608,11 @@
             },
             "expenseReport": {
               "displayName": "expenseReport",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ExpenseReportReference",
+              "referenceTo": [
+                "reports"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -10087,8 +10621,11 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "invoiceAmount": {
               "displayName": "invoiceAmount",
@@ -10102,8 +10639,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -10127,18 +10667,21 @@
             },
             "paymentMethod": {
               "displayName": "paymentMethod",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PaymentMethodReference"
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "status": {
               "displayName": "status",
@@ -10202,13 +10745,19 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ExpenseTypeReference",
+              "referenceTo": [
+                "expense/types"
+              ]
             }
           }
         },
@@ -10733,13 +11282,16 @@
             },
             "billingCycle": {
               "displayName": "billingCycle",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingCycleReference",
+              "referenceTo": [
+                "billingCycles"
+              ]
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "bottomCommentFlag": {
               "displayName": "bottomCommentFlag",
@@ -10808,13 +11360,13 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailTemplateReference"
             },
             "employeeCompNotExceed": {
               "displayName": "employeeCompNotExceed",
@@ -10902,8 +11454,11 @@
             },
             "invoiceTemplate": {
               "displayName": "invoiceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateReference",
+              "referenceTo": [
+                "invoiceTemplates"
+              ]
             },
             "invoicingCycle": {
               "displayName": "invoicingCycle",
@@ -10927,8 +11482,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -10962,8 +11517,11 @@
             },
             "projectType": {
               "displayName": "projectType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectTypeReference",
+              "referenceTo": [
+                "projectTypes"
+              ]
             },
             "prorateFlag": {
               "displayName": "prorateFlag",
@@ -10997,8 +11555,11 @@
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "taxableFlag": {
               "displayName": "taxableFlag",
@@ -11012,13 +11573,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -11053,8 +11620,8 @@
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "id": {
               "displayName": "id",
@@ -11112,8 +11679,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "id": {
               "displayName": "id",
@@ -11122,8 +11689,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "remitName": {
               "displayName": "remitName",
@@ -11238,8 +11805,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -11248,8 +11818,8 @@
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailTemplateReference"
             },
             "id": {
               "displayName": "id",
@@ -11673,13 +12243,16 @@
             },
             "mappedRecord": {
               "displayName": "mappedRecord",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MappedRecordReference"
             },
             "mappedType": {
               "displayName": "mappedType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MappedTypeReference",
+              "referenceTo": [
+                "mappedTypes"
+              ]
             },
             "productId": {
               "displayName": "productId",
@@ -12042,13 +12615,16 @@
             },
             "lastPaymentSyncBy": {
               "displayName": "lastPaymentSyncBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "path": {
               "displayName": "path",
@@ -12143,8 +12719,11 @@
             },
             "emailConnector": {
               "displayName": "emailConnector",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailConnectorReference",
+              "referenceTo": [
+                "emailConnectors"
+              ]
             },
             "failedFolder": {
               "displayName": "failedFolder",
@@ -12257,13 +12836,19 @@
             },
             "inOutType": {
               "displayName": "inOutType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InOutTypeReference",
+              "referenceTo": [
+                "inOutTypes"
+              ]
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             }
           }
         },
@@ -12464,8 +13049,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "canAccessAllApisFlag": {
               "displayName": "canAccessAllApisFlag",
@@ -12554,8 +13142,11 @@
             },
             "inactivatedBy": {
               "displayName": "inactivatedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "inactiveFlag": {
               "displayName": "inactiveFlag",
@@ -12589,8 +13180,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "memberApiFlag": {
               "displayName": "memberApiFlag",
@@ -12776,8 +13370,11 @@
             },
             "invoiceStatus": {
               "displayName": "invoiceStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingStatusReference",
+              "referenceTo": [
+                "billingStatuses"
+              ]
             },
             "lastName": {
               "displayName": "lastName",
@@ -12791,8 +13388,11 @@
             },
             "serviceSurvey": {
               "displayName": "serviceSurvey",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSurveyReference",
+              "referenceTo": [
+                "service/surveys"
+              ]
             },
             "subject": {
               "displayName": "subject",
@@ -13862,8 +14462,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAmount": {
               "displayName": "agreementAmount",
@@ -13918,18 +14521,24 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billingSetupReference": {
               "displayName": "billingSetupReference",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingSetupReference",
+              "referenceTo": [
+                "billingSetups"
+              ]
             },
             "billingSite": {
               "displayName": "billingSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingSiteAddressLine1": {
               "displayName": "billingSiteAddressLine1",
@@ -13963,8 +14572,8 @@
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "bottomComment": {
               "displayName": "bottomComment",
@@ -13978,8 +14587,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "credits": {
               "displayName": "credits",
@@ -13988,8 +14600,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -14008,8 +14620,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingUnitReference"
             },
             "departmentId": {
               "displayName": "departmentId",
@@ -14043,8 +14655,8 @@
             },
             "glBatch": {
               "displayName": "glBatch",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BatchReference"
             },
             "id": {
               "displayName": "id",
@@ -14063,13 +14675,13 @@
             },
             "invoiceTemplate": {
               "displayName": "invoiceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceTemplateDetailReference"
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -14088,8 +14700,8 @@
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "previousProgressApplied": {
               "displayName": "previousProgressApplied",
@@ -14103,8 +14715,11 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "reference": {
               "displayName": "reference",
@@ -14123,8 +14738,8 @@
             },
             "salesOrder": {
               "displayName": "salesOrder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SalesOrderReference"
             },
             "salesTax": {
               "displayName": "salesTax",
@@ -14148,13 +14763,16 @@
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shippingSite": {
               "displayName": "shippingSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "shippingSiteAddressLine1": {
               "displayName": "shippingSiteAddressLine1",
@@ -14193,8 +14811,11 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingStatusReference",
+              "referenceTo": [
+                "billingStatuses"
+              ]
             },
             "subtotal": {
               "displayName": "subtotal",
@@ -14203,8 +14824,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxableFlag": {
               "displayName": "taxableFlag",
@@ -14218,8 +14842,8 @@
             },
             "territory": {
               "displayName": "territory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "territoryId": {
               "displayName": "territoryId",
@@ -14228,8 +14852,11 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "topComment": {
               "displayName": "topComment",
@@ -14278,8 +14905,8 @@
             },
             "unbatchedBatch": {
               "displayName": "unbatchedBatch",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BatchReference"
             }
           }
         },
@@ -14295,8 +14922,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "businessUnitId": {
               "displayName": "businessUnitId",
@@ -14362,8 +14992,11 @@
             },
             "approver": {
               "displayName": "approver",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -14372,8 +15005,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -14382,8 +15015,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -14404,8 +15037,8 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "KBCategoryReference"
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -14414,8 +15047,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -14424,8 +15057,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -14468,8 +15101,11 @@
           "fields": {
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "KPICategoryReference",
+              "referenceTo": [
+                "kpiCategories"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -14676,13 +15312,13 @@
             },
             "defaultDepartment": {
               "displayName": "defaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "disableNewCrossReferencesFlag": {
               "displayName": "disableNewCrossReferencesFlag",
@@ -14706,8 +15342,11 @@
             },
             "integratorLogin": {
               "displayName": "integratorLogin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "IntegratorLoginReference",
+              "referenceTo": [
+                "integratorlogins"
+              ]
             },
             "loginBy": {
               "displayName": "loginBy",
@@ -14763,8 +15402,11 @@
             },
             "addedConfigurationStatus": {
               "displayName": "addedConfigurationStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationStatusReference",
+              "referenceTo": [
+                "company/configurations/statuses"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -14773,8 +15415,11 @@
             },
             "deletedConfigurationStatus": {
               "displayName": "deletedConfigurationStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationStatusReference",
+              "referenceTo": [
+                "company/configurations/statuses"
+              ]
             },
             "executiveSummaryReportScheduleDay": {
               "displayName": "executiveSummaryReportScheduleDay",
@@ -14798,8 +15443,11 @@
             },
             "integratorLogin": {
               "displayName": "integratorLogin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "IntegratorLoginReference",
+              "referenceTo": [
+                "integratorlogins"
+              ]
             },
             "runTime": {
               "displayName": "runTime",
@@ -14850,13 +15498,19 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CatalogItemReference",
+              "referenceTo": [
+                "catalog"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementTypeReference",
+              "referenceTo": [
+                "finance/agreements/types"
+              ]
             }
           }
         },
@@ -15389,8 +16043,8 @@
             },
             "menuLocation": {
               "displayName": "menuLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MenuLocationReference"
             },
             "newWindowFlag": {
               "displayName": "newWindowFlag",
@@ -15549,8 +16203,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "moduleDescription": {
               "displayName": "moduleDescription",
@@ -15802,8 +16459,11 @@
             },
             "catalogItem": {
               "displayName": "catalogItem",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CatalogItemReference",
+              "referenceTo": [
+                "catalog"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -15817,13 +16477,19 @@
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "warehouseBin": {
               "displayName": "warehouseBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             }
           }
         },
@@ -15849,23 +16515,29 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billToContact": {
               "displayName": "billToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billToSite": {
               "displayName": "billToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "bottomCommentFlag": {
               "displayName": "bottomCommentFlag",
@@ -15874,13 +16546,16 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "configIds": {
               "displayName": "configIds",
@@ -15889,13 +16564,16 @@
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -15904,8 +16582,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "description": {
               "displayName": "description",
@@ -15939,8 +16617,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "notes": {
               "displayName": "notes",
@@ -15949,8 +16627,11 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "orderDate": {
               "displayName": "orderDate",
@@ -15984,33 +16665,45 @@
             },
             "salesRep": {
               "displayName": "salesRep",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shipToContact": {
               "displayName": "shipToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "shipToSite": {
               "displayName": "shipToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OrderStatusReference",
+              "referenceTo": [
+                "sales/orders/statuses"
+              ]
             },
             "subTotal": {
               "displayName": "subTotal",
@@ -16019,8 +16712,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxTotal": {
               "displayName": "taxTotal",
@@ -16101,13 +16797,19 @@
             },
             "defaultAddressFormat": {
               "displayName": "defaultAddressFormat",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AddressFormatReference",
+              "referenceTo": [
+                "addressFormats"
+              ]
             },
             "defaultCalendar": {
               "displayName": "defaultCalendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "defaultFromAddress": {
               "displayName": "defaultFromAddress",
@@ -16116,8 +16818,11 @@
             },
             "defaultLdap": {
               "displayName": "defaultLdap",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "LdapConfigurationReference",
+              "referenceTo": [
+                "ldapConfigurations"
+              ]
             },
             "disableZAdminLoginFlag": {
               "displayName": "disableZAdminLoginFlag",
@@ -16136,8 +16841,8 @@
             },
             "locale": {
               "displayName": "locale",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "LocaleReference"
             },
             "logoPath": {
               "displayName": "logoPath",
@@ -16151,8 +16856,11 @@
             },
             "serverTimeZone": {
               "displayName": "serverTimeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "siteUrl": {
               "displayName": "siteUrl",
@@ -16306,8 +17014,11 @@
             },
             "classification": {
               "displayName": "classification",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ClassificationReference",
+              "referenceTo": [
+                "classifications"
+              ]
             },
             "companyFlag": {
               "displayName": "companyFlag",
@@ -16410,8 +17121,11 @@
             },
             "statusIndicator": {
               "displayName": "statusIndicator",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StatusIndicatorReference",
+              "referenceTo": [
+                "statusIndicators"
+              ]
             }
           }
         },
@@ -16442,8 +17156,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "configTypeIds": {
               "displayName": "configTypeIds",
@@ -16606,8 +17323,11 @@
             },
             "portalConfiguration": {
               "displayName": "portalConfiguration",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PortalConfigurationReference",
+              "referenceTo": [
+                "portalConfigurations"
+              ]
             },
             "portalConfigurationCwId": {
               "displayName": "portalConfigurationCwId",
@@ -16829,8 +17549,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -17309,8 +18029,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "id": {
               "displayName": "id",
@@ -17595,8 +18315,8 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductCategoryReference"
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -17642,8 +18362,8 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductCategoryReference"
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -17791,8 +18511,11 @@
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             }
           }
         },
@@ -17808,8 +18531,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -17850,8 +18576,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAmount": {
               "displayName": "agreementAmount",
@@ -17884,8 +18613,8 @@
             },
             "businessUnit": {
               "displayName": "businessUnit",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingUnitReference"
             },
             "businessUnitId": {
               "displayName": "businessUnitId",
@@ -17939,13 +18668,19 @@
             },
             "catalogItem": {
               "displayName": "catalogItem",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CatalogItemReference",
+              "referenceTo": [
+                "catalog"
+              ]
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "cost": {
               "displayName": "cost",
@@ -17979,8 +18714,11 @@
             },
             "entityType": {
               "displayName": "entityType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EntityTypeReference",
+              "referenceTo": [
+                "entityTypes"
+              ]
             },
             "extCost": {
               "displayName": "extCost",
@@ -17999,8 +18737,11 @@
             },
             "forecastStatus": {
               "displayName": "forecastStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityStatusReference",
+              "referenceTo": [
+                "sales/opportunities/statuses"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -18024,13 +18765,19 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "invoiceGrouping": {
               "displayName": "invoiceGrouping",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceGroupingReference",
+              "referenceTo": [
+                "invoicegrouping"
+              ]
             },
             "listPrice": {
               "displayName": "listPrice",
@@ -18039,8 +18786,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -18069,13 +18816,16 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "phaseProductFlag": {
               "displayName": "phaseProductFlag",
@@ -18149,8 +18899,11 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "purchaseDate": {
               "displayName": "purchaseDate",
@@ -18174,8 +18927,8 @@
             },
             "salesOrder": {
               "displayName": "salesOrder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SalesOrderReference"
             },
             "sequenceNumber": {
               "displayName": "sequenceNumber",
@@ -18199,8 +18952,11 @@
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "specialOrderFlag": {
               "displayName": "specialOrderFlag",
@@ -18219,8 +18975,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxableFlag": {
               "displayName": "taxableFlag",
@@ -18229,13 +18988,19 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "unitOfMeasure": {
               "displayName": "unitOfMeasure",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "UnitOfMeasureReference",
+              "referenceTo": [
+                "unitOfMeasures"
+              ]
             },
             "uom": {
               "displayName": "uom",
@@ -18244,8 +19009,11 @@
             },
             "vendor": {
               "displayName": "vendor",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "vendorSku": {
               "displayName": "vendorSku",
@@ -18269,8 +19037,11 @@
             },
             "warehouseBinIdObject": {
               "displayName": "warehouseBinIdObject",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "warehouseId": {
               "displayName": "warehouseId",
@@ -18279,8 +19050,11 @@
             },
             "warehouseIdObject": {
               "displayName": "warehouseIdObject",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             }
           }
         },
@@ -18363,8 +19137,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectTypeReference",
+              "referenceTo": [
+                "projectTypes"
+              ]
             }
           }
         },
@@ -18484,8 +19261,11 @@
             },
             "statusIndicator": {
               "displayName": "statusIndicator",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StatusIndicatorReference",
+              "referenceTo": [
+                "statusIndicators"
+              ]
             }
           }
         },
@@ -18558,8 +19338,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementType": {
               "displayName": "agreementType",
@@ -18667,8 +19450,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "budgetHours": {
               "displayName": "budgetHours",
@@ -18697,13 +19483,19 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "contactEmailAddress": {
               "displayName": "contactEmailAddress",
@@ -18732,13 +19524,16 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -18752,8 +19547,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "duration": {
               "displayName": "duration",
@@ -18792,8 +19587,8 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "knowledgeBaseCategoryId": {
               "displayName": "knowledgeBaseCategoryId",
@@ -18853,8 +19648,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -18863,18 +19658,24 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "owner": {
               "displayName": "owner",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "predecessorClosedFlag": {
               "displayName": "predecessorClosedFlag",
@@ -18903,8 +19704,11 @@
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "processNotifications": {
               "displayName": "processNotifications",
@@ -18913,8 +19717,11 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "requiredDate": {
               "displayName": "requiredDate",
@@ -18938,13 +19745,16 @@
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "siteName": {
               "displayName": "siteName",
@@ -18958,8 +19768,8 @@
             },
             "source": {
               "displayName": "source",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "stateIdentifier": {
               "displayName": "stateIdentifier",
@@ -18968,8 +19778,8 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "subBillingAmount": {
               "displayName": "subBillingAmount",
@@ -19006,8 +19816,8 @@
             },
             "subType": {
               "displayName": "subType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "summary": {
               "displayName": "summary",
@@ -19021,8 +19831,8 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "wbsCode": {
               "displayName": "wbsCode",
@@ -19031,13 +19841,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             },
             "zip": {
               "displayName": "zip",
@@ -19230,8 +20046,11 @@
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "projectTemplateId": {
               "displayName": "projectTemplateId",
@@ -19260,8 +20079,8 @@
             },
             "source": {
               "displayName": "source",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "wbsCode": {
               "displayName": "wbsCode",
@@ -19270,13 +20089,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -19349,8 +20174,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "billExpenses": {
               "displayName": "billExpenses",
@@ -19428,18 +20256,24 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billToContact": {
               "displayName": "billToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billToSite": {
               "displayName": "billToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billUnapprovedTimeAndExpense": {
               "displayName": "billUnapprovedTimeAndExpense",
@@ -19501,13 +20335,13 @@
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectBoardReference"
             },
             "budgetAnalysis": {
               "displayName": "budgetAnalysis",
@@ -19541,23 +20375,29 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocation": {
               "displayName": "companyLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -19571,8 +20411,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "description": {
               "displayName": "description",
@@ -19636,8 +20476,11 @@
             },
             "expenseApprover": {
               "displayName": "expenseApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -19656,13 +20499,16 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "manager": {
               "displayName": "manager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -19671,8 +20517,11 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "overridePercentComplete": {
               "displayName": "overridePercentComplete",
@@ -19716,18 +20565,24 @@
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shipToContact": {
               "displayName": "shipToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "shipToSite": {
               "displayName": "shipToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "showOverridePercentFlag": {
               "displayName": "showOverridePercentFlag",
@@ -19736,28 +20591,40 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectStatusReference",
+              "referenceTo": [
+                "project/statuses"
+              ]
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "timeApprover": {
               "displayName": "timeApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectTypeReference",
+              "referenceTo": [
+                "projectTypes"
+              ]
             }
           }
         },
@@ -19773,8 +20640,8 @@
             },
             "businessUnit": {
               "displayName": "businessUnit",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingUnitReference"
             },
             "businessUnitId": {
               "displayName": "businessUnitId",
@@ -19798,8 +20665,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -19813,18 +20680,27 @@
             },
             "customerCompany": {
               "displayName": "customerCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "customerContact": {
               "displayName": "customerContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "customerCountry": {
               "displayName": "customerCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "customerExtension": {
               "displayName": "customerExtension",
@@ -19843,8 +20719,8 @@
             },
             "customerSite": {
               "displayName": "customerSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "customerSiteName": {
               "displayName": "customerSiteName",
@@ -19913,8 +20789,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -19943,8 +20819,11 @@
             },
             "shipmentMethod": {
               "displayName": "shipmentMethod",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ShipmentMethodReference",
+              "referenceTo": [
+                "shipmentmethods"
+              ]
             },
             "shippingInstructions": {
               "displayName": "shippingInstructions",
@@ -19953,8 +20832,11 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PurchaseOrderStatusReference",
+              "referenceTo": [
+                "purchaseorderstatuses"
+              ]
             },
             "subTotal": {
               "displayName": "subTotal",
@@ -19963,8 +20845,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxFreightFlag": {
               "displayName": "taxFreightFlag",
@@ -19978,8 +20863,8 @@
             },
             "terms": {
               "displayName": "terms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "total": {
               "displayName": "total",
@@ -20003,13 +20888,19 @@
             },
             "vendorCompany": {
               "displayName": "vendorCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "vendorContact": {
               "displayName": "vendorContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "vendorInvoiceDate": {
               "displayName": "vendorInvoiceDate",
@@ -20028,18 +20919,24 @@
             },
             "vendorSite": {
               "displayName": "vendorSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "warehouseContact": {
               "displayName": "warehouseContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             }
           }
         },
@@ -20075,8 +20972,8 @@
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PurchaseOrderStatusEmailTemplateReference"
             },
             "id": {
               "displayName": "id",
@@ -20132,8 +21029,8 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductCategoryReference"
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -20142,8 +21039,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "decemberMargin": {
               "displayName": "decemberMargin",
@@ -20157,8 +21054,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "februaryMargin": {
               "displayName": "februaryMargin",
@@ -20212,8 +21109,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "marchMargin": {
               "displayName": "marchMargin",
@@ -20237,8 +21134,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "novemberMargin": {
               "displayName": "novemberMargin",
@@ -20272,8 +21172,8 @@
             },
             "subCategory": {
               "displayName": "subCategory",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProductSubCategoryReference"
             }
           }
         },
@@ -20314,8 +21214,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "newWindowFlag": {
               "displayName": "newWindowFlag",
@@ -20516,8 +21416,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "period": {
               "displayName": "period",
@@ -20650,8 +21553,8 @@
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "RmaStatusEmailTemplateReference"
             },
             "id": {
               "displayName": "id",
@@ -20682,13 +21585,19 @@
             },
             "accountManager": {
               "displayName": "accountManager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "closedBy": {
               "displayName": "closedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "closingNotes": {
               "displayName": "closingNotes",
@@ -20697,8 +21606,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -20712,8 +21621,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "dropShipFlag": {
               "displayName": "dropShipFlag",
@@ -20732,8 +21641,11 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "ivDescription": {
               "displayName": "ivDescription",
@@ -20747,8 +21659,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "mfgItemID": {
               "displayName": "mfgItemID",
@@ -20762,8 +21674,8 @@
             },
             "product": {
               "displayName": "product",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "IvItemReference"
             },
             "productDescription": {
               "displayName": "productDescription",
@@ -20772,18 +21684,27 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "purchasedCompany": {
               "displayName": "purchasedCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "purchasedContact": {
               "displayName": "purchasedContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "purchasedContactAddressLine1": {
               "displayName": "purchasedContactAddressLine1",
@@ -20802,8 +21723,11 @@
             },
             "purchasedContactCountry": {
               "displayName": "purchasedContactCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "purchasedContactEmail": {
               "displayName": "purchasedContactEmail",
@@ -20857,13 +21781,16 @@
             },
             "purchasedSite": {
               "displayName": "purchasedSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "purchasedVendorAction": {
               "displayName": "purchasedVendorAction",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "RmaActionReference",
+              "referenceTo": [
+                "rmaActions"
+              ]
             },
             "purchasedVendorRmaNumber": {
               "displayName": "purchasedVendorRmaNumber",
@@ -20872,13 +21799,19 @@
             },
             "repairCompany": {
               "displayName": "repairCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "repairContact": {
               "displayName": "repairContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "repairContactAddressLine1": {
               "displayName": "repairContactAddressLine1",
@@ -20897,8 +21830,11 @@
             },
             "repairContactCountry": {
               "displayName": "repairContactCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "repairContactEmail": {
               "displayName": "repairContactEmail",
@@ -20942,18 +21878,24 @@
             },
             "repairSite": {
               "displayName": "repairSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "returnedCompany": {
               "displayName": "returnedCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "returnedContact": {
               "displayName": "returnedContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "returnedContactAddressLine1": {
               "displayName": "returnedContactAddressLine1",
@@ -20972,8 +21914,11 @@
             },
             "returnedContactCountry": {
               "displayName": "returnedContactCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "returnedContactEmail": {
               "displayName": "returnedContactEmail",
@@ -21007,18 +21952,21 @@
             },
             "returnedSite": {
               "displayName": "returnedSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "rmaDisposition": {
               "displayName": "rmaDisposition",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "RmaDispositionReference",
+              "referenceTo": [
+                "RMADispositions"
+              ]
             },
             "salesOrder": {
               "displayName": "salesOrder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SalesOrderReference"
             },
             "serialNumber": {
               "displayName": "serialNumber",
@@ -21027,13 +21975,19 @@
             },
             "serviceTicket": {
               "displayName": "serviceTicket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "shipMethod": {
               "displayName": "shipMethod",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ShipmentMethodReference",
+              "referenceTo": [
+                "shipmentmethods"
+              ]
             },
             "shippingDate": {
               "displayName": "shippingDate",
@@ -21047,8 +22001,11 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "RmaStatusReference",
+              "referenceTo": [
+                "rmaStatuses"
+              ]
             },
             "summary": {
               "displayName": "summary",
@@ -21057,8 +22014,11 @@
             },
             "technicalContact": {
               "displayName": "technicalContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "unitPrice": {
               "displayName": "unitPrice",
@@ -21067,13 +22027,19 @@
             },
             "warrantyCompany": {
               "displayName": "warrantyCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "warrantyContact": {
               "displayName": "warrantyContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "warrantyContactAddressLine1": {
               "displayName": "warrantyContactAddressLine1",
@@ -21092,8 +22058,11 @@
             },
             "warrantyContactCountry": {
               "displayName": "warrantyContactCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "warrantyContactEmail": {
               "displayName": "warrantyContactEmail",
@@ -21132,8 +22101,8 @@
             },
             "warrantySite": {
               "displayName": "warrantySite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             }
           }
         },
@@ -21317,23 +22286,29 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billToContact": {
               "displayName": "billToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "billToSite": {
               "displayName": "billToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "businessUnitId": {
               "displayName": "businessUnitId",
@@ -21342,13 +22317,19 @@
             },
             "campaign": {
               "displayName": "campaign",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignReference",
+              "referenceTo": [
+                "campaigns"
+              ]
             },
             "closedBy": {
               "displayName": "closedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "closedDate": {
               "displayName": "closedDate",
@@ -21357,8 +22338,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyLocationId": {
               "displayName": "companyLocationId",
@@ -21367,13 +22351,16 @@
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -21422,48 +22409,63 @@
             },
             "primarySalesRep": {
               "displayName": "primarySalesRep",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityPriorityReference"
             },
             "probability": {
               "displayName": "probability",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityProbabilityReference"
             },
             "rating": {
               "displayName": "rating",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityRatingReference",
+              "referenceTo": [
+                "ratings"
+              ]
             },
             "secondarySalesRep": {
               "displayName": "secondarySalesRep",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shipToContact": {
               "displayName": "shipToContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "shipToSite": {
               "displayName": "shipToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "source": {
               "displayName": "source",
@@ -21472,23 +22474,35 @@
             },
             "stage": {
               "displayName": "stage",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityStageReference",
+              "referenceTo": [
+                "stages"
+              ]
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityStatusReference",
+              "referenceTo": [
+                "sales/opportunities/statuses"
+              ]
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "technicalContact": {
               "displayName": "technicalContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "totalSalesTax": {
               "displayName": "totalSalesTax",
@@ -21497,8 +22511,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityTypeReference",
+              "referenceTo": [
+                "sales/opportunities/types"
+              ]
             }
           }
         },
@@ -21709,8 +22726,8 @@
             },
             "emailTemplate": {
               "displayName": "emailTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OrderStatusEmailTemplateReference"
             },
             "id": {
               "displayName": "id",
@@ -21810,8 +22827,8 @@
             },
             "probability": {
               "displayName": "probability",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityProbabilityReference"
             },
             "sequenceNumber": {
               "displayName": "sequenceNumber",
@@ -21857,8 +22874,8 @@
             },
             "salesTeamLocation": {
               "displayName": "salesTeamLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             }
           }
         },
@@ -21884,8 +22901,11 @@
             },
             "holidayList": {
               "displayName": "holidayList",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "HolidayListReference",
+              "referenceTo": [
+                "holidayLists"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -22031,8 +23051,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -22076,13 +23099,13 @@
             },
             "reminder": {
               "displayName": "reminder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ReminderReference"
             },
             "span": {
               "displayName": "span",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ScheduleSpanReference"
             },
             "startTimeSet": {
               "displayName": "startTimeSet",
@@ -22091,8 +23114,11 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ScheduleStatusReference",
+              "referenceTo": [
+                "schedule/statuses"
+              ]
             },
             "ticketType": {
               "displayName": "ticketType",
@@ -22101,13 +23127,19 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ScheduleTypeReference",
+              "referenceTo": [
+                "schedule/types"
+              ]
             },
             "where": {
               "displayName": "where",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             }
           }
         },
@@ -22214,8 +23246,11 @@
             },
             "chargeCode": {
               "displayName": "chargeCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ChargeCodeReference",
+              "referenceTo": [
+                "chargeCodes"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -22244,8 +23279,11 @@
             },
             "where": {
               "displayName": "where",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             }
           }
         },
@@ -22261,8 +23299,11 @@
             },
             "chargeCode": {
               "displayName": "chargeCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ChargeCodeReference",
+              "referenceTo": [
+                "chargeCodes"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -22286,8 +23327,11 @@
             },
             "where": {
               "displayName": "where",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             }
           }
         },
@@ -22303,8 +23347,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "billableOption": {
               "displayName": "billableOption",
@@ -22361,8 +23408,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -22419,13 +23469,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -22560,8 +23616,8 @@
             },
             "autoCloseStatus": {
               "displayName": "autoCloseStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "billExpense": {
               "displayName": "billExpense",
@@ -22649,8 +23705,8 @@
             },
             "boardIcon": {
               "displayName": "boardIcon",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentReference"
             },
             "closedLoopAllFlag": {
               "displayName": "closedLoopAllFlag",
@@ -22679,13 +23735,16 @@
             },
             "contactTemplate": {
               "displayName": "contactTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceEmailTemplateReference",
+              "referenceTo": [
+                "emailTemplates"
+              ]
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "discussionsLockedFlag": {
               "displayName": "discussionsLockedFlag",
@@ -22694,13 +23753,19 @@
             },
             "dispatchMember": {
               "displayName": "dispatchMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "dutyManagerMember": {
               "displayName": "dutyManagerMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "emailConnectorAllowReopenClosedFlag": {
               "displayName": "emailConnectorAllowReopenClosedFlag",
@@ -22739,8 +23804,8 @@
             },
             "emailConnectorReopenStatus": {
               "displayName": "emailConnectorReopenStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "id": {
               "displayName": "id",
@@ -22769,8 +23834,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "markFirstNoteIssueFlag": {
               "displayName": "markFirstNoteIssueFlag",
@@ -22794,8 +23859,11 @@
             },
             "oncallMember": {
               "displayName": "oncallMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "overrideBillingSetupFlag": {
               "displayName": "overrideBillingSetupFlag",
@@ -22862,8 +23930,11 @@
             },
             "resourceTemplate": {
               "displayName": "resourceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceEmailTemplateReference",
+              "referenceTo": [
+                "emailTemplates"
+              ]
             },
             "restrictBoardByDefaultFlag": {
               "displayName": "restrictBoardByDefaultFlag",
@@ -22892,8 +23963,11 @@
             },
             "serviceManagerMember": {
               "displayName": "serviceManagerMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "showDependenciesFlag": {
               "displayName": "showDependenciesFlag",
@@ -22907,8 +23981,11 @@
             },
             "signOffTemplate": {
               "displayName": "signOffTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSignoffReference",
+              "referenceTo": [
+                "serviceSignoff"
+              ]
             },
             "timeEntryDiscussionFlag": {
               "displayName": "timeEntryDiscussionFlag",
@@ -22937,13 +24014,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -23073,8 +24156,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -23103,8 +24186,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -23540,13 +24623,16 @@
             },
             "notifyMember": {
               "displayName": "notifyMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "notifyWho": {
               "displayName": "notifyWho",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "GenericIdIdentifierReference"
             },
             "notifyWhoVisibleFlag": {
               "displayName": "notifyWhoVisibleFlag",
@@ -23651,8 +24737,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementType": {
               "displayName": "agreementType",
@@ -23788,8 +24877,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "budgetHours": {
               "displayName": "budgetHours",
@@ -23818,13 +24910,19 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "contactEmailAddress": {
               "displayName": "contactEmailAddress",
@@ -23853,13 +24951,16 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customFields": {
               "displayName": "customFields",
@@ -23888,8 +24989,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "duration": {
               "displayName": "duration",
@@ -24022,8 +25123,8 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "knowledgeBaseCategoryId": {
               "displayName": "knowledgeBaseCategoryId",
@@ -24083,13 +25184,16 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "mergedParentTicket": {
               "displayName": "mergedParentTicket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "minutesBeforeWaiting": {
               "displayName": "minutesBeforeWaiting",
@@ -24108,13 +25212,19 @@
             },
             "opportunity": {
               "displayName": "opportunity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityReference",
+              "referenceTo": [
+                "sales/opportunities"
+              ]
             },
             "owner": {
               "displayName": "owner",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "parentTicketId": {
               "displayName": "parentTicketId",
@@ -24153,8 +25263,11 @@
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "processNotifications": {
               "displayName": "processNotifications",
@@ -24267,8 +25380,11 @@
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "severity": {
               "displayName": "severity",
@@ -24291,8 +25407,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "siteName": {
               "displayName": "siteName",
@@ -24306,8 +25422,11 @@
             },
             "sla": {
               "displayName": "sla",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SLAReference",
+              "referenceTo": [
+                "SLAs"
+              ]
             },
             "slaStatus": {
               "displayName": "slaStatus",
@@ -24316,8 +25435,8 @@
             },
             "source": {
               "displayName": "source",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "stateIdentifier": {
               "displayName": "stateIdentifier",
@@ -24326,8 +25445,8 @@
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "subBillingAmount": {
               "displayName": "subBillingAmount",
@@ -24364,8 +25483,8 @@
             },
             "subType": {
               "displayName": "subType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "summary": {
               "displayName": "summary",
@@ -24374,23 +25493,32 @@
             },
             "team": {
               "displayName": "team",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTeamReference",
+              "referenceTo": [
+                "teams"
+              ]
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             },
             "zip": {
               "displayName": "zip",
@@ -24578,8 +25706,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -25025,8 +26156,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "period": {
               "displayName": "period",
@@ -25171,8 +26305,11 @@
             },
             "category": {
               "displayName": "category",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SkillCategoryReference",
+              "referenceTo": [
+                "skillCategories"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -25407,8 +26544,11 @@
             },
             "linkedMember": {
               "displayName": "linkedMember",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "ssoUserId": {
               "displayName": "ssoUserId",
@@ -25454,8 +26594,8 @@
             },
             "probability": {
               "displayName": "probability",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OpportunityProbabilityReference"
             },
             "sequenceNumber": {
               "displayName": "sequenceNumber",
@@ -25481,8 +26621,11 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "disabled": {
               "displayName": "disabled",
@@ -25565,8 +26708,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CampaignTypeReference",
+              "referenceTo": [
+                "marketing/campaigns/types"
+              ]
             }
           }
         },
@@ -25787,8 +26933,11 @@
             },
             "documentType": {
               "displayName": "documentType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentTypeReference",
+              "referenceTo": [
+                "system/documentTypes/info"
+              ]
             },
             "fileName": {
               "displayName": "fileName",
@@ -25874,8 +27023,11 @@
             },
             "defaultCompany": {
               "displayName": "defaultCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -25884,8 +27036,8 @@
             },
             "imapSetup": {
               "displayName": "imapSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ImapSetupReference"
             }
           }
         },
@@ -25938,8 +27090,11 @@
             },
             "emailConnector": {
               "displayName": "emailConnector",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailConnectorReference",
+              "referenceTo": [
+                "emailConnectors"
+              ]
             },
             "failedFolder": {
               "displayName": "failedFolder",
@@ -25995,8 +27150,11 @@
             },
             "emailConnector": {
               "displayName": "emailConnector",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "EmailConnectorReference",
+              "referenceTo": [
+                "emailConnectors"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -26134,8 +27292,11 @@
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CorporateStructureLevelReference",
+              "referenceTo": [
+                "corporateStructureLevels"
+              ]
             }
           }
         },
@@ -26214,8 +27375,8 @@
             },
             "photo": {
               "displayName": "photo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentReference"
             }
           }
         },
@@ -26231,8 +27392,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "contents": {
               "displayName": "contents",
@@ -26241,8 +27405,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -26251,8 +27415,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -26363,8 +27527,11 @@
             },
             "calendar": {
               "displayName": "calendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "clientFlag": {
               "displayName": "clientFlag",
@@ -26388,8 +27555,11 @@
             },
             "manager": {
               "displayName": "manager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -26413,8 +27583,11 @@
             },
             "overrideCountry": {
               "displayName": "overrideCountry",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "overrideFaxNumber": {
               "displayName": "overrideFaxNumber",
@@ -26453,8 +27626,8 @@
             },
             "reportsTo": {
               "displayName": "reportsTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "salesRep": {
               "displayName": "salesRep",
@@ -26463,13 +27636,19 @@
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CorporateStructureLevelReference",
+              "referenceTo": [
+                "corporateStructureLevels"
+              ]
             },
             "timeZoneSetup": {
               "displayName": "timeZoneSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "workRoleIds": {
               "displayName": "workRoleIds",
@@ -26576,8 +27755,11 @@
             },
             "calendar": {
               "displayName": "calendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "calendarSyncIntegrationFlag": {
               "displayName": "calendarSyncIntegrationFlag",
@@ -26621,8 +27803,11 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -26641,8 +27826,8 @@
             },
             "defaultDepartment": {
               "displayName": "defaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "defaultEmail": {
               "displayName": "defaultEmail",
@@ -26665,8 +27850,8 @@
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "defaultPhone": {
               "displayName": "defaultPhone",
@@ -26689,8 +27874,11 @@
             },
             "directionalSync": {
               "displayName": "directionalSync",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DirectionalSyncReference",
+              "referenceTo": [
+                "directionalSyncs"
+              ]
             },
             "disableOnlineFlag": {
               "displayName": "disableOnlineFlag",
@@ -26734,8 +27922,11 @@
             },
             "expenseApprover": {
               "displayName": "expenseApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "firstName": {
               "displayName": "firstName",
@@ -26915,8 +28106,11 @@
             },
             "ldapConfiguration": {
               "displayName": "ldapConfiguration",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "LdapConfigurationReference",
+              "referenceTo": [
+                "ldapConfigurations"
+              ]
             },
             "ldapUserName": {
               "displayName": "ldapUserName",
@@ -27050,8 +28244,8 @@
             },
             "photo": {
               "displayName": "photo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentReference"
             },
             "primaryEmail": {
               "displayName": "primaryEmail",
@@ -27060,28 +28254,34 @@
             },
             "projectDefaultBoard": {
               "displayName": "projectDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectBoardReference"
             },
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "reportCard": {
               "displayName": "reportCard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ReportCardReference",
+              "referenceTo": [
+                "reportCards"
+              ]
             },
             "reportsTo": {
               "displayName": "reportsTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "requireExpenseEntryFlag": {
               "displayName": "requireExpenseEntryFlag",
@@ -27150,8 +28350,8 @@
             },
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -27160,23 +28360,26 @@
             },
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityLocation": {
               "displayName": "securityLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityRole": {
               "displayName": "securityRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SecurityRoleReference",
+              "referenceTo": [
+                "securityroles"
+              ]
             },
             "serviceBoardTeamIds": {
               "displayName": "serviceBoardTeamIds",
@@ -27185,23 +28388,29 @@
             },
             "serviceDefaultBoard": {
               "displayName": "serviceDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "signature": {
               "displayName": "signature",
@@ -27210,13 +28419,13 @@
             },
             "ssoSettings": {
               "displayName": "ssoSettings",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberSsoSettingsReference"
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StructureReference"
             },
             "stsUserAdminUrl": {
               "displayName": "stsUserAdminUrl",
@@ -27230,8 +28439,11 @@
             },
             "timeApprover": {
               "displayName": "timeApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "timeReminderEmailFlag": {
               "displayName": "timeReminderEmailFlag",
@@ -27245,8 +28457,11 @@
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "timebasedOneTimePasswordActivated": {
               "displayName": "timebasedOneTimePasswordActivated",
@@ -27270,8 +28485,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberTypeReference",
+              "referenceTo": [
+                "system/members/types"
+              ]
             },
             "useBrowserLanguageFlag": {
               "displayName": "useBrowserLanguageFlag",
@@ -27285,23 +28503,35 @@
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "warehouseBin": {
               "displayName": "warehouseBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -27421,8 +28651,11 @@
             },
             "calendar": {
               "displayName": "calendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "companyActivityTabFormat": {
               "displayName": "companyActivityTabFormat",
@@ -27471,13 +28704,13 @@
             },
             "defaultDepartment": {
               "displayName": "defaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "enableMobileFlag": {
               "displayName": "enableMobileFlag",
@@ -27501,8 +28734,11 @@
             },
             "expenseApprover": {
               "displayName": "expenseApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "fromMemberRecId": {
               "displayName": "fromMemberRecId",
@@ -27657,28 +28893,34 @@
             },
             "projectDefaultBoard": {
               "displayName": "projectDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectBoardReference"
             },
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "reportCard": {
               "displayName": "reportCard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ReportCardReference",
+              "referenceTo": [
+                "reportCards"
+              ]
             },
             "reportsTo": {
               "displayName": "reportsTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "requireExpenseEntryFlag": {
               "displayName": "requireExpenseEntryFlag",
@@ -27747,8 +28989,8 @@
             },
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -27757,18 +28999,18 @@
             },
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityLocation": {
               "displayName": "securityLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "serviceBoardTeamIds": {
               "displayName": "serviceBoardTeamIds",
@@ -27777,28 +29019,34 @@
             },
             "serviceDefaultBoard": {
               "displayName": "serviceDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StructureReference"
             },
             "stsUserAdminUrl": {
               "displayName": "stsUserAdminUrl",
@@ -27817,8 +29065,11 @@
             },
             "timeApprover": {
               "displayName": "timeApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "timeReminderEmailFlag": {
               "displayName": "timeReminderEmailFlag",
@@ -27832,8 +29083,11 @@
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "title": {
               "displayName": "title",
@@ -27847,28 +29101,43 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberTypeReference",
+              "referenceTo": [
+                "system/members/types"
+              ]
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "warehouseBin": {
               "displayName": "warehouseBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -27884,8 +29153,8 @@
             },
             "baseCurrency": {
               "displayName": "baseCurrency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "groupCaption": {
               "displayName": "groupCaption",
@@ -27916,8 +29185,11 @@
             },
             "accountManagerRole": {
               "displayName": "accountManagerRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             },
             "field10Caption": {
               "displayName": "field10Caption",
@@ -27981,8 +29253,11 @@
             },
             "salesRepRole": {
               "displayName": "salesRepRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             },
             "secondaryRepCaption": {
               "displayName": "secondaryRepCaption",
@@ -27991,8 +29266,11 @@
             },
             "technicalContactRole": {
               "displayName": "technicalContactRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TeamRoleReference",
+              "referenceTo": [
+                "teamRoles"
+              ]
             }
           }
         },
@@ -28193,8 +29471,8 @@
             },
             "calendarSetup": {
               "displayName": "calendarSetup",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarSetupReference"
             },
             "contactColor": {
               "displayName": "contactColor",
@@ -28458,8 +29736,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -28473,8 +29754,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -28483,8 +29764,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -28761,13 +30042,19 @@
             },
             "activityStatus": {
               "displayName": "activityStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityStatusReference",
+              "referenceTo": [
+                "sales/activities/statuses"
+              ]
             },
             "activityType": {
               "displayName": "activityType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityTypeReference",
+              "referenceTo": [
+                "sales/activities/types"
+              ]
             },
             "attachConfigurationsFor": {
               "displayName": "attachConfigurationsFor",
@@ -28786,8 +30073,11 @@
             },
             "attachedTrack": {
               "displayName": "attachedTrack",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TrackReference",
+              "referenceTo": [
+                "tracks"
+              ]
             },
             "attachments": {
               "displayName": "attachments",
@@ -28801,43 +30091,61 @@
             },
             "automateScript": {
               "displayName": "automateScript",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AutomateScriptReference"
             },
             "bccContact": {
               "displayName": "bccContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "boardStatus": {
               "displayName": "boardStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "ccContact": {
               "displayName": "ccContact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "companyStatus": {
               "displayName": "companyStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyStatusReference",
+              "referenceTo": [
+                "company/companies/statuses"
+              ]
             },
             "configurationStatus": {
               "displayName": "configurationStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationStatusReference",
+              "referenceTo": [
+                "company/configurations/statuses"
+              ]
             },
             "configurationType": {
               "displayName": "configurationType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ConfigurationTypeReference",
+              "referenceTo": [
+                "company/configurations/types"
+              ]
             },
             "connectWiseID": {
               "displayName": "connectWiseID",
@@ -28876,8 +30184,11 @@
             },
             "group": {
               "displayName": "group",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "GroupReference",
+              "referenceTo": [
+                "groups"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -28901,18 +30212,24 @@
             },
             "notifyFrom": {
               "displayName": "notifyFrom",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "NotificationRecipientReference",
+              "referenceTo": [
+                "notificationRecipients"
+              ]
             },
             "notifyType": {
               "displayName": "notifyType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "NotifyTypeReference"
             },
             "notifyWho": {
               "displayName": "notifyWho",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "NotificationRecipientReference",
+              "referenceTo": [
+                "notificationRecipients"
+              ]
             },
             "parentConnectWiseId": {
               "displayName": "parentConnectWiseId",
@@ -28926,68 +30243,89 @@
             },
             "projectStatus": {
               "displayName": "projectStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectStatusReference",
+              "referenceTo": [
+                "project/statuses"
+              ]
             },
             "salesOrderStatus": {
               "displayName": "salesOrderStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OrderStatusReference",
+              "referenceTo": [
+                "sales/orders/statuses"
+              ]
             },
             "scriptFailStatus": {
               "displayName": "scriptFailStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "scriptSuccessStatus": {
               "displayName": "scriptSuccessStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "serviceItem": {
               "displayName": "serviceItem",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "servicePriority": {
               "displayName": "servicePriority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "serviceSubType": {
               "displayName": "serviceSubType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "serviceSurvey": {
               "displayName": "serviceSurvey",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSurveyReference",
+              "referenceTo": [
+                "service/surveys"
+              ]
             },
             "serviceTemplate": {
               "displayName": "serviceTemplate",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTemplateReference",
+              "referenceTo": [
+                "templates"
+              ]
             },
             "serviceType": {
               "displayName": "serviceType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "specificMemberFrom": {
               "displayName": "specificMemberFrom",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "specificMemberTo": {
               "displayName": "specificMemberTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "specificTeamTo": {
               "displayName": "specificTeamTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "GenericBoardTeamReference"
             },
             "subject": {
               "displayName": "subject",
@@ -29169,8 +30507,8 @@
             },
             "code": {
               "displayName": "code",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceCodeReference"
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -29266,8 +30604,11 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "defaultFlag": {
               "displayName": "defaultFlag",
@@ -29842,8 +31183,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -29852,13 +31193,16 @@
             },
             "leader": {
               "displayName": "leader",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -29879,13 +31223,19 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "assignedBy": {
               "displayName": "assignedBy",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "assignedNotifyFlag": {
               "displayName": "assignedNotifyFlag",
@@ -30011,23 +31361,32 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "emailCC": {
               "displayName": "emailCC",
@@ -30130,13 +31489,13 @@
             },
             "item": {
               "displayName": "item",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceItemReference"
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -30150,8 +31509,11 @@
             },
             "priority": {
               "displayName": "priority",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PriorityReference",
+              "referenceTo": [
+                "priorities"
+              ]
             },
             "problem": {
               "displayName": "problem",
@@ -30200,8 +31562,11 @@
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "severity": {
               "displayName": "severity",
@@ -30224,23 +31589,23 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "source": {
               "displayName": "source",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSourceReference"
             },
             "status": {
               "displayName": "status",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "subtype": {
               "displayName": "subtype",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceSubTypeReference"
             },
             "summary": {
               "displayName": "summary",
@@ -30249,8 +31614,11 @@
             },
             "team": {
               "displayName": "team",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTeamReference",
+              "referenceTo": [
+                "teams"
+              ]
             },
             "templateFlag": {
               "displayName": "templateFlag",
@@ -30269,18 +31637,24 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceTypeReference"
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -30338,8 +31712,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "id": {
               "displayName": "id",
@@ -30348,8 +31725,11 @@
             },
             "integratorLogin": {
               "displayName": "integratorLogin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "IntegratorLoginReference",
+              "referenceTo": [
+                "integratorlogins"
+              ]
             },
             "internalAnalysisFlag": {
               "displayName": "internalAnalysisFlag",
@@ -30416,8 +31796,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "billableOption": {
               "displayName": "billableOption",
@@ -30484,8 +31867,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -30499,8 +31885,8 @@
             },
             "serviceStatus": {
               "displayName": "serviceStatus",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceStatusReference"
             },
             "showNotesInDiscussionFlag": {
               "displayName": "showNotesInDiscussionFlag",
@@ -30547,8 +31933,11 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "ticketMobileGuid": {
               "displayName": "ticketMobileGuid",
@@ -30562,13 +31951,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -30589,8 +31984,11 @@
             },
             "activity": {
               "displayName": "activity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityReference",
+              "referenceTo": [
+                "activities"
+              ]
             },
             "activitySubject": {
               "displayName": "activitySubject",
@@ -30604,8 +32002,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAdjustmentFirm": {
               "displayName": "agreementAdjustmentFirm",
@@ -30729,8 +32130,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyAndAgreement": {
               "displayName": "companyAndAgreement",
@@ -30794,8 +32198,11 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "invoiceAdjustmentFirm": {
               "displayName": "invoiceAdjustmentFirm",
@@ -30839,8 +32246,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "memberDailyCapacity": {
               "displayName": "memberDailyCapacity",
@@ -30884,8 +32294,8 @@
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "processingStatus": {
               "displayName": "processingStatus",
@@ -30899,8 +32309,11 @@
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "projectActivity": {
               "displayName": "projectActivity",
@@ -30934,8 +32347,11 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "ticketCurrentBoard": {
               "displayName": "ticketCurrentBoard",
@@ -30989,13 +32405,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -31016,8 +32438,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "expenseEntryFlag": {
               "displayName": "expenseEntryFlag",
@@ -31036,8 +32458,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -31051,13 +32473,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -31073,8 +32501,11 @@
             },
             "activity": {
               "displayName": "activity",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ActivityReference",
+              "referenceTo": [
+                "activities"
+              ]
             },
             "actualHours": {
               "displayName": "actualHours",
@@ -31103,8 +32534,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAdjustment": {
               "displayName": "agreementAdjustment",
@@ -31193,8 +32627,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "companyType": {
               "displayName": "companyType",
@@ -31213,8 +32650,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingUnitReference"
             },
             "emailCc": {
               "displayName": "emailCc",
@@ -31278,8 +32715,11 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "invoiceFlag": {
               "displayName": "invoiceFlag",
@@ -31298,8 +32738,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OwnerLevelReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -31313,8 +32753,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "mobileGuid": {
               "displayName": "mobileGuid",
@@ -31338,13 +32781,16 @@
             },
             "phase": {
               "displayName": "phase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "projectActivity": {
               "displayName": "projectActivity",
@@ -31408,8 +32854,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "territory": {
               "displayName": "territory",
@@ -31418,8 +32867,11 @@
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "ticketBoard": {
               "displayName": "ticketBoard",
@@ -31448,8 +32900,11 @@
             },
             "timeSheet": {
               "displayName": "timeSheet",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeSheetReference",
+              "referenceTo": [
+                "sheets"
+              ]
             },
             "timeStart": {
               "displayName": "timeStart",
@@ -31458,13 +32913,19 @@
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -31589,8 +33050,11 @@
             },
             "internalCompany": {
               "displayName": "internalCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "invoiceStart": {
               "displayName": "invoiceStart",
@@ -31780,8 +33244,8 @@
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneReference"
             }
           }
         },
@@ -31807,8 +33271,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -31859,8 +33323,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "openInNewWindow": {
               "displayName": "openInNewWindow",
@@ -31928,8 +33392,11 @@
             },
             "customField": {
               "displayName": "customField",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "UserDefinedFieldReference",
+              "referenceTo": [
+                "userDefinedFields"
+              ]
             },
             "description": {
               "displayName": "description",
@@ -32032,8 +33499,11 @@
             },
             "agreement": {
               "displayName": "agreement",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "AgreementReference",
+              "referenceTo": [
+                "agreements"
+              ]
             },
             "agreementAmountCovered": {
               "displayName": "agreementAmountCovered",
@@ -32052,8 +33522,11 @@
             },
             "chargeCode": {
               "displayName": "chargeCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ChargeCodeReference",
+              "referenceTo": [
+                "chargeCodes"
+              ]
             },
             "chargeDescription": {
               "displayName": "chargeDescription",
@@ -32096,8 +33569,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "compositeTaxAmount": {
               "displayName": "compositeTaxAmount",
@@ -32151,8 +33627,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "dateClosed": {
               "displayName": "dateClosed",
@@ -32176,8 +33652,11 @@
             },
             "expenseType": {
               "displayName": "expenseType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ExpenseTypeReference",
+              "referenceTo": [
+                "expense/types"
+              ]
             },
             "glType": {
               "displayName": "glType",
@@ -32307,8 +33786,11 @@
             },
             "member": {
               "displayName": "member",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "nonBillableAmount": {
               "displayName": "nonBillableAmount",
@@ -32317,18 +33799,21 @@
             },
             "paymentMethod": {
               "displayName": "paymentMethod",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PaymentMethodReference"
             },
             "project": {
               "displayName": "project",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectReference",
+              "referenceTo": [
+                "projects"
+              ]
             },
             "projectPhase": {
               "displayName": "projectPhase",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectPhaseReference"
             },
             "salesTaxAmount": {
               "displayName": "salesTaxAmount",
@@ -32352,13 +33837,19 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "ticket": {
               "displayName": "ticket",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TicketReference",
+              "referenceTo": [
+                "service/tickets"
+              ]
             },
             "total": {
               "displayName": "total",
@@ -32389,13 +33880,16 @@
             },
             "billToCompany": {
               "displayName": "billToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "billToSite": {
               "displayName": "billToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "billingLogId": {
               "displayName": "billingLogId",
@@ -32404,8 +33898,8 @@
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "cityTaxAmount": {
               "displayName": "cityTaxAmount",
@@ -32424,8 +33918,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "compositeTaxAmount": {
               "displayName": "compositeTaxAmount",
@@ -32479,8 +33976,8 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "dateClosed": {
               "displayName": "dateClosed",
@@ -32489,8 +33986,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "departmentId": {
               "displayName": "departmentId",
@@ -32604,8 +34101,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "OwnerLevelReference"
             },
             "locationId": {
               "displayName": "locationId",
@@ -32619,13 +34116,16 @@
             },
             "shipToCompany": {
               "displayName": "shipToCompany",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "shipToSite": {
               "displayName": "shipToSite",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             },
             "stateTaxAmount": {
               "displayName": "stateTaxAmount",
@@ -32649,8 +34149,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "total": {
               "displayName": "total",
@@ -32691,8 +34194,11 @@
             },
             "invoice": {
               "displayName": "invoice",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "InvoiceReference",
+              "referenceTo": [
+                "invoices"
+              ]
             },
             "paymentAccount": {
               "displayName": "paymentAccount",
@@ -32758,8 +34264,8 @@
             },
             "billingTerms": {
               "displayName": "billingTerms",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BillingTermsReference"
             },
             "cityTaxAmount": {
               "displayName": "cityTaxAmount",
@@ -32823,13 +34329,16 @@
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "customer": {
               "displayName": "customer",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "dateClosed": {
               "displayName": "dateClosed",
@@ -32912,8 +34421,11 @@
             },
             "purchaseOrder": {
               "displayName": "purchaseOrder",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "PurchaseOrderReference",
+              "referenceTo": [
+                "purchaseorders"
+              ]
             },
             "purchaseOrderTaxableFlag": {
               "displayName": "purchaseOrderTaxableFlag",
@@ -32937,8 +34449,11 @@
             },
             "taxCode": {
               "displayName": "taxCode",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TaxCodeReference",
+              "referenceTo": [
+                "taxCodes"
+              ]
             },
             "taxFreightFlag": {
               "displayName": "taxFreightFlag",
@@ -32967,8 +34482,11 @@
             },
             "vendor": {
               "displayName": "vendor",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "vendorAccountNumber": {
               "displayName": "vendorAccountNumber",
@@ -33194,8 +34712,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -33209,8 +34730,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "height": {
               "displayName": "height",
@@ -33234,13 +34755,16 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "manager": {
               "displayName": "manager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "maxQuantity": {
               "displayName": "maxQuantity",
@@ -33259,8 +34783,11 @@
             },
             "overflowBin": {
               "displayName": "overflowBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "quantityOnHand": {
               "displayName": "quantityOnHand",
@@ -33269,13 +34796,19 @@
             },
             "transferBin": {
               "displayName": "transferBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "weight": {
               "displayName": "weight",
@@ -33301,8 +34834,11 @@
             },
             "company": {
               "displayName": "company",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CompanyReference",
+              "referenceTo": [
+                "companies"
+              ]
             },
             "connectWiseId": {
               "displayName": "connectWiseId",
@@ -33311,18 +34847,21 @@
             },
             "contact": {
               "displayName": "contact",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ContactReference",
+              "referenceTo": [
+                "contacts"
+              ]
             },
             "currency": {
               "displayName": "currency",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CurrencyReference"
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -33336,8 +34875,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "locationDefaultFlag": {
               "displayName": "locationDefaultFlag",
@@ -33356,8 +34895,11 @@
             },
             "manager": {
               "displayName": "manager",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "name": {
               "displayName": "name",
@@ -33371,8 +34913,8 @@
             },
             "site": {
               "displayName": "site",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SiteReference"
             }
           }
         },
@@ -33452,8 +34994,11 @@
             },
             "calendar": {
               "displayName": "calendar",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CalendarReference",
+              "referenceTo": [
+                "calendars"
+              ]
             },
             "calendarSyncIntegrationFlag": {
               "displayName": "calendarSyncIntegrationFlag",
@@ -33497,8 +35042,11 @@
             },
             "country": {
               "displayName": "country",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "CountryReference",
+              "referenceTo": [
+                "countries"
+              ]
             },
             "customFields": {
               "displayName": "customFields",
@@ -33517,8 +35065,8 @@
             },
             "defaultDepartment": {
               "displayName": "defaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "defaultEmail": {
               "displayName": "defaultEmail",
@@ -33541,8 +35089,8 @@
             },
             "defaultLocation": {
               "displayName": "defaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "defaultPhone": {
               "displayName": "defaultPhone",
@@ -33565,8 +35113,11 @@
             },
             "directionalSync": {
               "displayName": "directionalSync",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DirectionalSyncReference",
+              "referenceTo": [
+                "directionalSyncs"
+              ]
             },
             "disableOnlineFlag": {
               "displayName": "disableOnlineFlag",
@@ -33610,8 +35161,11 @@
             },
             "expenseApprover": {
               "displayName": "expenseApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "firstName": {
               "displayName": "firstName",
@@ -33791,8 +35345,11 @@
             },
             "ldapConfiguration": {
               "displayName": "ldapConfiguration",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "LdapConfigurationReference",
+              "referenceTo": [
+                "ldapConfigurations"
+              ]
             },
             "ldapUserName": {
               "displayName": "ldapUserName",
@@ -33926,8 +35483,8 @@
             },
             "photo": {
               "displayName": "photo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "DocumentReference"
             },
             "primaryEmail": {
               "displayName": "primaryEmail",
@@ -33936,28 +35493,34 @@
             },
             "projectDefaultBoard": {
               "displayName": "projectDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ProjectBoardReference"
             },
             "projectDefaultDepartment": {
               "displayName": "projectDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "projectDefaultLocation": {
               "displayName": "projectDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "reportCard": {
               "displayName": "reportCard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ReportCardReference",
+              "referenceTo": [
+                "reportCards"
+              ]
             },
             "reportsTo": {
               "displayName": "reportsTo",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "requireExpenseEntryFlag": {
               "displayName": "requireExpenseEntryFlag",
@@ -34026,8 +35589,8 @@
             },
             "salesDefaultLocation": {
               "displayName": "salesDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "scheduleCapacity": {
               "displayName": "scheduleCapacity",
@@ -34036,23 +35599,26 @@
             },
             "scheduleDefaultDepartment": {
               "displayName": "scheduleDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "scheduleDefaultLocation": {
               "displayName": "scheduleDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityLocation": {
               "displayName": "securityLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "securityRole": {
               "displayName": "securityRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SecurityRoleReference",
+              "referenceTo": [
+                "securityroles"
+              ]
             },
             "serviceBoardTeamIds": {
               "displayName": "serviceBoardTeamIds",
@@ -34061,23 +35627,29 @@
             },
             "serviceDefaultBoard": {
               "displayName": "serviceDefaultBoard",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "serviceDefaultDepartment": {
               "displayName": "serviceDefaultDepartment",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "serviceDefaultLocation": {
               "displayName": "serviceDefaultLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "serviceLocation": {
               "displayName": "serviceLocation",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "ServiceLocationReference",
+              "referenceTo": [
+                "service/locations"
+              ]
             },
             "signature": {
               "displayName": "signature",
@@ -34086,13 +35658,13 @@
             },
             "ssoSettings": {
               "displayName": "ssoSettings",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberSsoSettingsReference"
             },
             "structureLevel": {
               "displayName": "structureLevel",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "StructureReference"
             },
             "stsUserAdminUrl": {
               "displayName": "stsUserAdminUrl",
@@ -34106,8 +35678,11 @@
             },
             "timeApprover": {
               "displayName": "timeApprover",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberReference",
+              "referenceTo": [
+                "system/members"
+              ]
             },
             "timeReminderEmailFlag": {
               "displayName": "timeReminderEmailFlag",
@@ -34121,8 +35696,11 @@
             },
             "timeZone": {
               "displayName": "timeZone",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "TimeZoneSetupReference",
+              "referenceTo": [
+                "timeZoneSetups"
+              ]
             },
             "timebasedOneTimePasswordActivated": {
               "displayName": "timebasedOneTimePasswordActivated",
@@ -34146,8 +35724,11 @@
             },
             "type": {
               "displayName": "type",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "MemberTypeReference",
+              "referenceTo": [
+                "system/members/types"
+              ]
             },
             "useBrowserLanguageFlag": {
               "displayName": "useBrowserLanguageFlag",
@@ -34161,23 +35742,35 @@
             },
             "warehouse": {
               "displayName": "warehouse",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseReference",
+              "referenceTo": [
+                "warehouses"
+              ]
             },
             "warehouseBin": {
               "displayName": "warehouseBin",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WarehouseBinReference",
+              "referenceTo": [
+                "warehouseBins"
+              ]
             },
             "workRole": {
               "displayName": "workRole",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkRoleReference",
+              "referenceTo": [
+                "workRoles"
+              ]
             },
             "workType": {
               "displayName": "workType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkTypeReference",
+              "referenceTo": [
+                "workTypes"
+              ]
             }
           }
         },
@@ -34451,8 +36044,11 @@
             },
             "board": {
               "displayName": "board",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "BoardReference",
+              "referenceTo": [
+                "service/boards"
+              ]
             },
             "connectWiseID": {
               "displayName": "connectWiseID",
@@ -34461,8 +36057,8 @@
             },
             "department": {
               "displayName": "department",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemDepartmentReference"
             },
             "id": {
               "displayName": "id",
@@ -34471,8 +36067,8 @@
             },
             "location": {
               "displayName": "location",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "SystemLocationReference"
             },
             "name": {
               "displayName": "name",
@@ -34481,8 +36077,11 @@
             },
             "tableType": {
               "displayName": "tableType",
-              "valueType": "other",
-              "providerType": "object"
+              "valueType": "reference",
+              "providerType": "WorkflowTableTypeReference",
+              "referenceTo": [
+                "tableTypes"
+              ]
             }
           }
         }

--- a/providers/connectwise/metadata_test.go
+++ b/providers/connectwise/metadata_test.go
@@ -65,8 +65,9 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 							},
 							"taxCode": {
 								DisplayName:  "taxCode",
-								ValueType:    "other",
-								ProviderType: "object",
+								ValueType:    "reference",
+								ProviderType: "TaxCodeReference",
+								ReferenceTo:  []string{"taxCodes"},
 							},
 						},
 					},
@@ -109,6 +110,22 @@ func TestListObjectMetadata(t *testing.T) { // nolint:funlen,gocognit,cyclop
 								DisplayName:  "firstName",
 								ValueType:    "string",
 								ProviderType: "string",
+							},
+							"company": {
+								DisplayName:  "company",
+								ValueType:    "reference",
+								ProviderType: "CompanyReference",
+								ReferenceTo:  []string{"companies"},
+							},
+							"site": {
+								DisplayName:  "site",
+								ValueType:    "reference",
+								ProviderType: "SiteReference",
+							},
+							"communicationItems": {
+								DisplayName:  "communicationItems",
+								ValueType:    "other",
+								ProviderType: "array",
 							},
 							"gender": {
 								DisplayName:  "gender",

--- a/providers/connectwise/schemas_test.go
+++ b/providers/connectwise/schemas_test.go
@@ -1,0 +1,111 @@
+package connectwise
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/connectwise/internal/metadata"
+)
+
+// TestSchemasReferenceFields pins the reference classification baked into schemas.json
+// across objects, so a regeneration that loses lookup detection fails loudly.
+// Covers every naming shape ConnectWise uses for reference schemas:
+// exact (CompanyReference), prefixed (SystemDepartmentReference),
+// namespaced item schema (Finance.Currency -> CurrencyReference)
+// and pluralized (BillingTermsReference).
+func TestSchemasReferenceFields(t *testing.T) { // nolint:funlen
+	t.Parallel()
+
+	tests := []struct {
+		objectName   string
+		fieldName    string
+		providerType string
+		referenceTo  []string
+	}{
+		{
+			objectName:   "contacts",
+			fieldName:    "company",
+			providerType: "CompanyReference",
+			referenceTo:  []string{"companies"},
+		},
+		{
+			objectName:   "contacts",
+			fieldName:    "companyLocation",
+			providerType: "SystemLocationReference",
+			referenceTo:  []string{"system/locations"},
+		},
+		{
+			objectName:   "sales/opportunities",
+			fieldName:    "billingTerms",
+			providerType: "BillingTermsReference",
+			referenceTo:  []string{"billingTerms"},
+		},
+		{
+			objectName:   "sales/opportunities",
+			fieldName:    "contact",
+			providerType: "ContactReference",
+			referenceTo:  []string{"contacts"},
+		},
+		{
+			objectName:   "sales/opportunities",
+			fieldName:    "primarySalesRep",
+			providerType: "MemberReference",
+			referenceTo:  []string{"system/members"},
+		},
+		{
+			objectName:   "sales/opportunities",
+			fieldName:    "currency",
+			providerType: "CurrencyReference",
+			referenceTo:  []string{"currencies"},
+		},
+		{
+			objectName:   "system/members",
+			fieldName:    "defaultDepartment",
+			providerType: "SystemDepartmentReference",
+			referenceTo:  []string{"system/departments"},
+		},
+		{
+			objectName:   "system/members",
+			fieldName:    "reportsTo",
+			providerType: "MemberReference",
+			referenceTo:  []string{"system/members"},
+		},
+		{
+			// Lookup without a top-level target collection keeps reference type,
+			// with no referenceTo.
+			objectName:   "contacts",
+			fieldName:    "site",
+			providerType: "SiteReference",
+			referenceTo:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.objectName+"."+tt.fieldName, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := metadata.Schemas.Select(common.ModuleRoot, []string{tt.objectName})
+			if err != nil {
+				t.Fatalf("selecting %v: %v", tt.objectName, err)
+			}
+
+			field, ok := result.Result[tt.objectName].Fields[tt.fieldName]
+			if !ok {
+				t.Fatalf("field %v not found on %v", tt.fieldName, tt.objectName)
+			}
+
+			if field.ValueType != common.ValueTypeReference {
+				t.Errorf("valueType = %q, want %q", field.ValueType, common.ValueTypeReference)
+			}
+
+			if field.ProviderType != tt.providerType {
+				t.Errorf("providerType = %q, want %q", field.ProviderType, tt.providerType)
+			}
+
+			if !reflect.DeepEqual(field.ReferenceTo, tt.referenceTo) {
+				t.Errorf("referenceTo = %v, want %v", field.ReferenceTo, tt.referenceTo)
+			}
+		})
+	}
+}

--- a/scripts/openapi/connectwise/metadata/main.go
+++ b/scripts/openapi/connectwise/metadata/main.go
@@ -368,6 +368,8 @@ func main() {
 	registry := datautils.NamedLists[string]{}
 
 	objects := Objects()
+	referenceObjects := referenceSchemaToObjectName(objects)
+
 	for _, object := range objects {
 		objectName := getObjectName(object)
 
@@ -380,7 +382,7 @@ func main() {
 
 		for _, field := range object.Fields {
 			schemas.Add(common.ModuleRoot, objectName, object.DisplayName, object.URLPath, object.ResponseKey,
-				utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, object.Custom)
+				convertField(field, referenceObjects), nil, object.Custom)
 		}
 
 		for _, queryParam := range object.QueryParams {
@@ -418,6 +420,90 @@ func Objects() []metadatadef.Schema {
 	goutils.MustBeNil(err)
 
 	return readObjects
+}
+
+// referenceSchemaToObjectName maps ConnectWise reference schema names to the object they point to.
+// Every readable object is described by an item schema (ex: "Contact" for the contacts object),
+// and lookup fields on other objects reference it via a dedicated "<ItemSchema>Reference" schema.
+// When multiple objects share one item schema, the object named after the schema wins,
+// ex: MemberReference -> "system/members" rather than "withSso". Otherwise the mapping
+// is ambiguous and dropped with a warning.
+func referenceSchemaToObjectName(objects []metadatadef.Schema) map[string]string {
+	candidates := datautils.NamedLists[string]{}
+
+	for _, object := range objects {
+		if object.ItemSchemaName == "" {
+			continue
+		}
+
+		candidates.Add(object.ItemSchemaName, getObjectName(object))
+	}
+
+	result := make(map[string]string)
+
+	for itemSchemaName, objectNames := range candidates {
+		referenceName := itemSchemaName + "Reference"
+
+		objectName, ok := selectCanonicalObject(itemSchemaName, datautils.NewSet(objectNames...).List())
+		if !ok {
+			slog.Warn("ambiguous reference schema, referenceTo will be omitted",
+				"referenceSchema", referenceName,
+				"objects", objectNames,
+			)
+
+			continue
+		}
+
+		result[referenceName] = objectName
+	}
+
+	return result
+}
+
+// selectCanonicalObject picks the object a reference schema points to.
+// A single candidate wins outright, otherwise the object whose last URL segment
+// matches the pluralized schema name, ex: Member -> {"withSso", "system/members"} -> "system/members".
+func selectCanonicalObject(itemSchemaName string, objectNames []string) (string, bool) {
+	if len(objectNames) == 1 {
+		return objectNames[0], true
+	}
+
+	pluralName := naming.NewPluralString(itemSchemaName).String()
+
+	for _, objectName := range objectNames {
+		segment := objectName[strings.LastIndex(objectName, "/")+1:]
+		if strings.EqualFold(segment, pluralName) {
+			return objectName, true
+		}
+	}
+
+	return "", false
+}
+
+// convertField enhances the generic OpenAPI conversion with ConnectWise reference handling.
+// Lookup fields are represented in the spec as objects referencing a "*Reference" schema,
+// ex: Contact.company -> CompanyReference. They are reported as a reference value type,
+// pointing to the referenced object whenever the target is a supported object.
+func convertField(
+	field metadatadef.Field, referenceObjects map[string]string,
+) staticschema.FieldMetadataMapV2 {
+	if field.Type != "object" || !strings.HasSuffix(field.SchemaRefName, "Reference") {
+		return utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field)
+	}
+
+	var referenceTo []string
+	if objectName, found := referenceObjects[field.SchemaRefName]; found {
+		referenceTo = []string{objectName}
+	}
+
+	return staticschema.FieldMetadataMapV2{
+		field.Name: staticschema.FieldMetadata{
+			DisplayName:  field.Name,
+			ValueType:    common.ValueTypeReference,
+			ProviderType: field.SchemaRefName,
+			ReferenceTo:  referenceTo,
+		},
+	}
 }
 
 func collectionDisplayName(displayName string) string {

--- a/scripts/openapi/connectwise/metadata/main.go
+++ b/scripts/openapi/connectwise/metadata/main.go
@@ -424,10 +424,11 @@ func Objects() []metadatadef.Schema {
 
 // referenceSchemaToObjectName maps ConnectWise reference schema names to the object they point to.
 // Every readable object is described by an item schema (ex: "Contact" for the contacts object),
-// and lookup fields on other objects reference it via a dedicated "<ItemSchema>Reference" schema.
-// When multiple objects share one item schema, the object named after the schema wins,
-// ex: MemberReference -> "system/members" rather than "withSso". Otherwise the mapping
-// is ambiguous and dropped with a warning.
+// and lookup fields on other objects reference it via a dedicated "*Reference" schema.
+// Reference schema naming is not fully uniform, so each object registers several aliases,
+// see referenceSchemaAliases. When multiple objects claim one reference schema, the object
+// named after it wins, ex: MemberReference -> "system/members" rather than "withSso".
+// Otherwise the mapping is ambiguous and dropped with a warning.
 func referenceSchemaToObjectName(objects []metadatadef.Schema) map[string]string {
 	candidates := datautils.NamedLists[string]{}
 
@@ -436,15 +437,15 @@ func referenceSchemaToObjectName(objects []metadatadef.Schema) map[string]string
 			continue
 		}
 
-		candidates.Add(object.ItemSchemaName, getObjectName(object))
+		for _, referenceName := range referenceSchemaAliases(object.ItemSchemaName, object.URLPath) {
+			candidates.Add(referenceName, getObjectName(object))
+		}
 	}
 
 	result := make(map[string]string)
 
-	for itemSchemaName, objectNames := range candidates {
-		referenceName := itemSchemaName + "Reference"
-
-		objectName, ok := selectCanonicalObject(itemSchemaName, datautils.NewSet(objectNames...).List())
+	for referenceName, objectNames := range candidates {
+		objectName, ok := selectCanonicalObject(referenceName, datautils.NewSet(objectNames...).List())
 		if !ok {
 			slog.Warn("ambiguous reference schema, referenceTo will be omitted",
 				"referenceSchema", referenceName,
@@ -460,21 +461,55 @@ func referenceSchemaToObjectName(objects []metadatadef.Schema) map[string]string
 	return result
 }
 
+// referenceSchemaAliases returns the reference schema names that may point at the object
+// whose items are described by itemSchemaName. ConnectWise does not name these uniformly:
+//   - exact:      Contact           -> ContactReference
+//   - namespaced: Finance.Currency  -> CurrencyReference
+//   - pluralized: BillingTerm       -> BillingTermsReference
+//   - prefixed:   Location (object under /system/) -> SystemLocationReference
+//
+// Item schemas that already are a "*Reference" (ex: DocumentReference) are used as is.
+func referenceSchemaAliases(itemSchemaName, urlPath string) []string {
+	base := itemSchemaName[strings.LastIndex(itemSchemaName, ".")+1:]
+	if strings.HasSuffix(base, "Reference") {
+		return []string{base}
+	}
+
+	aliases := datautils.NewSet(
+		base+"Reference",
+		naming.NewPluralString(base).String()+"Reference",
+	)
+
+	if strings.HasPrefix(urlPath, "/system/") {
+		aliases.AddOne("System" + base + "Reference")
+	}
+
+	return aliases.List()
+}
+
 // selectCanonicalObject picks the object a reference schema points to.
-// A single candidate wins outright, otherwise the object whose last URL segment
-// matches the pluralized schema name, ex: Member -> {"withSso", "system/members"} -> "system/members".
-func selectCanonicalObject(itemSchemaName string, objectNames []string) (string, bool) {
+// A single candidate wins outright, otherwise the sole object whose last URL segment
+// matches the pluralized schema name, ex: MemberReference -> {"withSso", "system/members"}
+// -> "system/members". Zero or several such matches are ambiguous.
+func selectCanonicalObject(referenceName string, objectNames []string) (string, bool) {
 	if len(objectNames) == 1 {
 		return objectNames[0], true
 	}
 
-	pluralName := naming.NewPluralString(itemSchemaName).String()
+	base := strings.TrimSuffix(referenceName, "Reference")
+	pluralName := naming.NewPluralString(base).String()
+
+	matches := make([]string, 0)
 
 	for _, objectName := range objectNames {
 		segment := objectName[strings.LastIndex(objectName, "/")+1:]
 		if strings.EqualFold(segment, pluralName) {
-			return objectName, true
+			matches = append(matches, objectName)
 		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0], true
 	}
 
 	return "", false

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/metadatadef"
@@ -72,7 +73,7 @@ func (p PathItem[C]) RetrieveSchemaOperation(
 		displayName = displayProcessor(displayName)
 	}
 
-	fields, responseKey, err := extractObjectFields(
+	fields, responseKey, itemSchemaName, err := extractObjectFields(
 		p.urlPath, p.objectName,
 		schema, locator, propertyFlattener, autoSelectArrayItem,
 	)
@@ -81,13 +82,14 @@ func (p PathItem[C]) RetrieveSchemaOperation(
 	}
 
 	return &metadatadef.ExtendedSchema[C]{
-		ObjectName:  p.objectName,
-		DisplayName: displayName,
-		Fields:      fields,
-		QueryParams: getQueryParameters(operation),
-		URLPath:     p.urlPath,
-		ResponseKey: responseKey,
-		Problem:     err,
+		ObjectName:     p.objectName,
+		DisplayName:    displayName,
+		Fields:         fields,
+		QueryParams:    getQueryParameters(operation),
+		URLPath:        p.urlPath,
+		ResponseKey:    responseKey,
+		Problem:        err,
+		ItemSchemaName: itemSchemaName,
 	}, true, nil
 }
 
@@ -114,7 +116,7 @@ func extractObjectFields(
 	objectName string, schema *openapi3.Schema, locator ObjectArrayLocator,
 	propertyFlattener PropertyFlattener,
 	autoSelectArrayItem bool,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	switch getSchemaType(objectName, schema) {
 	case schemaTypeObject:
 		return extractFieldsFromArrayHolder(urlPath, objectName, schema, locator, propertyFlattener, autoSelectArrayItem)
@@ -126,7 +128,7 @@ func extractObjectFields(
 		// It seems that some OpenAPI files are not that strict about such things. Ex: Pipedrive, Zendesk.
 		return extractFieldsFromArrayHolder(urlPath, objectName, schema, locator, propertyFlattener, autoSelectArrayItem)
 	default:
-		return nil, "", createUnprocessableObjectError(objectName)
+		return nil, "", "", createUnprocessableObjectError(objectName)
 	}
 }
 
@@ -161,7 +163,7 @@ func extractFieldsFromArrayHolder(
 	objectName string, schema *openapi3.Schema, locator ObjectArrayLocator,
 	propertyFlattener PropertyFlattener,
 	autoSelectArrayItem bool,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	arrayOptions := extractPropertiesArrayType(urlPath, schema)
 
 	if len(arrayOptions) == 0 {
@@ -184,20 +186,20 @@ func extractFieldsFromArrayHolder(
 		if approved || locatorWrapper(urlPath, objectName, arrayOptions, locator, option) {
 			fields, err = extractFields(objectName, propertyFlattener, option.Item.Value)
 			if err != nil {
-				return nil, "", err
+				return nil, "", "", err
 			}
 
-			return fields, option.Name, nil
+			return fields, option.Name, schemaRefComponentName(option.Item.Ref), nil
 		}
 	}
 
 	if isBooleanTruthful(schema.AdditionalProperties.Has) {
 		// this schema is dynamic.
 		// the fields cannot be known.
-		return make(metadatadef.Fields), "", nil
+		return make(metadatadef.Fields), "", "", nil
 	}
 
-	return nil, "", createUnprocessableObjectError(objectName)
+	return nil, "", "", createUnprocessableObjectError(objectName)
 }
 
 func locatorWrapper(urlPath string, objectName string, options []Array, locator ObjectArrayLocator, option Array) bool {
@@ -271,16 +273,16 @@ func extractPropertiesArrayType(urlPath string, schema *openapi3.Schema) []Array
 func extractFieldsFromArray(
 	urlPath, objectName string, schema *openapi3.Schema,
 	propertyFlattener PropertyFlattener,
-) (fields metadatadef.Fields, location string, err error) {
+) (fields metadatadef.Fields, location string, itemSchemaName string, err error) {
 	items, isArray := getItems(urlPath, schema.NewRef())
 	if !isArray {
-		return nil, "", createUnprocessableObjectError(objectName)
+		return nil, "", "", createUnprocessableObjectError(objectName)
 	}
 
 	fields, err = extractFields(objectName, propertyFlattener, items.Value)
 	statsObjectsWithAutoSelectedArrays.Add("", urlPath)
 
-	return fields, "", err
+	return fields, "", schemaRefComponentName(items.Ref), err
 }
 
 func getItems(urlPath string, schema *openapi3.SchemaRef) (itemsSchemaRef *openapi3.SchemaRef, isArray bool) {
@@ -405,14 +407,40 @@ func extractFields(
 			propertyType := extractPropertyType(propertySchema)
 			enumOptions := extractEnumOptions(objectName, propertySchema)
 			combinedFields[property] = metadatadef.Field{
-				Name:         property,
-				Type:         propertyType,
-				ValueOptions: enumOptions,
+				Name:          property,
+				Type:          propertyType,
+				ValueOptions:  enumOptions,
+				SchemaRefName: extractPropertySchemaRefName(propertySchema),
 			}
 		}
 	}
 
 	return combinedFields, nil
+}
+
+// extractPropertySchemaRefName resolves the OpenAPI component name the property schema referenced.
+// For object properties it is the property's own $ref, for array properties the $ref of its items.
+// Empty string when the schema is inlined.
+func extractPropertySchemaRefName(propertySchema *openapi3.SchemaRef) string {
+	if name := schemaRefComponentName(propertySchema.Ref); name != "" {
+		return name
+	}
+
+	if propertySchema.Value != nil && propertySchema.Value.Items != nil {
+		return schemaRefComponentName(propertySchema.Value.Items.Ref)
+	}
+
+	return ""
+}
+
+// schemaRefComponentName converts a $ref URI to the component name.
+// Ex: "#/components/schemas/CompanyReference" -> "CompanyReference".
+func schemaRefComponentName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	return ref[strings.LastIndex(ref, "/")+1:]
 }
 
 func extractPropertyType(propertySchema *openapi3.SchemaRef) string {

--- a/tools/fileconv/api3/models.go
+++ b/tools/fileconv/api3/models.go
@@ -419,18 +419,55 @@ func extractFields(
 }
 
 // extractPropertySchemaRefName resolves the OpenAPI component name the property schema referenced.
-// For object properties it is the property's own $ref, for array properties the $ref of its items.
+// For object properties it is the property's own $ref, for array properties the $ref of its items,
+// even when the array is declared through a named wrapper schema.
 // Empty string when the schema is inlined.
 func extractPropertySchemaRefName(propertySchema *openapi3.SchemaRef) string {
-	if name := schemaRefComponentName(propertySchema.Ref); name != "" {
-		return name
+	if propertySchema == nil {
+		return ""
 	}
 
 	if propertySchema.Value != nil && propertySchema.Value.Items != nil {
-		return schemaRefComponentName(propertySchema.Value.Items.Ref)
+		return schemaRefNameWithComposites(propertySchema.Value.Items)
 	}
 
-	return ""
+	return schemaRefNameWithComposites(propertySchema)
+}
+
+// schemaRefNameWithComposites resolves the component name of the schema itself, falling back
+// to a lone $ref within allOf/oneOf/anyOf composition, a common idiom to attach extra keywords
+// to a reference, ex: {"allOf": [{"$ref": "#/components/schemas/CompanyReference"}], "nullable": true}.
+// Multiple distinct referenced components make the type ambiguous, resulting in an empty string.
+func schemaRefNameWithComposites(schema *openapi3.SchemaRef) string {
+	if schema == nil {
+		return ""
+	}
+
+	if name := schemaRefComponentName(schema.Ref); name != "" {
+		return name
+	}
+
+	if schema.Value == nil {
+		return ""
+	}
+
+	var result string
+
+	for _, composite := range datautils.MergeSlices(schema.Value.AllOf, schema.Value.OneOf, schema.Value.AnyOf) {
+		if composite == nil {
+			continue
+		}
+
+		if name := schemaRefComponentName(composite.Ref); name != "" {
+			if result != "" && result != name {
+				return ""
+			}
+
+			result = name
+		}
+	}
+
+	return result
 }
 
 // schemaRefComponentName converts a $ref URI to the component name.

--- a/tools/fileconv/api3/models_test.go
+++ b/tools/fileconv/api3/models_test.go
@@ -1,0 +1,91 @@
+package api3
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestSchemaRefComponentName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "OpenAPI 3 component ref",
+			ref:      "#/components/schemas/CompanyReference",
+			expected: "CompanyReference",
+		},
+		{
+			name:     "Swagger 2 definition ref",
+			ref:      "#/definitions/ContactReference",
+			expected: "ContactReference",
+		},
+		{
+			name:     "empty ref",
+			ref:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := schemaRefComponentName(tt.ref); got != tt.expected {
+				t.Errorf("schemaRefComponentName(%q) = %q, want %q", tt.ref, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractPropertySchemaRefName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		schema   *openapi3.SchemaRef
+		expected string
+	}{
+		{
+			name: "object property referencing a component",
+			schema: &openapi3.SchemaRef{
+				Ref:   "#/components/schemas/CompanyReference",
+				Value: &openapi3.Schema{},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "array property with referenced items",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					Items: &openapi3.SchemaRef{
+						Ref:   "#/components/schemas/ContactTypeReference",
+						Value: &openapi3.Schema{},
+					},
+				},
+			},
+			expected: "ContactTypeReference",
+		},
+		{
+			name: "inlined property schema",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := extractPropertySchemaRefName(tt.schema); got != tt.expected {
+				t.Errorf("extractPropertySchemaRefName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/tools/fileconv/api3/models_test.go
+++ b/tools/fileconv/api3/models_test.go
@@ -77,6 +77,46 @@ func TestExtractPropertySchemaRefName(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "object property wrapping a reference in allOf",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					AllOf: openapi3.SchemaRefs{{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					}},
+				},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "array property declared via named wrapper schema",
+			schema: &openapi3.SchemaRef{
+				Ref: "#/components/schemas/CompanyReferenceList",
+				Value: &openapi3.Schema{
+					Items: &openapi3.SchemaRef{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					},
+				},
+			},
+			expected: "CompanyReference",
+		},
+		{
+			name: "ambiguous composition of multiple distinct references",
+			schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					OneOf: openapi3.SchemaRefs{{
+						Ref:   "#/components/schemas/CompanyReference",
+						Value: &openapi3.Schema{},
+					}, {
+						Ref:   "#/components/schemas/ContactReference",
+						Value: &openapi3.Schema{},
+					}},
+				},
+			},
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

Stacked on #3269. Fixes ConnectWise metadata issues 2 and 3:

- Too many fields stuck at `valueType: "other"` (Opportunities 26/42, Members 45/126, Companies 30/124, Contacts 15/90) — lookup fields like `company`, `owner`, `status` were indistinguishable from nested objects.
- `referenceTo` never populated for any field.

## Root cause

ConnectWise's OpenAPI spec models every lookup as a $ref to a dedicated `*Reference` schema (`Contact.company` → `CompanyReference`; 199 such schemas). The generator collapsed all of them to `other`/`object` because the $ref name was dropped during extraction (fixed in #3269).

## Fix

The generator now maps every single-object `*Reference` field to `valueType: reference` with `providerType` set to the reference schema name, and resolves `referenceTo` by matching each readable object's item schema (`Contact` ⇄ `ContactReference` → `contacts`). When several objects share an item schema, the object named after it wins (`MemberReference` → `system/members`, not `withSso`); the two schemas that remain ambiguous (`BoardInfoReference`, `M365ContactSyncPropertyReference`) keep `reference` without `referenceTo`.

## Result (regenerated schemas.json)

| object | 'other' before | 'other' after | reference fields | with referenceTo |
|---|---|---|---|---|
| contacts | 15 | 6 | 9 | 5 |
| companies | 30 | 7 | 23 | 15 |
| sales/opportunities | 26 | 3 | 23 | 16 |
| system/members | 45 | 14 | 31 | 17 |

Remaining `other` fields are genuine nested objects/arrays (`_info`, `communicationItems`, `customFields`, …) — the Ampersand valueType enum has no object/array member, so `other` + `providerType: object|array` is the correct representation for them. Fields referencing objects ConnectWise doesn't expose as top-level collections (e.g. `site`) are typed `reference` without `referenceTo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)