### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cloud.google.com/go/bigquery v1.79.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260731000708-f42c9a178d9c
+	github.com/amp-labs/amp-common v0.0.0-20260803234739-9d2a972adb3d
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260731000708-f42c9a178d9c h1:oa48NbeZ8Q4hAVFObwVB9Ch0ZBoiWWRks0J8jOJ0Mso=
-github.com/amp-labs/amp-common v0.0.0-20260731000708-f42c9a178d9c/go.mod h1:MfvRXzJXpjTAKOyK12Rtc/Zl8xWJUbU80HNq41dabg4=
+github.com/amp-labs/amp-common v0.0.0-20260803234739-9d2a972adb3d h1:ySJXbEzKnQhkT264PPcnnd43Y3mwpHsArxHnIqF3qd8=
+github.com/amp-labs/amp-common v0.0.0-20260803234739-9d2a972adb3d/go.mod h1:MfvRXzJXpjTAKOyK12Rtc/Zl8xWJUbU80HNq41dabg4=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [9d2a972adb3d58da416ea594d827e755a6ed793e](https://github.com/amp-labs/amp-common/commit/9d2a972adb3d58da416ea594d827e755a6ed793e) from [main](https://github.com/amp-labs/amp-common/tree/main)