### PR TITLE
[ENG-4167][PR4] feat(mocksub): add mockgmail subscribe-testing provider

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -260,6 +260,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Mixmax:                    wrapper(newMixmaxConnector),
 	providers.MockAttio:                 wrapper(newMockAttioConnector),
 	providers.MockConnectWise:           wrapper(newMockConnectWiseConnector),
+	providers.MockGmail:                 wrapper(newMockGmailConnector),
 	providers.MockHubspot:               wrapper(newMockHubspotConnector),
 	providers.MockSalesforce:            wrapper(newMockSalesforceConnector),
 	providers.MockSalesloft:             wrapper(newMockSalesloftConnector),
@@ -470,6 +471,13 @@ func newMockSalesforceConnector(_ common.ConnectorParams) (*mocksub.Connector, e
 // canned records from the provider's process-wide mocksub store.
 func newMockConnectWiseConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
 	return mocksub.NewConnector(providers.MockConnectWise), nil
+}
+
+// newMockGmailConnector constructs the mockgmail subscribe-testing connector (see the mocksub
+// package). ConnectorParams is ignored: the mock talks to no HTTP API and serves canned records
+// from the provider's process-wide mocksub store.
+func newMockGmailConnector(_ common.ConnectorParams) (*mocksub.Connector, error) {
+	return mocksub.NewConnector(providers.MockGmail), nil
 }
 
 func newDynamicsCRMConnector(

--- a/providers/mockgmail.go
+++ b/providers/mockgmail.go
@@ -1,0 +1,31 @@
+package providers
+
+// MockGmail is a subscribe-testing mock provider mimicking Google Gmail. Its subscribe config
+// reuses Gmail's SubscriptionEvent type and caster (so the synthetic republished events the
+// receive path consumes parse and classify through the real code) while the connector serves
+// canned records without HTTP (see the mocksub package). Like Mock and MemStore, it is
+// intentionally not registered in init() and must be set up manually by calling
+// SetupMockGmailProvider().
+const MockGmail Provider = "mockgmail"
+
+// SetupMockGmailProvider initializes the MockGmail provider configuration. Call this
+// explicitly in tests that use the MockGmail provider. The Support and SubscribeRequirements
+// flags mirror the Gmail module's (maintenance-renewed watch subscriptions created via API);
+// the mock is single-module, so no Modules tree is declared.
+func SetupMockGmailProvider() {
+	SetInfo(MockGmail, ProviderInfo{
+		AuthType:    None,
+		BaseURL:     "http://mockgmail.test",
+		DisplayName: "Mock Gmail",
+		Support: Support{
+			Proxy:     true,
+			Read:      true,
+			Subscribe: true,
+			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			Maintenance:    new(true),
+			SubscribeByAPI: new(true),
+		},
+	})
+}

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -135,6 +135,7 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 	providers.MockAttio:       {DefaultModuleConfig: &mockAttioConfig},
 	providers.MockSalesforce:  {DefaultModuleConfig: &mockSalesforceConfig},
 	providers.MockConnectWise: {DefaultModuleConfig: &mockConnectWiseConfig},
+	providers.MockGmail:       {DefaultModuleConfig: &mockGmailConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in

--- a/subscribe/mockgmail.go
+++ b/subscribe/mockgmail.go
@@ -1,0 +1,29 @@
+package subscribe
+
+import (
+	"time"
+
+	"github.com/amp-labs/connectors/mocksub"
+	"github.com/amp-labs/connectors/providers"
+	google "github.com/amp-labs/connectors/providers/google"
+)
+
+// mockGmailConfig is the subscribe-config bundle for the mockgmail test provider. It mirrors
+// googleConfig (the Gmail module): verification bypassed — Gmail events reaching verification
+// are synthetic republishes from the Gmail event workflow carrying no provider signature — and
+// crucially the same event caster, so regression tests cast those synthetic payloads through
+// Gmail's real SubscriptionEvent implementation. The maintenance renewal interval is mirrored
+// for fidelity; the subscribe-time request builder (Gmail watch Pub/Sub topic resolution) is
+// omitted, as the receive path under test never invokes it.
+//
+//nolint:mnd
+var mockGmailConfig = ProviderConfig{
+	Maintenance: MaintenanceConfig{
+		renewalInterval: time.Hour * 24,
+	},
+	Verification: VerificationConfig{
+		bypassed:          true,
+		verifierConnector: mocksub.NewConnector(providers.MockGmail),
+		eventCaster:       CastSubscriptionEvents[google.SubscriptionEvent],
+	},
+}

--- a/subscribe/mockgmail_test.go
+++ b/subscribe/mockgmail_test.go
@@ -1,0 +1,105 @@
+package subscribe
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// mockGmailEventsPayload is an array of the synthetic Gmail events the Gmail event workflow
+// republishes into the subscribe pipeline (google.SubscriptionEvent's documented wire shape:
+// one event per affected message, derived from a history.list expansion — Gmail's raw push
+// carries only {emailAddress, historyId} and never reaches this path).
+const mockGmailEventsPayload = `[
+  {
+    "messageId": "18c2f4a9b7d3e510",
+    "historyId": "5723461",
+    "emailAddress": "consumer@example.com",
+    "rawEventName": "messagesAdded",
+    "occurredAt": 1731612159499000000
+  },
+  {
+    "messageId": "18c2f4a9b7d3e511",
+    "historyId": "5723462",
+    "emailAddress": "consumer@example.com",
+    "rawEventName": "labelsAdded",
+    "occurredAt": 1731612210994000000
+  },
+  {
+    "messageId": "18c2f4a9b7d3e512",
+    "historyId": "5723463",
+    "emailAddress": "consumer@example.com",
+    "rawEventName": "messagesDeleted",
+    "occurredAt": 1731612299001000000
+  }
+]`
+
+// TestMockGmailConfigResolutionAndEventCasting verifies the mockgmail registry entry resolves
+// like the Gmail module's (verification bypassed, subscribe-by-API with maintenance) and that
+// its event caster is Gmail's real one: synthetic republished payloads must cast into
+// google.SubscriptionEvent values that classify identically to real Gmail events.
+func TestMockGmailConfigResolutionAndEventCasting(t *testing.T) { //nolint:paralleltest,funlen // mutates the provider catalog
+	providers.SetupMockGmailProvider()
+
+	info, err := providers.ReadInfo(providers.MockGmail)
+	if err != nil {
+		t.Fatalf("ReadInfo: %v", err)
+	}
+
+	cfg, err := GetProviderConfig("", ResolveProviderInfoAlias(info), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("GetProviderConfig: %v", err)
+	}
+
+	if !cfg.Verification.ShouldBypass() {
+		t.Error("expected mockgmail webhook verification to be bypassed")
+	}
+
+	if !cfg.Subscription.IsSupportedViaAPI() {
+		t.Error("expected mockgmail to mirror Gmail's subscribe-by-API support")
+	}
+
+	var list []map[string]any
+	if err := json.Unmarshal([]byte(mockGmailEventsPayload), &list); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	events, err := cfg.Verification.CastEvents(list)
+	if err != nil {
+		t.Fatalf("CastEvents: %v", err)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	wantByIndex := []struct {
+		eventType common.SubscriptionEventType
+		recordID  string
+	}{
+		{common.SubscriptionEventTypeCreate, "18c2f4a9b7d3e510"},
+		{common.SubscriptionEventTypeUpdate, "18c2f4a9b7d3e511"},
+		{common.SubscriptionEventTypeDelete, "18c2f4a9b7d3e512"},
+	}
+
+	for i, event := range events {
+		if evtType, err := event.EventType(); err != nil || evtType != wantByIndex[i].eventType {
+			t.Errorf("event %d: expected %q event, got %q (err %v)", i, wantByIndex[i].eventType, evtType, err)
+		}
+
+		if recordID, err := event.RecordId(); err != nil || recordID != wantByIndex[i].recordID {
+			t.Errorf("event %d: expected record id %q, got %q (err %v)", i, wantByIndex[i].recordID, recordID, err)
+		}
+
+		if objectName, err := event.ObjectName(); err != nil || objectName != "messages" {
+			t.Errorf("event %d: expected object name %q, got %q (err %v)", i, "messages", objectName, err)
+		}
+
+		if workspace, err := event.Workspace(); err != nil || workspace != "consumer@example.com" {
+			t.Errorf("event %d: expected workspace (mailbox) %q, got %q (err %v)", i, "consumer@example.com", workspace, err)
+		}
+	}
+}


### PR DESCRIPTION
Complete the mocksub mock-provider set. mockgmail mirrors the Gmail module's
subscribe config: verification bypassed (Gmail events reaching the receive
path are synthetic republishes from the Gmail event workflow, carrying no
provider signature), the same event caster
(CastSubscriptionEvents[google.SubscriptionEvent]) so synthetic payloads
classify through Gmail's real event code, and the maintenance renewal
interval mirrored for fidelity. The Gmail watch topic request builder is
omitted — the receive path never invokes it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
## Test evidence

Local run at `dcbd7ffa6`: **97 passed, 0 failed** — full log attached: [eng-4167-pr4-test-run.log](https://gist.github.com/jlimatampersand/56cfd2261faa3c442b0a5354bc4db12f)

```sh
RUNNING_ENV=test go test -v -count=1 ./mocksub/... ./subscribe/... ./connector/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)