### PR TITLE
[ENG-4167][PR3] feat(mocksub): add mocksalesforce and mockconnectwise subscribe-testing providers

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -259,7 +259,9 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.MicrosoftAdminConsent:     wrapper(newMicrosoftAdminConsentConnector),
 	providers.Mixmax:                    wrapper(newMixmaxConnector),
 	providers.MockAttio:                 wrapper(newMockAttioConnector),
+	providers.MockConnectWise:           wrapper(newMockConnectWiseConnector),
 	providers.MockHubspot:               wrapper(newMockHubspotConnector),
+	providers.MockSalesforce:            wrapper(newMockSalesforceConnector),
 	providers.MockSalesloft:             wrapper(newMockSalesloftConnector),
 	providers.Monday:                    wrapper(newMondayConnector),
 	providers.Netsuite:                  wrapper(newNetsuiteConnector),
@@ -454,6 +456,20 @@ func newMockAttioConnector(_ common.ConnectorParams) (*mocksub.Connector, error)
 		providers.MockAttio,
 		mocksub.WithObjectNameFromEvent(mocksub.ObjectIDIndexResolver(store)),
 	), nil
+}
+
+// newMockSalesforceConnector constructs the mocksalesforce subscribe-testing connector (see the
+// mocksub package). ConnectorParams is ignored: the mock talks to no HTTP API and serves canned
+// records from the provider's process-wide mocksub store.
+func newMockSalesforceConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	return mocksub.NewConnector(providers.MockSalesforce), nil
+}
+
+// newMockConnectWiseConnector constructs the mockconnectwise subscribe-testing connector (see
+// the mocksub package). ConnectorParams is ignored: the mock talks to no HTTP API and serves
+// canned records from the provider's process-wide mocksub store.
+func newMockConnectWiseConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	return mocksub.NewConnector(providers.MockConnectWise), nil
 }
 
 func newDynamicsCRMConnector(

--- a/providers/mockconnectwise.go
+++ b/providers/mockconnectwise.go
@@ -1,0 +1,30 @@
+package providers
+
+// MockConnectWise is a subscribe-testing mock provider mimicking ConnectWise. Its subscribe
+// config reuses ConnectWise's SubscriptionEvent types — including the inline-record Entity
+// extraction (SubscriptionEventWithRecord) — so event parsing and classification run the real
+// code, while the connector serves canned records without HTTP (see the mocksub package). Like
+// Mock and MemStore, it is intentionally not registered in init() and must be set up manually
+// by calling SetupMockConnectWiseProvider().
+const MockConnectWise Provider = "mockconnectwise"
+
+// SetupMockConnectWiseProvider initializes the MockConnectWise provider configuration. Call
+// this explicitly in tests that use the MockConnectWise provider. The Support and
+// SubscribeRequirements flags mirror ConnectWise's so the subscribe flow takes the same
+// branches; the region metadata input is omitted (the mock talks to no HTTP API).
+func SetupMockConnectWiseProvider() {
+	SetInfo(MockConnectWise, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mockconnectwise.test",
+		DisplayName: "Mock ConnectWise",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			SubscribeByAPI: new(true),
+		},
+	})
+}

--- a/providers/mocksalesforce.go
+++ b/providers/mocksalesforce.go
@@ -1,0 +1,28 @@
+package providers
+
+// MockSalesforce is a subscribe-testing mock provider mimicking Salesforce. Its subscribe
+// config reuses Salesforce's SubscriptionEvent types — including the AWS EventBridge envelope
+// unwrap and per-recordIds fan-out — so event parsing and classification run the real code,
+// while the connector serves canned records without HTTP (see the mocksub package). Like Mock
+// and MemStore, it is intentionally not registered in init() and must be set up manually by
+// calling SetupMockSalesforceProvider().
+const MockSalesforce Provider = "mocksalesforce"
+
+// SetupMockSalesforceProvider initializes the MockSalesforce provider configuration. Call this
+// explicitly in tests that use the MockSalesforce provider. SubscribeRequirements is
+// deliberately omitted: Salesforce's Registration/PostProcess flags declare Ampersand-side AWS
+// EventBridge infrastructure with no mock counterpart, and the webhook receive path under test
+// does not read them.
+func SetupMockSalesforceProvider() {
+	SetInfo(MockSalesforce, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mocksalesforce.test",
+		DisplayName: "Mock Salesforce",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+	})
+}

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -130,9 +130,11 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 
 	// Subscribe-testing mock providers (see the mocksub package). Inert unless the mock
 	// provider is explicitly set up via providers.SetupMock*Provider() in a test.
-	providers.MockSalesloft: {DefaultModuleConfig: &mockSalesloftConfig},
-	providers.MockHubspot:   {DefaultModuleConfig: &mockHubspotConfig},
-	providers.MockAttio:     {DefaultModuleConfig: &mockAttioConfig},
+	providers.MockSalesloft:   {DefaultModuleConfig: &mockSalesloftConfig},
+	providers.MockHubspot:     {DefaultModuleConfig: &mockHubspotConfig},
+	providers.MockAttio:       {DefaultModuleConfig: &mockAttioConfig},
+	providers.MockSalesforce:  {DefaultModuleConfig: &mockSalesforceConfig},
+	providers.MockConnectWise: {DefaultModuleConfig: &mockConnectWiseConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in

--- a/subscribe/events.go
+++ b/subscribe/events.go
@@ -40,7 +40,7 @@ func GetObjectTypeSubscribeEventsList(
 	var collapsedEvents common.CollapsedSubscriptionEvent
 
 	switch provider {
-	case providers.Salesforce, providers.SalesforceJWT:
+	case providers.Salesforce, providers.SalesforceJWT, providers.MockSalesforce:
 		unwrapped, err := unwrapSalesforceEvent(rawEvent)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unwrap salesforce event: %w", err)
@@ -59,7 +59,7 @@ func GetObjectTypeSubscribeEventsList(
 		collapsedEvents = housecallpro.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Jobber:
 		collapsedEvents = jobber.CollapsedSubscriptionEvent(rawEvent)
-	case providers.ConnectWise:
+	case providers.ConnectWise, providers.MockConnectWise:
 		collapsedEvents = connectwise.CollapsedSubscriptionEvent(rawEvent)
 	case providers.AccuLynx:
 		collapsedEvents = acculynx.CollapsedSubscriptionEvent(rawEvent)

--- a/subscribe/mockconnectwise.go
+++ b/subscribe/mockconnectwise.go
@@ -1,0 +1,25 @@
+package subscribe
+
+import (
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// mockConnectWiseConfig is the subscribe-config bundle for the mockconnectwise test provider.
+// It mirrors connectWiseConfig — the same subscribe-time request builder, the WatchFieldsAuto
+// quirk, and bypassed verification (the real connector's verification needs an authenticated
+// client, so ConnectWise itself is bypassed too) — while the verifier connector serves canned
+// records without HTTP. Object-shaped webhook payloads are dispatched to ConnectWise's real
+// CollapsedSubscriptionEvent in GetObjectTypeSubscribeEventsList, so event parsing — including
+// the inline-record Entity extraction (SubscriptionEventWithRecord) — runs the real
+// ConnectWise code.
+var mockConnectWiseConfig = ProviderConfig{
+	Subscription: SubscriptionConfig{
+		buildRequestFn:          getConnectWiseRequest,
+		requiresWatchFieldsAuto: true,
+	},
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockConnectWise),
+	},
+}

--- a/subscribe/mockconnectwise_test.go
+++ b/subscribe/mockconnectwise_test.go
@@ -1,0 +1,112 @@
+package subscribe
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockConnectWiseWebhookPayload is an object-shaped ConnectWise callback body, a trimmed copy
+// of providers/connectwise/internal/webhook/test/contact-update.json. The changed record
+// travels inline as an escaped JSON string under Entity.
+const mockConnectWiseWebhookPayload = `{
+  "Action": "updated",
+  "CallbackObjectRecId": 26604,
+  "CompanyId": "Cobalt",
+  "Entity": "{\"id\":57961,\"firstName\":\"Xzavier Sawayn\",\"inactiveFlag\":false}",
+  "FromUrl": "sandbox-na.myconnectwise.net",
+  "ID": 57961,
+  "MemberId": "Aurasell",
+  "MessageId": "6dd82302-5e46-47c0-8c84-702868125b76",
+  "Type": "contact"
+}`
+
+// TestMockConnectWiseConfigResolution verifies the mockconnectwise registry entry resolves
+// like ConnectWise's: verification bypassed, the WatchFieldsAuto quirk, and subscribe-by-API
+// support mirrored.
+func TestMockConnectWiseConfigResolution(t *testing.T) { //nolint:paralleltest // mutates the provider catalog
+	providers.SetupMockConnectWiseProvider()
+
+	info, err := providers.ReadInfo(providers.MockConnectWise)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mockconnectwise webhook verification to be bypassed")
+	}
+
+	if !cfg.Subscription.RequiresWatchFieldsAutoAll() {
+		t.Error("expected mockconnectwise to mirror ConnectWise's WatchFieldsAuto quirk")
+	}
+
+	if !cfg.Subscription.IsSupportedViaAPI() {
+		t.Error("expected mockconnectwise to mirror ConnectWise's subscribe-by-API support")
+	}
+}
+
+// TestMockConnectWiseEventParsing runs a ConnectWise-shaped callback body through the same
+// object-payload dispatch the server's receive path uses and asserts ConnectWise's real event
+// implementation classifies it — including the inline-record Entity extraction
+// (SubscriptionEventWithRecord) the receive path falls back to when a record is not queryable.
+func TestMockConnectWiseEventParsing(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal([]byte(mockConnectWiseWebhookPayload), &rawEvent); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := GetObjectTypeSubscribeEventsList(providers.MockConnectWise, rawEvent)
+	if err != nil {
+		t.Fatalf("GetObjectTypeSubscribeEventsList: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected ConnectWise's one-record-per-callback shape, got %d events", len(events))
+	}
+
+	event := events[0]
+
+	if evtType, err := event.EventType(); err != nil || evtType != common.SubscriptionEventTypeUpdate {
+		t.Errorf("expected update event, got %q (err %v)", evtType, err)
+	}
+
+	if objectName, err := event.ObjectName(); err != nil || objectName != "contacts" {
+		t.Errorf("expected object name %q, got %q (err %v)", "contacts", objectName, err)
+	}
+
+	if recordID, err := event.RecordId(); err != nil || recordID != "57961" {
+		t.Errorf("expected record id %q, got %q (err %v)", "57961", recordID, err)
+	}
+
+	withRecord, ok := event.(common.SubscriptionEventWithRecord)
+	if !ok {
+		t.Fatal("expected ConnectWise event to carry its record inline (SubscriptionEventWithRecord)")
+	}
+
+	row, err := withRecord.Record([]string{"firstName"})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if row.Id != "57961" {
+		t.Errorf("expected inline record id %q, got %q", "57961", row.Id)
+	}
+
+	if got := row.Fields["firstname"]; got != "Xzavier Sawayn" {
+		t.Errorf("expected requested field in Fields, got %v", got)
+	}
+
+	if got := row.Raw["inactiveFlag"]; got != false {
+		t.Errorf("expected Raw to carry the full inline record, got inactiveFlag=%v", got)
+	}
+}

--- a/subscribe/mocksalesforce.go
+++ b/subscribe/mocksalesforce.go
@@ -1,0 +1,24 @@
+package subscribe
+
+import (
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+)
+
+// mockSalesforceConfig is the subscribe-config bundle for the mocksalesforce test provider.
+// Its object-shaped webhook payloads take Salesforce's real receive path in
+// GetObjectTypeSubscribeEventsList — the AWS EventBridge envelope unwrap and the
+// per-recordIds fan-out into salesforce.SubscriptionEvent values — so regression tests parse
+// and classify events through the real Salesforce code.
+//
+// Verification is declared bypassed, unlike the real config: Salesforce's non-bypassed path
+// makes the server fetch a ProviderApp row even though its VerifyWebhookMessage accepts
+// everything, and the mock skips that requirement. The Registration/Subscription builders are
+// omitted: they feed subscribe-creation-time AWS EventBridge / CDC-optimization machinery with
+// no mock counterpart, which the receive path under test never invokes.
+var mockSalesforceConfig = ProviderConfig{
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockSalesforce),
+	},
+}

--- a/subscribe/mocksalesforce_test.go
+++ b/subscribe/mocksalesforce_test.go
@@ -1,0 +1,113 @@
+package subscribe
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockSalesforceEventBridgePayload is a Salesforce CDC event inside the AWS EventBridge
+// envelope the receive path sees (metadata layers around detail.payload). The CDC payload is a
+// trimmed copy of providers/salesforce/test/subscription/new_account.json; recordIds carries
+// two ids to exercise the per-record fan-out.
+const mockSalesforceEventBridgePayload = `{
+  "version": "0",
+  "id": "5c42b99e-c214-4a9c-8fbd-1a41e5faa44a",
+  "detail-type": "AccountChangeEvent",
+  "source": "aws.partner/salesforce.com/00D5f000005KcCnEAK/0YL5f000000CabWGAS",
+  "detail": {
+    "payload": {
+      "ChangeEventHeader": {
+        "entityName": "Account",
+        "recordIds": [
+          "0015f00002J9YYEAA3",
+          "0015f00002J9YYFAA3"
+        ],
+        "changeType": "CREATE",
+        "changeOrigin": "com/salesforce/api/soap/60.0;client=SfdcInternalAPI/",
+        "transactionKey": "0001ade9-3f74-0b99-dbc4-42e73424b774",
+        "sequenceNumber": 1,
+        "commitTimestamp": 1712693965000,
+        "commitUser": "0055f000005mc66AAA",
+        "nulledFields": [],
+        "diffFields": [],
+        "changedFields": []
+      },
+      "Name": "Acme",
+      "Description": "Sample account record.",
+      "OwnerId": "0055f000005mc66AAA",
+      "CreatedDate": 1712693965000
+    }
+  }
+}`
+
+// TestMockSalesforceConfigResolution verifies the mocksalesforce registry entry resolves with
+// verification bypassed (unlike real Salesforce, whose non-bypassed path requires a
+// ProviderApp row despite accepting every message).
+func TestMockSalesforceConfigResolution(t *testing.T) { //nolint:paralleltest // mutates the provider catalog
+	providers.SetupMockSalesforceProvider()
+
+	info, err := providers.ReadInfo(providers.MockSalesforce)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mocksalesforce webhook verification to be bypassed")
+	}
+}
+
+// TestMockSalesforceEventParsing runs an EventBridge-wrapped CDC payload through the same
+// object-payload dispatch the server's receive path uses and asserts Salesforce's real event
+// implementation handles it: the envelope is unwrapped and the event fans out per record id.
+func TestMockSalesforceEventParsing(t *testing.T) {
+	t.Parallel()
+
+	var rawEvent map[string]any
+	if err := json.Unmarshal([]byte(mockSalesforceEventBridgePayload), &rawEvent); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := GetObjectTypeSubscribeEventsList(providers.MockSalesforce, rawEvent)
+	if err != nil {
+		t.Fatalf("GetObjectTypeSubscribeEventsList: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected recordIds to fan out into 2 events, got %d", len(events))
+	}
+
+	first := events[0]
+
+	if evtType, err := first.EventType(); err != nil || evtType != common.SubscriptionEventTypeCreate {
+		t.Errorf("expected create event, got %q (err %v)", evtType, err)
+	}
+
+	if objectName, err := first.ObjectName(); err != nil || objectName != "Account" {
+		t.Errorf("expected object name %q, got %q (err %v)", "Account", objectName, err)
+	}
+
+	if rawName, err := first.RawEventName(); err != nil || rawName != "CREATE" {
+		t.Errorf("expected raw event name %q, got %q (err %v)", "CREATE", rawName, err)
+	}
+
+	wantIDs := []string{"0015f00002J9YYEAA3", "0015f00002J9YYFAA3"}
+	for i, event := range events {
+		recordID, err := event.RecordId()
+		if err != nil {
+			t.Fatalf("RecordId event %d: %v", i, err)
+		}
+
+		if recordID != wantIDs[i] {
+			t.Errorf("event %d: expected record id %q, got %q", i, wantIDs[i], recordID)
+		}
+	}
+}


### PR DESCRIPTION
Extend the mocksub mock-provider set with the third batch:

- mocksalesforce routes EventBridge-wrapped CDC payloads through Salesforce's
  real receive path (envelope unwrap + per-recordIds fan-out into
  salesforce.SubscriptionEvent). Verification is bypassed — real Salesforce's
  non-bypassed path requires a ProviderApp row despite accepting every
  message — and the registration/CDC-optimization builders are omitted (they
  feed subscribe-creation-time AWS infrastructure the receive path never uses)
- mockconnectwise mirrors ConnectWise: subscribe-by-API with the
  WatchFieldsAuto quirk, verification bypassed like the real config, and
  object payloads dispatched to ConnectWise's real CollapsedSubscriptionEvent,
  covering the inline-record Entity extraction (SubscriptionEventWithRecord)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
## Test evidence

Local run at `f1a107077`: **96 passed, 0 failed** — full log attached: [eng-4167-pr3-test-run.log](https://gist.github.com/jlimatampersand/da50b4a43aaa321403c223436186e362)

```sh
RUNNING_ENV=test go test -v -count=1 ./mocksub/... ./subscribe/... ./connector/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)