### PR TITLE
[ENG-4123]fix: treat truncated JSON responses as retryable

### DIFF
--- a/common/json.go
+++ b/common/json.go
@@ -135,6 +135,21 @@ func (j *JSONHTTPClient) Delete(ctx context.Context, url string, headers ...Head
 	return ParseJSONResponse(ctx, res, body)
 }
 
+// isTruncatedJSON reports whether parsing failed because the document ended early,
+// rather than because it contained something invalid.
+//
+// The error type alone is not enough to tell those apart. ajson reports a cut at a
+// structural boundary as UnexpectedEOF, but a cut inside a string or an object key
+// surfaces as WrongSymbol — and since most bytes of a JSON payload sit inside string
+// values, that is the likelier place for a truncated stream to stop. What both cases
+// share is that no byte was available at the failure position, which ajson signals
+// with Char == 0. A body that is malformed but complete always reports the offending
+// character instead, so it stays unclassified.
+func isTruncatedJSON(err ajson.Error) bool {
+	return err.Type == ajson.UnexpectedEOF ||
+		(err.Type == ajson.WrongSymbol && err.Char == 0)
+}
+
 // ParseJSONResponse parses the given HTTP response and returns a JSONHTTPResponse.
 func ParseJSONResponse(ctx context.Context, res *http.Response, body []byte) (*JSONHTTPResponse, error) {
 	// empty response body should not be parsed as JSON since it will cause ajson to err
@@ -177,7 +192,7 @@ func ParseJSONResponse(ctx context.Context, res *http.Response, body []byte) (*J
 		// complete (an HTML error page, a mislabelled content type) is not
 		// transient and is deliberately left unclassified.
 		var ajsonErr ajson.Error
-		if errors.As(err, &ajsonErr) && ajsonErr.Type == ajson.UnexpectedEOF {
+		if errors.As(err, &ajsonErr) && isTruncatedJSON(ajsonErr) {
 			wrapped = fmt.Errorf("%w: %w", ErrRetryable, wrapped)
 		}
 

--- a/common/json.go
+++ b/common/json.go
@@ -170,9 +170,18 @@ func ParseJSONResponse(ctx context.Context, res *http.Response, body []byte) (*J
 	jsonBody, err := ajson.Unmarshal(body)
 	if err != nil {
 		headers := GetResponseHeaders(res)
+		wrapped := fmt.Errorf("failed to unmarshall response body into JSON: %w", err)
 
-		return nil, NewHTTPError(res.StatusCode, body, headers,
-			fmt.Errorf("failed to unmarshall response body into JSON: %w", err))
+		// A truncated body means the response stream was cut short, so the same
+		// request will usually succeed on retry. A body that is malformed but
+		// complete (an HTML error page, a mislabelled content type) is not
+		// transient and is deliberately left unclassified.
+		var ajsonErr ajson.Error
+		if errors.As(err, &ajsonErr) && ajsonErr.Type == ajson.UnexpectedEOF {
+			wrapped = fmt.Errorf("%w: %w", ErrRetryable, wrapped)
+		}
+
+		return nil, NewHTTPError(res.StatusCode, body, headers, wrapped)
 	}
 
 	return &JSONHTTPResponse{

--- a/common/json_test.go
+++ b/common/json_test.go
@@ -762,6 +762,7 @@ func TestParseJSONResponse_TruncatedBodyIsRetryable(t *testing.T) {
 		body          string
 		wantRetryable bool
 	}{
+		// Cuts at a structural boundary. ajson reports these as UnexpectedEOF.
 		{
 			name:          "truncated object",
 			body:          `{"value":[{"id":"1"`,
@@ -773,10 +774,40 @@ func TestParseJSONResponse_TruncatedBodyIsRetryable(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
+			name:          "truncated after colon",
+			body:          `{"value":[{"subject":`,
+			wantRetryable: true,
+		},
+		{
+			name:          "truncated mid-number",
+			body:          `{"value":[{"count":123`,
+			wantRetryable: true,
+		},
+		// Cuts inside a string or key. ajson reports these as WrongSymbol, not
+		// UnexpectedEOF, and since most bytes of a payload live inside string values
+		// this is where a truncated stream most often stops.
+		{
+			name:          "truncated mid-string",
+			body:          `{"value":[{"subject":"Hello wor`,
+			wantRetryable: true,
+		},
+		{
+			name:          "truncated mid-string containing a space",
+			body:          `{"value":[{"from":"Shain John`,
+			wantRetryable: true,
+		},
+		{
+			name:          "truncated mid-key",
+			body:          `{"value":[{"subj`,
+			wantRetryable: true,
+		},
+		{
 			name:          "whitespace only",
 			body:          "   \n",
 			wantRetryable: true,
 		},
+		// Complete but invalid bodies. These report the offending character, so they
+		// must stay unclassified: retrying cannot make them parse.
 		{
 			name:          "complete but not JSON",
 			body:          `invalid json`,
@@ -785,6 +816,11 @@ func TestParseJSONResponse_TruncatedBodyIsRetryable(t *testing.T) {
 		{
 			name:          "HTML error page mislabelled as JSON",
 			body:          `<html><body>Bad Gateway</body></html>`,
+			wantRetryable: false,
+		},
+		{
+			name:          "complete with a stray closing brace",
+			body:          `{"value":[]}}`,
 			wantRetryable: false,
 		},
 	}

--- a/common/json_test.go
+++ b/common/json_test.go
@@ -751,6 +751,85 @@ func TestParseJSONResponse_InvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to unmarshall response body into JSON")
 }
 
+// A 200 response whose body was cut off mid-stream is transient and must be
+// marked retryable. A body that is malformed but complete is not: retrying it
+// would burn the whole retry budget on a request that can never succeed.
+func TestParseJSONResponse_TruncatedBodyIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		body          string
+		wantRetryable bool
+	}{
+		{
+			name:          "truncated object",
+			body:          `{"value":[{"id":"1"`,
+			wantRetryable: true,
+		},
+		{
+			name:          "truncated array after comma",
+			body:          `[{"id":1},`,
+			wantRetryable: true,
+		},
+		{
+			name:          "whitespace only",
+			body:          "   \n",
+			wantRetryable: true,
+		},
+		{
+			name:          "complete but not JSON",
+			body:          `invalid json`,
+			wantRetryable: false,
+		},
+		{
+			name:          "HTML error page mislabelled as JSON",
+			body:          `<html><body>Bad Gateway</body></html>`,
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(tt.body)),
+			}
+
+			_, err := ParseJSONResponse(context.Background(), res, []byte(tt.body))
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to unmarshall response body into JSON")
+			assert.Equal(t, tt.wantRetryable, errors.Is(err, ErrRetryable))
+		})
+	}
+}
+
+// The early return for an empty body must keep working: it is not an error, and
+// callers rely on receiving an empty response rather than a parse failure.
+func TestParseJSONResponse_EmptyBodyIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	res := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(strings.NewReader("")),
+	}
+
+	parsed, err := ParseJSONResponse(context.Background(), res, []byte{})
+
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.Equal(t, http.StatusOK, parsed.Code)
+}
+
 func TestUnmarshalJSON_ComplexTypes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?
- Microsoft Graph intermittently returns HTTP 200 with a body that was cut off mid-stream (missing its closing brackets), so JSON parsing fails.
- That error carried no classification, so it surfaced everywhere as `unknown`.
- Truncated bodies are now tagged with `common.ErrRetryable` — the same request succeeds on retry, which we confirmed against prod responses.
- Only truncation (`ajson.UnexpectedEOF`) is tagged. A body that is malformed but complete (e.g. an HTML error page served as JSON) is deliberately left alone, since retrying it would never succeed.
- Classification only — no change to retry behavior. These errors are already retried today; this makes the intent explicit and fixes their reporting.

## How did you test the changes in this PR?

- [x] I added tests