### PR TITLE
[ENG-4167][PR2] feat(mocksub): add mockhubspot and mockattio subscribe-testing providers

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -258,6 +258,8 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Microsoft:                 wrapper(newMicrosoftConnector),
 	providers.MicrosoftAdminConsent:     wrapper(newMicrosoftAdminConsentConnector),
 	providers.Mixmax:                    wrapper(newMixmaxConnector),
+	providers.MockAttio:                 wrapper(newMockAttioConnector),
+	providers.MockHubspot:               wrapper(newMockHubspotConnector),
 	providers.MockSalesloft:             wrapper(newMockSalesloftConnector),
 	providers.Monday:                    wrapper(newMondayConnector),
 	providers.Netsuite:                  wrapper(newNetsuiteConnector),
@@ -431,6 +433,27 @@ func newSalesloftConnector(
 // records from the provider's process-wide mocksub store.
 func newMockSalesloftConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
 	return mocksub.NewConnector(providers.MockSalesloft), nil
+}
+
+// newMockHubspotConnector constructs the mockhubspot subscribe-testing connector (see the
+// mocksub package). ConnectorParams is ignored: the mock talks to no HTTP API and serves canned
+// records from the provider's process-wide mocksub store.
+func newMockHubspotConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	return mocksub.NewConnector(providers.MockHubspot), nil
+}
+
+// newMockAttioConnector constructs the mockattio subscribe-testing connector (see the mocksub
+// package). ConnectorParams is ignored: the mock talks to no HTTP API and serves canned records
+// from the provider's process-wide mocksub store. The object-name resolver stands in for
+// Attio's API-backed GetObjectNameFromEvent, answering record.* events' id.object_id from the
+// same store's seeded object-name index.
+func newMockAttioConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	store := mocksub.StoreFor(providers.MockAttio)
+
+	return mocksub.NewConnector(
+		providers.MockAttio,
+		mocksub.WithObjectNameFromEvent(mocksub.ObjectIDIndexResolver(store)),
+	), nil
 }
 
 func newDynamicsCRMConnector(

--- a/mocksub/objectname.go
+++ b/mocksub/objectname.go
@@ -1,0 +1,42 @@
+package mocksub
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// ObjectIDIndexResolver returns an ObjectNameFromEventFunc mirroring Attio's
+// GetObjectNameFromEvent: standard/custom-object changes arrive as generic record.* events that
+// identify their object only by an id.object_id UUID, which the real connector maps to an
+// object name by fetching the workspace's objects. The mock resolves the same id.object_id
+// against the store's seeded object-name index instead (SeedObjectName). Events whose id map
+// carries no object_id (core-object events like note.*, task.*) fall back to their own
+// ObjectName, exactly as the real resolver does.
+func ObjectIDIndexResolver(store *Store) ObjectNameFromEventFunc {
+	return func(_ context.Context, event common.SubscriptionEvent) (string, error) {
+		raw, err := event.RawMap()
+		if err != nil {
+			return "", fmt.Errorf("getting raw event map: %w", err)
+		}
+
+		idMap, ok := raw["id"].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: expected id to be map[string]any, got %T", common.ErrBadRequest, raw["id"])
+		}
+
+		objectID, ok := idMap["object_id"].(string)
+		if !ok {
+			// No object_id: a core-object event whose object is in the event type.
+			return event.ObjectName()
+		}
+
+		name, found := store.ObjectNameFor(objectID)
+		if !found {
+			return "", fmt.Errorf("%w: object id %q not seeded in object-name index", common.ErrNotFound, objectID)
+		}
+
+		return name, nil
+	}
+}

--- a/mocksub/store.go
+++ b/mocksub/store.go
@@ -13,12 +13,19 @@ import (
 type Store struct {
 	mu      sync.RWMutex
 	records map[string]map[string]map[string]any
+
+	// objectNames indexes provider-side object ids to object names, for mock providers
+	// mimicking a provider whose events identify their object only by id (e.g. Attio's
+	// record.* events carry an id.object_id UUID). Seeded via SeedObjectName and consumed
+	// by ObjectIDIndexResolver.
+	objectNames map[string]string
 }
 
 // NewStore returns an empty Store.
 func NewStore() *Store {
 	return &Store{
-		records: map[string]map[string]map[string]any{},
+		records:     map[string]map[string]map[string]any{},
+		objectNames: map[string]string{},
 	}
 }
 
@@ -49,12 +56,32 @@ func (s *Store) Get(objectName, recordID string) (map[string]any, bool) {
 	return maps.Clone(record), true
 }
 
-// Clear removes all seeded records.
+// SeedObjectName indexes a provider-side object id to its object name (see Store.objectNames).
+func (s *Store) SeedObjectName(objectID, objectName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.objectNames[objectID] = objectName
+}
+
+// ObjectNameFor returns the object name indexed under the provider-side object id, and whether
+// one is seeded.
+func (s *Store) ObjectNameFor(objectID string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	name, ok := s.objectNames[objectID]
+
+	return name, ok
+}
+
+// Clear removes all seeded records and object-name index entries.
 func (s *Store) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.records = map[string]map[string]map[string]any{}
+	s.objectNames = map[string]string{}
 }
 
 // stores holds the per-provider singletons handed out by StoreFor.

--- a/providers/mockattio.go
+++ b/providers/mockattio.go
@@ -1,0 +1,29 @@
+package providers
+
+// MockAttio is a subscribe-testing mock provider mimicking Attio. Its subscribe config reuses
+// Attio's SubscriptionEvent types (so event parsing and classification run the real code)
+// while the connector serves canned records — and resolves record.* events' id.object_id via a
+// seeded index instead of the Attio API — without HTTP (see the mocksub package). Like Mock
+// and MemStore, it is intentionally not registered in init() and must be set up manually by
+// calling SetupMockAttioProvider().
+const MockAttio Provider = "mockattio"
+
+// SetupMockAttioProvider initializes the MockAttio provider configuration. Call this
+// explicitly in tests that use the MockAttio provider. The Support and SubscribeRequirements
+// flags mirror Attio's so the subscribe flow takes the same branches.
+func SetupMockAttioProvider() {
+	SetInfo(MockAttio, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mockattio.test",
+		DisplayName: "Mock Attio",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			SubscribeByAPI: new(true),
+		},
+	})
+}

--- a/providers/mockhubspot.go
+++ b/providers/mockhubspot.go
@@ -1,0 +1,26 @@
+package providers
+
+// MockHubspot is a subscribe-testing mock provider mimicking HubSpot. Its subscribe config
+// reuses HubSpot's SubscriptionEvent types and caster (so event parsing and classification run
+// the real code) while the connector serves canned records without HTTP (see the mocksub
+// package). Like Mock and MemStore, it is intentionally not registered in init() and must be
+// set up manually by calling SetupMockHubspotProvider().
+const MockHubspot Provider = "mockhubspot"
+
+// SetupMockHubspotProvider initializes the MockHubspot provider configuration. Call this
+// explicitly in tests that use the MockHubspot provider. Like HubSpot, it declares no
+// SubscribeRequirements: HubSpot subscriptions are managed at the provider-app level
+// (look-up-only), not created via API.
+func SetupMockHubspotProvider() {
+	SetInfo(MockHubspot, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mockhubspot.test",
+		DisplayName: "Mock HubSpot",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+	})
+}

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -131,6 +131,8 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 	// Subscribe-testing mock providers (see the mocksub package). Inert unless the mock
 	// provider is explicitly set up via providers.SetupMock*Provider() in a test.
 	providers.MockSalesloft: {DefaultModuleConfig: &mockSalesloftConfig},
+	providers.MockHubspot:   {DefaultModuleConfig: &mockHubspotConfig},
+	providers.MockAttio:     {DefaultModuleConfig: &mockAttioConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in

--- a/subscribe/events.go
+++ b/subscribe/events.go
@@ -67,7 +67,7 @@ func GetObjectTypeSubscribeEventsList(
 		collapsedEvents = slack.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Microsoft:
 		collapsedEvents = microsoft.CollapsedSubscriptionEvent(rawEvent)
-	case providers.Attio:
+	case providers.Attio, providers.MockAttio:
 		collapsedEvents = attio.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Stripe:
 		collapsedEvents = stripe.CollapsedSubscriptionEvent(rawEvent)

--- a/subscribe/mockattio.go
+++ b/subscribe/mockattio.go
@@ -1,0 +1,25 @@
+package subscribe
+
+import (
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// mockAttioConfig is the subscribe-config bundle for the mockattio test provider. It mirrors
+// attioConfig — the same subscribe-time request builder and WatchFieldsAuto quirk, and its
+// object-shaped webhook payloads are fanned out by Attio's real CollapsedSubscriptionEvent in
+// GetObjectTypeSubscribeEventsList — while webhook verification is bypassed (the real config's
+// stored-secret HMAC needs subscription results the mock does not create) and the verifier
+// connector serves canned records without HTTP. The connector.New factory additionally wires
+// the mock connector with an object-name resolver answering record.* events' id.object_id from
+// the store's seeded index, standing in for Attio's API-backed GetObjectNameFromEvent.
+var mockAttioConfig = ProviderConfig{
+	Subscription: SubscriptionConfig{
+		buildRequestFn:          getAttioRequest,
+		requiresWatchFieldsAuto: true,
+	},
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockAttio),
+	},
+}

--- a/subscribe/mockattio_test.go
+++ b/subscribe/mockattio_test.go
@@ -1,0 +1,145 @@
+package subscribe
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockAttioWebhookPayload is an object-shaped Attio webhook body ({webhook_id, events}). The
+// envelope mirrors the example documented in providers/attio/subscriptionEvent.go; the record.*
+// id shape ({workspace_id, object_id, record_id}) follows the same file's webhook-reference
+// notes (https://docs.attio.com/rest-api/webhook-reference, record-events/recordcreated).
+const mockAttioWebhookPayload = `{
+  "webhook_id": "04731154-70d3-42bb-8320-760304c9bbfd",
+  "events": [
+    {
+      "event_type": "record.created",
+      "id": {
+        "workspace_id": "e293215c-210a-4d4a-9913-e2b33da318ab",
+        "object_id": "ee1e6aa1-ec69-4ef4-a101-3a9abb12e281",
+        "record_id": "9bcad14b-55a5-478d-963b-a4ec598265c6"
+      },
+      "actor": {
+        "type": "workspace-member",
+        "id": "f0519378-80b8-4d7c-8874-c6acc1850442"
+      }
+    },
+    {
+      "event_type": "note.updated",
+      "id": {
+        "workspace_id": "e293215c-210a-4d4a-9913-e2b33da318ab",
+        "note_id": "f83d5cab-571b-47a8-8018-57146f848d19"
+      },
+      "actor": {
+        "type": "workspace-member",
+        "id": "f0519378-80b8-4d7c-8874-c6acc1850442"
+      }
+    }
+  ]
+}`
+
+// TestMockAttioConfigResolution verifies the mockattio registry entry resolves like Attio's:
+// the WatchFieldsAuto quirk and subscribe-by-API support are mirrored, with verification
+// bypassed (the real config's stored-secret HMAC has no mock counterpart).
+func TestMockAttioConfigResolution(t *testing.T) { //nolint:paralleltest // mutates the provider catalog
+	providers.SetupMockAttioProvider()
+
+	info, err := providers.ReadInfo(providers.MockAttio)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mockattio webhook verification to be bypassed")
+	}
+
+	if !cfg.Subscription.RequiresWatchFieldsAutoAll() {
+		t.Error("expected mockattio to mirror Attio's WatchFieldsAuto quirk")
+	}
+
+	if !cfg.Subscription.IsSupportedViaAPI() {
+		t.Error("expected mockattio to mirror Attio's subscribe-by-API support")
+	}
+}
+
+// TestMockAttioEventParsingAndObjectNameResolution runs an Attio-shaped webhook body through
+// the same object-payload dispatch the server's receive path uses (Attio's real
+// CollapsedSubscriptionEvent fan-out), then resolves object names through the mock connector:
+// record.* events answer from the store's seeded id.object_id index (standing in for Attio's
+// API-backed resolver), and core-object events fall back to the event's own object name.
+func TestMockAttioEventParsingAndObjectNameResolution(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal([]byte(mockAttioWebhookPayload), &rawEvent); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := GetObjectTypeSubscribeEventsList(providers.MockAttio, rawEvent)
+	if err != nil {
+		t.Fatalf("GetObjectTypeSubscribeEventsList: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected the events array to fan out into 2 events, got %d", len(events))
+	}
+
+	recordCreated, noteUpdated := events[0], events[1]
+
+	if evtType, err := recordCreated.EventType(); err != nil || evtType != common.SubscriptionEventTypeCreate {
+		t.Errorf("expected create event, got %q (err %v)", evtType, err)
+	}
+
+	if recordID, err := recordCreated.RecordId(); err != nil || recordID != "9bcad14b-55a5-478d-963b-a4ec598265c6" {
+		t.Errorf("unexpected record id %q (err %v)", recordID, err)
+	}
+
+	if workspace, err := recordCreated.Workspace(); err != nil || workspace != "e293215c-210a-4d4a-9913-e2b33da318ab" {
+		t.Errorf("unexpected workspace %q (err %v)", workspace, err)
+	}
+
+	store := mocksub.NewStore()
+	store.SeedObjectName("ee1e6aa1-ec69-4ef4-a101-3a9abb12e281", "people")
+
+	conn := mocksub.NewConnector(
+		providers.MockAttio,
+		mocksub.WithStore(store),
+		mocksub.WithObjectNameFromEvent(mocksub.ObjectIDIndexResolver(store)),
+	)
+
+	name, err := conn.GetObjectNameFromEvent(context.Background(), recordCreated)
+	if err != nil {
+		t.Fatalf("GetObjectNameFromEvent (record.*): %v", err)
+	}
+
+	if name != "people" {
+		t.Errorf("expected seeded object-name index to resolve %q, got %q", "people", name)
+	}
+
+	name, err = conn.GetObjectNameFromEvent(context.Background(), noteUpdated)
+	if err != nil {
+		t.Fatalf("GetObjectNameFromEvent (core object): %v", err)
+	}
+
+	if name != "note" {
+		t.Errorf("expected core-object fallback to event object name %q, got %q", "note", name)
+	}
+
+	// An unseeded object_id must surface as not-found rather than silently misrouting.
+	store.Clear()
+
+	if _, err := conn.GetObjectNameFromEvent(context.Background(), recordCreated); err == nil {
+		t.Error("expected unseeded object id to resolve with an error")
+	}
+}

--- a/subscribe/mockhubspot.go
+++ b/subscribe/mockhubspot.go
@@ -1,0 +1,21 @@
+package subscribe
+
+import (
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/hubspot"
+)
+
+// mockHubspotConfig is the subscribe-config bundle for the mockhubspot test provider. It
+// mirrors hubspotConfig — look-up-only (no subscribe/registration declarations), verification
+// bypassed, and crucially the same event caster, so regression tests cast webhook payloads
+// through HubSpot's real SubscriptionEvent implementation — while the verifier connector
+// serves canned records without HTTP. The verification-params builder is omitted: it feeds
+// signature verification, which the mock bypasses.
+var mockHubspotConfig = ProviderConfig{
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockHubspot),
+		eventCaster:       CastSubscriptionEvents[hubspot.SubscriptionEvent],
+	},
+}

--- a/subscribe/mockhubspot_test.go
+++ b/subscribe/mockhubspot_test.go
@@ -1,0 +1,117 @@
+package subscribe
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockHubspotEventsPayload is an array-shaped webhook body built from the example events
+// documented in providers/hubspot/subscriptionEvent.go (HubSpot delivers a JSON array of
+// events per webhook).
+const mockHubspotEventsPayload = `[
+  {
+    "appId": 4210286,
+    "eventId": 100,
+    "subscriptionId": 2881778,
+    "portalId": 44237313,
+    "occurredAt": 1731612159499,
+    "subscriptionType": "contact.creation",
+    "attemptNumber": 0,
+    "objectId": 123,
+    "changeSource": "CRM",
+    "changeFlag": "NEW"
+  },
+  {
+    "appId": 4210286,
+    "eventId": 100,
+    "subscriptionId": 2902227,
+    "portalId": 44237313,
+    "occurredAt": 1731612210994,
+    "subscriptionType": "contact.propertyChange",
+    "attemptNumber": 0,
+    "objectId": 123,
+    "changeSource": "CRM",
+    "propertyName": "message",
+    "propertyValue": "sample-value"
+  }
+]`
+
+// TestMockHubspotConfigResolutionAndEventCasting verifies the mockhubspot registry entry
+// resolves like HubSpot's (verification bypassed, look-up-only) and that its event caster is
+// HubSpot's real one: an array-shaped webhook body must cast into hubspot.SubscriptionEvent
+// values that classify identically to real HubSpot events.
+func TestMockHubspotConfigResolutionAndEventCasting(t *testing.T) { //nolint:paralleltest,funlen // mutates the provider catalog
+	providers.SetupMockHubspotProvider()
+
+	info, err := providers.ReadInfo(providers.MockHubspot)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mockhubspot webhook verification to be bypassed")
+	}
+
+	if cfg.Subscription.IsSupportedViaAPI() {
+		t.Error("expected mockhubspot to mirror HubSpot's look-up-only subscribe support")
+	}
+
+	var list []map[string]any
+	if err := json.Unmarshal([]byte(mockHubspotEventsPayload), &list); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := cfg.Verification.CastEvents(list)
+	if err != nil {
+		t.Fatalf("CastEvents: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	created, updated := events[0], events[1]
+
+	if evtType, err := created.EventType(); err != nil || evtType != common.SubscriptionEventTypeCreate {
+		t.Errorf("expected create event, got %q (err %v)", evtType, err)
+	}
+
+	if objectName, err := created.ObjectName(); err != nil || objectName != "contact" {
+		t.Errorf("expected object name %q, got %q (err %v)", "contact", objectName, err)
+	}
+
+	if workspace, err := created.Workspace(); err != nil || workspace != "44237313" {
+		t.Errorf("expected workspace (portalId) %q, got %q (err %v)", "44237313", workspace, err)
+	}
+
+	if recordID, err := created.RecordId(); err != nil || recordID != "123" {
+		t.Errorf("expected record id %q, got %q (err %v)", "123", recordID, err)
+	}
+
+	if evtType, err := updated.EventType(); err != nil || evtType != common.SubscriptionEventTypeUpdate {
+		t.Errorf("expected update event, got %q (err %v)", evtType, err)
+	}
+
+	updateEvent, ok := updated.(common.SubscriptionUpdateEvent)
+	if !ok {
+		t.Fatal("expected cast event to implement SubscriptionUpdateEvent")
+	}
+
+	fields, err := updateEvent.UpdatedFields()
+	if err != nil {
+		t.Fatalf("UpdatedFields: %v", err)
+	}
+
+	if len(fields) != 1 || fields[0] != "message" {
+		t.Errorf("expected updated fields [message], got %v", fields)
+	}
+}


### PR DESCRIPTION
Extend the mocksub mock-provider set with the second batch:

- mockhubspot mirrors HubSpot: look-up-only, verification bypassed, and the
  same event caster (CastSubscriptionEvents[hubspot.SubscriptionEvent]), so
  array-shaped webhook payloads classify through HubSpot's real event code
- mockattio mirrors Attio: subscribe-by-API with the WatchFieldsAuto quirk,
  object payloads fanned out by Attio's real CollapsedSubscriptionEvent, and
  record.* events' id.object_id resolved via a seeded object-name index on the
  mocksub store (ObjectIDIndexResolver), standing in for Attio's API-backed
  GetObjectNameFromEvent

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
## Test evidence

Local run at `672803fac`: **92 passed, 0 failed** — full log attached: [eng-4167-pr2-test-run.log](https://gist.github.com/jlimatampersand/b5841777910a581fae0df7f2f993b2b6)

```sh
RUNNING_ENV=test go test -v -count=1 ./mocksub/... ./subscribe/... ./connector/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)