### PR TITLE
[ENG-4090] docs(subscribe): integrate ProviderConfig guide into the onboarding stack as PR 6

### DIFF
--- a/CONTRIBUTING_SUBSCRIBE_ACTION.md
+++ b/CONTRIBUTING_SUBSCRIBE_ACTION.md
@@ -15,10 +15,12 @@ The stack is **linear** — each PR builds on the one below it. Registration (PR
 (PR 5) are **optional**; include them only if the provider needs them. Their positions are fixed by
 dependency: **Registration comes before Subscribe** (it creates a shared resource that all object
 subscriptions hang off of, which `Subscribe` consumes), and **Maintenance comes after Subscribe** (it
-renews what Subscribe created). `Enable` is always last.
+renews what Subscribe created). **ProviderConfig comes after the connector methods** (it declares how the caller drives what PR 2–5 built). `Enable` is always last.
 
 ```
-  Enable the provider (PR 6)             flip Support.Subscribe on   ← merge last
+  Enable the provider (PR 7)             flip Support.Subscribe on   ← merge last
+        ▲
+  ProviderConfig declaration (PR 6)      subscribe/<provider>.go + registry entry — how the caller drives PR 2–5
         ▲
   Maintenance (PR 5, if needed)          SubscriptionMaintainerConnector — renews after subscribe
         ▲
@@ -45,7 +47,8 @@ renews what Subscribe created). `Enable` is always last.
 | 3 | Registration | `RegisterSubscribeConnector` — before Subscribe | ⬜ if needed |
 | 4 | Subscribe / Update / Delete | `SubscribeConnector` | ✅ |
 | 5 | Maintenance | `SubscriptionMaintainerConnector` — after Subscribe | ⬜ if needed |
-| 6 | Enable the provider | flips the gate on | ✅ (last) |
+| 6 | ProviderConfig declaration | `subscribe/<provider>.go` + `providerConfigs` registry entry | ✅ |
+| 7 | Enable the provider | flips the gate on | ✅ (last) |
 
 ---
 
@@ -82,7 +85,8 @@ implement, files, step-by-step, an example, a checklist, and reviewer focus. Lin
 | 3 | Registration | [pr-3-registration.md](./docs/subscribe-onboarding/pr-3-registration.md) | ⬜ if needed |
 | 4 | Subscribe / Update / Delete | [pr-4-subscribe-update-delete.md](./docs/subscribe-onboarding/pr-4-subscribe-update-delete.md) | ✅ |
 | 5 | Maintenance | [pr-5-maintenance.md](./docs/subscribe-onboarding/pr-5-maintenance.md) | ⬜ if needed |
-| 6 | Enable the provider | [pr-6-enable.md](./docs/subscribe-onboarding/pr-6-enable.md) | ✅ (last) |
+| 6 | ProviderConfig declaration | [pr-6-provider-config.md](./docs/subscribe-onboarding/pr-6-provider-config.md) | ✅ |
+| 7 | Enable the provider | [pr-7-enable.md](./docs/subscribe-onboarding/pr-7-enable.md) | ✅ (last) |
 
 > **Live tests** are performed as part of PRs 2 and 4. See [**`live-tests.md`**](./docs/subscribe-onboarding/live-tests.md).
 
@@ -109,11 +113,13 @@ production, even after they merge — that's what makes incremental merging safe
 `Registration` / `PostProcess` / `Maintenance` — are only consulted once subscribe is active, so
 declaring them earlier is harmless.)
 
+> **Testing while gated:** the gate doesn't block you from testing. Installations under the Ampersand project **`connectors-test-project`** (id `8b257c62-6b89-4b9b-9271-6fe3f6b700f1`) **bypass the support gates** — the platform treats core support flags (including subscribe) as enabled for that project. Use it to exercise the full subscribe flow end-to-end once PR 6 (ProviderConfig) is in, before the Enable PR flips the switch for everyone. See [Live testing before the flip](./docs/subscribe-onboarding/pr-6-provider-config.md#live-testing-before-the-flip).
+
 ---
 
 ## Managing the stack
 
-Branch each PR off the one below it: PR 1 → 2 → 3 → 4 → 5 → 6. Skip PR 3 (Registration) and/or PR 5
+Branch each PR off the one below it: PR 1 → 2 → 3 → 4 → 5 → 6 → 7. Skip PR 3 (Registration) and/or PR 5
 (Maintenance) if the provider doesn't need them — the chain just closes up.
 
 ```
@@ -123,7 +129,8 @@ main
          └─ subscribe/<provider>/registration  (PR 3, if needed)
              └─ subscribe/<provider>/subscribe   (PR 4)
                  └─ subscribe/<provider>/maintenance  (PR 5, if needed)
-                     └─ subscribe/<provider>/enable     (PR 6, merge last)
+                     └─ subscribe/<provider>/provider-config  (PR 6)
+                         └─ subscribe/<provider>/enable     (PR 7, merge last)
 ```
 
 - Skip PR 3 / PR 5 entirely when the provider doesn't need registration / maintenance; the next PR

--- a/SUBSCRIBE_REFERENCES.md
+++ b/SUBSCRIBE_REFERENCES.md
@@ -188,4 +188,5 @@ signatures, examples, files, checklist, reviewer focus):
 | 3 | Registration                  | [pr-3-registration.md](./docs/subscribe-onboarding/pr-3-registration.md)                       | ⬜ if needed |
 | 4 | Subscribe / Update / Delete   | [pr-4-subscribe-update-delete.md](./docs/subscribe-onboarding/pr-4-subscribe-update-delete.md) | ✅           |
 | 5 | Maintenance                   | [pr-5-maintenance.md](./docs/subscribe-onboarding/pr-5-maintenance.md)                         | ⬜ if needed |
-| 6 | Enable the provider           | [pr-6-enable.md](./docs/subscribe-onboarding/pr-6-enable.md)                                   | ✅ (last)    |
+| 6 | ProviderConfig declaration    | [pr-6-provider-config.md](./docs/subscribe-onboarding/pr-6-provider-config.md)                 | ✅           |
+| 7 | Enable the provider           | [pr-7-enable.md](./docs/subscribe-onboarding/pr-7-enable.md)                                   | ✅ (last)    |

--- a/docs/subscribe-onboarding/pr-1-provider-info.md
+++ b/docs/subscribe-onboarding/pr-1-provider-info.md
@@ -10,7 +10,7 @@
 Declare the provider's subscribe metadata on its `ProviderInfo` — `Support.Subscribe` and
 `SubscribeRequirements` — with the gate (`Support.Subscribe`) **off**, and wire the connector into the
 factory if it's brand-new. This PR changes **no runtime behavior**; it's a safe no-op until the final
-[`Enable`](./pr-6-enable.md) PR.
+[`Enable`](./pr-7-enable.md) PR.
 
 ## What you implement
 
@@ -45,7 +45,7 @@ dormant regardless:
 Support: Support{
     Read:      true,
     Write:     true,
-    Subscribe: false, // ← the gate; flip to true in PR 6
+    Subscribe: false, // ← the gate; flip to true in PR 7
 },
 SubscribeRequirements: &SubscribeRequirements{
     // <provider> supports creating webhook subscriptions via API: <link to provider docs>
@@ -124,7 +124,7 @@ SubscribeRequirements: &SubscribeRequirements{
 > `Support.Subscribe` is the **gate** — it must be `true` for the provider to subscribe at all (via API
 > or manual/UI); `SubscribeByAPI` says whether the programmatic API approach is available. **Keep
 > `Support.Subscribe` off** for the entire stack and flip it on only in the final
-> [`Enable`](./pr-6-enable.md) PR — that's what keeps every intermediate PR a safe no-op even after it
+> [`Enable`](./pr-7-enable.md) PR — that's what keeps every intermediate PR a safe no-op even after it
 > merges.
 
 ## Factory wiring

--- a/docs/subscribe-onboarding/pr-2-verification.md
+++ b/docs/subscribe-onboarding/pr-2-verification.md
@@ -111,12 +111,7 @@ complete, readable implementation.
 `VerifyWebhookMessage(ctx, request *common.WebhookRequest, params *common.VerificationParams)` receives
 two objects, both populated by the caller:
 
-> **`VerifyWebhookMessage` cannot rely on the connector's authenticated client.** On the server the
-> verifier connector is instantiated as a bare zero value (`&<provider>.Connector{}` in
-> `shared/subscribe/providers/*.go`) — it has **no `AuthorizationClient` and no authenticated HTTP
-> client**. Unlike other connector methods, it must verify using only the `request` (headers/body) and
-> `params` (the signing secret threaded in via `VerificationParams.Param`); it must not make
-> authenticated API calls.
+> **`VerifyWebhookMessage` cannot rely on the connector's authenticated client.** The verifier connector is instantiated as a bare zero value — the `verifierConnector: &<provider>.Connector{}` you'll declare in your ProviderConfig ([PR 6 — VerificationConfig](./pr-6-provider-config.md#verificationconfig-subscribeverificationgo)) — so it has **no `AuthorizationClient` and no authenticated HTTP client**. Unlike other connector methods, it must verify using only the `request` (headers/body) and `params` (the signing secret threaded in via `VerificationParams.Param`); it must not make authenticated API calls.
 
 **`request *common.WebhookRequest`** — the raw incoming webhook HTTP request, exactly as the provider
 sent it:
@@ -137,12 +132,7 @@ provider-specific verification struct:
 type VerificationParams struct{ Param any }   // e.g. Param = &SalesloftVerificationParams{Secret: ...}
 ```
 
-The caller fills `Param` per installation; cast it back to your type with `common.AssertType`. The
-values inside (a signing secret, a token, an account ref, …) come from whatever your connector
-persisted — **anything your `Subscribe` returns in the `SubscriptionResult` is available to the caller
-to thread back here.** So if the provider issues a signing secret at subscribe time, return it in the
-`SubscriptionResult` (PR 3), and the caller will supply it back through `VerificationParams.Param` when
-it calls `VerifyWebhookMessage`.
+Concretely, `Param` is filled per installation by the `paramsFn` you'll declare in your ProviderConfig ([PR 6 — VerificationConfig](./pr-6-provider-config.md#verificationconfig-subscribeverificationgo)); cast it back to your type with `common.AssertType`. The values inside (a signing secret, a token, an account ref, …) come from whatever your connector persisted — **anything your `Subscribe` returns in the `SubscriptionResult` is available to the `paramsFn` to thread back here** (via the `deps.Subscriptions` resolver — Attio recovers its signing secret this way). So if the provider issues a signing secret at subscribe time, return it in the `SubscriptionResult` (PR 4), and PR 6's `paramsFn` supplies it back through `VerificationParams.Param` when the caller invokes `VerifyWebhookMessage`.
 
 Implement `VerifyWebhookMessage` on your `*Connector`. The pattern (from
 [`providers/salesloft/subscribeEvent.go`](../../providers/salesloft/subscribeEvent.go)):
@@ -188,11 +178,7 @@ func (c *Connector) VerifyWebhookMessage(ctx context.Context,
 }
 ```
 
-The provider-specific `*VerificationParams` struct (here `SalesloftVerificationParams`) is populated
-per installation by the caller and passed through `common.VerificationParams.Param`. Hubspot and
-Outreach show HMAC-SHA256 variants; Salesloft uses HMAC-SHA1. For UI Subscription only providers whose
-events carry no provider signature, verification is bypassed by the caller rather than implemented here
-(still implement it if the provider does sign its webhooks).
+The provider-specific `*VerificationParams` struct (here `SalesloftVerificationParams`) is populated per installation by your ProviderConfig's `paramsFn` ([PR 6 — VerificationConfig](./pr-6-provider-config.md#verificationconfig-subscribeverificationgo)) and passed through `common.VerificationParams.Param`. Hubspot and Outreach show HMAC-SHA256 variants; Salesloft uses HMAC-SHA1. For UI Subscription only providers whose events carry no provider signature, verification is bypassed via the `bypassed` flag in the ProviderConfig (PR 6) rather than implemented here (still implement it if the provider does sign its webhooks).
 
 See [Live Tests (Stage 1)](./live-tests.md#stage-1-webhook-verification-runwebhookconsumer) for how to verify this end-to-end.
 

--- a/docs/subscribe-onboarding/pr-6-provider-config.md
+++ b/docs/subscribe-onboarding/pr-6-provider-config.md
@@ -1,15 +1,26 @@
-# Onboarding a New Provider to Subscribe
+# PR 6 — ProviderConfig declaration
 
-This guide walks through adding subscribe support for a new provider in `subscribe/`.
+> Part of [Contributing a Subscribe Action](../../CONTRIBUTING_SUBSCRIBE_ACTION.md). Shared concepts: [`SUBSCRIBE_REFERENCES.md`](../../SUBSCRIBE_REFERENCES.md).
 
-## Summary of steps
+**Required, second-to-last.** Declares the provider's subscribe configuration bundle in the `subscribe/` package so the caller can drive the connector methods you built in PR 2–5. Merges right before [Enable](./pr-7-enable.md) — the provider is still gated off, so this PR is a safe no-op in production.
+
+## Goal
+
+Register a `ProviderConfig` for your provider: the per-provider declarative bundle the Ampersand platform reads at subscribe time — request-payload building, verification params, maintenance cadence, and the derived should-we answers.
+
+## Prerequisites
+
+- [PR 1 — ProviderInfo + Factory wiring](./pr-1-provider-info.md) merged (the derived answers read `SubscribeRequirements`).
+- The connector methods this config points at exist: [PR 2 — Verification](./pr-2-verification.md), [PR 3 — Registration](./pr-3-registration.md) *(only if the provider needs it)*, [PR 4 — Subscribe / Update / Delete](./pr-4-subscribe-update-delete.md), [PR 5 — Maintenance](./pr-5-maintenance.md) *(only if the provider needs it)*.
+
+## What you implement
 
 1. **Create** `subscribe/<provider>.go` declaring `var <provider>Config = ProviderConfig{...}` and populating only the subcomponents the provider needs.
-2. **Register** it in the `providerConfigs` map in `config.go`, keyed by `providers.<Provider>`.
+2. **Register** it in the `providerConfigs` map in `subscribe/config.go`, keyed by `providers.<Provider>`.
 
 That's it. The Ampersand server already reads everything through
 `subscribe.GetProviderConfig(module, providerInfo, deps).<Subcomponent>.<Method>()` — you do not
-touch server code.
+touch anything else.
 
 (For "twin" providers that reuse another provider's connector, also see [Twin providers](#twin-providers--providerinfoaliases).)
 
@@ -17,7 +28,7 @@ touch server code.
 
 ## ProviderConfig and Registry
 
-A `ProviderConfig` is the per-provider declarative bundle of subscribe-related configuration — the `var <provider>Config = ProviderConfig{...}` literal you write in step 1. The `providerConfigs` map in `config.go` wraps each entry in a `ProviderConfigRegistry`:
+A `ProviderConfig` is the per-provider declarative bundle of subscribe-related configuration — the `var <provider>Config = ProviderConfig{...}` literal you write in step 1. The `providerConfigs` map in `subscribe/config.go` wraps each entry in a `ProviderConfigRegistry`:
 
 ```go
 type ProviderConfigRegistry struct {
@@ -64,9 +75,7 @@ The server implements these interfaces and passes a `Dependencies` value to `Get
 
 If your provider needs an Ampersand-owned capability that doesn't exist yet, add a new narrow resolver interface in `subscribe/deps` (one file per resolver, mirroring `project.go` / `cdcoptimization.go` / `subscriptions.go`), add a field to `Dependencies`, and coordinate the implementation with the Ampersand team. Keep the interface as small as the provider function actually needs.
 
-## Examples
-
-### A worked example: adding `acme`
+## Step-by-step: adding `acme`
 
 Suppose Acme subscribes via API, builds a webhook-endpoint payload at subscribe time, and verifies webhook signatures with a per-installation secret.
 
@@ -130,9 +139,11 @@ func getAcmeRequest(
 
 Note that `webhookURL` — the event-receipt endpoint — arrives pre-constructed from the caller; endpoint construction depends on Ampersand deployment configuration, so it never happens inside this package.
 
+`AcmeVerificationParams` is the provider-specific struct you defined next to `VerifyWebhookMessage` in [PR 2](./pr-2-verification.md#verification) — the value `getAcmeVerificationParams` puts in `Param` here is exactly what that method casts back out with `common.AssertType`.
+
 **Step 2: register in `providerConfigs`**
 
-Edit [`subscribe/config.go`](https://github.com/amp-labs/connectors/blob/main/subscribe/config.go) and add an entry to the `providerConfigs` map:
+Edit [`subscribe/config.go`](../../subscribe/config.go) and add an entry to the `providerConfigs` map:
 
 ```go
 var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
@@ -147,7 +158,7 @@ Use `DefaultModuleConfig` when the provider has no module-specific differences. 
 
 ## Component reference
 
-### `RegistrationConfig` (`registration.go`)
+### `RegistrationConfig` (`subscribe/registration.go`)
 
 For providers that need a one-time installation-level setup before per-object subscriptions can be created (Salesforce → AWS EventBridge wiring is the canonical example).
 
@@ -166,7 +177,7 @@ Methods:
 | `EmptyResult()`                         | `*common.RegistrationResult` | `nil` when no `emptyResultFn` declared. |
 | `BuildParams(ctx, inst)`                | `(any, error)` | Returns `ErrRegistrationParamsBuilderNotDeclared` for providers that don't require registration; `(nil, nil)` for providers that do require it but declared no builder (connector accepts an empty `Request`). |
 
-### `SubscriptionConfig` (`subscription.go`)
+### `SubscriptionConfig` (`subscribe/subscription.go`)
 
 For providers that subscribe to webhook events, whether programmatically or by manual provider-app configuration.
 
@@ -202,7 +213,7 @@ Methods:
 | `RequiresWatchFieldsAutoAll()`    | bool    | Reads `requiresWatchFieldsAuto`. |
 | `BuildRequest(ctx, inst, rev, regResult, webhookURL)` | `(any, error)` | Invokes `buildRequestFn` with the bound `deps` and `&inst.Connection` as the `conn` arg. Returns `(nil, nil)` when no builder declared. |
 
-### `MaintenanceConfig` (`maintenance.go`)
+### `MaintenanceConfig` (`subscribe/maintenance.go`)
 
 For providers whose webhook subscriptions expire and need renewal (Gmail watch subscriptions expire after 7 days and are renewed daily; Zoho renews weekly).
 
@@ -212,7 +223,7 @@ Fields you populate:
 |-------------------|---------|
 | `renewalInterval` | How often maintenance runs. |
 
-Also add an entry to the `maintenancePeriods` map in `maintenance.go` — it backs the package function `GetMaintenancePeriod(provider)`, used by callers that have only a provider in scope (no resolved config).
+Also add an entry to the `maintenancePeriods` map in `subscribe/maintenance.go` — it backs the package function `GetMaintenancePeriod(provider)`, used by callers that have only a provider in scope (no resolved config).
 
 Methods:
 
@@ -221,7 +232,7 @@ Methods:
 | `ShouldPerform()` | bool    | Reads `ProviderInfo.SubscribeRequirements.Maintenance`. |
 | `Interval()`      | `(time.Duration, bool)` | Comma-ok: returns `(0, false)` when `renewalInterval` is zero/unset. Idiomatic use: `if p, ok := cfg.Maintenance.Interval(); ok { ... }`. |
 
-### `PostProcessConfig` (`postprocess.go`)
+### `PostProcessConfig` (`subscribe/postprocess.go`)
 
 For providers needing third-party setup after the connector's Subscribe returns (e.g. Salesforce — AWS EventBridge wiring).
 
@@ -231,16 +242,18 @@ Only the derived answer lives in this package:
 |-------------------|---------|-------|
 | `ShouldPerform()` | bool    | Reads `ProviderInfo.SubscribeRequirements.PostProcess`. |
 
-The setup/teardown functions themselves are Ampersand-infrastructure concerns — they reach AWS EventBridge and other Ampersand-managed services — and live in Ampersand's internal systems. If your provider needs post-processing, set `SubscribeRequirements.PostProcess` in its `ProviderInfo` and coordinate the internal implementation with the Ampersand team.
+The setup/teardown functions themselves are Ampersand-infrastructure concerns — they reach AWS EventBridge and other Ampersand-managed services — and live in Ampersand's internal systems. If your provider needs post-processing, set `SubscribeRequirements.PostProcess` in its `ProviderInfo` (PR 1) and coordinate the internal implementation with the Ampersand team — see [PostProcess](../../SUBSCRIBE_REFERENCES.md#postprocess).
 
-### `VerificationConfig` (`verification.go`)
+### `VerificationConfig` (`subscribe/verification.go`)
+
+This is the config side of the verification flow you built in [PR 2 — Verification](./pr-2-verification.md#verification): `paramsFn` builds the `*common.VerificationParams` whose `.Param` your connector's `VerifyWebhookMessage` casts back with `common.AssertType`, and `verifierConnector` is the zero-value connector instance the caller invokes that method on.
 
 Fields you populate:
 
 | Field               | Purpose |
 |---------------------|---------|
-| `paramsFn`          | Builds the provider-specific `*common.VerificationParams`. |
-| `verifierConnector` | The zero-value connector pointer used for webhook signature verification (e.g. `&hubspot.Connector{}`). Returned unwrapped — callers wanting instrumentation (e.g. metrics) decorate it themselves. |
+| `paramsFn`          | Builds the provider-specific `*common.VerificationParams` consumed by `VerifyWebhookMessage` ([PR 2](./pr-2-verification.md#verification)). |
+| `verifierConnector` | The zero-value connector pointer used for webhook signature verification (e.g. `&hubspot.Connector{}`) — the connector whose `VerifyWebhookMessage` you implemented in [PR 2](./pr-2-verification.md). Returned unwrapped — callers wanting instrumentation (e.g. metrics) decorate it themselves. |
 | `bypassed`          | When true, webhook signature verification is skipped (e.g. when events are synthetic republishes carrying no provider signature). |
 | `eventCaster`       | Casts raw webhook event maps into typed `common.SubscriptionEvent` slices. Usually `CastSubscriptionEvents[<provider>.SubscriptionEvent]`. |
 
@@ -283,7 +296,7 @@ There is also a package function `IsHookdeckGatewayProvider(provider) bool` — 
 
 ## Twin providers — `providerInfoAliases`
 
-If your provider in the connectors library reuses another provider's connector implementation and does not have its own `SubscribeRequirements` declared, add an entry to `providerInfoAliases` in `aliases.go`. Calls to `ResolveProviderInfoAlias` swap in the twin's `ProviderInfo`, with the original `.Name` preserved so log attribution stays accurate.
+If your provider in this library reuses another provider's connector implementation and does not have its own `SubscribeRequirements` declared, add an entry to `providerInfoAliases` in `subscribe/aliases.go`. Calls to `ResolveProviderInfoAlias` swap in the twin's `ProviderInfo`, with the original `.Name` preserved so log attribution stays accurate.
 
 `SalesforceJWT → Salesforce` is the canonical example: SalesforceJWT shares the Salesforce connector implementation and the same modules, but its own `ProviderInfo` entry doesn't declare subscribe metadata.
 
@@ -319,7 +332,7 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 
 ---
 
-## Real providers, different shapes
+## Example configs: real providers, different shapes
 
 ### Salesforce — full surface
 
@@ -417,3 +430,33 @@ var gongConfig = ProviderConfig{
 }
 ```
 
+---
+
+## Live testing before the flip
+
+You don't have to wait for [PR 7 — Enable](./pr-7-enable.md) to see your provider working live. Installations under the Ampersand project **`connectors-test-project`** (id `8b257c62-6b89-4b9b-9271-6fe3f6b700f1`) **bypass the `Support.Subscribe` gate** — the platform treats core support flags (including subscribe) as enabled for that project — so once this PR's config is registered, you can install the provider there, subscribe, and receive real webhooks end-to-end while the provider stays gated off for everyone else.
+
+This is the recommended way to validate the whole stack (PR 2–6) before opening the Enable PR; the Enable PR's required live test can then reuse the same setup.
+
+## Files
+
+- `subscribe/<provider>.go` — the `ProviderConfig` literal and its per-provider helper functions.
+- `subscribe/config.go` — one `providerConfigs` map entry.
+- `subscribe/maintenance.go` — a `maintenancePeriods` entry *(only if the provider declares maintenance)*.
+- `subscribe/aliases.go` — a `providerInfoAliases` entry *(only for twin providers)*.
+
+## Checklist
+
+- [ ] `subscribe/<provider>.go` declares `var <provider>Config = ProviderConfig{...}` populating only the subcomponents the provider needs.
+- [ ] Registered in `providerConfigs` (`subscribe/config.go`) — `DefaultModuleConfig` vs `Modules` matches the provider's module story.
+- [ ] Builders use only the wire types and `deps.Dependencies` — no new external dependencies.
+- [ ] If maintenance is declared: `renewalInterval` set **and** `maintenancePeriods` entry added.
+- [ ] Twin providers: `providerInfoAliases` entry + same config pointer under both keys.
+- [ ] Provider still gated off (`Support.Subscribe` stays `false`) — the flip happens in [PR 7 — Enable](./pr-7-enable.md).
+
+## Reviewer focus
+
+- The config shape matches the provider's actual capabilities from PR 2–5 (e.g. no `buildRequestFn` for a look-up-only provider; `verifierConnector` matches the PR 2 connector).
+- Zero-value subcomponents are left alone — only populated concerns appear in the literal.
+- Secrets: verification params take secrets from `VerificationRequest` (`req.ProviderAppClientSecret`) or stored results via `deps` — never hardcoded.
+- The registry entry's module scoping is right (module-agnostic providers under `DefaultModuleConfig`; module-specific ones under `Modules` with no entries for non-subscribe modules).

--- a/docs/subscribe-onboarding/pr-7-enable.md
+++ b/docs/subscribe-onboarding/pr-7-enable.md
@@ -1,4 +1,4 @@
-# PR 6 — Enable the provider *(top)*
+# PR 7 — Enable the provider *(top)*
 
 > Part of [Contributing a Subscribe Action](../../CONTRIBUTING_SUBSCRIBE_ACTION.md). Shared concepts:
 > [`SUBSCRIBE_REFERENCES.md`](../../SUBSCRIBE_REFERENCES.md).
@@ -17,6 +17,7 @@ All prerequisite PRs are merged:
 - [PR 3 — Registration](./pr-3-registration.md) *(only if the provider needs it)*
 - [PR 4 — Subscribe / Update / Delete](./pr-4-subscribe-update-delete.md)
 - [PR 5 — Maintenance](./pr-5-maintenance.md) *(only if the provider needs it)*
+- [PR 6 — ProviderConfig declaration](./pr-6-provider-config.md)
 
 Additionally, the implementation should have been verified using the automated scenarios in [Live Tests](./live-tests.md).
 
@@ -38,7 +39,7 @@ Support: Support{
 
 ## Live testing (required)
 
-Because this PR turns the provider on, it must be verified **live on Ampersand** — not just with the local harness or [live tests](./live-tests.md).
+Because this PR turns the provider on, it must be verified **live on Ampersand** — not just with the local harness or [live tests](./live-tests.md). If you already validated end-to-end under `connectors-test-project` ([PR 6 — Live testing before the flip](./pr-6-provider-config.md#live-testing-before-the-flip)), reuse that setup here — but note that project **bypasses the gate**, so it doesn't by itself prove the flag flip; run this verification as described below.
 
 1. Install the provider on **Ampersand**. The **MailMonkey demo app** is a convenient test app for this.
 2. Create an installation and subscribe.

--- a/subscribe/OnboardingProviders.md
+++ b/subscribe/OnboardingProviders.md
@@ -1,0 +1,419 @@
+# Onboarding a New Provider to Subscribe
+
+This guide walks through adding subscribe support for a new provider in `subscribe/`.
+
+## Summary of steps
+
+1. **Create** `subscribe/<provider>.go` declaring `var <provider>Config = ProviderConfig{...}` and populating only the subcomponents the provider needs.
+2. **Register** it in the `providerConfigs` map in `config.go`, keyed by `providers.<Provider>`.
+
+That's it. The Ampersand server already reads everything through
+`subscribe.GetProviderConfig(module, providerInfo, deps).<Subcomponent>.<Method>()` — you do not
+touch server code.
+
+(For "twin" providers that reuse another provider's connector, also see [Twin providers](#twin-providers--providerinfoaliases).)
+
+---
+
+## ProviderConfig and Registry
+
+A `ProviderConfig` is the per-provider declarative bundle of subscribe-related configuration — the `var <provider>Config = ProviderConfig{...}` literal you write in step 1. The `providerConfigs` map in `config.go` wraps each entry in a `ProviderConfigRegistry`:
+
+```go
+type ProviderConfigRegistry struct {
+    DefaultModuleConfig *ProviderConfig
+    Modules             map[common.ModuleID]*ProviderConfig
+}
+```
+
+**Use `DefaultModuleConfig`** when subscribe behavior is module-agnostic (Outreach, Salesloft, Hubspot, Gong, HousecallPro).
+
+**Use `Modules`** when your provider has multiple modules with differing subscribe behavior (Salesforce, Zoho, Google all do this — their non-subscribe modules have no entry).
+
+You can use both (one `DefaultModuleConfig` plus a few module overrides) if needed.
+
+`GetProviderConfig(module, providerInfo, deps)` resolves the module in this order: the `module` argument (typically the installation revision's module) → `providerInfo.DefaultModule` → empty string. If the resolved module has an entry in `Modules`, that's used; otherwise `DefaultModuleConfig`; if neither matches, it returns `ErrProviderConfigNotFound`. On success the returned pointer is a fresh copy with `module` / `providerInfo` / `deps` bound onto each subcomponent, so subcomponent methods answer module-aware questions without callers threading the arguments per call.
+
+---
+
+## Config Components
+
+`ProviderConfig` bundles five subcomponents — one per subscribe-related concern. Each is value-embedded (not a pointer), and its zero value is a safe no-op, so a provider that needs only `Verification` populates only that field and leaves the others alone.
+
+| Subcomponent          | Concern                                                                                                       | Typical providers              |
+|-----------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `Registration`        | One-time per-installation setup (e.g. Salesforce → AWS EventBridge wiring).                                  | Salesforce, Zoho               |
+| `Subscription`        | Programmatic-API support, look-up-only status, the WatchFieldsAuto Salesloft quirk, and the subscribe-time request payload builder. | Anything that subscribes via API |
+| `Maintenance`         | Periodic renewal of expiring webhook subscriptions.                                                          | Gmail (daily), Zoho (weekly)   |
+| `PostProcess`         | Whether third-party setup runs after the connector's `Subscribe` returns. **Derived answer only** — the setup/teardown functions themselves are Ampersand-infrastructure concerns and live in Ampersand's internal systems. | Salesforce |
+| `Verification`        | Webhook signature verification: params builder, verifier connector, bypass flag, event caster.               | Anyone whose webhooks need verification |
+
+## The `deps` resolver seam
+
+Some per-provider functions need data that only the Ampersand server can resolve (it lives behind the server's database or customer configuration). Those capabilities are declared as narrow interfaces in the `subscribe/deps` package and carried in `deps.Dependencies`:
+
+```go
+type Dependencies struct {
+    Project         ProjectResolver          // project attributes (Salesforce CDC event-flag field naming)
+    CDCOptimization CDCOptimizationResolver  // per-(project, group) Salesforce CDC quota opt-in
+    Subscriptions   SubscriptionResultLister // stored subscription results (Attio signing secret recovery)
+}
+```
+
+The server implements these interfaces and passes a `Dependencies` value to `GetProviderConfig`, which binds it onto the returned config; subcomponent methods thread it into your per-provider functions as their `deps deps.Dependencies` parameter. Most providers ignore it (`_ deps.Dependencies`).
+
+If your provider needs an Ampersand-owned capability that doesn't exist yet, add a new narrow resolver interface in `subscribe/deps` (one file per resolver, mirroring `project.go` / `cdcoptimization.go` / `subscriptions.go`), add a field to `Dependencies`, and coordinate the implementation with the Ampersand team. Keep the interface as small as the provider function actually needs.
+
+## Examples
+
+### A worked example: adding `acme`
+
+Suppose Acme subscribes via API, builds a webhook-endpoint payload at subscribe time, and verifies webhook signatures with a per-installation secret.
+
+**Step 1: `subscribe/acme.go`**
+
+```go
+package subscribe
+
+import (
+    "context"
+
+    "github.com/amp-labs/amp-common/openapi"
+    "github.com/amp-labs/connectors/common"
+    "github.com/amp-labs/connectors/providers/acme"
+    "github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// acmeConfig is the per-provider subscribe-config bundle for Acme. Acme subscribes via API,
+// builds a subscribe-time webhook-endpoint payload, and verifies incoming webhooks with a
+// per-installation secret.
+var acmeConfig = ProviderConfig{
+    Subscription: SubscriptionConfig{
+        buildRequestFn: getAcmeRequest,
+    },
+    Verification: VerificationConfig{
+        paramsFn:          getAcmeVerificationParams,
+        verifierConnector: &acme.Connector{},
+    },
+}
+
+func getAcmeVerificationParams(
+    _ context.Context,
+    _ deps.Dependencies,
+    req *deps.VerificationRequest,
+) (*common.VerificationParams, error) {
+    if req == nil || req.Installation == nil {
+        return nil, errInstallationNotFound
+    }
+
+    return &common.VerificationParams{
+        Param: &acme.AcmeVerificationParams{Secret: req.Installation.Id},
+    }, nil
+}
+
+func getAcmeRequest(
+    _ context.Context,
+    _ deps.Dependencies,
+    inst *openapi.Installation,
+    _ *openapi.Revision,
+    _ *common.RegistrationResult,
+    _ *openapi.Connection,
+    webhookURL string,
+) (any, error) {
+    return &acme.SubscriptionRequest{
+        UniqueRef:       "amp_" + inst.Id,
+        WebhookEndPoint: webhookURL,
+        Secret:          inst.Id,
+    }, nil
+}
+```
+
+Note that `webhookURL` — the event-receipt endpoint — arrives pre-constructed from the caller; endpoint construction depends on Ampersand deployment configuration, so it never happens inside this package.
+
+**Step 2: register in `providerConfigs`**
+
+Edit [`subscribe/config.go`](https://github.com/amp-labs/connectors/blob/main/subscribe/config.go) and add an entry to the `providerConfigs` map:
+
+```go
+var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
+    // ...existing entries...
+    providers.Acme: {DefaultModuleConfig: &acmeConfig},
+}
+```
+
+Use `DefaultModuleConfig` when the provider has no module-specific differences. Use `Modules` when it does.
+
+---
+
+## Component reference
+
+### `RegistrationConfig` (`registration.go`)
+
+For providers that need a one-time installation-level setup before per-object subscriptions can be created (Salesforce → AWS EventBridge wiring is the canonical example).
+
+Fields you populate:
+
+| Field            | Purpose |
+|------------------|---------|
+| `emptyResultFn`  | Returns a fresh `*common.RegistrationResult` with provider-specific `.Result`. Must be a factory (not a singleton) — `.Result` is mutated downstream. |
+| `buildParamsFn`  | Builds the payload inside `common.SubscriptionRegistrationParams.Request` for a given installation. Signature: `func(ctx context.Context, inst *openapi.Installation) (any, error)`. |
+
+Methods:
+
+| Method                                  | Returns | Notes |
+|-----------------------------------------|---------|-------|
+| `IsRequired(connector)`                 | bool    | Reads `ProviderInfo.SubscribeRequirements.Registration`, gated on the connector implementing `connectors.RegisterSubscribeConnector`. |
+| `EmptyResult()`                         | `*common.RegistrationResult` | `nil` when no `emptyResultFn` declared. |
+| `BuildParams(ctx, inst)`                | `(any, error)` | Returns `ErrRegistrationParamsBuilderNotDeclared` for providers that don't require registration; `(nil, nil)` for providers that do require it but declared no builder (connector accepts an empty `Request`). |
+
+### `SubscriptionConfig` (`subscription.go`)
+
+For providers that subscribe to webhook events, whether programmatically or by manual provider-app configuration.
+
+Fields you populate:
+
+| Field                       | Purpose |
+|-----------------------------|---------|
+| `requiresWatchFieldsAuto`   | Salesloft quirk — requires `WatchFieldsAuto="all"` for subscribe update events. |
+| `buildRequestFn`            | Builds the per-installation subscribe-time payload (Pub/Sub topic, webhook URL, secret, …). Nil when no custom payload is needed. |
+
+The `SubscriptionRequestBuilder` signature:
+
+```go
+type SubscriptionRequestBuilder func(
+    ctx context.Context,
+    deps deps.Dependencies,
+    inst *openapi.Installation,
+    rev *openapi.Revision,
+    registrationResult *common.RegistrationResult,
+    conn *openapi.Connection,
+    webhookURL string,
+) (any, error)
+```
+
+`conn` is the same value as `&inst.Connection`; `webhookURL` is the caller-constructed event-receipt endpoint (ignore it if your provider doesn't need one, e.g. Google's Pub/Sub topic builder).
+
+Methods:
+
+| Method                            | Returns | Notes |
+|-----------------------------------|---------|-------|
+| `IsSupportedViaAPI()`             | bool    | Reads `ProviderInfo.SubscribeRequirements.SubscribeByAPI`. |
+| `SubscribeManually()`             | bool    | True when the integration is configured at the provider-app level rather than registered via API (`ProviderInfo.Support.Subscribe && !SubscribeByAPI`). |
+| `RequiresWatchFieldsAutoAll()`    | bool    | Reads `requiresWatchFieldsAuto`. |
+| `BuildRequest(ctx, inst, rev, regResult, webhookURL)` | `(any, error)` | Invokes `buildRequestFn` with the bound `deps` and `&inst.Connection` as the `conn` arg. Returns `(nil, nil)` when no builder declared. |
+
+### `MaintenanceConfig` (`maintenance.go`)
+
+For providers whose webhook subscriptions expire and need renewal (Gmail watch subscriptions expire after 7 days and are renewed daily; Zoho renews weekly).
+
+Fields you populate:
+
+| Field             | Purpose |
+|-------------------|---------|
+| `renewalInterval` | How often maintenance runs. |
+
+Also add an entry to the `maintenancePeriods` map in `maintenance.go` — it backs the package function `GetMaintenancePeriod(provider)`, used by callers that have only a provider in scope (no resolved config).
+
+Methods:
+
+| Method            | Returns | Notes |
+|-------------------|---------|-------|
+| `ShouldPerform()` | bool    | Reads `ProviderInfo.SubscribeRequirements.Maintenance`. |
+| `Interval()`      | `(time.Duration, bool)` | Comma-ok: returns `(0, false)` when `renewalInterval` is zero/unset. Idiomatic use: `if p, ok := cfg.Maintenance.Interval(); ok { ... }`. |
+
+### `PostProcessConfig` (`postprocess.go`)
+
+For providers needing third-party setup after the connector's Subscribe returns (e.g. Salesforce — AWS EventBridge wiring).
+
+Only the derived answer lives in this package:
+
+| Method            | Returns | Notes |
+|-------------------|---------|-------|
+| `ShouldPerform()` | bool    | Reads `ProviderInfo.SubscribeRequirements.PostProcess`. |
+
+The setup/teardown functions themselves are Ampersand-infrastructure concerns — they reach AWS EventBridge and other Ampersand-managed services — and live in Ampersand's internal systems. If your provider needs post-processing, set `SubscribeRequirements.PostProcess` in its `ProviderInfo` and coordinate the internal implementation with the Ampersand team.
+
+### `VerificationConfig` (`verification.go`)
+
+Fields you populate:
+
+| Field               | Purpose |
+|---------------------|---------|
+| `paramsFn`          | Builds the provider-specific `*common.VerificationParams`. |
+| `verifierConnector` | The zero-value connector pointer used for webhook signature verification (e.g. `&hubspot.Connector{}`). Returned unwrapped — callers wanting instrumentation (e.g. metrics) decorate it themselves. |
+| `bypassed`          | When true, webhook signature verification is skipped (e.g. when events are synthetic republishes carrying no provider signature). |
+| `eventCaster`       | Casts raw webhook event maps into typed `common.SubscriptionEvent` slices. Usually `CastSubscriptionEvents[<provider>.SubscriptionEvent]`. |
+
+Methods:
+
+| Method                | Returns | Notes |
+|-----------------------|---------|-------|
+| `Params(ctx, req)`    | `(*common.VerificationParams, error)` | Returns `errVerificationParamsFuncNotFound` when no `paramsFn`. |
+| `Connector(ctx)`      | `(connectors.WebhookVerifierConnector, error)` | Returns `errWebhookVerificationNotSupported` when no `verifierConnector`. |
+| `ShouldBypass()`      | bool    | Reads `bypassed`. |
+| `CastEvents(list)`    | `([]common.SubscriptionEvent, error)` | Returns `errSubscriptionEventCasterNotDeclared` when no `eventCaster`. |
+
+The `VerificationParamsFunc` signature:
+
+```go
+type VerificationParamsFunc func(
+    ctx context.Context,
+    deps deps.Dependencies,
+    req *deps.VerificationRequest,
+) (*common.VerificationParams, error)
+```
+
+`deps.VerificationRequest` bundles the delivery being verified with its wire-type context:
+
+```go
+type VerificationRequest struct {
+    Payload                 *webhook.PubsubPayload // the inbound webhook delivery being verified
+    Integration             *openapi.Integration
+    Installation            *openapi.Installation
+    ProviderApp             *openapi.ProviderApp
+    ProviderAppClientSecret string // carried separately — the openapi.ProviderApp wire type deliberately excludes secrets
+}
+```
+
+`ProviderAppClientSecret` is required by providers that sign webhooks with the OAuth client secret (Hubspot, Jobber).
+
+There is also a package function `IsHookdeckGatewayProvider(provider) bool` — true for everyone except Hubspot, Salesforce, SalesforceJWT. It's not a `VerificationConfig` method because its callers have only a provider string in scope (no `providerInfo` / module); the server uses it to choose between Hookdeck and CloudFunction event endpoints when constructing the `webhookURL` your builder receives.
+
+---
+
+## Twin providers — `providerInfoAliases`
+
+If your provider in the connectors library reuses another provider's connector implementation and does not have its own `SubscribeRequirements` declared, add an entry to `providerInfoAliases` in `aliases.go`. Calls to `ResolveProviderInfoAlias` swap in the twin's `ProviderInfo`, with the original `.Name` preserved so log attribution stays accurate.
+
+`SalesforceJWT → Salesforce` is the canonical example: SalesforceJWT shares the Salesforce connector implementation and the same modules, but its own `ProviderInfo` entry doesn't declare subscribe metadata.
+
+```go
+// subscribe/aliases.go
+var providerInfoAliases = map[providers.Provider]providers.Provider{
+    // SalesforceJWT shares the Salesforce connector implementation and the same modules,
+    // but salesforceJWT.go does not yet declare SubscribeRequirements.
+    providers.SalesforceJWT: providers.Salesforce,
+}
+```
+
+Pair this with registering the same `*ProviderConfig` pointer under both provider keys in `providerConfigs`:
+
+```go
+// subscribe/config.go
+var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
+    providers.Salesforce: {
+        Modules: map[common.ModuleID]*ProviderConfig{
+            providers.ModuleSalesforceCRM: &salesforceConfig,
+        },
+    },
+    providers.SalesforceJWT: {
+        Modules: map[common.ModuleID]*ProviderConfig{
+            providers.ModuleSalesforceCRM: &salesforceConfig,
+        },
+    },
+    // ...
+}
+```
+
+`ResolveProviderInfoAlias` must be called by the caller exactly once, immediately after fetching `ProviderInfo`. The Ampersand server's existing entry points already do this, so unless a new entry point that fetches `ProviderInfo` is being added, you don't need to think about it.
+
+---
+
+## Real providers, different shapes
+
+### Salesforce — full surface
+
+Touches Registration, Subscription, and Verification. Registered for both `Salesforce` and `SalesforceJWT` (same `&salesforceConfig` pointer under both keys, scoped to `ModuleSalesforceCRM`). Its post-processing (AWS EventBridge wiring) is Ampersand infrastructure, so no `PostProcess` declaration appears here — `ShouldPerform` still answers true via `ProviderInfo.SubscribeRequirements.PostProcess`.
+
+```go
+var salesforceConfig = ProviderConfig{
+    Registration: RegistrationConfig{
+        emptyResultFn: func() *common.RegistrationResult {
+            return &common.RegistrationResult{Result: &salesforce.ResultData{}}
+        },
+        buildParamsFn: buildSalesforceRegistrationParams,
+    },
+    Subscription: SubscriptionConfig{
+        buildRequestFn: getSalesforceRequest,
+    },
+    Verification: VerificationConfig{
+        paramsFn:          getSalesforceVerificationParams,
+        verifierConnector: &salesforce.Connector{},
+    },
+}
+```
+
+Salesforce's request builder is also the only one that uses the `deps` resolvers today (project app name + CDC optimization config). See `subscribe/salesforce.go` for the per-provider helpers.
+
+### Outreach / Salesloft — subscribe-via-API with webhook verification
+
+Subscribes via API + builds a webhook-endpoint payload + verifies with a per-installation secret. Salesloft adds the WatchFieldsAuto quirk.
+
+```go
+var salesloftConfig = ProviderConfig{
+    Subscription: SubscriptionConfig{
+        buildRequestFn:          getSalesloftRequest,
+        requiresWatchFieldsAuto: true,
+    },
+    Verification: VerificationConfig{
+        paramsFn:          getSalesloftVerificationParams,
+        verifierConnector: &salesloft.Connector{},
+    },
+}
+```
+
+### Google (Gmail / Calendar) — module-scoped with maintenance and bypass
+
+Only the `gmail` and `calendar` modules support subscribe, so they're registered under `Modules` (as `googleConfig` and `googleCalendarConfig` respectively), not `DefaultModuleConfig`. Webhooks arrive as synthetic Pub/Sub republishes so verification is bypassed.
+
+```go
+var googleConfig = ProviderConfig{
+    Subscription: SubscriptionConfig{
+        buildRequestFn: getGoogleRequest,
+    },
+    Maintenance: MaintenanceConfig{
+        renewalInterval: time.Hour * 24,
+    },
+    Verification: VerificationConfig{
+        bypassed:    true,
+        eventCaster: CastSubscriptionEvents[google.SubscriptionEvent],
+    },
+}
+
+// In providerConfigs:
+providers.Google: {
+    Modules: map[common.ModuleID]*ProviderConfig{
+        providers.ModuleGoogleGmail:    &googleConfig,
+        providers.ModuleGoogleCalendar: &googleCalendarConfig,
+    },
+},
+```
+
+### Hubspot — look-up-only with verification
+
+Subscriptions are configured at the provider-app level so there's no `Subscription` / `Registration` declaration; only verification data. Its params builder reads `req.ProviderAppClientSecret`.
+
+```go
+var hubspotConfig = ProviderConfig{
+    Verification: VerificationConfig{
+        paramsFn:          getHubspotVerificationParams,
+        verifierConnector: &hubspot.Connector{},
+        bypassed:          true,
+        eventCaster:       CastSubscriptionEvents[hubspot.SubscriptionEvent],
+    },
+}
+```
+
+### Gong / HousecallPro — minimal look-up-only
+
+The smallest possible config: a verifier connector and the bypass flag. Two-line declaration.
+
+```go
+var gongConfig = ProviderConfig{
+    Verification: VerificationConfig{
+        verifierConnector: &gong.Connector{},
+        bypassed:          true,
+    },
+}
+```
+


### PR DESCRIPTION
## What

Stacked on #3274. Integrates the ProviderConfig onboarding guide into the subscribe onboarding PR stack as **PR 6** — right before the gate PR (Enable, which becomes **PR 7**).

- **Moved + restructured:** `subscribe/OnboardingProviders.md` (added in #3274) → [`docs/subscribe-onboarding/pr-6-provider-config.md`](docs/subscribe-onboarding/pr-6-provider-config.md), rewritten in the shared per-PR guide format (goal, prerequisites, what you implement, step-by-step example, files, checklist, reviewer focus). Content unchanged otherwise.
- **New: "Live testing before the flip".** Installations under the Ampersand project `connectors-test-project` (id `8b257c62-6b89-4b9b-9271-6fe3f6b700f1`) bypass the `Support.Subscribe` gate, so contributors can validate the full PR 2–6 stack end-to-end with real webhooks before opening the Enable PR. Also called out in `CONTRIBUTING_SUBSCRIBE_ACTION.md` (gate section) and `pr-7-enable.md` (with the caveat that the bypassing project doesn't prove the flag flip itself).
- **Renamed:** `pr-6-enable.md` → `pr-7-enable.md`; its prerequisites now include the ProviderConfig PR.
- **PR 2 ↔ PR 6 cross-links:** `pr-2-verification.md` now names who fills `VerificationParams.Param` (the ProviderConfig's `paramsFn`, PR 6) at each spot where "the caller" was vague, and PR 6's VerificationConfig section links back to PR 2's `VerifyWebhookMessage` as the consumer. Also fixed a stale pre-migration internal path reference in PR 2.
- **Stack bookkeeping:** `CONTRIBUTING_SUBSCRIBE_ACTION.md` (stack diagram, both tables, branch flow — now a seven-PR stack), `SUBSCRIBE_REFERENCES.md` (guide table), `pr-1-provider-info.md` (gate-flip references now point at PR 7).

## Why

The connector methods built in PR 2–5 aren't reachable until the provider is registered in the `subscribe/` package's config registry — the caller drives everything through `subscribe.GetProviderConfig`. That registration now has its own PR slot, sequenced before Enable so the whole stack stays gated until the final flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
