### PR TITLE
[CON-3397] feat(mailgun): add mailgun-metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,6 +51,7 @@ providers/justcall/openapi/api-v21.json filter=lfs diff=lfs merge=lfs -text
 providers/keap/openapi/rest-v1.json filter=lfs diff=lfs merge=lfs -text
 providers/keap/openapi/rest-v2.json filter=lfs diff=lfs merge=lfs -text
 providers/klaviyo/openapi/stable.json filter=lfs diff=lfs merge=lfs -text
+providers/mailgun/metadata/openapi/mailgun.yaml filter=lfs diff=lfs merge=lfs -text
 providers/okta/metadata/openapi/management-minimal.yaml filter=lfs diff=lfs merge=lfs -text
 providers/paddle/openapi/openapi.yaml filter=lfs diff=lfs merge=lfs -text
 providers/pipedrive/openapi/specs.yaml filter=lfs diff=lfs merge=lfs -text

--- a/connector/new.go
+++ b/connector/new.go
@@ -95,6 +95,7 @@ import (
 	"github.com/amp-labs/connectors/providers/linkedin"
 	"github.com/amp-labs/connectors/providers/livestorm"
 	"github.com/amp-labs/connectors/providers/loxo"
+	"github.com/amp-labs/connectors/providers/mailgun"
 	"github.com/amp-labs/connectors/providers/marketo"
 	"github.com/amp-labs/connectors/providers/meta"
 	"github.com/amp-labs/connectors/providers/microsoft"
@@ -250,6 +251,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.LinkedIn:                   wrapper(newLinkedInConnector),
 	providers.Livestorm:                  wrapper(newLivestormConnector),
 	providers.Loxo:                       wrapper(newLoxoConnector),
+	providers.Mailgun:                    wrapper(newMailgunConnector),
 	providers.Marketo:                    wrapper(newMarketoConnector),
 	providers.Meta:                       wrapper(newMetaConnector),
 	providers.Microsoft:                  wrapper(newMicrosoftConnector),
@@ -470,6 +472,12 @@ func newSmartleadConnector(
 	return smartlead.NewConnector(
 		smartlead.WithAuthenticatedClient(params.AuthenticatedClient),
 	)
+}
+
+func newMailgunConnector(
+	params common.ConnectorParams,
+) (*mailgun.Connector, error) {
+	return mailgun.NewConnector(params)
 }
 
 func newMarketoConnector(

--- a/providers/mailgun/connector.go
+++ b/providers/mailgun/connector.go
@@ -1,0 +1,38 @@
+// Package mailgun provides a connector for the Mailgun API.
+//
+// API Documentation: https://documentation.mailgun.com/docs/mailgun/api-reference/intro/
+// Authentication: HTTP Basic auth ("api" as username, API key as password).
+// Base URL: https://api.mailgun.net (US) or https://api.eu.mailgun.net (EU).
+package mailgun
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/mailgun/metadata"
+)
+
+// Connector is the Mailgun connector.
+type Connector struct {
+	*components.Connector
+	common.RequireAuthenticatedClient
+
+	components.SchemaProvider
+}
+
+// NewConnector creates a new Mailgun connector.
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Initialize(providers.Mailgun, params, constructor)
+}
+
+func constructor(base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
+		connector.ProviderContext.Module(),
+		metadata.Schemas,
+	)
+
+	return connector, nil
+}

--- a/providers/mailgun/metadata/README.md
+++ b/providers/mailgun/metadata/README.md
@@ -1,0 +1,63 @@
+# Mailgun Metadata
+
+`schemas.json` is auto-generated from the Mailgun OpenAPI specification by
+`scripts/openapi/mailgun/metadata`. Do not edit it by hand.
+
+The OpenAPI spec lives at `openapi/mailgun.yaml` in this directory. It is
+OpenAPI 3.1.0 and declares both regional servers (US `https://api.mailgun.net`
+and EU `https://api.eu.mailgun.net`).
+
+## Refreshing the spec
+
+Mailgun does not link a downloadable spec from its developer site, but the
+Redocly docs portal serves it from a `_spec` path (the same URL Mailgun's own
+SDK build uses). To refresh:
+
+1. Download the latest spec:
+
+   ```sh
+   curl -o providers/mailgun/metadata/openapi/mailgun.yaml \
+     "https://documentation.mailgun.com/_spec/docs/mailgun/api-reference/send/mailgun.yaml?download"
+   ```
+
+2. From the repo root, run:
+
+   ```sh
+   go run ./scripts/openapi/mailgun/metadata
+   ```
+
+The generator projects the spec down to the connector's supported object
+inventory (defined in `getEndpoints` / `postEndpoints` in the script). To add
+or remove an object, edit those maps and re-run the generator.
+
+## Why some endpoints aren't here
+
+The spec is a merged, multi-version (v1..v5) bundle of several internal Mailgun
+services with ~169 paths; we expose 27 as connector objects. Object names are
+curated (rather than auto-derived from the last path segment) because
+auto-naming collides across versions and leaks path parameters.
+
+Excluded categories:
+
+- **Get-by-id singletons** (`/v3/routes/{id}`, `/v4/domains/{name}`,
+  `/v5/users/{user_id}`, `.../bounces/{address}`, …) — no list semantics; the
+  read layer fetches these by id.
+- **Aggregated analytics** — both the legacy GET `/v3/stats/*`,
+  `/v3/{domain}/aggregates/*`, `/v3/{domain}/tag/stats`, `/v1/thresholds/hits`,
+  `/v1/bounce-classification/stats` and the modern POST `/v1/analytics/metrics`.
+  These return computed totals, not records ("expose data, not endpoints").
+- **Action endpoints** (`/v3/routes/match`, `/v3/ips/request/new`,
+  `/v3/ips/account/settings`, `/v5/accounts/http_signing_key`, …).
+- **Reference lookups** (`/v3/domains/{domain}/tag/{countries,devices,providers}`).
+- **Pagination-variant duplicates** (`/v3/lists/pages`,
+  `/v3/lists/{list_address}/members/pages`).
+- **Sandbox-only** (`/v5/sandbox/auth_recipients`).
+- **Deprecated** GET `/v3/{domain_name}/events` — superseded by the modern
+  Logs API (POST `/v1/analytics/logs`), which is exposed as the `logs` object.
+
+## Domain scope
+
+Most objects are domain-scoped: their path contains a domain placeholder that
+appears under several names in the spec (`{domain_name}`, `{domain}`, `{name}`,
+`{authority_name}`). The placeholder is kept verbatim in `schemas.json`; the
+read connector substitutes it from connector metadata (the Mailgun domain).

--- a/providers/mailgun/metadata/metadata.go
+++ b/providers/mailgun/metadata/metadata.go
@@ -1,0 +1,21 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+var (
+	// Static file containing a list of object metadata is embedded and can be served.
+	//
+	//go:embed schemas.json
+	schemas     []byte
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV2]( // nolint:gochecknoglobals
+		schemas, fileconv.NewSiblingFileLocator())
+
+	// Schemas is cached Object schemas.
+	Schemas = FileManager.MustLoadSchemas() // nolint:gochecknoglobals
+)

--- a/providers/mailgun/metadata/openapi/file.go
+++ b/providers/mailgun/metadata/openapi/file.go
@@ -1,0 +1,16 @@
+package openapi
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+)
+
+var (
+	// Static file containing openapi spec.
+	//
+	//go:embed mailgun.yaml
+	apiFile []byte
+
+	FileManager = api3.NewOpenapiFileManager[any](apiFile) // nolint:gochecknoglobals
+)

--- a/providers/mailgun/metadata/openapi/mailgun.yaml
+++ b/providers/mailgun/metadata/openapi/mailgun.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19c7b6166eae6cbf545d83d81651c7c7fbe827a145dd95901d5de8749b578155
+size 866852

--- a/providers/mailgun/metadata/schemas.json
+++ b/providers/mailgun/metadata/schemas.json
@@ -1,0 +1,1293 @@
+{
+  "modules": {
+    "root": {
+      "id": "root",
+      "path": "/v",
+      "objects": {
+        "account/templates": {
+          "displayName": "Account Templates",
+          "path": "4/templates",
+          "responseKey": "items",
+          "fields": {
+            "createdAt": {
+              "displayName": "createdAt",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdBy": {
+              "displayName": "createdBy",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "domain": {
+              "displayName": "domain",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "version": {
+              "displayName": "version",
+              "valueType": "other"
+            },
+            "versions": {
+              "displayName": "versions",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "accounts/subaccounts": {
+          "displayName": "Subaccounts",
+          "path": "5/accounts/subaccounts",
+          "responseKey": "subaccounts",
+          "fields": {
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "features": {
+              "displayName": "features",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "status": {
+              "displayName": "status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "disabled",
+                  "displayValue": "disabled"
+                },
+                {
+                  "value": "open",
+                  "displayValue": "open"
+                },
+                {
+                  "value": "closed",
+                  "displayValue": "closed"
+                }
+              ]
+            },
+            "updated_at": {
+              "displayName": "updated_at",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "accounts/subaccounts/ip_pools/all": {
+          "displayName": "Delegated IP Pools",
+          "path": "5/accounts/subaccounts/ip_pools/all",
+          "responseKey": "items",
+          "fields": {
+            "pool_id": {
+              "displayName": "pool_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "subaccount_id": {
+              "displayName": "subaccount_id",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "analytics/logs": {
+          "displayName": "Logs",
+          "path": "1/analytics/logs",
+          "responseKey": "items",
+          "fields": {
+            "@timestamp": {
+              "displayName": "@timestamp",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "account": {
+              "displayName": "account",
+              "valueType": "other"
+            },
+            "api-key-id": {
+              "displayName": "api-key-id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "campaigns": {
+              "displayName": "campaigns",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "client-info": {
+              "displayName": "client-info",
+              "valueType": "other"
+            },
+            "delivered-at": {
+              "displayName": "delivered-at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "delivery-status": {
+              "displayName": "delivery-status",
+              "valueType": "other"
+            },
+            "domain": {
+              "displayName": "domain",
+              "valueType": "other"
+            },
+            "envelope": {
+              "displayName": "envelope",
+              "valueType": "other"
+            },
+            "event": {
+              "displayName": "event",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "flags": {
+              "displayName": "flags",
+              "valueType": "other"
+            },
+            "geolocation": {
+              "displayName": "geolocation",
+              "valueType": "other"
+            },
+            "i-delivery-optimizer": {
+              "displayName": "i-delivery-optimizer",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "ip": {
+              "displayName": "ip",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "log-level": {
+              "displayName": "log-level",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "mailing-list": {
+              "displayName": "mailing-list",
+              "valueType": "other"
+            },
+            "message": {
+              "displayName": "message",
+              "valueType": "other"
+            },
+            "method": {
+              "displayName": "method",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "originating-ip": {
+              "displayName": "originating-ip",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "primary-dkim": {
+              "displayName": "primary-dkim",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "reason": {
+              "displayName": "reason",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "recipient": {
+              "displayName": "recipient",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "recipient-domain": {
+              "displayName": "recipient-domain",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "recipient-provider": {
+              "displayName": "recipient-provider",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "routes": {
+              "displayName": "routes",
+              "valueType": "other"
+            },
+            "severity": {
+              "displayName": "severity",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "storage": {
+              "displayName": "storage",
+              "valueType": "other"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "template": {
+              "displayName": "template",
+              "valueType": "other"
+            },
+            "url": {
+              "displayName": "url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "user-variables": {
+              "displayName": "user-variables",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "bounces": {
+          "displayName": "Bounces",
+          "path": "3/{domain_name}/bounces",
+          "responseKey": "items",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "code": {
+              "displayName": "code",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "error": {
+              "displayName": "error",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "complaints": {
+          "displayName": "Complaints",
+          "path": "3/{domain_name}/complaints",
+          "responseKey": "items",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "other",
+              "providerType": "object"
+            }
+          }
+        },
+        "dkim/keys": {
+          "displayName": "DKIM Keys",
+          "path": "1/dkim/keys",
+          "responseKey": "items",
+          "fields": {
+            "dns_record": {
+              "displayName": "dns_record",
+              "valueType": "other"
+            },
+            "selector": {
+              "displayName": "selector",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "signing_domain": {
+              "displayName": "signing_domain",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "domains": {
+          "displayName": "Domains",
+          "path": "4/domains",
+          "responseKey": "items",
+          "fields": {
+            "archive_to": {
+              "displayName": "archive_to",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "disabled": {
+              "displayName": "disabled",
+              "valueType": "other"
+            },
+            "encrypt_incoming_message": {
+              "displayName": "encrypt_incoming_message",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "is_disabled": {
+              "displayName": "is_disabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "message_ttl": {
+              "displayName": "message_ttl",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "require_tls": {
+              "displayName": "require_tls",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "skip_verification": {
+              "displayName": "skip_verification",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "smtp_login": {
+              "displayName": "smtp_login",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "smtp_password": {
+              "displayName": "smtp_password",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "spam_action": {
+              "displayName": "spam_action",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "state": {
+              "displayName": "state",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "subaccount_id": {
+              "displayName": "subaccount_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tracking_host": {
+              "displayName": "tracking_host",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "use_automatic_sender_security": {
+              "displayName": "use_automatic_sender_security",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "web_prefix": {
+              "displayName": "web_prefix",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "web_scheme": {
+              "displayName": "web_scheme",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "webhooks_redact_pii": {
+              "displayName": "webhooks_redact_pii",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "wildcard": {
+              "displayName": "wildcard",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            }
+          }
+        },
+        "domains/credentials": {
+          "displayName": "Domain Credentials",
+          "path": "3/domains/{domain_name}/credentials",
+          "responseKey": "items",
+          "fields": {
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "login": {
+              "displayName": "login",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "mailbox": {
+              "displayName": "mailbox",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "size_bytes": {
+              "displayName": "size_bytes",
+              "valueType": "other"
+            }
+          }
+        },
+        "domains/keys": {
+          "displayName": "Domain Keys",
+          "path": "4/domains/{authority_name}/keys",
+          "responseKey": "items",
+          "fields": {
+            "dns_record": {
+              "displayName": "dns_record",
+              "valueType": "other"
+            },
+            "selector": {
+              "displayName": "selector",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "signing_domain": {
+              "displayName": "signing_domain",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "dynamic_pools/domains": {
+          "displayName": "Dynamic IP Pool Domains",
+          "path": "1/dynamic_pools/domains",
+          "responseKey": "items",
+          "fields": {
+            "account_id": {
+              "displayName": "account_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "account_name": {
+              "displayName": "account_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "bounce_rate": {
+              "displayName": "bounce_rate",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "complaint_rate": {
+              "displayName": "complaint_rate",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "override": {
+              "displayName": "override",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "pool": {
+              "displayName": "pool",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "processed_count": {
+              "displayName": "processed_count",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "registered_at": {
+              "displayName": "registered_at",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "forwards": {
+          "displayName": "Forwards",
+          "path": "3/forwards",
+          "responseKey": "items",
+          "fields": {
+            "account_id": {
+              "displayName": "account_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "domain_id": {
+              "displayName": "domain_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "domain_name": {
+              "displayName": "domain_name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "forward": {
+              "displayName": "forward",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "match": {
+              "displayName": "match",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "updated_at": {
+              "displayName": "updated_at",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "ip_pools": {
+          "displayName": "IP Pools",
+          "path": "3/ip_pools",
+          "responseKey": "ip_pools",
+          "fields": {
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "ips": {
+              "displayName": "ips",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "is_inherited": {
+              "displayName": "is_inherited",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "is_linked": {
+              "displayName": "is_linked",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "pool_id": {
+              "displayName": "pool_id",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "ip_whitelist": {
+          "displayName": "IP Allowlist",
+          "path": "2/ip_whitelist",
+          "responseKey": "addresses",
+          "fields": {
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "ip_address": {
+              "displayName": "ip_address",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "ips": {
+          "displayName": "IPs",
+          "path": "3/ips",
+          "responseKey": "details",
+          "fields": {
+            "dedicated": {
+              "displayName": "dedicated",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "enabled": {
+              "displayName": "enabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "ip": {
+              "displayName": "ip",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "is_on_warmup": {
+              "displayName": "is_on_warmup",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            }
+          }
+        },
+        "keys": {
+          "displayName": "Keys",
+          "path": "1/keys",
+          "responseKey": "items",
+          "fields": {
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "disabled_reason": {
+              "displayName": "disabled_reason",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "domain_name": {
+              "displayName": "domain_name",
+              "valueType": "other"
+            },
+            "expires_at": {
+              "displayName": "expires_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "is_disabled": {
+              "displayName": "is_disabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "kind": {
+              "displayName": "kind",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "requestor": {
+              "displayName": "requestor",
+              "valueType": "other"
+            },
+            "role": {
+              "displayName": "role",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "updated_at": {
+              "displayName": "updated_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "user_name": {
+              "displayName": "user_name",
+              "valueType": "other"
+            }
+          }
+        },
+        "lists": {
+          "displayName": "Mailing Lists",
+          "path": "3/lists",
+          "responseKey": "items",
+          "fields": {
+            "access_level": {
+              "displayName": "access_level",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "address": {
+              "displayName": "address",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "members_count": {
+              "displayName": "members_count",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "reply_preference": {
+              "displayName": "reply_preference",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "lists/members": {
+          "displayName": "Mailing List Members",
+          "path": "3/lists/{list_address}/members",
+          "responseKey": "items",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "subscribed": {
+              "displayName": "subscribed",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "vars": {
+              "displayName": "vars",
+              "valueType": "other",
+              "providerType": "object"
+            }
+          }
+        },
+        "routes": {
+          "displayName": "Routes",
+          "path": "3/routes",
+          "responseKey": "items",
+          "fields": {
+            "actions": {
+              "displayName": "actions",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "expression": {
+              "displayName": "expression",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "priority": {
+              "displayName": "priority",
+              "valueType": "int",
+              "providerType": "integer"
+            }
+          }
+        },
+        "tags": {
+          "displayName": "Tags",
+          "path": "3/{domain}/tags",
+          "responseKey": "items",
+          "fields": {
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "first-seen": {
+              "displayName": "first-seen",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "last-seen": {
+              "displayName": "last-seen",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "tag": {
+              "displayName": "tag",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "templates": {
+          "displayName": "Templates",
+          "path": "3/{domain_name}/templates",
+          "responseKey": "items",
+          "fields": {
+            "createdAt": {
+              "displayName": "createdAt",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "createdBy": {
+              "displayName": "createdBy",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "domain": {
+              "displayName": "domain",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "version": {
+              "displayName": "version",
+              "valueType": "other"
+            },
+            "versions": {
+              "displayName": "versions",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "thresholds/alerts/send": {
+          "displayName": "Send Alerts",
+          "path": "1/thresholds/alerts/send",
+          "responseKey": "items",
+          "fields": {
+            "account_group": {
+              "displayName": "account_group",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "alert_channels": {
+              "displayName": "alert_channels",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "comparator": {
+              "displayName": "comparator",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "dimension": {
+              "displayName": "dimension",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "filters": {
+              "displayName": "filters",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "last_checked": {
+              "displayName": "last_checked",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "limit": {
+              "displayName": "limit",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "metric": {
+              "displayName": "metric",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "parent_account_id": {
+              "displayName": "parent_account_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "period": {
+              "displayName": "period",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "subaccount_id": {
+              "displayName": "subaccount_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "updated_at": {
+              "displayName": "updated_at",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "thresholds/limits": {
+          "displayName": "Limits",
+          "path": "1/thresholds/limits",
+          "responseKey": "items",
+          "fields": {
+            "account_group": {
+              "displayName": "account_group",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "comparator": {
+              "displayName": "comparator",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "dimension": {
+              "displayName": "dimension",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "filters": {
+              "displayName": "filters",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "last_checked": {
+              "displayName": "last_checked",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "limit": {
+              "displayName": "limit",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "metric": {
+              "displayName": "metric",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "parent_account_id": {
+              "displayName": "parent_account_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "period": {
+              "displayName": "period",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "subaccount_id": {
+              "displayName": "subaccount_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "updated_at": {
+              "displayName": "updated_at",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "unsubscribes": {
+          "displayName": "Unsubscribes",
+          "path": "3/{domain_name}/unsubscribes",
+          "responseKey": "items",
+          "fields": {
+            "address": {
+              "displayName": "address",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "tags": {
+              "displayName": "tags",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "users": {
+          "displayName": "Users",
+          "path": "5/users",
+          "responseKey": "users",
+          "fields": {
+            "account_id": {
+              "displayName": "account_id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "activated": {
+              "displayName": "activated",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "auth": {
+              "displayName": "auth",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "email": {
+              "displayName": "email",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "email_details": {
+              "displayName": "email_details",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "github_user_id": {
+              "displayName": "github_user_id",
+              "valueType": "other"
+            },
+            "id": {
+              "displayName": "id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "is_disabled": {
+              "displayName": "is_disabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "is_master": {
+              "displayName": "is_master",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "metadata": {
+              "displayName": "metadata",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "migration_status": {
+              "displayName": "migration_status",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "opened_ip": {
+              "displayName": "opened_ip",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "password_updated_at": {
+              "displayName": "password_updated_at",
+              "valueType": "other"
+            },
+            "preferences": {
+              "displayName": "preferences",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "role": {
+              "displayName": "role",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "salesforce_user_id": {
+              "displayName": "salesforce_user_id",
+              "valueType": "other"
+            },
+            "tfa_active": {
+              "displayName": "tfa_active",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "tfa_created_at": {
+              "displayName": "tfa_created_at",
+              "valueType": "other"
+            },
+            "tfa_enabled": {
+              "displayName": "tfa_enabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            }
+          }
+        },
+        "webhooks": {
+          "displayName": "Webhooks",
+          "path": "1/webhooks",
+          "responseKey": "webhooks",
+          "fields": {
+            "created_at": {
+              "displayName": "created_at",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "event_types": {
+              "displayName": "event_types",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "url": {
+              "displayName": "url",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "webhook_id": {
+              "displayName": "webhook_id",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "whitelists": {
+          "displayName": "Whitelists",
+          "path": "3/{domain_name}/whitelists",
+          "responseKey": "items",
+          "fields": {
+            "createdAt": {
+              "displayName": "createdAt",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "reason": {
+              "displayName": "reason",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "value": {
+              "displayName": "value",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/mailgun/metadata_test.go
+++ b/providers/mailgun/metadata_test.go
@@ -1,0 +1,147 @@
+package mailgun
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestListObjectMetadata(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	tests := []testconn.TestCaseListObjectMetadata{
+		{
+			Name:         "At least one object name must be queried",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:       "Unknown object returns ErrObjectNotSupported",
+			Input:      []string{"nonexistent"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Errors: map[string]error{
+					"nonexistent": common.ErrObjectNotSupported,
+				},
+			},
+		},
+		{
+			// Metadata is served statically from the embedded OpenAPI schema,
+			// so no provider call is made (Dummy server).
+			Name:       "Describe account-scoped domains object",
+			Input:      []string{"domains"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"domains": {
+						DisplayName: "Domains",
+						FieldsMap: map[string]string{
+							"id":         "id",
+							"name":       "name",
+							"state":      "state",
+							"created_at": "created_at",
+						},
+					},
+				},
+			},
+		},
+		{
+			// Slash-named sub-resource resolves correctly.
+			Name:       "Describe slash-named lists/members object",
+			Input:      []string{"lists/members"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"lists/members": {
+						DisplayName: "Mailing List Members",
+						FieldsMap: map[string]string{
+							"address":    "address",
+							"subscribed": "subscribed",
+						},
+					},
+				},
+			},
+		},
+		{
+			// The analytics/logs object comes from the POST /v1/analytics/logs
+			// endpoint, proving POST-sourced schemas are included in metadata.
+			Name:       "Describe POST-sourced analytics/logs object",
+			Input:      []string{"analytics/logs"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"analytics/logs": {
+						DisplayName: "Logs",
+						FieldsMap: map[string]string{
+							"id":        "id",
+							"event":     "event",
+							"recipient": "recipient",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:       "Describe multiple objects at once",
+			Input:      []string{"webhooks", "routes", "tags"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"webhooks": {
+						DisplayName: "Webhooks",
+						FieldsMap: map[string]string{
+							"url":        "url",
+							"webhook_id": "webhook_id",
+						},
+					},
+					"routes": {
+						DisplayName: "Routes",
+						FieldsMap: map[string]string{
+							"id":         "id",
+							"expression": "expression",
+						},
+					},
+					"tags": {
+						DisplayName: "Tags",
+						FieldsMap: map[string]string{
+							"tag": "tag",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(common.ConnectorParams{
+		Module:              common.ModuleRoot,
+		AuthenticatedClient: &http.Client{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetUnitTestBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/scripts/openapi/mailgun/metadata/main.go
+++ b/scripts/openapi/mailgun/metadata/main.go
@@ -1,0 +1,176 @@
+// Generates providers/mailgun/metadata/schemas.json from the Mailgun OpenAPI spec.
+//
+// Run from repo root:
+//
+//	go run ./scripts/openapi/mailgun/metadata
+//
+// The Mailgun spec is a merged, multi-version (v1..v5) bundle of several internal
+// services, so objects are curated explicitly (allow-list) rather than auto-discovered:
+//   - Only genuine list resources scoped by at most the domain are included.
+//   - Get-by-id singletons, aggregated analytics (legacy /v3/stats/* and modern
+//     /v1/analytics/metrics), action endpoints, reference lookups, pagination
+//     variants and sandbox-only endpoints are excluded.
+//   - The modern Logs API (POST /v1/analytics/logs) replaces the deprecated GET
+//     events endpoint and is read via POST.
+//
+// Domain-scoped paths keep their placeholder ({domain_name}/{domain}/{name}/
+// {authority_name}); the read layer substitutes it from connector metadata.
+package main
+
+import (
+	"log/slog"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/goutils"
+	"github.com/amp-labs/connectors/internal/metadatadef"
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/providers/mailgun/metadata"
+	"github.com/amp-labs/connectors/providers/mailgun/metadata/openapi"
+	utilsopenapi "github.com/amp-labs/connectors/scripts/openapi/utils"
+	"github.com/amp-labs/connectors/tools/fileconv/api3"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// getEndpoints maps GET list URL paths → ObjectName. Domain-scoped placeholders
+// are kept verbatim; the read connector substitutes them at request time.
+//
+//nolint:gochecknoglobals
+var getEndpoints = map[string]string{
+	// Domain-scoped (domain supplied via connector metadata).
+	"/v3/{domain_name}/bounces":             "bounces",
+	"/v3/{domain_name}/complaints":          "complaints",
+	"/v3/{domain_name}/unsubscribes":        "unsubscribes",
+	"/v3/{domain_name}/whitelists":          "whitelists",
+	"/v3/{domain}/tags":                     "tags",
+	"/v3/domains/{domain_name}/credentials": "domains/credentials",
+	"/v3/{domain_name}/templates":           "templates",
+	"/v4/domains/{authority_name}/keys":     "domains/keys",
+
+	// Account-scoped.
+	"/v4/domains":                           "domains",
+	"/v3/routes":                            "routes",
+	"/v3/lists":                             "lists",
+	"/v3/lists/{list_address}/members":      "lists/members",
+	"/v3/forwards":                          "forwards",
+	"/v3/ip_pools":                          "ip_pools",
+	"/v3/ips":                               "ips",
+	"/v1/keys":                              "keys",
+	"/v1/dkim/keys":                         "dkim/keys",
+	"/v1/webhooks":                          "webhooks",
+	"/v5/accounts/subaccounts":              "accounts/subaccounts",
+	"/v5/users":                             "users",
+	"/v2/ip_whitelist":                      "ip_whitelist",
+	"/v1/dynamic_pools/domains":             "dynamic_pools/domains",
+	"/v1/thresholds/limits":                 "thresholds/limits",
+	"/v1/thresholds/alerts/send":            "thresholds/alerts/send",
+	"/v5/accounts/subaccounts/ip_pools/all": "accounts/subaccounts/ip_pools/all",
+	// Account-level templates collide with domain templates after truncation
+	// (both → "templates"); no distinguishing real path segment exists, so this
+	// is a documented naming exception. See metadata/README.md.
+	"/v4/templates": "account/templates",
+}
+
+// postEndpoints maps POST list URL paths → ObjectName (read via POST body).
+//
+//nolint:gochecknoglobals
+var postEndpoints = map[string]string{
+	"/v1/analytics/logs": "analytics/logs",
+}
+
+//nolint:gochecknoglobals
+var displayNameOverride = map[string]string{
+	"ips":                               "IPs",
+	"ip_pools":                          "IP Pools",
+	"ip_whitelist":                      "IP Allowlist",
+	"dkim/keys":                         "DKIM Keys",
+	"domains/keys":                      "Domain Keys",
+	"domains/credentials":               "Domain Credentials",
+	"lists/members":                     "Mailing List Members",
+	"lists":                             "Mailing Lists",
+	"analytics/logs":                    "Logs",
+	"thresholds/limits":                 "Limits",
+	"thresholds/alerts/send":            "Send Alerts",
+	"account/templates":                 "Account Templates",
+	"accounts/subaccounts":              "Subaccounts",
+	"accounts/subaccounts/ip_pools/all": "Delegated IP Pools",
+	"dynamic_pools/domains":             "Dynamic IP Pool Domains",
+}
+
+func pathsOf(m map[string]string) []string {
+	paths := make([]string, 0, len(m))
+	for path := range m {
+		paths = append(paths, path)
+	}
+
+	return paths
+}
+
+func main() {
+	schemas := staticschema.NewMetadata[staticschema.FieldMetadataMapV2]()
+	registry := datautils.NamedLists[string]{}
+
+	objects := Objects()
+
+	for _, object := range objects {
+		if object.Problem != nil {
+			slog.Error("schema not extracted",
+				"objectName", object.ObjectName,
+				"urlPath", object.URLPath,
+				"error", object.Problem,
+			)
+
+			continue
+		}
+
+		for _, field := range object.Fields {
+			schemas.Add(common.ModuleRoot, object.ObjectName, object.DisplayName,
+				object.URLPath, object.ResponseKey,
+				utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, object.Custom)
+		}
+
+		for _, queryParam := range object.QueryParams {
+			registry.Add(queryParam, object.ObjectName)
+		}
+	}
+
+	goutils.MustBeNil(metadata.FileManager.SaveSchemas(schemas))
+	goutils.MustBeNil(metadata.FileManager.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
+
+	slog.Info("Completed.", "objects", len(objects))
+}
+
+// Objects extracts schemas for curated GET list endpoints and the POST Logs
+// endpoint. ReadObjects is used (not ReadObjectsGet) so single-level {id} paths
+// — the {domain} scope — are kept; NestedIDPathIgnorer rejects 2-level nesting.
+func Objects() []metadatadef.Schema {
+	explorer, err := openapi.FileManager.GetExplorer(
+		api3.WithArrayItemAutoSelection(),
+		api3.WithDisplayNamePostProcessors(
+			api3.SlashesToSpaceSeparated,
+			api3.CapitalizeFirstLetterEveryWord,
+		),
+	)
+	goutils.MustBeNil(err)
+
+	getObjects, err := explorer.ReadObjects("GET",
+		api3.AndPathMatcher{
+			api3.NewAllowPathStrategy(pathsOf(getEndpoints)),
+			api3.NestedIDPathIgnorer{},
+		},
+		getEndpoints,
+		displayNameOverride,
+		nil,
+	)
+	goutils.MustBeNil(err)
+
+	postObjects, err := explorer.ReadObjectsPost(
+		api3.NewAllowPathStrategy(pathsOf(postEndpoints)),
+		postEndpoints,
+		displayNameOverride,
+		nil,
+	)
+	goutils.MustBeNil(err)
+
+	return append(getObjects, postObjects...)
+}

--- a/test/mailgun/connector.go
+++ b/test/mailgun/connector.go
@@ -1,0 +1,28 @@
+package mailgun
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/mailgun"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func GetMailgunConnector(ctx context.Context) *mailgun.Connector {
+	filePath := credscanning.LoadPath(providers.Mailgun)
+	reader := utils.MustCreateProvCredJSON(filePath, false)
+
+	// Mailgun uses HTTP Basic Auth ("api" as username, API key as password).
+	client := utils.NewBasicAuthClient(ctx, reader)
+
+	conn, err := mailgun.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: client,
+	})
+	if err != nil {
+		utils.Fail("error creating mailgun connector", "error", err)
+	}
+
+	return conn
+}

--- a/test/mailgun/metadata/main.go
+++ b/test/mailgun/metadata/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	mailgun "github.com/amp-labs/connectors/test/mailgun"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+	connector := mailgun.GetMailgunConnector(ctx)
+
+	objectNames := []string{
+		// Domain-scoped (domain supplied via connector metadata).
+		"bounces",
+		"complaints",
+		"unsubscribes",
+		"whitelists",
+		"tags",
+		"domains/credentials",
+		"templates",
+		"domains/keys",
+
+		// Account-scoped.
+		"domains",
+		"routes",
+		"lists",
+		"lists/members",
+		"forwards",
+		"ip_pools",
+		"ips",
+		"keys",
+		"dkim/keys",
+		"webhooks",
+		"accounts/subaccounts",
+		"accounts/subaccounts/ip_pools/all",
+		"users",
+		"ip_whitelist",
+		"dynamic_pools/domains",
+		"thresholds/limits",
+		"thresholds/alerts/send",
+		"account/templates",
+
+		// POST-sourced.
+		"analytics/logs",
+	}
+
+	m, err := connector.ListObjectMetadata(ctx, objectNames)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	utils.DumpJSON(m, os.Stdout)
+}


### PR DESCRIPTION
# Conventions

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in `/providers/mailgun`)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).

# Tests

## Unit Test
<img width="1285" height="562" alt="image" src="https://github.com/user-attachments/assets/867c47c7-85f8-4043-9a5a-df8b555c2b1f" />

## Live Test
<img width="1285" height="899" alt="image" src="https://github.com/user-attachments/assets/262b6b11-dc14-48cc-a880-35e5332cbb74" />

<img width="1285" height="899" alt="image" src="https://github.com/user-attachments/assets/436d3f43-094d-409c-a1da-b533cf2ebc71" />

<img width="1285" height="899" alt="image" src="https://github.com/user-attachments/assets/19f84aa3-8d95-4aa7-8c85-ebef5d052eef" />

<img width="1285" height="899" alt="image" src="https://github.com/user-attachments/assets/12941789-4b27-4d49-8819-8953f2f58f13" />

