### PR TITLE
[CON-3448,CON-3450] feat: add Monaco provider

### DIFF
--- a/providers/monaco.go
+++ b/providers/monaco.go
@@ -41,12 +41,12 @@ func init() {
 		//nolint:lll
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://www.monaco.com/global/logo-mark-square.svg",
-				LogoURL: "https://www.monaco.com/global/logo-mark.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1785823470/media/monaco.com_1785823468.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1785823514/media/monaco.com_1785823514.svg",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://www.monaco.com/global/logo-mark-square.svg",
-				LogoURL: "https://www.monaco.com/global/logo-mark-square.svg",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1785823470/media/monaco.com_1785823468.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1785823514/media/monaco.com_1785823514.svg",
 			},
 		},
 	})

--- a/providers/monaco.go
+++ b/providers/monaco.go
@@ -1,0 +1,53 @@
+package providers
+
+import "net/http"
+
+const Monaco Provider = "monaco"
+
+func init() {
+	// Monaco API Key authentication.
+	// Keys are created in the Monaco app under Settings > API Keys and are
+	// prefixed with "mks_". They are sent as a bearer token.
+	// https://docs.monaco.com/auth
+	SetInfo(Monaco, ProviderInfo{
+		DisplayName: "Monaco",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.monaco.com",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://docs.monaco.com/auth",
+		},
+		AuthHealthCheck: &AuthHealthCheck{
+			Method:             http.MethodGet,
+			SuccessStatusCodes: []int{http.StatusOK},
+			Url:                "https://api.monaco.com/v1/me",
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://www.monaco.com/global/logo-mark-square.svg",
+				LogoURL: "https://www.monaco.com/global/logo-mark.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://www.monaco.com/global/logo-mark-square.svg",
+				LogoURL: "https://www.monaco.com/global/logo-mark-square.svg",
+			},
+		},
+	})
+}


### PR DESCRIPTION
Context:
We have no sandbox for this, so its not fully live tested but  Monaco returns two distinguishable auth failures, which lets us prove the header wiring is correct without a valid key.

| What we send | Response | What it tells us |
|---|---|---|
| No `Authorization` header | `401` — `{"error":{"code":"unauthorized","message":"Authorization header must be a bearer token"}}` | Auth is enforced on every `/v1` route |
| `Authorization: mks_bogus` (no `Bearer ` prefix) | `401` — same message | The `Bearer ` prefix is genuinely required |
| `Authorization: Bearer mks_bogus` | `403` — `{"error":{"code":"forbidden","message":"Invalid API key or organization"}}` | **Header shape accepted.** Request got past the auth-header parser and was rejected on key lookup |

That 401 → 403 transition is the signal: our `ApiKeyOpts` produces a header the API parses successfully, and the only remaining unknown is the key value itself.

## Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`) 
- [ ] Should cover all modules within the connector
- [x] Base URLs do NOT have version information 
- [ ] DocsURLs actually link to user-friendly documentation 
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true — N/A, API key auth
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because.
