### PR TITLE
[CON-3327] feat(square): add write support

### DIFF
--- a/providers/square/connector.go
+++ b/providers/square/connector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -16,6 +17,7 @@ type Connector struct {
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -45,6 +47,17 @@ func constructor(_ common.ConnectorParams, base *components.Connector) (*Connect
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -1,10 +1,10 @@
 package square
 
-import "net/http"
-
 const apiVersion = "v2"
 
-// objectConfig describes how to list an object's records on the Square API.
+// objectConfig is the single source of truth for a Square object: how to list
+// its records, and (when supported) how to create/update them. Write fields
+// left at their zero value mean the object is read-only.
 type objectConfig struct {
 	// path is the URL path (after the base URL and API version) that lists the
 	// object's records, e.g. "/customers" or "/catalog/list".
@@ -18,269 +18,117 @@ type objectConfig struct {
 	// supportsTimeRange reports whether the endpoint filters by creation time via
 	// `begin_time`/`end_time` query params, enabling incremental reads.
 	supportsTimeRange bool
-}
 
-// writeConfig describes how to create and/or update an object's records on the
-// Square API.
-type writeConfig struct {
-	// createPath is the URL path (after the base URL and API version) that
-	// creates a record, e.g. "/customers". Empty means create is unsupported.
-	createPath string
-	// updatePath is the URL path that updates a record. The record id is
-	// appended to it unless updateIDInBody is set. Empty means update is
-	// unsupported.
-	updatePath string
-	// createKey and updateKey name the JSON envelope wrapping the record in the
-	// request body, e.g. {"gift_card": {...}}. Empty sends the record fields at
-	// the top level of the body.
-	createKey string
-	updateKey string
-	// responseKey is the JSON key in the response that holds the written record.
-	responseKey string
+	// supportsWrite reports whether records can be written: created via
+	// POST path and updated via PUT path/{id}.
+	supportsWrite bool
+	// writePath overrides path for writes; only catalog needs it (lists via
+	// /catalog/list, writes via /catalog/object).
+	writePath string
+	// writeKey is the JSON envelope wrapping the record in write request and
+	// response bodies, e.g. {"gift_card": {...}}. Empty means flat bodies.
+	writeKey string
+	// flatCreate sends the create body without the writeKey envelope; only
+	// updates wrap (payments, payment_links).
+	flatCreate bool
+	// writeResponseKey overrides writeKey as the response envelope, for objects
+	// whose request body is flat but whose response is wrapped (customers,
+	// refunds) or whose response key differs (catalog).
+	writeResponseKey string
 	// idField is the record field holding its identifier. Empty defaults to "id".
 	idField string
-	// createNeedsIdempotency and updateNeedsIdempotency report whether the
-	// endpoint requires a top-level idempotency_key. When the caller omits it,
-	// the connector generates a UUID.
-	createNeedsIdempotency bool
-	updateNeedsIdempotency bool
+	// needsIdempotency reports whether writes require a top-level
+	// idempotency_key. When the caller omits it, the connector generates a UUID.
+	needsIdempotency bool
 	// topLevelFields are record fields the endpoint expects as siblings of the
-	// envelope rather than inside it, e.g. source_id when creating a card. They
-	// are hoisted out of the record before wrapping.
+	// envelope rather than inside it, e.g. source_id when creating a card.
 	topLevelFields []string
-	// updateMethod overrides the HTTP method for updates. Empty defaults to PUT.
-	updateMethod string
-	// updateIDInBody injects the record id into the wrapped record instead of
-	// appending it to the URL path. Used by the catalog upsert endpoint.
-	updateIDInBody bool
-}
-
-// writeObjects is the set of objects the Square connector can create and/or
-// update. Objects absent from this map are read-only on the Square API.
-var writeObjects = map[string]writeConfig{ //nolint:gochecknoglobals
-	// https://developer.squareup.com/reference/square/customers-api/create-customer
-	"customers": {
-		createPath:  "/customers",
-		updatePath:  "/customers",
-		responseKey: "customer",
-	},
-	// https://developer.squareup.com/reference/square/locations-api/create-location
-	"locations": {
-		createPath:  "/locations",
-		updatePath:  "/locations",
-		createKey:   "location",
-		updateKey:   "location",
-		responseKey: "location",
-	},
-	// https://developer.squareup.com/reference/square/payments-api/create-payment
-	// CreatePayment takes a flat body; UpdatePayment wraps the record in
-	// "payment". Both require an idempotency key.
-	"payments": {
-		createPath:             "/payments",
-		updatePath:             "/payments",
-		updateKey:              "payment",
-		responseKey:            "payment",
-		createNeedsIdempotency: true,
-		updateNeedsIdempotency: true,
-	},
-	// https://developer.squareup.com/reference/square/refunds-api/refund-payment
-	"refunds": {
-		createPath:             "/refunds",
-		responseKey:            "refund",
-		createNeedsIdempotency: true,
-	},
-	// https://developer.squareup.com/reference/square/catalog-api/upsert-catalog-object
-	// The upsert endpoint both creates and updates: updates POST to the same
-	// path with the record id (set from RecordId) and current version inside
-	// the object.
-	"catalog": {
-		createPath:             "/catalog/object",
-		updatePath:             "/catalog/object",
-		createKey:              "object",
-		updateKey:              "object",
-		responseKey:            "catalog_object",
-		createNeedsIdempotency: true,
-		updateNeedsIdempotency: true,
-		updateMethod:           http.MethodPost,
-		updateIDInBody:         true,
-	},
-	// https://developer.squareup.com/reference/square/cards-api/create-card
-	// source_id and verification_token sit beside the "card" envelope.
-	"cards": {
-		createPath:             "/cards",
-		createKey:              "card",
-		responseKey:            "card",
-		createNeedsIdempotency: true,
-		topLevelFields:         []string{"source_id", "verification_token"},
-	},
-	// https://developer.squareup.com/reference/square/gift-cards-api/create-gift-card
-	// location_id sits beside the "gift_card" envelope.
-	"gift_cards": {
-		createPath:             "/gift-cards",
-		createKey:              "gift_card",
-		responseKey:            "gift_card",
-		createNeedsIdempotency: true,
-		topLevelFields:         []string{"location_id"},
-	},
-	// https://developer.squareup.com/reference/square/gift-card-activities-api/create-gift-card-activity
-	"gift_cards/activities": {
-		createPath:             "/gift-cards/activities",
-		createKey:              "gift_card_activity",
-		responseKey:            "gift_card_activity",
-		createNeedsIdempotency: true,
-	},
-	// https://developer.squareup.com/reference/square/devices-api/create-device-code
-	"devices/codes": {
-		createPath:             "/devices/codes",
-		createKey:              "device_code",
-		responseKey:            "device_code",
-		createNeedsIdempotency: true,
-	},
-	// https://developer.squareup.com/reference/square/bookings-api/create-booking
-	"bookings": {
-		createPath:  "/bookings",
-		updatePath:  "/bookings",
-		createKey:   "booking",
-		updateKey:   "booking",
-		responseKey: "booking",
-	},
-	// https://developer.squareup.com/reference/square/booking-custom-attributes-api
-	"bookings/custom_attribute_definitions": {
-		createPath:  "/bookings/custom-attribute-definitions",
-		updatePath:  "/bookings/custom-attribute-definitions",
-		createKey:   "custom_attribute_definition",
-		updateKey:   "custom_attribute_definition",
-		responseKey: "custom_attribute_definition",
-		idField:     "key",
-	},
-	// https://developer.squareup.com/reference/square/customer-custom-attributes-api
-	"customers/custom_attribute_definitions": {
-		createPath:  "/customers/custom-attribute-definitions",
-		updatePath:  "/customers/custom-attribute-definitions",
-		createKey:   "custom_attribute_definition",
-		updateKey:   "custom_attribute_definition",
-		responseKey: "custom_attribute_definition",
-		idField:     "key",
-	},
-	// https://developer.squareup.com/reference/square/location-custom-attributes-api
-	"locations/custom_attribute_definitions": {
-		createPath:  "/locations/custom-attribute-definitions",
-		updatePath:  "/locations/custom-attribute-definitions",
-		createKey:   "custom_attribute_definition",
-		updateKey:   "custom_attribute_definition",
-		responseKey: "custom_attribute_definition",
-		idField:     "key",
-	},
-	// https://developer.squareup.com/reference/square/merchant-custom-attributes-api
-	"merchants/custom_attribute_definitions": {
-		createPath:  "/merchants/custom-attribute-definitions",
-		updatePath:  "/merchants/custom-attribute-definitions",
-		createKey:   "custom_attribute_definition",
-		updateKey:   "custom_attribute_definition",
-		responseKey: "custom_attribute_definition",
-		idField:     "key",
-	},
-	// https://developer.squareup.com/reference/square/order-custom-attributes-api
-	"orders/custom_attribute_definitions": {
-		createPath:  "/orders/custom-attribute-definitions",
-		updatePath:  "/orders/custom-attribute-definitions",
-		createKey:   "custom_attribute_definition",
-		updateKey:   "custom_attribute_definition",
-		responseKey: "custom_attribute_definition",
-		idField:     "key",
-	},
-	// https://developer.squareup.com/reference/square/customer-groups-api/create-customer-group
-	"customers/groups": {
-		createPath:  "/customers/groups",
-		updatePath:  "/customers/groups",
-		createKey:   "group",
-		updateKey:   "group",
-		responseKey: "group",
-	},
-	// https://developer.squareup.com/reference/square/labor-api/create-break-type
-	"labor/break_types": {
-		createPath:  "/labor/break-types",
-		updatePath:  "/labor/break-types",
-		createKey:   "break_type",
-		updateKey:   "break_type",
-		responseKey: "break_type",
-	},
-	// https://developer.squareup.com/reference/square/labor-api/update-workweek-config
-	// Workweek configs cannot be created, only updated.
-	"labor/workweek_configs": {
-		updatePath:  "/labor/workweek-configs",
-		updateKey:   "workweek_config",
-		responseKey: "workweek_config",
-	},
-	// https://developer.squareup.com/reference/square/checkout-api/create-payment-link
-	// CreatePaymentLink takes a flat body; UpdatePaymentLink wraps the record
-	// in "payment_link".
-	"online_checkout/payment_links": {
-		createPath:  "/online-checkout/payment-links",
-		updatePath:  "/online-checkout/payment-links",
-		updateKey:   "payment_link",
-		responseKey: "payment_link",
-	},
-	// https://developer.squareup.com/reference/square/team-api/create-job
-	"team_members/jobs": {
-		createPath:  "/team-members/jobs",
-		updatePath:  "/team-members/jobs",
-		createKey:   "job",
-		updateKey:   "job",
-		responseKey: "job",
-	},
-	// https://developer.squareup.com/reference/square/webhook-subscriptions-api/create-webhook-subscription
-	"webhooks/subscriptions": {
-		createPath:  "/webhooks/subscriptions",
-		updatePath:  "/webhooks/subscriptions",
-		createKey:   "subscription",
-		updateKey:   "subscription",
-		responseKey: "subscription",
-	},
+	// upsertViaPost makes updates POST to writePath with the record id injected
+	// into the body instead of PUT path/{id} (the catalog upsert endpoint).
+	upsertViaPost bool
 }
 
 // objects is the set of objects the Square connector supports. Each exposes a
 // GET list endpoint that returns an array of records under responseKey.
 var objects = map[string]objectConfig{ //nolint:gochecknoglobals
+	// https://developer.squareup.com/reference/square/customers-api/create-customer
+	// Create and update take flat bodies; the response wraps the record in "customer".
 	"customers": {
-		path:           "/customers",
-		responseKey:    "customers",
-		supportsLimit:  true,
-		supportsCursor: true,
+		path:             "/customers",
+		responseKey:      "customers",
+		supportsLimit:    true,
+		supportsCursor:   true,
+		supportsWrite:    true,
+		writeResponseKey: "customer",
 	},
+	// https://developer.squareup.com/reference/square/locations-api/create-location
 	"locations": {
-		path:        "/locations",
-		responseKey: "locations",
+		path:          "/locations",
+		responseKey:   "locations",
+		supportsWrite: true,
+		writeKey:      "location",
 	},
+	// https://developer.squareup.com/reference/square/payments-api/create-payment
+	// CreatePayment takes a flat body; UpdatePayment wraps the record in "payment".
 	"payments": {
 		path:              "/payments",
 		responseKey:       "payments",
 		supportsLimit:     true,
 		supportsCursor:    true,
 		supportsTimeRange: true,
+		supportsWrite:     true,
+		writeKey:          "payment",
+		flatCreate:        true,
+		needsIdempotency:  true,
 	},
+	// https://developer.squareup.com/reference/square/refunds-api/refund-payment
 	"refunds": {
 		path:              "/refunds",
 		responseKey:       "refunds",
 		supportsLimit:     true,
 		supportsCursor:    true,
 		supportsTimeRange: true,
+		supportsWrite:     true,
+		writeResponseKey:  "refund",
+		needsIdempotency:  true,
 	},
+	// https://developer.squareup.com/reference/square/catalog-api/upsert-catalog-object
+	// The upsert endpoint both creates and updates: updates POST to the same
+	// path with the record id (set from RecordId) and current version inside
+	// the object.
 	"catalog": {
-		path:           "/catalog/list",
-		responseKey:    "objects",
-		supportsCursor: true,
+		path:             "/catalog/list",
+		responseKey:      "objects",
+		supportsCursor:   true,
+		supportsWrite:    true,
+		writePath:        "/catalog/object",
+		writeKey:         "object",
+		writeResponseKey: "catalog_object",
+		needsIdempotency: true,
+		upsertViaPost:    true,
 	},
+	// https://developer.squareup.com/reference/square/cards-api/create-card
+	// source_id and verification_token sit beside the "card" envelope.
 	"cards": {
-		path:           "/cards",
-		responseKey:    "cards",
-		supportsCursor: true,
+		path:             "/cards",
+		responseKey:      "cards",
+		supportsCursor:   true,
+		supportsWrite:    true,
+		writeKey:         "card",
+		needsIdempotency: true,
+		topLevelFields:   []string{"source_id", "verification_token"},
 	},
+	// https://developer.squareup.com/reference/square/gift-cards-api/create-gift-card
+	// location_id sits beside the "gift_card" envelope.
 	"gift_cards": {
-		path:           "/gift-cards",
-		responseKey:    "gift_cards",
-		supportsLimit:  true,
-		supportsCursor: true,
+		path:             "/gift-cards",
+		responseKey:      "gift_cards",
+		supportsLimit:    true,
+		supportsCursor:   true,
+		supportsWrite:    true,
+		writeKey:         "gift_card",
+		needsIdempotency: true,
+		topLevelFields:   []string{"location_id"},
 	},
 	"payouts": {
 		path:              "/payouts",
@@ -305,17 +153,24 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		responseKey:    "merchant",
 		supportsCursor: true,
 	},
+	// https://developer.squareup.com/reference/square/booking-custom-attributes-api
 	"bookings/custom_attribute_definitions": {
 		path:           "/bookings/custom-attribute-definitions",
 		responseKey:    "custom_attribute_definitions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "custom_attribute_definition",
+		idField:        "key",
 	},
+	// https://developer.squareup.com/reference/square/bookings-api/create-booking
 	"bookings": {
 		path:           "/bookings",
 		responseKey:    "bookings",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "booking",
 	},
 
 	"bookings/location_booking_profiles": {
@@ -336,23 +191,36 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsCursor: true,
 		supportsLimit:  true,
 	},
+	// https://developer.squareup.com/reference/square/checkout-api/create-payment-link
+	// CreatePaymentLink takes a flat body; UpdatePaymentLink wraps the record
+	// in "payment_link".
 	"online_checkout/payment_links": {
 		path:           "/online-checkout/payment-links",
 		responseKey:    "payment_links",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "payment_link",
+		flatCreate:     true,
 	},
+	// https://developer.squareup.com/reference/square/customer-custom-attributes-api
 	"customers/custom_attribute_definitions": {
 		path:           "/customers/custom-attribute-definitions",
 		responseKey:    "custom_attribute_definitions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "custom_attribute_definition",
+		idField:        "key",
 	},
+	// https://developer.squareup.com/reference/square/customer-groups-api/create-customer-group
 	"customers/groups": {
 		path:           "/customers/groups",
 		responseKey:    "groups",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "group",
 	},
 	"customers/segments": {
 		path:           "/customers/segments",
@@ -367,11 +235,15 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsCursor: true,
 		supportsLimit:  true,
 	},
+	// https://developer.squareup.com/reference/square/devices-api/create-device-code
 	"devices/codes": {
-		path:           "/devices/codes",
-		responseKey:    "device_codes",
-		supportsCursor: true,
-		supportsLimit:  false,
+		path:             "/devices/codes",
+		responseKey:      "device_codes",
+		supportsCursor:   true,
+		supportsLimit:    false,
+		supportsWrite:    true,
+		writeKey:         "device_code",
+		needsIdempotency: true,
 	},
 
 	"events/types": {
@@ -381,19 +253,26 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsLimit:  false,
 	},
 
+	// https://developer.squareup.com/reference/square/gift-card-activities-api/create-gift-card-activity
 	"gift_cards/activities": {
 		path:              "/gift-cards/activities",
 		responseKey:       "gift_card_activities",
 		supportsCursor:    true,
 		supportsLimit:     true,
 		supportsTimeRange: true,
+		supportsWrite:     true,
+		writeKey:          "gift_card_activity",
+		needsIdempotency:  true,
 	},
 
+	// https://developer.squareup.com/reference/square/labor-api/create-break-type
 	"labor/break_types": {
 		path:           "/labor/break-types",
 		responseKey:    "break_types",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "break_type",
 	},
 
 	"labor/team_member_wages": {
@@ -403,51 +282,72 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsLimit:  true,
 	},
 
+	// https://developer.squareup.com/reference/square/labor-api/update-workweek-config
 	"labor/workweek_configs": {
 		path:           "/labor/workweek-configs",
 		responseKey:    "workweek_configs",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "workweek_config",
 	},
+	// https://developer.squareup.com/reference/square/location-custom-attributes-api
 	"locations/custom_attribute_definitions": {
 		path:           "/locations/custom-attribute-definitions",
 		responseKey:    "custom_attribute_definitions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "custom_attribute_definition",
+		idField:        "key",
 	},
 	"loyalty/programs": {
 		path:        "/loyalty/programs",
 		responseKey: "programs",
 	},
+	// https://developer.squareup.com/reference/square/merchant-custom-attributes-api
 	"merchants/custom_attribute_definitions": {
 		path:           "/merchants/custom-attribute-definitions",
 		responseKey:    "custom_attribute_definitions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "custom_attribute_definition",
+		idField:        "key",
 	},
+	// https://developer.squareup.com/reference/square/order-custom-attributes-api
 	"orders/custom_attribute_definitions": {
 		path:           "/orders/custom-attribute-definitions",
 		responseKey:    "custom_attribute_definitions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "custom_attribute_definition",
+		idField:        "key",
 	},
 	"sites": {
 		path:        "/sites",
 		responseKey: "sites",
 	},
+	// https://developer.squareup.com/reference/square/team-api/create-job
 	"team_members/jobs": {
 		path:           "/team-members/jobs",
 		responseKey:    "jobs",
 		supportsCursor: true,
+		supportsWrite:  true,
+		writeKey:       "job",
 	},
 	"webhooks/event_types": {
 		path:        "/webhooks/event-types",
 		responseKey: "event_types",
 	},
+	// https://developer.squareup.com/reference/square/webhook-subscriptions-api/create-webhook-subscription
 	"webhooks/subscriptions": {
 		path:           "/webhooks/subscriptions",
 		responseKey:    "subscriptions",
 		supportsCursor: true,
 		supportsLimit:  true,
+		supportsWrite:  true,
+		writeKey:       "subscription",
 	},
 }

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -22,9 +22,6 @@ type objectConfig struct {
 	// supportsWrite reports whether records can be written: created via
 	// POST path and updated via PUT path/{id}.
 	supportsWrite bool
-	// writePath overrides path for writes; only catalog needs it (lists via
-	// /catalog/list, writes via /catalog/object).
-	writePath string
 	// writeKey is the JSON envelope wrapping the record in write request and
 	// response bodies, e.g. {"gift_card": {...}}. Empty means flat bodies.
 	writeKey string
@@ -43,9 +40,10 @@ type objectConfig struct {
 	// topLevelFields are record fields the endpoint expects as siblings of the
 	// envelope rather than inside it, e.g. source_id when creating a card.
 	topLevelFields []string
-	// upsertViaPost makes updates POST to writePath with the record id injected
+	// upsertPath, when set, is where writes go instead of path, and marks the
+	// endpoint as an upsert: updates POST there with the record id injected
 	// into the body instead of PUT path/{id} (the catalog upsert endpoint).
-	upsertViaPost bool
+	upsertPath string
 }
 
 // objects is the set of objects the Square connector supports. Each exposes a
@@ -101,11 +99,10 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		responseKey:      "objects",
 		supportsCursor:   true,
 		supportsWrite:    true,
-		writePath:        "/catalog/object",
+		upsertPath:       "/catalog/object",
 		writeKey:         "object",
 		writeResponseKey: "catalog_object",
 		needsIdempotency: true,
-		upsertViaPost:    true,
 	},
 	// https://developer.squareup.com/reference/square/cards-api/create-card
 	// source_id and verification_token sit beside the "card" envelope.

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -18,7 +18,6 @@ type objectConfig struct {
 	// supportsTimeRange reports whether the endpoint filters by creation time via
 	// `begin_time`/`end_time` query params, enabling incremental reads.
 	supportsTimeRange bool
-
 	// supportsWrite reports whether records can be written: created via
 	// POST path and updated via PUT path/{id}.
 	supportsWrite bool
@@ -43,8 +42,6 @@ type objectConfig struct {
 	upsertPath string
 }
 
-// objects is the set of objects the Square connector supports. Each exposes a
-// GET list endpoint that returns an array of records under responseKey.
 var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 	// https://developer.squareup.com/reference/square/customers-api/create-customer
 	// Create and update take flat bodies; the response wraps the record in "customer".

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -1,5 +1,7 @@
 package square
 
+import "net/http"
+
 const apiVersion = "v2"
 
 // objectConfig describes how to list an object's records on the Square API.
@@ -16,6 +18,225 @@ type objectConfig struct {
 	// supportsTimeRange reports whether the endpoint filters by creation time via
 	// `begin_time`/`end_time` query params, enabling incremental reads.
 	supportsTimeRange bool
+}
+
+// writeConfig describes how to create and/or update an object's records on the
+// Square API.
+type writeConfig struct {
+	// createPath is the URL path (after the base URL and API version) that
+	// creates a record, e.g. "/customers". Empty means create is unsupported.
+	createPath string
+	// updatePath is the URL path that updates a record. The record id is
+	// appended to it unless updateIDInBody is set. Empty means update is
+	// unsupported.
+	updatePath string
+	// createKey and updateKey name the JSON envelope wrapping the record in the
+	// request body, e.g. {"gift_card": {...}}. Empty sends the record fields at
+	// the top level of the body.
+	createKey string
+	updateKey string
+	// responseKey is the JSON key in the response that holds the written record.
+	responseKey string
+	// idField is the record field holding its identifier. Empty defaults to "id".
+	idField string
+	// createNeedsIdempotency and updateNeedsIdempotency report whether the
+	// endpoint requires a top-level idempotency_key. When the caller omits it,
+	// the connector generates a UUID.
+	createNeedsIdempotency bool
+	updateNeedsIdempotency bool
+	// topLevelFields are record fields the endpoint expects as siblings of the
+	// envelope rather than inside it, e.g. source_id when creating a card. They
+	// are hoisted out of the record before wrapping.
+	topLevelFields []string
+	// updateMethod overrides the HTTP method for updates. Empty defaults to PUT.
+	updateMethod string
+	// updateIDInBody injects the record id into the wrapped record instead of
+	// appending it to the URL path. Used by the catalog upsert endpoint.
+	updateIDInBody bool
+}
+
+// writeObjects is the set of objects the Square connector can create and/or
+// update. Objects absent from this map are read-only on the Square API.
+var writeObjects = map[string]writeConfig{ //nolint:gochecknoglobals
+	// https://developer.squareup.com/reference/square/customers-api/create-customer
+	"customers": {
+		createPath:  "/customers",
+		updatePath:  "/customers",
+		responseKey: "customer",
+	},
+	// https://developer.squareup.com/reference/square/locations-api/create-location
+	"locations": {
+		createPath:  "/locations",
+		updatePath:  "/locations",
+		createKey:   "location",
+		updateKey:   "location",
+		responseKey: "location",
+	},
+	// https://developer.squareup.com/reference/square/payments-api/create-payment
+	// CreatePayment takes a flat body; UpdatePayment wraps the record in
+	// "payment". Both require an idempotency key.
+	"payments": {
+		createPath:             "/payments",
+		updatePath:             "/payments",
+		updateKey:              "payment",
+		responseKey:            "payment",
+		createNeedsIdempotency: true,
+		updateNeedsIdempotency: true,
+	},
+	// https://developer.squareup.com/reference/square/refunds-api/refund-payment
+	"refunds": {
+		createPath:             "/refunds",
+		responseKey:            "refund",
+		createNeedsIdempotency: true,
+	},
+	// https://developer.squareup.com/reference/square/catalog-api/upsert-catalog-object
+	// The upsert endpoint both creates and updates: updates POST to the same
+	// path with the record id (set from RecordId) and current version inside
+	// the object.
+	"catalog": {
+		createPath:             "/catalog/object",
+		updatePath:             "/catalog/object",
+		createKey:              "object",
+		updateKey:              "object",
+		responseKey:            "catalog_object",
+		createNeedsIdempotency: true,
+		updateNeedsIdempotency: true,
+		updateMethod:           http.MethodPost,
+		updateIDInBody:         true,
+	},
+	// https://developer.squareup.com/reference/square/cards-api/create-card
+	// source_id and verification_token sit beside the "card" envelope.
+	"cards": {
+		createPath:             "/cards",
+		createKey:              "card",
+		responseKey:            "card",
+		createNeedsIdempotency: true,
+		topLevelFields:         []string{"source_id", "verification_token"},
+	},
+	// https://developer.squareup.com/reference/square/gift-cards-api/create-gift-card
+	// location_id sits beside the "gift_card" envelope.
+	"gift_cards": {
+		createPath:             "/gift-cards",
+		createKey:              "gift_card",
+		responseKey:            "gift_card",
+		createNeedsIdempotency: true,
+		topLevelFields:         []string{"location_id"},
+	},
+	// https://developer.squareup.com/reference/square/gift-card-activities-api/create-gift-card-activity
+	"gift_cards/activities": {
+		createPath:             "/gift-cards/activities",
+		createKey:              "gift_card_activity",
+		responseKey:            "gift_card_activity",
+		createNeedsIdempotency: true,
+	},
+	// https://developer.squareup.com/reference/square/devices-api/create-device-code
+	"devices/codes": {
+		createPath:             "/devices/codes",
+		createKey:              "device_code",
+		responseKey:            "device_code",
+		createNeedsIdempotency: true,
+	},
+	// https://developer.squareup.com/reference/square/bookings-api/create-booking
+	"bookings": {
+		createPath:  "/bookings",
+		updatePath:  "/bookings",
+		createKey:   "booking",
+		updateKey:   "booking",
+		responseKey: "booking",
+	},
+	// https://developer.squareup.com/reference/square/booking-custom-attributes-api
+	"bookings/custom_attribute_definitions": {
+		createPath:  "/bookings/custom-attribute-definitions",
+		updatePath:  "/bookings/custom-attribute-definitions",
+		createKey:   "custom_attribute_definition",
+		updateKey:   "custom_attribute_definition",
+		responseKey: "custom_attribute_definition",
+		idField:     "key",
+	},
+	// https://developer.squareup.com/reference/square/customer-custom-attributes-api
+	"customers/custom_attribute_definitions": {
+		createPath:  "/customers/custom-attribute-definitions",
+		updatePath:  "/customers/custom-attribute-definitions",
+		createKey:   "custom_attribute_definition",
+		updateKey:   "custom_attribute_definition",
+		responseKey: "custom_attribute_definition",
+		idField:     "key",
+	},
+	// https://developer.squareup.com/reference/square/location-custom-attributes-api
+	"locations/custom_attribute_definitions": {
+		createPath:  "/locations/custom-attribute-definitions",
+		updatePath:  "/locations/custom-attribute-definitions",
+		createKey:   "custom_attribute_definition",
+		updateKey:   "custom_attribute_definition",
+		responseKey: "custom_attribute_definition",
+		idField:     "key",
+	},
+	// https://developer.squareup.com/reference/square/merchant-custom-attributes-api
+	"merchants/custom_attribute_definitions": {
+		createPath:  "/merchants/custom-attribute-definitions",
+		updatePath:  "/merchants/custom-attribute-definitions",
+		createKey:   "custom_attribute_definition",
+		updateKey:   "custom_attribute_definition",
+		responseKey: "custom_attribute_definition",
+		idField:     "key",
+	},
+	// https://developer.squareup.com/reference/square/order-custom-attributes-api
+	"orders/custom_attribute_definitions": {
+		createPath:  "/orders/custom-attribute-definitions",
+		updatePath:  "/orders/custom-attribute-definitions",
+		createKey:   "custom_attribute_definition",
+		updateKey:   "custom_attribute_definition",
+		responseKey: "custom_attribute_definition",
+		idField:     "key",
+	},
+	// https://developer.squareup.com/reference/square/customer-groups-api/create-customer-group
+	"customers/groups": {
+		createPath:  "/customers/groups",
+		updatePath:  "/customers/groups",
+		createKey:   "group",
+		updateKey:   "group",
+		responseKey: "group",
+	},
+	// https://developer.squareup.com/reference/square/labor-api/create-break-type
+	"labor/break_types": {
+		createPath:  "/labor/break-types",
+		updatePath:  "/labor/break-types",
+		createKey:   "break_type",
+		updateKey:   "break_type",
+		responseKey: "break_type",
+	},
+	// https://developer.squareup.com/reference/square/labor-api/update-workweek-config
+	// Workweek configs cannot be created, only updated.
+	"labor/workweek_configs": {
+		updatePath:  "/labor/workweek-configs",
+		updateKey:   "workweek_config",
+		responseKey: "workweek_config",
+	},
+	// https://developer.squareup.com/reference/square/checkout-api/create-payment-link
+	// CreatePaymentLink takes a flat body; UpdatePaymentLink wraps the record
+	// in "payment_link".
+	"online_checkout/payment_links": {
+		createPath:  "/online-checkout/payment-links",
+		updatePath:  "/online-checkout/payment-links",
+		updateKey:   "payment_link",
+		responseKey: "payment_link",
+	},
+	// https://developer.squareup.com/reference/square/team-api/create-job
+	"team_members/jobs": {
+		createPath:  "/team-members/jobs",
+		updatePath:  "/team-members/jobs",
+		createKey:   "job",
+		updateKey:   "job",
+		responseKey: "job",
+	},
+	// https://developer.squareup.com/reference/square/webhook-subscriptions-api/create-webhook-subscription
+	"webhooks/subscriptions": {
+		createPath:  "/webhooks/subscriptions",
+		updatePath:  "/webhooks/subscriptions",
+		createKey:   "subscription",
+		updateKey:   "subscription",
+		responseKey: "subscription",
+	},
 }
 
 // objects is the set of objects the Square connector supports. Each exposes a

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -25,9 +25,6 @@ type objectConfig struct {
 	// writeKey is the JSON envelope wrapping the record in write request and
 	// response bodies, e.g. {"gift_card": {...}}. Empty means flat bodies.
 	writeKey string
-	// flatCreate sends the create body without the writeKey envelope; only
-	// updates wrap (payments, payment_links).
-	flatCreate bool
 	// writeResponseKey overrides writeKey as the response envelope, for objects
 	// whose request body is flat but whose response is wrapped (customers,
 	// refunds) or whose response key differs (catalog).
@@ -76,7 +73,6 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsTimeRange: true,
 		supportsWrite:     true,
 		writeKey:          "payment",
-		flatCreate:        true,
 		needsIdempotency:  true,
 	},
 	// https://developer.squareup.com/reference/square/refunds-api/refund-payment
@@ -198,7 +194,6 @@ var objects = map[string]objectConfig{ //nolint:gochecknoglobals
 		supportsLimit:  true,
 		supportsWrite:  true,
 		writeKey:       "payment_link",
-		flatCreate:     true,
 	},
 	// https://developer.squareup.com/reference/square/customer-custom-attributes-api
 	"customers/custom_attribute_definitions": {

--- a/providers/square/test/write/create-custom-attribute-definition.json
+++ b/providers/square/test/write/create-custom-attribute-definition.json
@@ -1,0 +1,10 @@
+{
+  "custom_attribute_definition": {
+    "key": "favorite-drink",
+    "name": "Favorite Drink",
+    "description": "The customer's favorite drink",
+    "version": 1,
+    "updated_at": "2026-07-27T10:00:00Z",
+    "created_at": "2026-07-27T10:00:00Z"
+  }
+}

--- a/providers/square/test/write/create-customer.json
+++ b/providers/square/test/write/create-customer.json
@@ -1,0 +1,11 @@
+{
+  "customer": {
+    "id": "JDKYHBWT1D4F8MFH63DBMEN8Y4",
+    "created_at": "2026-07-27T10:00:00Z",
+    "updated_at": "2026-07-27T10:00:00Z",
+    "given_name": "Amelia",
+    "family_name": "Earhart",
+    "email_address": "amelia.earhart@example.com",
+    "version": 0
+  }
+}

--- a/providers/square/test/write/create-gift-card.json
+++ b/providers/square/test/write/create-gift-card.json
@@ -1,0 +1,12 @@
+{
+  "gift_card": {
+    "id": "gftc:6d55a92ac6db4f4c9b78be6a9b1a1a1a",
+    "type": "DIGITAL",
+    "state": "PENDING",
+    "balance_money": {
+      "amount": 0,
+      "currency": "USD"
+    },
+    "created_at": "2026-07-27T10:00:00Z"
+  }
+}

--- a/providers/square/test/write/create-payment.json
+++ b/providers/square/test/write/create-payment.json
@@ -1,0 +1,12 @@
+{
+  "payment": {
+    "id": "bP9mAsEMYPUGjjGNaNO5ZDVyLhSZY",
+    "status": "COMPLETED",
+    "amount_money": {
+      "amount": 1000,
+      "currency": "USD"
+    },
+    "source_type": "CARD",
+    "created_at": "2026-07-27T10:00:00Z"
+  }
+}

--- a/providers/square/test/write/update-booking.json
+++ b/providers/square/test/write/update-booking.json
@@ -1,0 +1,9 @@
+{
+  "booking": {
+    "id": "zkbugu5jyvgfdqrp",
+    "version": 2,
+    "status": "ACCEPTED",
+    "location_id": "LEQHH0YY8B42M",
+    "start_at": "2026-08-01T15:00:00Z"
+  }
+}

--- a/providers/square/test/write/upsert-catalog-object.json
+++ b/providers/square/test/write/upsert-catalog-object.json
@@ -1,0 +1,13 @@
+{
+  "catalog_object": {
+    "type": "ITEM",
+    "id": "W62UWFY35CWMYGVWK6TWJPNI",
+    "version": 3,
+    "updated_at": "2026-07-27T10:00:00Z",
+    "item_data": {
+      "name": "Cocoa",
+      "description": "Hot chocolate"
+    }
+  },
+  "id_mappings": []
+}

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -90,8 +90,12 @@ func buildWriteBody(cfg objectConfig, params common.WriteParams) (map[string]any
 		body[idempotencyKeyField] = uuid.NewString()
 	}
 
+	// If the endpoint requires a writeKey, wrap the record under it;
+	// otherwise, send the record flat. Payments and payment links are the odd
+	// ones out: their creates take flat bodies while their updates wrap.
 	envelopeKey := cfg.writeKey
-	if !params.IsUpdate() && cfg.flatCreate {
+	if !params.IsUpdate() &&
+		(params.ObjectName == "payments" || params.ObjectName == "online_checkout/payment_links") {
 		envelopeKey = ""
 	}
 

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -125,6 +125,8 @@ func (c *Connector) parseWriteResponse(
 	record := body
 
 	responseKey := cfg.writeResponseKey
+
+	// If the endpoint doesn't have a writeResponseKey, use the writeKey instead.
 	if responseKey == "" {
 		responseKey = cfg.writeKey
 	}

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -71,21 +71,23 @@ func buildWriteBody(cfg objectConfig, params common.WriteParams) (map[string]any
 	body := make(map[string]any)
 
 	for _, field := range cfg.topLevelFields {
-		if value, ok := record[field]; ok {
+		value, ok := record[field]
+		// If the caller provided a value for a top-level field,
+		// Use it and remove it from the record so it doesn't get wrapped under writeKey.
+		if ok {
 			body[field] = value
 			delete(record, field)
 		}
 	}
 
-	if value, ok := record[idempotencyKeyField]; ok {
+	value, ok := record[idempotencyKeyField]
+	if ok {
+		// Caller provided an idempotency key; use it and remove it from the record.
 		body[idempotencyKeyField] = value
 		delete(record, idempotencyKeyField)
 	} else if cfg.needsIdempotency {
+		// Caller didn't provide an idempotency key, but the endpoint requires one; generate a UUID.
 		body[idempotencyKeyField] = uuid.NewString()
-	}
-
-	if cfg.upsertPath != "" && params.IsUpdate() && params.RecordId != "" {
-		record["id"] = params.RecordId
 	}
 
 	envelopeKey := cfg.writeKey

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -16,29 +16,26 @@ import (
 
 const idempotencyKeyField = "idempotency_key"
 
-// writeOperation is the create or update half of a writeConfig, resolved
-// against the incoming WriteParams.
-type writeOperation struct {
-	method           string
-	path             string
-	envelopeKey      string
-	needsIdempotency bool
-	idInBody         bool
-}
-
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
-	cfg, ok := writeObjects[params.ObjectName]
-	if !ok {
+	cfg, ok := objects[params.ObjectName]
+	if !ok || !cfg.supportsWrite {
 		return nil, fmt.Errorf("%w: %q", common.ErrOperationNotSupportedForObject, params.ObjectName)
 	}
 
-	operation, err := resolveWriteOperation(cfg, params)
-	if err != nil {
-		return nil, err
+	path := cfg.path
+	if cfg.writePath != "" {
+		path = cfg.writePath
 	}
 
-	urlParts := []string{apiVersion, operation.path}
-	if params.IsUpdate() && !operation.idInBody {
+	// Everything is a POST except plain updates, which PUT to path/{id}.
+	// upsertViaPost updates (catalog) keep POSTing to the create path with the
+	// record id in the body instead.
+	method := http.MethodPost
+	urlParts := []string{apiVersion, path}
+
+	if params.IsUpdate() && !cfg.upsertViaPost {
+		method = http.MethodPut
+
 		urlParts = append(urlParts, params.RecordId)
 	}
 
@@ -47,7 +44,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	body, err := buildWriteBody(cfg, operation, params)
+	body, err := buildWriteBody(cfg, params)
 	if err != nil {
 		return nil, err
 	}
@@ -57,49 +54,15 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	return http.NewRequestWithContext(ctx, operation.method, url.String(), bytes.NewReader(jsonData))
-}
-
-// resolveWriteOperation picks the create or update endpoint for the request,
-// erroring when the object doesn't support that operation.
-func resolveWriteOperation(cfg writeConfig, params common.WriteParams) (*writeOperation, error) {
-	if params.IsUpdate() {
-		if cfg.updatePath == "" {
-			return nil, fmt.Errorf("%w: %q cannot be updated", common.ErrOperationNotSupportedForObject, params.ObjectName)
-		}
-
-		method := cfg.updateMethod
-		if method == "" {
-			method = http.MethodPut
-		}
-
-		return &writeOperation{
-			method:           method,
-			path:             cfg.updatePath,
-			envelopeKey:      cfg.updateKey,
-			needsIdempotency: cfg.updateNeedsIdempotency,
-			idInBody:         cfg.updateIDInBody,
-		}, nil
-	}
-
-	if cfg.createPath == "" {
-		return nil, fmt.Errorf("%w: %q cannot be created", common.ErrOperationNotSupportedForObject, params.ObjectName)
-	}
-
-	return &writeOperation{
-		method:           http.MethodPost,
-		path:             cfg.createPath,
-		envelopeKey:      cfg.createKey,
-		needsIdempotency: cfg.createNeedsIdempotency,
-	}, nil
+	return http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(jsonData))
 }
 
 // buildWriteBody shapes RecordData into the request body Square expects:
 // topLevelFields and idempotency_key are hoisted out of the record to the top
-// level, the rest is wrapped under the envelope key (or sent flat without one).
+// level, the rest is wrapped under writeKey (or sent flat without one).
 // When the endpoint requires an idempotency key and the caller didn't supply
 // one, a UUID is generated so callers don't need to know Square's quirk.
-func buildWriteBody(cfg writeConfig, operation *writeOperation, params common.WriteParams) (map[string]any, error) {
+func buildWriteBody(cfg objectConfig, params common.WriteParams) (map[string]any, error) {
 	record, err := common.RecordDataToMap(params.RecordData)
 	if err != nil {
 		return nil, err
@@ -119,16 +82,21 @@ func buildWriteBody(cfg writeConfig, operation *writeOperation, params common.Wr
 	if value, ok := record[idempotencyKeyField]; ok {
 		body[idempotencyKeyField] = value
 		delete(record, idempotencyKeyField)
-	} else if operation.needsIdempotency {
+	} else if cfg.needsIdempotency {
 		body[idempotencyKeyField] = uuid.NewString()
 	}
 
-	if operation.idInBody && params.RecordId != "" {
+	if cfg.upsertViaPost && params.IsUpdate() && params.RecordId != "" {
 		record["id"] = params.RecordId
 	}
 
-	if operation.envelopeKey != "" {
-		body[operation.envelopeKey] = record
+	envelopeKey := cfg.writeKey
+	if !params.IsUpdate() && cfg.flatCreate {
+		envelopeKey = ""
+	}
+
+	if envelopeKey != "" {
+		body[envelopeKey] = record
 	} else {
 		maps.Copy(body, record)
 	}
@@ -147,13 +115,18 @@ func (c *Connector) parseWriteResponse(
 		return &common.WriteResult{Success: true}, nil
 	}
 
-	cfg := writeObjects[params.ObjectName]
+	cfg := objects[params.ObjectName]
 
 	// Square wraps the written record in an envelope, e.g. {"customer": {...}}.
 	record := body
 
-	if cfg.responseKey != "" {
-		wrapped, err := jsonquery.New(body).ObjectOptional(cfg.responseKey)
+	responseKey := cfg.writeResponseKey
+	if responseKey == "" {
+		responseKey = cfg.writeKey
+	}
+
+	if responseKey != "" {
+		wrapped, err := jsonquery.New(body).ObjectOptional(responseKey)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -22,18 +22,18 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, fmt.Errorf("%w: %q", common.ErrOperationNotSupportedForObject, params.ObjectName)
 	}
 
+	// Everything is a POST except plain updates, which PUT to path/{id}.
+	// Upsert endpoints (catalog) keep POSTing to upsertPath with the record id
+	// in the body instead.
 	path := cfg.path
-	if cfg.writePath != "" {
-		path = cfg.writePath
+	if cfg.upsertPath != "" {
+		path = cfg.upsertPath
 	}
 
-	// Everything is a POST except plain updates, which PUT to path/{id}.
-	// upsertViaPost updates (catalog) keep POSTing to the create path with the
-	// record id in the body instead.
 	method := http.MethodPost
 	urlParts := []string{apiVersion, path}
 
-	if params.IsUpdate() && !cfg.upsertViaPost {
+	if params.IsUpdate() && cfg.upsertPath == "" {
 		method = http.MethodPut
 
 		urlParts = append(urlParts, params.RecordId)
@@ -86,7 +86,7 @@ func buildWriteBody(cfg objectConfig, params common.WriteParams) (map[string]any
 		body[idempotencyKeyField] = uuid.NewString()
 	}
 
-	if cfg.upsertViaPost && params.IsUpdate() && params.RecordId != "" {
+	if cfg.upsertPath != "" && params.IsUpdate() && params.RecordId != "" {
 		record["id"] = params.RecordId
 	}
 

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -22,26 +22,24 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, fmt.Errorf("%w: %q", common.ErrOperationNotSupportedForObject, params.ObjectName)
 	}
 
-	// Everything is a POST except plain updates, which PUT to path/{id}.
-	// Upsert endpoints (catalog) keep POSTing to upsertPath with the record id
-	// in the body instead.
+	// Writes POST, except updates, which PUT to path/{id} — unless the
+	// endpoint is an upsert (upsertPath set), which always POSTs.
 	path := cfg.path
 	if cfg.upsertPath != "" {
 		path = cfg.upsertPath
 	}
 
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, apiVersion, path)
+	if err != nil {
+		return nil, err
+	}
+
 	method := http.MethodPost
-	urlParts := []string{apiVersion, path}
 
 	if params.IsUpdate() && cfg.upsertPath == "" {
 		method = http.MethodPut
 
-		urlParts = append(urlParts, params.RecordId)
-	}
-
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, urlParts...)
-	if err != nil {
-		return nil, err
+		url.AddPath(params.RecordId)
 	}
 
 	body, err := buildWriteBody(cfg, params)

--- a/providers/square/write.go
+++ b/providers/square/write.go
@@ -1,0 +1,186 @@
+package square
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/google/uuid"
+)
+
+const idempotencyKeyField = "idempotency_key"
+
+// writeOperation is the create or update half of a writeConfig, resolved
+// against the incoming WriteParams.
+type writeOperation struct {
+	method           string
+	path             string
+	envelopeKey      string
+	needsIdempotency bool
+	idInBody         bool
+}
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	cfg, ok := writeObjects[params.ObjectName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", common.ErrOperationNotSupportedForObject, params.ObjectName)
+	}
+
+	operation, err := resolveWriteOperation(cfg, params)
+	if err != nil {
+		return nil, err
+	}
+
+	urlParts := []string{apiVersion, operation.path}
+	if params.IsUpdate() && !operation.idInBody {
+		urlParts = append(urlParts, params.RecordId)
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, urlParts...)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := buildWriteBody(cfg, operation, params)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, operation.method, url.String(), bytes.NewReader(jsonData))
+}
+
+// resolveWriteOperation picks the create or update endpoint for the request,
+// erroring when the object doesn't support that operation.
+func resolveWriteOperation(cfg writeConfig, params common.WriteParams) (*writeOperation, error) {
+	if params.IsUpdate() {
+		if cfg.updatePath == "" {
+			return nil, fmt.Errorf("%w: %q cannot be updated", common.ErrOperationNotSupportedForObject, params.ObjectName)
+		}
+
+		method := cfg.updateMethod
+		if method == "" {
+			method = http.MethodPut
+		}
+
+		return &writeOperation{
+			method:           method,
+			path:             cfg.updatePath,
+			envelopeKey:      cfg.updateKey,
+			needsIdempotency: cfg.updateNeedsIdempotency,
+			idInBody:         cfg.updateIDInBody,
+		}, nil
+	}
+
+	if cfg.createPath == "" {
+		return nil, fmt.Errorf("%w: %q cannot be created", common.ErrOperationNotSupportedForObject, params.ObjectName)
+	}
+
+	return &writeOperation{
+		method:           http.MethodPost,
+		path:             cfg.createPath,
+		envelopeKey:      cfg.createKey,
+		needsIdempotency: cfg.createNeedsIdempotency,
+	}, nil
+}
+
+// buildWriteBody shapes RecordData into the request body Square expects:
+// topLevelFields and idempotency_key are hoisted out of the record to the top
+// level, the rest is wrapped under the envelope key (or sent flat without one).
+// When the endpoint requires an idempotency key and the caller didn't supply
+// one, a UUID is generated so callers don't need to know Square's quirk.
+func buildWriteBody(cfg writeConfig, operation *writeOperation, params common.WriteParams) (map[string]any, error) {
+	record, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	// RecordDataToMap may return the caller's own map; clone before mutating.
+	record = maps.Clone(record)
+	body := make(map[string]any)
+
+	for _, field := range cfg.topLevelFields {
+		if value, ok := record[field]; ok {
+			body[field] = value
+			delete(record, field)
+		}
+	}
+
+	if value, ok := record[idempotencyKeyField]; ok {
+		body[idempotencyKeyField] = value
+		delete(record, idempotencyKeyField)
+	} else if operation.needsIdempotency {
+		body[idempotencyKeyField] = uuid.NewString()
+	}
+
+	if operation.idInBody && params.RecordId != "" {
+		record["id"] = params.RecordId
+	}
+
+	if operation.envelopeKey != "" {
+		body[operation.envelopeKey] = record
+	} else {
+		maps.Copy(body, record)
+	}
+
+	return body, nil
+}
+
+func (c *Connector) parseWriteResponse(
+	ctx context.Context,
+	params common.WriteParams,
+	_ *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok {
+		return &common.WriteResult{Success: true}, nil
+	}
+
+	cfg := writeObjects[params.ObjectName]
+
+	// Square wraps the written record in an envelope, e.g. {"customer": {...}}.
+	record := body
+
+	if cfg.responseKey != "" {
+		wrapped, err := jsonquery.New(body).ObjectOptional(cfg.responseKey)
+		if err != nil {
+			return nil, err
+		}
+
+		if wrapped != nil {
+			record = wrapped
+		}
+	}
+
+	idField := cfg.idField
+	if idField == "" {
+		idField = "id"
+	}
+
+	recordID, err := jsonquery.New(record).StrWithDefault(idField, params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(record)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     data,
+	}, nil
+}

--- a/providers/square/write_test.go
+++ b/providers/square/write_test.go
@@ -181,12 +181,13 @@ func TestWrite(t *testing.T) { //nolint:funlen
 		},
 		{
 			// Catalog updates go through the upsert endpoint: POST to the same
-			// path with the record id injected into the object body.
+			// path with the record id and current version inside the object.
 			Name: "Update catalog object via upsert",
 			Input: common.WriteParams{
 				ObjectName: "catalog",
 				RecordId:   "W62UWFY35CWMYGVWK6TWJPNI",
 				RecordData: map[string]any{
+					"id":      "W62UWFY35CWMYGVWK6TWJPNI",
 					"type":    "ITEM",
 					"version": 2,
 					"item_data": map[string]any{

--- a/providers/square/write_test.go
+++ b/providers/square/write_test.go
@@ -1,0 +1,286 @@
+package square
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	createCustomerResponse := testutils.DataFromFile(t, "write/create-customer.json")
+	createGiftCardResponse := testutils.DataFromFile(t, "write/create-gift-card.json")
+	createPaymentResponse := testutils.DataFromFile(t, "write/create-payment.json")
+	updateBookingResponse := testutils.DataFromFile(t, "write/update-booking.json")
+	upsertCatalogResponse := testutils.DataFromFile(t, "write/upsert-catalog-object.json")
+	createDefinitionResponse := testutils.DataFromFile(t, "write/create-custom-attribute-definition.json")
+
+	tests := []testconn.TestCaseWrite{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs data payload",
+			Input:        common.WriteParams{ObjectName: "customers"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name: "Read-only object is not supported",
+			Input: common.WriteParams{
+				ObjectName: "payouts",
+				RecordData: map[string]any{"foo": "bar"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Create-only object cannot be updated",
+			Input: common.WriteParams{
+				ObjectName: "refunds",
+				RecordId:   "refund-001",
+				RecordData: map[string]any{"foo": "bar"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Update-only object cannot be created",
+			Input: common.WriteParams{
+				ObjectName: "labor/workweek_configs",
+				RecordData: map[string]any{"start_of_week": "MON"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			// Customer creation takes a flat body while the response wraps the
+			// record in a "customer" envelope.
+			Name: "Create customer with flat request body",
+			Input: common.WriteParams{
+				ObjectName: "customers",
+				RecordData: map[string]any{
+					"given_name":    "Amelia",
+					"family_name":   "Earhart",
+					"email_address": "amelia.earhart@example.com",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/customers"),
+					mockcond.Body(`{
+						"given_name": "Amelia",
+						"family_name": "Earhart",
+						"email_address": "amelia.earhart@example.com"
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, createCustomerResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "JDKYHBWT1D4F8MFH63DBMEN8Y4",
+				Data: map[string]any{
+					"id":         "JDKYHBWT1D4F8MFH63DBMEN8Y4",
+					"given_name": "Amelia",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// The record is wrapped under "gift_card", location_id is hoisted to
+			// the top level, and a missing idempotency_key is auto-generated.
+			Name: "Create gift card wraps record and injects idempotency key",
+			Input: common.WriteParams{
+				ObjectName: "gift_cards",
+				RecordData: map[string]any{
+					"type":        "DIGITAL",
+					"location_id": "L72WA3EVDJ8FY",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/gift-cards"),
+					mockcond.Body(`{
+						"location_id": "L72WA3EVDJ8FY",
+						"gift_card": {"type": "DIGITAL"}
+					}`, mockcond.IgnoreBodyField("idempotency_key")),
+				},
+				Then: mockserver.Response(http.StatusOK, createGiftCardResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "gftc:6d55a92ac6db4f4c9b78be6a9b1a1a1a",
+				Data: map[string]any{
+					"id":    "gftc:6d55a92ac6db4f4c9b78be6a9b1a1a1a",
+					"state": "PENDING",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// A caller-supplied idempotency_key is passed through untouched.
+			Name: "Create payment passes caller idempotency key through",
+			Input: common.WriteParams{
+				ObjectName: "payments",
+				RecordData: map[string]any{
+					"idempotency_key": "my-key-123",
+					"source_id":       "cnon:card-nonce-ok",
+					"amount_money":    map[string]any{"amount": 1000, "currency": "USD"},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/payments"),
+					mockcond.Body(`{
+						"idempotency_key": "my-key-123",
+						"source_id": "cnon:card-nonce-ok",
+						"amount_money": {"amount": 1000, "currency": "USD"}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, createPaymentResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "bP9mAsEMYPUGjjGNaNO5ZDVyLhSZY",
+				Data: map[string]any{
+					"id":     "bP9mAsEMYPUGjjGNaNO5ZDVyLhSZY",
+					"status": "COMPLETED",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update booking puts wrapped record to id path",
+			Input: common.WriteParams{
+				ObjectName: "bookings",
+				RecordId:   "zkbugu5jyvgfdqrp",
+				RecordData: map[string]any{
+					"version":  1,
+					"start_at": "2026-08-01T15:00:00Z",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPUT(),
+					mockcond.Path("/v2/bookings/zkbugu5jyvgfdqrp"),
+					mockcond.Body(`{
+						"booking": {"version": 1, "start_at": "2026-08-01T15:00:00Z"}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, updateBookingResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "zkbugu5jyvgfdqrp",
+				Data: map[string]any{
+					"id":     "zkbugu5jyvgfdqrp",
+					"status": "ACCEPTED",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// Catalog updates go through the upsert endpoint: POST to the same
+			// path with the record id injected into the object body.
+			Name: "Update catalog object via upsert",
+			Input: common.WriteParams{
+				ObjectName: "catalog",
+				RecordId:   "W62UWFY35CWMYGVWK6TWJPNI",
+				RecordData: map[string]any{
+					"type":    "ITEM",
+					"version": 2,
+					"item_data": map[string]any{
+						"name": "Cocoa",
+					},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/catalog/object"),
+					mockcond.Body(`{
+						"object": {
+							"id": "W62UWFY35CWMYGVWK6TWJPNI",
+							"type": "ITEM",
+							"version": 2,
+							"item_data": {"name": "Cocoa"}
+						}
+					}`, mockcond.IgnoreBodyField("idempotency_key")),
+				},
+				Then: mockserver.Response(http.StatusOK, upsertCatalogResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "W62UWFY35CWMYGVWK6TWJPNI",
+				Data: map[string]any{
+					"id":      "W62UWFY35CWMYGVWK6TWJPNI",
+					"version": float64(3),
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			// Custom attribute definitions identify records by "key", not "id".
+			Name: "Create customer custom attribute definition uses key as id",
+			Input: common.WriteParams{
+				ObjectName: "customers/custom_attribute_definitions",
+				RecordData: map[string]any{
+					"key":  "favorite-drink",
+					"name": "Favorite Drink",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v2/customers/custom-attribute-definitions"),
+					mockcond.Body(`{
+						"custom_attribute_definition": {"key": "favorite-drink", "name": "Favorite Drink"}
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, createDefinitionResponse),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "favorite-drink",
+				Data: map[string]any{
+					"key":  "favorite-drink",
+					"name": "Favorite Drink",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableWriter, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/square/write_test.go
+++ b/providers/square/write_test.go
@@ -43,25 +43,6 @@ func TestWrite(t *testing.T) { //nolint:funlen
 			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
 		},
 		{
-			Name: "Create-only object cannot be updated",
-			Input: common.WriteParams{
-				ObjectName: "refunds",
-				RecordId:   "refund-001",
-				RecordData: map[string]any{"foo": "bar"},
-			},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
-		},
-		{
-			Name: "Update-only object cannot be created",
-			Input: common.WriteParams{
-				ObjectName: "labor/workweek_configs",
-				RecordData: map[string]any{"start_of_week": "MON"},
-			},
-			Server:       mockserver.Dummy(),
-			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
-		},
-		{
 			// Customer creation takes a flat body while the response wraps the
 			// record in a "customer" envelope.
 			Name: "Create customer with flat request body",

--- a/test/square/write/main.go
+++ b/test/square/write/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/square"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetSquareConnector(ctx)
+
+	// Create a customer, then update it with the returned record id.
+	res, err := conn.Write(ctx, common.WriteParams{
+		ObjectName: "customers",
+		RecordData: map[string]any{
+			"given_name":    "Amelia",
+			"family_name":   "Earhart",
+			"email_address": "amelia.earhart@example.com",
+			"note":          "created by the connectors write test",
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating customer", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Write(ctx, common.WriteParams{
+		ObjectName: "customers",
+		RecordId:   res.RecordId,
+		RecordData: map[string]any{
+			"note": "updated by the connectors write test",
+		},
+	})
+	if err != nil {
+		utils.Fail("error updating customer", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	// Create a customer group, then update it.
+	res, err = conn.Write(ctx, common.WriteParams{
+		ObjectName: "customers/groups",
+		RecordData: map[string]any{
+			"name": "Connectors Write Test Group",
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating customer group", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	res, err = conn.Write(ctx, common.WriteParams{
+		ObjectName: "customers/groups",
+		RecordId:   res.RecordId,
+		RecordData: map[string]any{
+			"name": "Connectors Write Test Group (updated)",
+		},
+	})
+	if err != nil {
+		utils.Fail("error updating customer group", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	// Create a digital gift card; exercises envelope wrapping, the hoisted
+	// location_id field, and idempotency key injection.
+	locations, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "locations",
+		Fields:     connectors.Fields("id"),
+	})
+	if err != nil {
+		utils.Fail("error reading locations", "error", err)
+	}
+
+	if len(locations.Data) == 0 {
+		utils.Fail("no locations available for gift card creation")
+	}
+
+	locationID, ok := locations.Data[0].Fields["id"].(string)
+	if !ok {
+		utils.Fail("location id is not a string")
+	}
+
+	res, err = conn.Write(ctx, common.WriteParams{
+		ObjectName: "gift_cards",
+		RecordData: map[string]any{
+			"type":        "DIGITAL",
+			"location_id": locationID,
+		},
+	})
+	if err != nil {
+		utils.Fail("error creating gift card", "error", err)
+	}
+
+	utils.DumpJSON(res, os.Stdout)
+
+	slog.Info("Write operation completed successfully.")
+}

--- a/test/square/write/main.go
+++ b/test/square/write/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -52,11 +54,15 @@ func main() {
 
 	utils.DumpJSON(res, os.Stdout)
 
-	// Create a customer group, then update it.
+	// Create a customer group, then update it. Square rejects duplicate group
+	// names, so include a timestamp to keep reruns from colliding with groups
+	// left behind by earlier runs.
+	groupName := fmt.Sprintf("Connectors Write Test Group %d", time.Now().Unix())
+
 	res, err = conn.Write(ctx, common.WriteParams{
 		ObjectName: "customers/groups",
 		RecordData: map[string]any{
-			"name": "Connectors Write Test Group",
+			"name": groupName,
 		},
 	})
 	if err != nil {
@@ -69,7 +75,7 @@ func main() {
 		ObjectName: "customers/groups",
 		RecordId:   res.RecordId,
 		RecordData: map[string]any{
-			"name": "Connectors Write Test Group (updated)",
+			"name": groupName + " (updated)",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [ ] Read supports pagination and incremental sync
- [x] Raw response is returned as is, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
  
## Sample read response
```
time=2026-08-06T17:47:37.899+05:45 level=DEBUG msg="loading credentials file" path=./square-sandbox-creds.json
{
  "Data": {
    "created_at": "2026-08-06T12:02:38.232Z",
    "creation_source": "THIRD_PARTY",
    "email_address": "amelia.earhart@example.com",
    "family_name": "Earhart",
    "given_name": "Amelia",
    "id": "66FK6RSDM27DQJAMMQ1FKAY29R",
    "note": "created by the connectors write test",
    "preferences": {
      "email_unsubscribed": false
    },
    "updated_at": "2026-08-06T12:02:38Z",
    "version": 0
  },
  "Errors": [],
  "RecordId": "66FK6RSDM27DQJAMMQ1FKAY29R",
  "Success": true
}
{
  "Data": {
    "created_at": "2026-08-06T12:02:38.232Z",
    "creation_source": "THIRD_PARTY",
    "email_address": "amelia.earhart@example.com",
    "family_name": "Earhart",
    "given_name": "Amelia",
    "id": "66FK6RSDM27DQJAMMQ1FKAY29R",
    "note": "updated by the connectors write test",
    "preferences": {
      "email_unsubscribed": false
    },
    "segment_ids": [
      "MLAFRBK7WAQNY.REACHABLE"
    ],
    "updated_at": "2026-08-06T12:02:39Z",
    "version": 1
  },
  "Errors": [],
  "RecordId": "66FK6RSDM27DQJAMMQ1FKAY29R",
  "Success": true
}
{
  "Data": {
    "created_at": "2026-08-06T12:02:38.984Z",
    "id": "5QB13Q5QZAT13DYTK8HD5K9S4N",
    "name": "Connectors Write Test Group 1786017758",
    "updated_at": "2026-08-06T12:02:39Z"
  },
  "Errors": [],
  "RecordId": "5QB13Q5QZAT13DYTK8HD5K9S4N",
  "Success": true
}
{
  "Data": {
    "created_at": "2026-08-06T12:02:38.984Z",
    "id": "5QB13Q5QZAT13DYTK8HD5K9S4N",
    "name": "Connectors Write Test Group 1786017758 (updated)",
    "updated_at": "2026-08-06T12:02:39Z"
  },
  "Errors": [],
  "RecordId": "5QB13Q5QZAT13DYTK8HD5K9S4N",
  "Success": true
}
{
  "Data": {
    "balance_money": {
      "amount": 0,
      "currency": "USD"
    },
    "created_at": "2026-08-06T12:02:40Z",
    "gan": "7783326152242530",
    "gan_source": "SQUARE",
    "id": "gftc:c0ad8f9bd4d9404792f8b5949597f711",
    "state": "PENDING",
    "type": "DIGITAL"
  },
  "Errors": [],
  "RecordId": "gftc:c0ad8f9bd4d9404792f8b5949597f711",
  "Success": true
}
time=2026-08-06T17:47:40.188+05:45 level=INFO msg="Write operation completed successfully."

```

