### PR TITLE
feat(common): add HTTPOption client wrapper for extra request headers/query params

### DIFF
--- a/common/httpoption.go
+++ b/common/httpoption.go
@@ -1,0 +1,91 @@
+// nolint:revive,godoclint
+package common
+
+import (
+	"net/http"
+)
+
+// HTTPOptionIn identifies where an HTTPOption is attached on the request.
+type HTTPOptionIn string
+
+const (
+	// HTTPOptionInHeader attaches the option as an HTTP request header.
+	HTTPOptionInHeader HTTPOptionIn = "header"
+
+	// HTTPOptionInQuery attaches the option as a URL query parameter.
+	// Note that query parameter values end up in URLs, which are commonly
+	// logged; prefer HTTPOptionInHeader for sensitive values.
+	HTTPOptionInQuery HTTPOptionIn = "query"
+)
+
+// HTTPOption is a static key/value pair attached to every request made by an
+// AuthenticatedHTTPClient, either as a header or a URL query parameter. It is
+// meant for provider requirements beyond the primary auth credential, such as
+// an extra client id or subscription key header, typically sourced from
+// connection metadata.
+type HTTPOption struct {
+	In    HTTPOptionIn `json:"in"`
+	Key   string       `json:"key"`
+	Value string       `json:"value"`
+}
+
+// NewHTTPOptionsClient wraps an AuthenticatedHTTPClient so that the given
+// options are attached to every request it makes. Options are applied
+// set-if-missing: a value already present on the request (set by the caller
+// or by a connector) wins, so nothing is overwritten or double-applied.
+// If opts is empty, the client is returned unwrapped.
+func NewHTTPOptionsClient(client AuthenticatedHTTPClient, opts []HTTPOption) AuthenticatedHTTPClient { //nolint:ireturn,lll
+	if len(opts) == 0 {
+		return client
+	}
+
+	var (
+		headers     Headers
+		queryParams QueryParams
+	)
+
+	for _, opt := range opts {
+		switch opt.In {
+		case HTTPOptionInHeader:
+			headers = append(headers, Header{
+				Key:   opt.Key,
+				Value: opt.Value,
+				Mode:  HeaderModeSetIfMissing,
+			})
+		case HTTPOptionInQuery:
+			queryParams = append(queryParams, QueryParam{
+				Key:   opt.Key,
+				Value: opt.Value,
+				Mode:  QueryParamModeSetIfMissing,
+			})
+		}
+	}
+
+	return &httpOptionsClient{
+		client:      client,
+		headers:     headers,
+		queryParams: queryParams,
+	}
+}
+
+// httpOptionsClient decorates an AuthenticatedHTTPClient with static headers
+// and query parameters that are attached to every request.
+type httpOptionsClient struct {
+	client      AuthenticatedHTTPClient
+	headers     Headers
+	queryParams QueryParams
+}
+
+func (c *httpOptionsClient) Do(req *http.Request) (*http.Response, error) {
+	// This allows us to attach headers/query params without mutating the input.
+	req2 := req.Clone(req.Context())
+
+	c.headers.ApplyToRequest(req2)
+	c.queryParams.ApplyToRequest(req2)
+
+	return c.client.Do(req2)
+}
+
+func (c *httpOptionsClient) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}

--- a/common/httpoption_test.go
+++ b/common/httpoption_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+	"net/http"
+	"testing"
+)
+
+type captureClient struct {
+	req *http.Request
+}
+
+func (c *captureClient) Do(req *http.Request) (*http.Response, error) {
+	c.req = req
+
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func (c *captureClient) CloseIdleConnections() {}
+
+func TestNewHTTPOptionsClientEmptyReturnsUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	inner := &captureClient{}
+
+	if got := NewHTTPOptionsClient(inner, nil); got != AuthenticatedHTTPClient(inner) {
+		t.Errorf("expected inner client to be returned unwrapped, got %T", got)
+	}
+}
+
+func TestHTTPOptionsClientAppliesHeaderAndQuery(t *testing.T) {
+	t.Parallel()
+
+	inner := &captureClient{}
+	client := NewHTTPOptionsClient(inner, []HTTPOption{
+		{In: HTTPOptionInHeader, Key: "ClientId", Value: "my-client-id"},
+		{In: HTTPOptionInQuery, Key: "apiVersion", Value: "3.0"},
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/path?existing=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := inner.req.Header.Get("ClientId"); got != "my-client-id" {
+		t.Errorf("expected ClientId header %q, got %q", "my-client-id", got)
+	}
+
+	query := inner.req.URL.Query()
+	if got := query.Get("apiVersion"); got != "3.0" {
+		t.Errorf("expected apiVersion query param %q, got %q", "3.0", got)
+	}
+
+	if got := query.Get("existing"); got != "1" {
+		t.Errorf("expected existing query param to be preserved, got %q", got)
+	}
+
+	// The original request must not be mutated.
+	if got := req.Header.Get("ClientId"); got != "" {
+		t.Errorf("expected original request to be unmodified, got ClientId=%q", got)
+	}
+
+	if got := req.URL.Query().Get("apiVersion"); got != "" {
+		t.Errorf("expected original request URL to be unmodified, got apiVersion=%q", got)
+	}
+}
+
+func TestHTTPOptionsClientDoesNotOverwriteExistingValues(t *testing.T) {
+	t.Parallel()
+
+	inner := &captureClient{}
+	client := NewHTTPOptionsClient(inner, []HTTPOption{
+		{In: HTTPOptionInHeader, Key: "ClientId", Value: "from-options"},
+		{In: HTTPOptionInQuery, Key: "apiVersion", Value: "from-options"},
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/path?apiVersion=caller", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("ClientId", "caller")
+
+	if _, err := client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := inner.req.Header.Get("ClientId"); got != "caller" {
+		t.Errorf("expected caller-supplied header to win, got %q", got)
+	}
+
+	if got := inner.req.URL.Query()["apiVersion"]; len(got) != 1 || got[0] != "caller" {
+		t.Errorf("expected caller-supplied query param to win, got %v", got)
+	}
+}

--- a/providers/connectWise.go
+++ b/providers/connectWise.go
@@ -1,8 +1,20 @@
 package providers
 
+import (
+	"github.com/amp-labs/connectors/common"
+)
+
 const ConnectWise Provider = "connectWise"
 
 func init() {
+	// ConnectWise requires a ClientId header on every request in addition to
+	// Basic Auth; the value comes from the clientId connection metadata input.
+	SetHTTPOptionSpecs(ConnectWise, HTTPOptionSpec{
+		In:            common.HTTPOptionInHeader,
+		Key:           "ClientId",
+		MetadataField: "clientId",
+	})
+
 	SetInfo(ConnectWise, ProviderInfo{
 		DisplayName: "ConnectWise",
 		AuthType:    Basic,

--- a/providers/requestoptions.go
+++ b/providers/requestoptions.go
@@ -1,0 +1,66 @@
+package providers
+
+import (
+	"github.com/amp-labs/connectors/common"
+)
+
+// HTTPOptionSpec declares an extra header or query parameter that a provider
+// requires on every request beyond the primary auth credential, with the
+// value sourced from a connection metadata field (see ProviderMetadata.Input).
+// Specs are registered next to the provider's SetInfo call and resolved
+// against connection metadata with ResolveHTTPOptions.
+type HTTPOptionSpec struct {
+	// In is where the option is attached on the request (header or query).
+	In common.HTTPOptionIn
+
+	// Key is the header or query parameter name, e.g. "ClientId".
+	Key string
+
+	// MetadataField is the connection metadata key holding the value,
+	// matching the Name of a ProviderMetadata.Input item, e.g. "clientId".
+	MetadataField string
+}
+
+//nolint:gochecknoglobals
+var httpOptionSpecs = make(map[Provider][]HTTPOptionSpec)
+
+// SetHTTPOptionSpecs registers the extra request options a provider requires.
+// Like SetInfo, it is meant to be called from the provider's init.
+func SetHTTPOptionSpecs(provider Provider, specs ...HTTPOptionSpec) {
+	httpOptionSpecs[provider] = specs
+}
+
+// GetHTTPOptionSpecs returns the specs registered for the provider, if any.
+func GetHTTPOptionSpecs(provider Provider) []HTTPOptionSpec {
+	return httpOptionSpecs[provider]
+}
+
+// ResolveHTTPOptions resolves the provider's registered specs against
+// connection metadata, producing options ready for NewClientParams.HTTPOptions
+// or common.NewHTTPOptionsClient. Specs whose metadata field is absent or
+// empty are skipped: connectors enforce their own metadata requirements, and
+// failing client construction here would take down flows that never needed
+// the option.
+func ResolveHTTPOptions(provider Provider, metadata map[string]string) []common.HTTPOption {
+	specs := httpOptionSpecs[provider]
+	if len(specs) == 0 {
+		return nil
+	}
+
+	opts := make([]common.HTTPOption, 0, len(specs))
+
+	for _, spec := range specs {
+		value := metadata[spec.MetadataField]
+		if value == "" {
+			continue
+		}
+
+		opts = append(opts, common.HTTPOption{
+			In:    spec.In,
+			Key:   spec.Key,
+			Value: value,
+		})
+	}
+
+	return opts
+}

--- a/providers/requestoptions_test.go
+++ b/providers/requestoptions_test.go
@@ -1,0 +1,41 @@
+package providers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+func TestResolveHTTPOptionsConnectWise(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveHTTPOptions(ConnectWise, map[string]string{
+		"clientId": "my-client-id",
+		"region":   "na",
+	})
+
+	want := []common.HTTPOption{
+		{In: common.HTTPOptionInHeader, Key: "ClientId", Value: "my-client-id"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestResolveHTTPOptionsSkipsMissingMetadata(t *testing.T) {
+	t.Parallel()
+
+	if got := ResolveHTTPOptions(ConnectWise, map[string]string{"region": "na"}); len(got) != 0 {
+		t.Errorf("expected missing metadata to be skipped, got %v", got)
+	}
+}
+
+func TestResolveHTTPOptionsUnregisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	if got := ResolveHTTPOptions(Salesforce, map[string]string{"clientId": "x"}); got != nil {
+		t.Errorf("expected nil for provider without specs, got %v", got)
+	}
+}

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -360,14 +360,30 @@ type NewClientParams struct {
 	// CustomCreds is the custom auth credentials to use for the client. If the provider uses
 	// custom auth, this field must be set.
 	CustomCreds *CustomAuthParams
+
+	// HTTPOptions are extra headers or query parameters attached to every
+	// request the client makes, in addition to the auth credential. They are
+	// applied set-if-missing, so values already present on a request win.
+	// Works with any auth type.
+	HTTPOptions []common.HTTPOption
 }
 
 // NewClient will create a new authenticated client based on the provider's auth type.
-func (i *ProviderInfo) NewClient(ctx context.Context, params *NewClientParams) (common.AuthenticatedHTTPClient, error) { //nolint:lll,cyclop,ireturn,funlen
+func (i *ProviderInfo) NewClient(ctx context.Context, params *NewClientParams) (common.AuthenticatedHTTPClient, error) { //nolint:lll,ireturn
 	if params == nil {
 		params = &NewClientParams{}
 	}
 
+	client, err := i.newAuthClient(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.NewHTTPOptionsClient(client, params.HTTPOptions), nil
+}
+
+// newAuthClient creates the auth-type-specific client for the provider.
+func (i *ProviderInfo) newAuthClient(ctx context.Context, params *NewClientParams) (common.AuthenticatedHTTPClient, error) { //nolint:lll,cyclop,ireturn,funlen
 	switch i.AuthType {
 	case None:
 		return createUnauthenticatedClient(ctx, params.Client, params.Debug)


### PR DESCRIPTION
## Motivation

Some providers require an extra header or query parameter on **every** request beyond the primary auth credential — ConnectWise needs `ClientId`, Blackbaud needs `Bb-Api-Subscription-Key`. Today those are hand-rolled inside each connector's read/write handlers, so any consumer that only uses the authenticated HTTP client never sends them. Notably, the server's proxy action wraps the `generic` connector and forwards requests through the auth client directly, so proxied ConnectWise calls fail with 401 "Incorrect or disabled client ID" even though the clientId is stored in connection metadata.

## Changes

**Mechanism (common):**
- `common.HTTPOption{In, Key, Value}` — a static header (`in: header`) or URL query parameter (`in: query`) attached to every request.
- `common.NewHTTPOptionsClient(client, opts)` — decorates any `AuthenticatedHTTPClient`. Options are applied **set-if-missing**, so values already present on a request (set by the caller or by a connector's own header logic, e.g. ConnectWise's `clientIdHeader()`) win and nothing double-applies. Returns the inner client unwrapped when `opts` is empty.
- `providers.NewClientParams.HTTPOptions` — applied by `NewClient` around the auth-type-specific client, so basic/oauth2/apiKey/custom clients all inherit the behavior uniformly.

**Per-provider declaration (providers):**
- `providers.HTTPOptionSpec{In, Key, MetadataField}` + `SetHTTPOptionSpecs(provider, specs...)` — each provider declares the options it requires next to its `SetInfo` call, with values sourced from connection metadata (`ProviderMetadata.Input`).
- `providers.ResolveHTTPOptions(provider, metadata)` — consumers (the server) resolve the specs against connection metadata generically; specs with missing/empty metadata are skipped.
- Registered ConnectWise: `clientId` metadata → `ClientId` header.

## Follow-up

- Server wiring: amp-labs/server#6945 resolves the specs in `createAuthenticatedClient` so the proxy and all operations inject them automatically.
- Blackbaud registration once its metadata field is validated.
- Longer term this declaration could move into the generated catalog (amp-labs/openapi).

## Test plan

- Unit tests for the decorator (header+query application, original-request immutability for 401-retry replay, caller-value precedence, empty-options passthrough) and for spec resolution (present / missing / unregistered provider).
- `go build ./...`, `go test ./common/... ./providers/`, and `./custom-gcl run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)