### PR TITLE
[ENG-4167][PR1] feat(mocksub): add subscribe-testing mock providers with mocksalesloft

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/mocksub"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/acculynx"
 	"github.com/amp-labs/connectors/providers/acuityscheduling"
@@ -257,6 +258,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Microsoft:                 wrapper(newMicrosoftConnector),
 	providers.MicrosoftAdminConsent:     wrapper(newMicrosoftAdminConsentConnector),
 	providers.Mixmax:                    wrapper(newMixmaxConnector),
+	providers.MockSalesloft:             wrapper(newMockSalesloftConnector),
 	providers.Monday:                    wrapper(newMondayConnector),
 	providers.Netsuite:                  wrapper(newNetsuiteConnector),
 	providers.NetsuiteM2M:               wrapper(newNetsuiteM2MConnector),
@@ -422,6 +424,13 @@ func newSalesloftConnector(
 	return salesloft.NewConnector(
 		salesloft.WithAuthenticatedClient(params.AuthenticatedClient),
 	)
+}
+
+// newMockSalesloftConnector constructs the mocksalesloft subscribe-testing connector (see the
+// mocksub package). ConnectorParams is ignored: the mock talks to no HTTP API and serves canned
+// records from the provider's process-wide mocksub store.
+func newMockSalesloftConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	return mocksub.NewConnector(providers.MockSalesloft), nil
 }
 
 func newDynamicsCRMConnector(

--- a/mocksub/connector.go
+++ b/mocksub/connector.go
@@ -1,0 +1,136 @@
+package mocksub
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// ObjectNameFromEventFunc resolves the object name for a subscription event. Declared for mock
+// providers mimicking a provider whose events identify the object indirectly (e.g. Attio's
+// record.* events carry a provider-side object id), matching
+// connectors.SubscriptionEventObjectNameConnector.
+type ObjectNameFromEventFunc func(ctx context.Context, event common.SubscriptionEvent) (string, error)
+
+// Connector is the generic connector behind the mock subscribe providers. The webhook-receive
+// path needs only the WebhookVerifierConnector surface; every method answers from in-process
+// state, so no HTTP call ever leaves the test.
+type Connector struct {
+	provider            providers.Provider
+	client              *common.JSONHTTPClient
+	store               *Store
+	objectNameFromEvent ObjectNameFromEventFunc
+}
+
+var (
+	_ connectors.WebhookVerifierConnector             = (*Connector)(nil)
+	_ connectors.SubscriptionEventObjectNameConnector = (*Connector)(nil)
+)
+
+// Option configures a Connector.
+type Option func(*Connector)
+
+// WithStore overrides the canned-record store. Defaults to the provider's StoreFor singleton,
+// which is what the connector.New factory path uses.
+func WithStore(store *Store) Option {
+	return func(c *Connector) {
+		c.store = store
+	}
+}
+
+// WithObjectNameFromEvent declares the event-to-object-name resolver for mock providers whose
+// events identify the object indirectly. When absent, GetObjectNameFromEvent falls back to the
+// event's own ObjectName.
+func WithObjectNameFromEvent(fn ObjectNameFromEventFunc) Option {
+	return func(c *Connector) {
+		c.objectNameFromEvent = fn
+	}
+}
+
+// NewConnector returns a mock connector answering for the given provider name.
+func NewConnector(provider providers.Provider, opts ...Option) *Connector {
+	conn := &Connector{
+		provider: provider,
+		client: &common.JSONHTTPClient{
+			HTTPClient: &common.HTTPClient{
+				Client: http.DefaultClient,
+			},
+		},
+		store: StoreFor(provider),
+	}
+
+	for _, opt := range opts {
+		opt(conn)
+	}
+
+	return conn
+}
+
+func (c *Connector) String() string {
+	return c.provider
+}
+
+func (c *Connector) JSONHTTPClient() *common.JSONHTTPClient {
+	return c.client
+}
+
+func (c *Connector) HTTPClient() *common.HTTPClient {
+	return c.client.HTTPClient
+}
+
+func (c *Connector) Provider() providers.Provider {
+	return c.provider
+}
+
+// GetRecordsByIds serves records from the canned store with real-connector semantics: ids with
+// no stored record are silently omitted (providers omit unknown ids from batch reads), and rows
+// are built by common.GetMarshaledData — the same helper real connectors use — so Raw carries
+// the full record, Fields the lowercased requested subset, and Id the record's "id" value.
+//
+//nolint:revive // recordIds parameter name matches the connectors interface.
+func (c *Connector) GetRecordsByIds(
+	_ context.Context,
+	objectName string,
+	recordIds []string,
+	fields []string,
+	_ []string,
+) ([]common.ReadResultRow, error) {
+	records := make([]map[string]any, 0, len(recordIds))
+
+	for _, id := range recordIds {
+		if record, ok := c.store.Get(objectName, id); ok {
+			records = append(records, record)
+		}
+	}
+
+	return common.GetMarshaledData(records, fields)
+}
+
+// VerifyWebhookMessage reports every message as valid. Mock providers declare verification
+// bypassed in their subscribe configs, so this exists to satisfy the WebhookVerifierConnector
+// interface rather than to gate anything; happy-path regression tests never exercise rejection.
+func (c *Connector) VerifyWebhookMessage(
+	_ context.Context,
+	_ *common.WebhookRequest,
+	_ *common.VerificationParams,
+) (bool, error) {
+	return true, nil
+}
+
+// GetObjectNameFromEvent resolves the event's object name via the declared resolver, falling
+// back to the event's own ObjectName when the mock provider declares none — the same answer
+// the receive path computes for connectors that do not implement
+// SubscriptionEventObjectNameConnector.
+func (c *Connector) GetObjectNameFromEvent(
+	ctx context.Context,
+	event common.SubscriptionEvent,
+) (string, error) {
+	if c.objectNameFromEvent != nil {
+		return c.objectNameFromEvent(ctx, event)
+	}
+
+	return event.ObjectName()
+}

--- a/mocksub/connector_test.go
+++ b/mocksub/connector_test.go
@@ -1,0 +1,172 @@
+package mocksub_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// fakeEvent is a minimal common.SubscriptionEvent used to exercise GetObjectNameFromEvent.
+type fakeEvent struct {
+	objectName string
+}
+
+func (e fakeEvent) RawMap() (map[string]any, error) { return map[string]any{}, nil }
+
+func (e fakeEvent) EventType() (common.SubscriptionEventType, error) {
+	return common.SubscriptionEventTypeCreate, nil
+}
+
+func (e fakeEvent) RawEventName() (string, error) { return "fake_created", nil }
+
+func (e fakeEvent) ObjectName() (string, error) { return e.objectName, nil }
+
+func (e fakeEvent) Workspace() (string, error) { return "", nil }
+
+func (e fakeEvent) RecordId() (string, error) { return "1", nil }
+
+func (e fakeEvent) EventTimeStampNano() (int64, error) { return 0, nil }
+
+func (e fakeEvent) PreLoadData(*common.SubscriptionEventPreLoadData) error { return nil }
+
+func TestGetRecordsByIds(t *testing.T) {
+	t.Parallel()
+
+	store := mocksub.NewStore()
+	store.Seed("people", "436664215", map[string]any{
+		"id":            float64(436664215),
+		"email_address": "john.kelly@example.com",
+		"first_name":    "John",
+		"last_name":     "Kelly",
+	})
+	store.Seed("people", "436664216", map[string]any{
+		"id":            float64(436664216),
+		"email_address": "ada.osei@example.com",
+		"first_name":    "Ada",
+		"last_name":     "Osei",
+	})
+
+	conn := mocksub.NewConnector(providers.MockSalesloft, mocksub.WithStore(store))
+
+	rows, err := conn.GetRecordsByIds(
+		context.Background(),
+		"people",
+		[]string{"436664215", "436664216", "999999999"}, // last id is not seeded
+		[]string{"email_address"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("GetRecordsByIds: %v", err)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (missing id skipped), got %d", len(rows))
+	}
+
+	first := rows[0]
+	if first.Id != "436664215" {
+		t.Errorf("expected Id extracted from record, got %q", first.Id)
+	}
+
+	if got := first.Fields["email_address"]; got != "john.kelly@example.com" {
+		t.Errorf("expected requested field in Fields, got %v", got)
+	}
+
+	if _, ok := first.Fields["first_name"]; ok {
+		t.Error("expected unrequested field to be absent from Fields")
+	}
+
+	if got := first.Raw["first_name"]; got != "John" {
+		t.Errorf("expected Raw to carry the full record, got first_name=%v", got)
+	}
+}
+
+func TestGetRecordsByIdsEmptyStore(t *testing.T) {
+	t.Parallel()
+
+	conn := mocksub.NewConnector(providers.MockSalesloft, mocksub.WithStore(mocksub.NewStore()))
+
+	rows, err := conn.GetRecordsByIds(context.Background(), "people", []string{"1"}, nil, nil)
+	if err != nil {
+		t.Fatalf("GetRecordsByIds: %v", err)
+	}
+
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows from empty store, got %d", len(rows))
+	}
+}
+
+func TestVerifyWebhookMessage(t *testing.T) {
+	t.Parallel()
+
+	conn := mocksub.NewConnector(providers.MockSalesloft, mocksub.WithStore(mocksub.NewStore()))
+
+	valid, err := conn.VerifyWebhookMessage(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyWebhookMessage: %v", err)
+	}
+
+	if !valid {
+		t.Error("expected mock verification to always pass")
+	}
+}
+
+func TestGetObjectNameFromEvent(t *testing.T) {
+	t.Parallel()
+
+	// Without a resolver, the connector falls back to the event's own ObjectName.
+	conn := mocksub.NewConnector(providers.MockSalesloft, mocksub.WithStore(mocksub.NewStore()))
+
+	name, err := conn.GetObjectNameFromEvent(context.Background(), fakeEvent{objectName: "people"})
+	if err != nil {
+		t.Fatalf("GetObjectNameFromEvent: %v", err)
+	}
+
+	if name != "people" {
+		t.Errorf("expected fallback to event.ObjectName, got %q", name)
+	}
+
+	// With a resolver, the connector delegates to it.
+	resolved := mocksub.NewConnector(
+		providers.MockSalesloft,
+		mocksub.WithStore(mocksub.NewStore()),
+		mocksub.WithObjectNameFromEvent(func(context.Context, common.SubscriptionEvent) (string, error) {
+			return "companies", nil
+		}),
+	)
+
+	name, err = resolved.GetObjectNameFromEvent(context.Background(), fakeEvent{objectName: "people"})
+	if err != nil {
+		t.Fatalf("GetObjectNameFromEvent: %v", err)
+	}
+
+	if name != "companies" {
+		t.Errorf("expected declared resolver to win, got %q", name)
+	}
+}
+
+func TestStoreForSingleton(t *testing.T) {
+	t.Parallel()
+
+	first := mocksub.StoreFor("mocksub-test-provider")
+	second := mocksub.StoreFor("mocksub-test-provider")
+
+	if first != second {
+		t.Fatal("expected StoreFor to return the same store per provider")
+	}
+
+	first.Seed("people", "1", map[string]any{"id": "1"})
+
+	if _, ok := second.Get("people", "1"); !ok {
+		t.Fatal("expected record seeded via one reference to be visible via the other")
+	}
+
+	first.Clear()
+
+	if _, ok := second.Get("people", "1"); ok {
+		t.Fatal("expected Clear to remove seeded records")
+	}
+}

--- a/mocksub/doc.go
+++ b/mocksub/doc.go
@@ -1,0 +1,19 @@
+// Package mocksub provides a generic subscribe-testing connector for the mock providers
+// (providers.MockSalesloft, ...) used by subscribe regression tests.
+//
+// Each mock provider mimics a real provider's webhook-receive behavior: its subscribe config
+// (subscribe/mock<provider>.go) reuses the real provider's SubscriptionEvent types and casters,
+// so event parsing and classification run the real code, while this connector stands in for the
+// HTTP-touching connector methods the receive path needs — GetRecordsByIds serves canned records
+// from an in-process Store instead of calling a provider API, and webhook signature verification
+// is a happy-path no-op (the mock configs declare verification bypassed).
+//
+// A test seeds records through the provider's process-wide store before running the flow under
+// test:
+//
+//	providers.SetupMockSalesloftProvider()
+//	mocksub.StoreFor(providers.MockSalesloft).Seed("people", "42", map[string]any{"id": 42, ...})
+//
+// The connector constructed by the connector.New factory for a mock provider reads from that
+// same store.
+package mocksub

--- a/mocksub/store.go
+++ b/mocksub/store.go
@@ -1,0 +1,82 @@
+package mocksub
+
+import (
+	"maps"
+	"sync"
+
+	"github.com/amp-labs/connectors/providers"
+)
+
+// Store holds the canned records a mock provider serves from GetRecordsByIds, keyed by object
+// name then record id. It is safe for concurrent use so a test can seed records while the flow
+// under test reads them.
+type Store struct {
+	mu      sync.RWMutex
+	records map[string]map[string]map[string]any
+}
+
+// NewStore returns an empty Store.
+func NewStore() *Store {
+	return &Store{
+		records: map[string]map[string]map[string]any{},
+	}
+}
+
+// Seed stores a canned record under the given object name and record id, replacing any
+// existing record with the same id.
+func (s *Store) Seed(objectName, recordID string, record map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.records[objectName] == nil {
+		s.records[objectName] = map[string]map[string]any{}
+	}
+
+	s.records[objectName][recordID] = maps.Clone(record)
+}
+
+// Get returns a copy of the record stored under the object name and record id, and whether
+// one exists.
+func (s *Store) Get(objectName, recordID string) (map[string]any, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	record, ok := s.records[objectName][recordID]
+	if !ok {
+		return nil, false
+	}
+
+	return maps.Clone(record), true
+}
+
+// Clear removes all seeded records.
+func (s *Store) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.records = map[string]map[string]map[string]any{}
+}
+
+// stores holds the per-provider singletons handed out by StoreFor.
+//
+//nolint:gochecknoglobals
+var stores = struct {
+	mu sync.Mutex
+	m  map[providers.Provider]*Store
+}{m: map[providers.Provider]*Store{}}
+
+// StoreFor returns the process-wide Store for the given mock provider, creating it on first
+// use. Connectors constructed by the connector.New factory read from this store, so tests seed
+// records through it before running the flow under test (and Clear it between scenarios).
+func StoreFor(provider providers.Provider) *Store {
+	stores.mu.Lock()
+	defer stores.mu.Unlock()
+
+	store, ok := stores.m[provider]
+	if !ok {
+		store = NewStore()
+		stores.m[provider] = store
+	}
+
+	return store
+}

--- a/providers/mocksalesloft.go
+++ b/providers/mocksalesloft.go
@@ -1,0 +1,28 @@
+package providers
+
+// MockSalesloft is a subscribe-testing mock provider mimicking Salesloft. Its subscribe config
+// reuses Salesloft's SubscriptionEvent types (so event parsing and classification run the real
+// code) while the connector serves canned records without HTTP (see the mocksub package).
+// Like Mock and MemStore, it is intentionally not registered in init() and must be set up
+// manually by calling SetupMockSalesloftProvider().
+const MockSalesloft Provider = "mocksalesloft"
+
+// SetupMockSalesloftProvider initializes the MockSalesloft provider configuration. Call this
+// explicitly in tests that use the MockSalesloft provider. The Support and
+// SubscribeRequirements flags mirror Salesloft's so the subscribe flow takes the same branches.
+func SetupMockSalesloftProvider() {
+	SetInfo(MockSalesloft, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mocksalesloft.test",
+		DisplayName: "Mock Salesloft",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			SubscribeByAPI: new(true),
+		},
+	})
+}

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -127,6 +127,10 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 	providers.Microsoft:    {DefaultModuleConfig: &microsoftConfig},
 	providers.Attio:        {DefaultModuleConfig: &attioConfig},
 	providers.Stripe:       {DefaultModuleConfig: &stripeConfig},
+
+	// Subscribe-testing mock providers (see the mocksub package). Inert unless the mock
+	// provider is explicitly set up via providers.SetupMock*Provider() in a test.
+	providers.MockSalesloft: {DefaultModuleConfig: &mockSalesloftConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in

--- a/subscribe/events.go
+++ b/subscribe/events.go
@@ -51,7 +51,7 @@ func GetObjectTypeSubscribeEventsList(
 		collapsedEvents = zoho.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Outreach:
 		collapsedEvents = outreach.CollapsedSubscriptionEvent(rawEvent)
-	case providers.Salesloft:
+	case providers.Salesloft, providers.MockSalesloft:
 		collapsedEvents = salesloft.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Gong:
 		collapsedEvents = gong.CollapsedSubscriptionEvent(rawEvent)

--- a/subscribe/mocksalesloft.go
+++ b/subscribe/mocksalesloft.go
@@ -1,0 +1,24 @@
+package subscribe
+
+import (
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// mockSalesloftConfig is the subscribe-config bundle for the mocksalesloft test provider. It
+// mirrors salesloftConfig — the same subscribe-time request builder and WatchFieldsAuto quirk,
+// so regression tests exercise the same routing behavior — but declares webhook verification
+// bypassed (happy-path tests carry no signatures) and a mocksub verifier connector serving
+// canned records without HTTP. Object-shaped webhook payloads are dispatched to Salesloft's
+// real CollapsedSubscriptionEvent in GetObjectTypeSubscribeEventsList, so event parsing and
+// classification run the real Salesloft code.
+var mockSalesloftConfig = ProviderConfig{
+	Subscription: SubscriptionConfig{
+		buildRequestFn:          getSalesloftRequest,
+		requiresWatchFieldsAuto: true,
+	},
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockSalesloft),
+	},
+}

--- a/subscribe/mocksalesloft_test.go
+++ b/subscribe/mocksalesloft_test.go
@@ -1,0 +1,125 @@
+package subscribe
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockSalesloftTaskPayload is a trimmed copy of the example webhook payload documented in
+// providers/salesloft/subscribeEvent.go. Salesloft delivers one record per webhook as a bare
+// JSON object; the event name travels in the x-salesloft-event request header.
+const mockSalesloftTaskPayload = `{
+  "created_at": "2025-11-20T07:21:04.176528-05:00",
+  "current_state": "scheduled",
+  "description": "noted updated ",
+  "due_date": "2025-11-27",
+  "id": 693873531,
+  "person": {
+    "_href": "https://api.salesloft.com/v2/people/436664215",
+    "id": 436664215
+  },
+  "subject": "Follow-up with John Kelly",
+  "task_type": "general",
+  "updated_at": "2025-11-20T07:21:16.193200-05:00"
+}`
+
+// TestMockSalesloftConfigResolution verifies the mocksalesloft registry entry resolves through
+// GetProviderConfig exactly like Salesloft's: verification bypassed, the WatchFieldsAuto quirk
+// declared, and subscribe-via-API supported.
+func TestMockSalesloftConfigResolution(t *testing.T) { //nolint:paralleltest // mutates the provider catalog
+	providers.SetupMockSalesloftProvider()
+
+	info, err := providers.ReadInfo(providers.MockSalesloft)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mocksalesloft webhook verification to be bypassed")
+	}
+
+	if !cfg.Subscription.RequiresWatchFieldsAutoAll() {
+		t.Error("expected mocksalesloft to mirror Salesloft's WatchFieldsAuto quirk")
+	}
+
+	if !cfg.Subscription.IsSupportedViaAPI() {
+		t.Error("expected mocksalesloft to mirror Salesloft's subscribe-by-API support")
+	}
+}
+
+// TestMockSalesloftEventParsing runs a Salesloft-shaped webhook payload through the same
+// object-payload dispatch the server's receive path uses and asserts the real Salesloft event
+// implementation classifies it: the mock provider name must parse events identically to
+// Salesloft itself.
+func TestMockSalesloftEventParsing(t *testing.T) {
+	t.Parallel()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal([]byte(mockSalesloftTaskPayload), &rawEvent); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := GetObjectTypeSubscribeEventsList(providers.MockSalesloft, rawEvent)
+	if err != nil {
+		t.Fatalf("GetObjectTypeSubscribeEventsList: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected Salesloft's one-record-per-webhook shape, got %d events", len(events))
+	}
+
+	event := events[0]
+
+	headers := http.Header{}
+	headers.Set("x-salesloft-event", "task_updated")
+
+	if err := event.PreLoadData(&common.SubscriptionEventPreLoadData{RequestHeaders: &headers}); err != nil {
+		t.Fatalf("PreLoadData: %v", err)
+	}
+
+	eventType, err := event.EventType()
+	if err != nil {
+		t.Fatalf("EventType: %v", err)
+	}
+
+	if eventType != common.SubscriptionEventTypeUpdate {
+		t.Errorf("expected update event, got %q", eventType)
+	}
+
+	objectName, err := event.ObjectName()
+	if err != nil {
+		t.Fatalf("ObjectName: %v", err)
+	}
+
+	if objectName != "tasks" {
+		t.Errorf("expected object name %q, got %q", "tasks", objectName)
+	}
+
+	recordID, err := event.RecordId()
+	if err != nil {
+		t.Fatalf("RecordId: %v", err)
+	}
+
+	if recordID != "693873531" {
+		t.Errorf("expected record id %q, got %q", "693873531", recordID)
+	}
+
+	rawEventName, err := event.RawEventName()
+	if err != nil {
+		t.Fatalf("RawEventName: %v", err)
+	}
+
+	if rawEventName != "task_updated" {
+		t.Errorf("expected raw event name %q, got %q", "task_updated", rawEventName)
+	}
+}


### PR DESCRIPTION
Introduce the mocksub package: a generic subscribe-testing connector whose
GetRecordsByIds serves canned records from an in-process store (no HTTP), for
use by server-side subscribe regression tests. Wire up the first mock
provider, mocksalesloft, end to end:

- providers.MockSalesloft catalog entry, registered explicitly via
  SetupMockSalesloftProvider() (same opt-in pattern as Mock/MemStore)
- subscribe config mirroring salesloftConfig (WatchFieldsAuto quirk,
  subscribe-time request builder) with verification bypassed
- object-payload dispatch reusing Salesloft's real CollapsedSubscriptionEvent,
  so event parsing/classification run the real Salesloft code
- connector.New factory constructor

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
## Test evidence

Local run at `3ef56d842`: **89 passed, 0 failed** — full log attached: [eng-4167-pr1-test-run.log](https://gist.github.com/jlimatampersand/c6864120817f6a6d929a0b8dd8461435)

```sh
RUNNING_ENV=test go test -v -count=1 ./mocksub/... ./subscribe/... ./connector/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)