### PR TITLE
[CON-2753][PR3] Stripe subscribe: ProviderInfo metadata (gated off)

### DIFF
--- a/providers/stripe.go
+++ b/providers/stripe.go
@@ -24,8 +24,13 @@ func init() {
 			},
 			Proxy:     true,
 			Read:      true,
-			Subscribe: false,
+			Subscribe: false, // the gate; flipped to true in the final Enable PR of the subscribe stack
 			Write:     true,
+		},
+		SubscribeRequirements: &SubscribeRequirements{
+			// Stripe supports creating webhook subscriptions programmatically via the
+			// webhook endpoints API: https://docs.stripe.com/api/webhook_endpoints/create
+			SubscribeByAPI: new(true),
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
## Subscribe Action — Stripe — [PR 3: ProviderInfo + Factory wiring]

Part of the Subscribe Action stack for `stripe` (CON-2753). See [pr-1-provider-info.md](https://github.com/amp-labs/connectors/blob/main/docs/subscribe-onboarding/pr-1-provider-info.md).

Declares the subscribe metadata (this rung did not exist in #2504):

- `Support.Subscribe` stays **false** (the gate; flipped in the final Enable PR)
- `SubscribeRequirements.SubscribeByAPI: new(true)` — Stripe supports programmatic webhook subscriptions: https://docs.stripe.com/api/webhook_endpoints/create
- No `Registration`/`PostProcess`/`Maintenance` — Stripe endpoints need no shared setup resource, no third-party system, and don't expire
- No factory wiring needed — stripe already has its `connector/new.go` entry

Note on stack position: the docs put ProviderInfo at the bottom for greenfield work; here the implementation was already merged via #2504 and the build-repair PR must sit at the bottom instead, so this rung rides above it. It's still a no-op while gated off.

- [x] Provider genuinely gated off
- [x] `SubscribeRequirements` flags carry doc-link comments
- [x] Linked [SUBSCRIBE_REFERENCES.md — How the caller uses ProviderInfo](https://github.com/amp-labs/connectors/blob/main/SUBSCRIBE_REFERENCES.md#how-the-caller-uses-providerinfo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
