### PR TITLE
[CON-2753][PR1] Stripe subscribe: fix build & restructure implementation merged in #2504

### DIFF
--- a/providers/stripe/record.go
+++ b/providers/stripe/record.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/internal/jsonquery"
@@ -117,8 +119,15 @@ func (c *Connector) fetchSingleRecord(
 // buildGetRecordURL constructs a URL for fetching a single record by ID.
 // Format: /v1/{objectName}/{id}
 // Supports expand[] query parameters for associated objects.
+//
+// Stripe's retrieve endpoints use plural collection names (/v1/setup_intents/{id}),
+// while webhook events carry the singular object type (SubscriptionEvent.ObjectName
+// returns e.g. "setup_intent"). Pluralize so both forms resolve to the collection,
+// mirroring providers/hubspot/record.go.
 func (c *Connector) buildGetRecordURL(objectName string, id string, associations []string) (*urlbuilder.URL, error) {
-	url, err := c.GetURL(objectName)
+	pluralObjectName := naming.NewPluralString(objectName).String()
+
+	url, err := c.GetURL(pluralObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -248,14 +257,11 @@ func extractAssociations(record map[string]any, associationNames []string) map[s
 	associations := make(map[string][]common.Association)
 
 	for _, assocName := range associationNames {
-		assocValue, exists := record[assocName]
-		if !exists || assocValue == nil {
-			continue
-		}
-
-		// Handle expanded object
-		assocMap, isMap := assocValue.(map[string]any)
-		if !isMap {
+		// Association names may be dot-separated paths to nested properties
+		// (e.g. "customer.default_source"), matching Stripe's expand[] convention
+		// documented on common.ReadParams.AssociatedObjects.
+		assocMap, found := lookupAssociationPath(record, assocName)
+		if !found {
 			continue
 		}
 
@@ -281,4 +287,32 @@ func extractAssociations(record map[string]any, associationNames []string) map[s
 	}
 
 	return associations
+}
+
+// lookupAssociationPath walks a dot-separated path of nested objects within a record
+// and returns the expanded object found at the end of the path.
+// Example: "customer.default_source" -> record["customer"]["default_source"].
+func lookupAssociationPath(record map[string]any, path string) (map[string]any, bool) {
+	current := record
+
+	segments := strings.Split(path, ".")
+	for index, segment := range segments {
+		value, exists := current[segment]
+		if !exists || value == nil {
+			return nil, false
+		}
+
+		valueMap, isMap := value.(map[string]any)
+		if !isMap {
+			return nil, false
+		}
+
+		if index == len(segments)-1 {
+			return valueMap, true
+		}
+
+		current = valueMap
+	}
+
+	return nil, false
 }

--- a/providers/stripe/record_test.go
+++ b/providers/stripe/record_test.go
@@ -2,16 +2,18 @@ package stripe
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-func TestGetRecordsByIds(t *testing.T) {
+func TestGetRecordsByIds(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	paymentIntentWithAssociations := testutils.DataFromFile(t, "read/payment_intents/expand_payment_method_charge.json")
@@ -20,10 +22,9 @@ func TestGetRecordsByIds(t *testing.T) {
 		{
 			Name: "Empty IDs returns empty slice",
 			Input: testconn.ReadByIdsParams{
-				ObjectName:   "payment_intents",
-				RecordIds:    []string{},
-				Fields:       []string{"id", "amount", "currency"},
-				Associations: nil,
+				ObjectName: "payment_intents",
+				RecordIds:  []string{},
+				Fields:     []string{"id", "amount", "currency"},
 			},
 			Server:       mockserver.Dummy(),
 			Expected:     []common.ReadResultRow{},
@@ -32,10 +33,9 @@ func TestGetRecordsByIds(t *testing.T) {
 		{
 			Name: "Missing object name",
 			Input: testconn.ReadByIdsParams{
-				ObjectName:   "",
-				RecordIds:    []string{"pi_123"},
-				Fields:       []string{"id"},
-				Associations: nil,
+				ObjectName: "",
+				RecordIds:  []string{"pi_123"},
+				Fields:     []string{"id"},
 			},
 			Server:       mockserver.Dummy(),
 			Expected:     nil,
@@ -44,14 +44,43 @@ func TestGetRecordsByIds(t *testing.T) {
 		{
 			Name: "Missing fields",
 			Input: testconn.ReadByIdsParams{
-				ObjectName:   "payment_intents",
-				RecordIds:    []string{"pi_123"},
-				Fields:       []string{},
-				Associations: nil,
+				ObjectName: "payment_intents",
+				RecordIds:  []string{"pi_123"},
+				Fields:     []string{},
 			},
 			Server:       mockserver.Dummy(),
 			Expected:     nil,
 			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			// Webhook events carry singular object types (SubscriptionEvent.ObjectName
+			// returns e.g. "payment_intent"); the fetch URL must use the plural collection.
+			Name: "Singular object name resolves to plural collection",
+			Input: testconn.ReadByIdsParams{
+				ObjectName: "payment_intent",
+				RecordIds:  []string{"pi_3SsAwzF6iHem4voo03GfTErP"},
+				Fields:     []string{"id", "amount", "currency"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/payment_intents/pi_3SsAwzF6iHem4voo03GfTErP"),
+				},
+				Then: mockserver.Response(http.StatusOK, paymentIntentWithAssociations),
+			}.Server(),
+			Comparator: compareReadResultRows,
+			Expected: []common.ReadResultRow{
+				{
+					Id: "pi_3SsAwzF6iHem4voo03GfTErP",
+					Fields: map[string]any{
+						"id":       "pi_3SsAwzF6iHem4voo03GfTErP",
+						"amount":   float64(100),
+						"currency": "usd",
+					},
+				},
+			},
+			ExpectedErrs: nil,
 		},
 		{
 			Name: "With associations (expand)",
@@ -110,4 +139,115 @@ func TestGetRecordsByIds(t *testing.T) {
 			})
 		})
 	}
+}
+
+// compareReadResultRows compares two slices of ReadResultRow by wrapping them
+// into ReadResult and using existing utilities for Fields and Raw, plus association validation.
+func compareReadResultRows(_ string, actual, expected []common.ReadResultRow) *testutils.CompareResult {
+	// Wrap slices into ReadResult to use existing utilities
+	actualResult := &common.ReadResult{Data: actual}
+	expectedResult := &common.ReadResult{Data: expected}
+
+	// Use existing utilities for Fields and Raw
+	result := mockutils.ReadResultComparator.SubsetFields(actualResult, expectedResult)
+
+	for i := range expectedResult.Data {
+		// Check that Raw is populated for all rows
+		if actualResult.Data[i].Raw == nil {
+			result.AddDiff("row [%v] has no Raw data", i)
+		}
+
+		// Validate associations if expected
+		result.Merge(compareRowAssociations(i, actualResult.Data[i].Associations, expectedResult.Data[i].Associations))
+	}
+
+	return result
+}
+
+func compareRowAssociations( // nolint:cyclop
+	rowIndex int,
+	actualAssoc, expectedAssoc map[string][]common.Association,
+) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+
+	// If expected has no associations, actual can have none or some (we don't care)
+	if len(expectedAssoc) == 0 {
+		return result
+	}
+
+	// If expected has associations but actual doesn't, that's a failure
+	if len(actualAssoc) == 0 {
+		return result.AddDiff("row [%v] has no associations", rowIndex)
+	}
+
+	// Check each expected association type
+	for assocType, expectedAssociations := range expectedAssoc {
+		actualAssociations, ok := actualAssoc[assocType]
+		if !ok || len(actualAssociations) != len(expectedAssociations) {
+			result.AddDiff("row [%v] association [%v] is missing or has mismatching length", rowIndex, assocType)
+
+			continue
+		}
+
+		for j, expectedItem := range expectedAssociations {
+			actualItem := actualAssociations[j]
+
+			// Check ObjectId matches
+			if expectedItem.ObjectId != "" {
+				result.Assert("association ObjectId", expectedItem.ObjectId, actualItem.ObjectId)
+			}
+
+			// Verify Raw is populated (contains the full associated object)
+			if actualItem.Raw == nil {
+				result.AddDiff("row [%v] association [%v][%v] has no Raw data", rowIndex, assocType, j)
+			}
+
+			// If expected Raw is specified, verify key fields match (subset matching)
+			for key, expectedVal := range expectedItem.Raw {
+				actualVal, exists := actualItem.Raw[key]
+				if !exists || !reflect.DeepEqual(actualVal, expectedVal) {
+					result.AddDiff("row [%v] association [%v][%v] Raw key [%v] mismatch", rowIndex, assocType, j, key)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func TestExtractAssociationsDotPath(t *testing.T) {
+	t.Parallel()
+
+	record := map[string]any{
+		"id":     "pi_123",
+		"object": "payment_intent",
+		"customer": map[string]any{
+			"id":     "cus_123",
+			"object": "customer",
+			"default_source": map[string]any{
+				"id":     "card_123",
+				"object": "card",
+				"last4":  "4242",
+			},
+		},
+	}
+
+	associations := extractAssociations(record, []string{"customer", "customer.default_source", "customer.missing"})
+
+	result := testutils.NewCompareResult()
+
+	customer, found := associations["customer"]
+	if result.Assert("customer association found", true, found) {
+		result.Assert("customer ObjectId", "cus_123", customer[0].ObjectId)
+	}
+
+	defaultSource, found := associations["customer.default_source"]
+	if result.Assert("customer.default_source association found", true, found) {
+		result.Assert("customer.default_source ObjectId", "card_123", defaultSource[0].ObjectId)
+	}
+
+	_, found = associations["customer.missing"]
+	result.Assert("customer.missing association absent", false, found)
+
+	result.Validate(t, "extract associations by dot-separated path")
 }

--- a/providers/stripe/subscribe.go
+++ b/providers/stripe/subscribe.go
@@ -2,15 +2,10 @@ package stripe
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
@@ -94,10 +89,16 @@ func buildWebhookPayloadFromParams(
 }
 
 // buildRequestedEventSet builds a set of requested events from subscription events.
+// Every object must resolve to at least one Stripe event; otherwise the object would be
+// reported as successfully subscribed while no event is enabled for it on the endpoint.
 func buildRequestedEventSet(subscriptionEvents map[common.ObjectName]common.ObjectEvents) (map[string]bool, error) {
 	requestedEventsSet := make(map[string]bool)
 
 	for obj, events := range subscriptionEvents {
+		if len(events.Events) == 0 && len(events.PassThroughEvents) == 0 {
+			return nil, fmt.Errorf("%w: object %s has no events to subscribe to", errMissingParams, obj)
+		}
+
 		for _, event := range events.Events {
 			stripeEventName, err := getStripeEventName(event, obj)
 			if err != nil {
@@ -137,7 +138,10 @@ func buildSubscriptionResult(
 	subscriptionsMap := make(map[common.ObjectName]WebhookResponse)
 
 	for obj, events := range subscriptionEvents {
-		// Filter enabled events to only include events for this object
+		// Filter enabled events to only include events for this object.
+		// Deduplicate so stored state matches the deduplicated enabled_events
+		// actually sent to Stripe (Events and PassThroughEvents may overlap).
+		seenEvents := make(map[string]bool)
 		objectEvents := make([]string, 0)
 
 		for _, event := range events.Events {
@@ -146,11 +150,21 @@ func buildSubscriptionResult(
 				return nil, fmt.Errorf("failed to convert event type %s for object %s: %w", event, obj, err)
 			}
 
-			objectEvents = append(objectEvents, stripeEventName)
+			if !seenEvents[stripeEventName] {
+				seenEvents[stripeEventName] = true
+
+				objectEvents = append(objectEvents, stripeEventName)
+			}
 		}
 
 		// Add pass-through events directly
-		objectEvents = append(objectEvents, events.PassThroughEvents...)
+		for _, passthroughEvent := range events.PassThroughEvents {
+			if !seenEvents[passthroughEvent] {
+				seenEvents[passthroughEvent] = true
+
+				objectEvents = append(objectEvents, passthroughEvent)
+			}
+		}
 
 		objectResponse := *response
 		objectResponse.EnabledEvents = objectEvents
@@ -262,7 +276,7 @@ func getStripeEventName(event common.SubscriptionEventType, obj common.ObjectNam
 }
 
 func getExpectedObjectTypeFromMetadata(objectName string) (string, error) {
-	objMetadata, err := metadata.Schemas.SelectOne(common.ModuleID("root"), objectName)
+	objMetadata, err := metadata.Schemas.SelectOne(common.ModuleRoot, objectName)
 	if err != nil {
 		return "", err
 	}
@@ -280,9 +294,8 @@ func getExpectedObjectTypeFromMetadata(objectName string) (string, error) {
 }
 
 // parseWebhookEndpointResponse parses and validates the webhook endpoint response.
-func parseWebhookEndpointResponse(ctx context.Context,
-	httpResp *http.Response,
-	bodyBytes []byte,
+func parseWebhookEndpointResponse(
+	ctx context.Context, httpResp *http.Response, bodyBytes []byte,
 ) (*WebhookResponse, error) {
 	// Use common JSON parsing utilities
 	jsonResp, err := common.ParseJSONResponse(ctx, httpResp, bodyBytes)
@@ -366,7 +379,7 @@ func (c *Connector) executeFormPostRequest(
 	formEncoded := formData.Encode()
 	formBytes := []byte(formEncoded)
 
-	httpResp, bodyBytes, err := c.JSONHTTPClient().HTTPClient.Post(ctx, endpointURL.String(), formBytes, common.Header{
+	httpResp, bodyBytes, err := c.HTTPClient().Post(ctx, endpointURL.String(), formBytes, common.Header{
 		Key:   "Content-Type",
 		Value: "application/x-www-form-urlencoded",
 		Mode:  common.HeaderModeOverwrite,
@@ -391,139 +404,4 @@ func buildFormData(payload *WebhookPayload) url.Values {
 	}
 
 	return formData
-}
-
-const (
-	stripeSignatureHeader = "Stripe-Signature"
-	keyValuePairParts     = 2
-	defaultTolerance      = 5 * time.Minute
-)
-
-// VerifyWebhookMessage verifies the signature of a webhook message from Stripe.
-// Stripe uses HMAC-SHA256 with the format: signed_payload = timestamp + "." + requestBody.
-func (c *Connector) VerifyWebhookMessage(
-	_ context.Context,
-	request *common.WebhookRequest,
-	params *common.VerificationParams,
-) (bool, error) {
-	if request == nil || params == nil {
-		return false, fmt.Errorf("%w: request and params cannot be nil", errMissingParams)
-	}
-
-	verificationParams, err := common.AssertType[*VerificationParams](params.Param)
-	if err != nil {
-		return false, fmt.Errorf("%w: %w", errMissingParams, err)
-	}
-
-	if verificationParams.Secret == "" {
-		return false, fmt.Errorf("%w: secret cannot be empty", errMissingParams)
-	}
-
-	// Determine tolerance: use provided value or default to 5 minutes
-	tolerance := verificationParams.Tolerance
-	if tolerance == 0 {
-		tolerance = defaultTolerance
-	} else if tolerance < 0 {
-		return false, fmt.Errorf("%w", errInvalidTolerance)
-	}
-
-	signatureHeader := request.Headers.Get(stripeSignatureHeader)
-	if signatureHeader == "" {
-		return false, fmt.Errorf("%w: missing %s header", errMissingSignature, stripeSignatureHeader)
-	}
-
-	timestampStr, signatures, err := parseStripeSignature(signatureHeader)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse Stripe signature: %w", err)
-	}
-
-	if err := validateTimestampRecency(timestampStr, tolerance); err != nil {
-		return false, err
-	}
-
-	return verifySignature(verificationParams.Secret, timestampStr, request.Body, signatures)
-}
-
-// verifySignature computes the expected HMAC-SHA256 signature and compares it with the received signatures.
-func verifySignature(secret, timestampStr string, body []byte, receivedSignatures []string) (bool, error) {
-	// Create signed_payload: timestamp + "." + requestBody
-	signedPayload := fmt.Sprintf("%s.%s", timestampStr, string(body))
-
-	// Compute expected signature using HMAC-SHA256
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(signedPayload))
-	expectedSignature := hex.EncodeToString(mac.Sum(nil))
-
-	// Compare signatures using constant-time comparison
-	// Check if any of the received signatures matches the expected signature
-	for _, sig := range receivedSignatures {
-		if hmac.Equal([]byte(expectedSignature), []byte(sig)) {
-			return true, nil
-		}
-	}
-
-	return false, fmt.Errorf("%w: signature mismatch", errInvalidSignature)
-}
-
-// validateTimestampRecency validates that the webhook timestamp is within the allowed tolerance.
-func validateTimestampRecency(timestampStr string, tolerance time.Duration) error {
-	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse timestamp: %w", err)
-	}
-
-	timestampTime := time.Unix(timestamp, 0)
-	now := time.Now()
-	timeDiff := now.Sub(timestampTime)
-
-	if timeDiff < 0 {
-		timeDiff = -timeDiff
-	}
-
-	if timeDiff > tolerance {
-		if timestampTime.Before(now) {
-			return errTimestampTooOld
-		}
-
-		return errTimestampTooFarInFuture
-	}
-
-	return nil
-}
-
-func parseStripeSignature(header string) (string, []string, error) {
-	elements := strings.Split(header, ",")
-
-	var timestamp string
-
-	var signatures []string
-
-	for _, element := range elements {
-		element = strings.TrimSpace(element)
-
-		parts := strings.SplitN(element, "=", keyValuePairParts)
-		if len(parts) != keyValuePairParts {
-			continue
-		}
-
-		prefix := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		switch prefix {
-		case "t":
-			timestamp = value
-		case "v1", "v2", "v0":
-			signatures = append(signatures, value)
-		}
-	}
-
-	if timestamp == "" {
-		return "", nil, fmt.Errorf("%w", errMissingTimestamp)
-	}
-
-	if len(signatures) == 0 {
-		return "", nil, fmt.Errorf("%w", errNoSignaturesFound)
-	}
-
-	return timestamp, signatures, nil
 }

--- a/providers/stripe/subscribeDelete.go
+++ b/providers/stripe/subscribeDelete.go
@@ -7,7 +7,8 @@ import (
 	"github.com/amp-labs/connectors/common"
 )
 
-// DeleteSubscription deletes webhook subscriptions for the specified objects.
+// DeleteSubscription removes the shared webhook endpoint carrying all of the
+// installation's object subscriptions.
 // Extracts the real endpoint ID from composite IDs (format: "endpointID:objectName").
 func (c *Connector) DeleteSubscription(
 	ctx context.Context,
@@ -18,12 +19,12 @@ func (c *Connector) DeleteSubscription(
 		return err
 	}
 
-	endpointInfo, err := extractEndpointInfo(subscriptionData)
+	endpointID, err := extractEndpointID(subscriptionData)
 	if err != nil {
 		return err
 	}
 
-	return c.deleteWebhookEndpoint(ctx, endpointInfo.ID)
+	return c.deleteWebhookEndpoint(ctx, endpointID)
 }
 
 // validateSubscriptionResult validates the subscription result and extracts the subscription data.
@@ -49,20 +50,13 @@ func validateSubscriptionResult(result common.SubscriptionResult) (*Subscription
 	return subscriptionData, nil
 }
 
-// endpointInfo holds information about the endpoint to delete from.
-type endpointInfo struct {
-	ID              string
-	ObjectsToDelete map[common.ObjectName]bool
-}
-
-// extractEndpointInfo extracts the real endpoint ID and objects to delete from composite IDs.
-func extractEndpointInfo(subscriptionData *SubscriptionResult) (*endpointInfo, error) {
+// extractEndpointID extracts the real endpoint ID shared by all composite IDs.
+func extractEndpointID(subscriptionData *SubscriptionResult) (string, error) {
 	endpointIDs := make(map[string]bool)
-	objectsToDelete := make(map[common.ObjectName]bool)
 
 	var realEndpointID string
 
-	for obj, response := range subscriptionData.Subscriptions {
+	for _, response := range subscriptionData.Subscriptions {
 		compositeID := response.ID
 		baseID := extractBaseEndpointID(compositeID)
 		endpointIDs[baseID] = true
@@ -70,12 +64,10 @@ func extractEndpointInfo(subscriptionData *SubscriptionResult) (*endpointInfo, e
 		if realEndpointID == "" {
 			realEndpointID = baseID
 		}
-
-		objectsToDelete[obj] = true
 	}
 
 	if len(endpointIDs) != 1 {
-		return nil, fmt.Errorf(
+		return "", fmt.Errorf(
 			"%w: expected all subscriptions to share the same endpoint ID, but found %d different IDs: %v",
 			errInvalidRequestType,
 			len(endpointIDs),
@@ -84,11 +76,8 @@ func extractEndpointInfo(subscriptionData *SubscriptionResult) (*endpointInfo, e
 	}
 
 	if realEndpointID == "" {
-		return nil, fmt.Errorf("%w: endpoint ID is empty", errMissingParams)
+		return "", fmt.Errorf("%w: endpoint ID is empty", errMissingParams)
 	}
 
-	return &endpointInfo{
-		ID:              realEndpointID,
-		ObjectsToDelete: objectsToDelete,
-	}, nil
+	return realEndpointID, nil
 }

--- a/providers/stripe/subscribeDelete_test.go
+++ b/providers/stripe/subscribeDelete_test.go
@@ -59,7 +59,8 @@ func TestDeleteSubscription(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/stripe/subscribeUpdate.go
+++ b/providers/stripe/subscribeUpdate.go
@@ -3,14 +3,14 @@ package stripe
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/amp-labs/connectors/common"
 )
 
-// UpdateSubscription updates an existing subscription by comparing the previous
-// subscription state with the new desired state.
-// It merges events: keeps events for objects not in params, adds/updates events for objects in params.
+// UpdateSubscription reconciles the existing subscription (previousResult) with the new
+// desired state (params). params.SubscriptionEvents is the full desired state: objects
+// present in the previous state but absent from params are unsubscribed, since the shared
+// endpoint's enabled_events is replaced with exactly the desired event set.
 // Doc URL: https://docs.stripe.com/api/webhook_endpoints/update
 func (c *Connector) UpdateSubscription(
 	ctx context.Context,
@@ -37,10 +37,13 @@ func (c *Connector) UpdateSubscription(
 		return nil, fmt.Errorf("failed to update webhook endpoint: %w", err)
 	}
 
-	// Build result with merged subscription events
-	mergedSubscriptionEvents := buildMergedSubscriptionEvents(previousResult, params)
+	// Stripe returns the signing secret only when the endpoint is created; carry it over
+	// from the previous state so the stored result keeps verifying webhook signatures.
+	if response.Secret == "" {
+		response.Secret = existingEndpoint.Secret
+	}
 
-	result, err := buildSubscriptionResult(response, mergedSubscriptionEvents)
+	result, err := buildSubscriptionResult(response, params.SubscriptionEvents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build subscription result: %w", err)
 	}
@@ -84,27 +87,4 @@ func getExistingEndpoint(subscriptions map[common.ObjectName]WebhookResponse) (W
 	}
 
 	return WebhookResponse{}, fmt.Errorf("%w: unable to extract existing endpoint", errMissingParams)
-}
-
-// buildMergedSubscriptionEvents builds a merged subscription events map by keeping previous objects
-// not being updated and adding new/updated objects from params.
-func buildMergedSubscriptionEvents(
-	previousResult *common.SubscriptionResult,
-	params common.SubscribeParams,
-) map[common.ObjectName]common.ObjectEvents {
-	mergedSubscriptionEvents := make(map[common.ObjectName]common.ObjectEvents)
-
-	// Keep previous objects not being updated - use ObjectEvents from previousResult if available
-	if previousResult != nil && previousResult.ObjectEvents != nil {
-		for obj, events := range previousResult.ObjectEvents {
-			if _, isBeingUpdated := params.SubscriptionEvents[obj]; !isBeingUpdated {
-				mergedSubscriptionEvents[obj] = events
-			}
-		}
-	}
-
-	// Add new/updated objects
-	maps.Copy(mergedSubscriptionEvents, params.SubscriptionEvents)
-
-	return mergedSubscriptionEvents
 }

--- a/providers/stripe/subscribeUpdate_test.go
+++ b/providers/stripe/subscribeUpdate_test.go
@@ -12,21 +12,15 @@ import (
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
-// UpdateSubscriptionInput contains both params and previousResult needed for UpdateSubscription
-type UpdateSubscriptionInput struct {
-	Params         common.SubscribeParams
-	PreviousResult *common.SubscriptionResult
-}
-
-func TestUpdateSubscription(t *testing.T) {
+func TestUpdateSubscription(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	webhookEndpointUpdatedResponse := testutils.DataFromFile(t, "subscribe/webhook-endpoint-updated-response.json")
 
-	tests := []testconn.TestCase[UpdateSubscriptionInput, *common.SubscriptionResult]{
+	tests := []testconn.TestCaseUpdateSubscription{
 		{
 			Name: "Missing previous result",
-			Input: UpdateSubscriptionInput{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"account": {
@@ -41,7 +35,7 @@ func TestUpdateSubscription(t *testing.T) {
 		},
 		{
 			Name: "Nil result field",
-			Input: UpdateSubscriptionInput{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"account": {
@@ -58,7 +52,7 @@ func TestUpdateSubscription(t *testing.T) {
 		},
 		{
 			Name: "Invalid previous result type",
-			Input: UpdateSubscriptionInput{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"account": {
@@ -75,7 +69,7 @@ func TestUpdateSubscription(t *testing.T) {
 		},
 		{
 			Name: "Update single object events",
-			Input: UpdateSubscriptionInput{
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"account": {
@@ -109,11 +103,11 @@ func TestUpdateSubscription(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointUpdatedResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator:   successSubResultComparator,
+			Comparator:   compareUpdateResultObjects("account"),
 		},
 		{
-			Name: "Update multiple objects with different events",
-			Input: UpdateSubscriptionInput{
+			Name: "Desired state replaces previous objects (removal reconciliation)",
+			Input: testconn.UpdateSubscriptionParams{
 				Params: common.SubscribeParams{
 					SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
 						"account": {
@@ -133,6 +127,11 @@ func TestUpdateSubscription(t *testing.T) {
 					},
 				},
 				PreviousResult: &common.SubscriptionResult{
+					ObjectEvents: map[common.ObjectName]common.ObjectEvents{
+						"balance": {
+							Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
+						},
+					},
 					Result: &SubscriptionResult{
 						Subscriptions: map[common.ObjectName]WebhookResponse{
 							"balance": {
@@ -152,25 +151,56 @@ func TestUpdateSubscription(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointUpdatedResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator:   successSubResultComparator,
+			// "balance" is absent from the desired state, so it must not survive the update.
+			Comparator: compareUpdateResultObjects("account", "charge"),
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			t.Cleanup(func() {
-				tt.Close()
-			})
 
-			conn, err := constructTestConnector(tt.Server)
-			if err != nil {
-				t.Fatalf("failed to construct test connector: %v", err)
+			tt.Run(t, func() (testconn.TestableSubscriptionUpdater, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}
+
+// compareUpdateResultObjects verifies the update succeeded and that the resulting state
+// contains exactly the desired objects (both in ObjectEvents and stored Subscriptions).
+func compareUpdateResultObjects(
+	objects ...common.ObjectName,
+) func(string, *common.SubscriptionResult, *common.SubscriptionResult) *testutils.CompareResult {
+	return func(_ string, actual, _ *common.SubscriptionResult) *testutils.CompareResult {
+		result := testutils.NewCompareResult()
+
+		if actual == nil {
+			return result.AddDiff("subscription result is nil")
+		}
+
+		result.Assert("Status", common.SubscriptionStatusSuccess, actual.Status)
+		result.Assert("ObjectEvents length", len(objects), len(actual.ObjectEvents))
+
+		subscriptionData, ok := actual.Result.(*SubscriptionResult)
+		if !ok {
+			return result.AddDiff("expected Result of type *SubscriptionResult, got %T", actual.Result)
+		}
+
+		result.Assert("Subscriptions length", len(objects), len(subscriptionData.Subscriptions))
+
+		for _, obj := range objects {
+			if _, found := actual.ObjectEvents[obj]; !found {
+				result.AddDiff("ObjectEvents is missing object [%v]", obj)
 			}
 
-			result, err := conn.UpdateSubscription(t.Context(), tt.Input.Params, tt.Input.PreviousResult)
-			tt.Validate(t, err, result)
-		})
+			if _, found := subscriptionData.Subscriptions[obj]; !found {
+				result.AddDiff("Subscriptions is missing object [%v]", obj)
+			}
+		}
+
+		return result
 	}
 }
 
@@ -315,74 +345,6 @@ func TestGetExistingEndpoint(t *testing.T) {
 				}
 				if result.ID != tt.expectedID {
 					t.Errorf("expected ID %s, got %s", tt.expectedID, result.ID)
-				}
-			}
-		})
-	}
-}
-
-func TestBuildMergedSubscriptionEvents(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name            string
-		previousResult  *common.SubscriptionResult
-		params          common.SubscribeParams
-		expectedObjects []common.ObjectName
-		description     string
-	}{
-		{
-			name: "Keep existing objects and add new",
-			previousResult: &common.SubscriptionResult{
-				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
-					"balance": {
-						Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
-					},
-				},
-			},
-			params: common.SubscribeParams{
-				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
-					"account": {
-						Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
-					},
-				},
-			},
-			expectedObjects: []common.ObjectName{"balance", "account"},
-			description:     "Test merging keeps existing objects and adds new",
-		},
-		{
-			name: "Update existing object",
-			previousResult: &common.SubscriptionResult{
-				ObjectEvents: map[common.ObjectName]common.ObjectEvents{
-					"account": {
-						Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
-					},
-				},
-			},
-			params: common.SubscribeParams{
-				SubscriptionEvents: map[common.ObjectName]common.ObjectEvents{
-					"account": {
-						Events: []common.SubscriptionEventType{
-							common.SubscriptionEventTypeCreate,
-							common.SubscriptionEventTypeUpdate,
-						},
-					},
-				},
-			},
-			expectedObjects: []common.ObjectName{"account"},
-			description:     "Test merging updates existing object events",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := buildMergedSubscriptionEvents(tt.previousResult, tt.params)
-			if len(result) != len(tt.expectedObjects) {
-				t.Errorf("expected %d objects, got %d", len(tt.expectedObjects), len(result))
-			}
-			for _, expectedObj := range tt.expectedObjects {
-				if _, ok := result[expectedObj]; !ok {
-					t.Errorf("expected object %s to be in result", expectedObj)
 				}
 			}
 		})

--- a/providers/stripe/subscribe_test.go
+++ b/providers/stripe/subscribe_test.go
@@ -1,30 +1,32 @@
 package stripe
 
 import (
-	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"gotest.tools/v3/assert"
 )
 
-func TestSubscribe(t *testing.T) {
+// Decomposed per-method interface assertions, so Subscribe, UpdateSubscription and
+// DeleteSubscription are each verified independently (see pr-4-subscribe-update-delete.md).
+var (
+	_ testconn.TestableSubscriptionCreator = &Connector{} // Subscribe
+	_ testconn.TestableSubscriptionUpdater = &Connector{} // UpdateSubscription
+	_ testconn.TestableSubscriptionRemover = &Connector{} // DeleteSubscription
+)
+
+func TestSubscribe(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	webhookEndpointResponse := testutils.DataFromFile(t, "subscribe/webhook-endpoint-response.json")
 
-	tests := []testconn.TestCase[common.SubscribeParams, *common.SubscriptionResult]{
+	tests := []testconn.TestCaseSubscribe{
 		{
 			Name: "Empty events",
 			Input: common.SubscribeParams{
@@ -60,7 +62,7 @@ func TestSubscribe(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator:   successSubResultComparator,
+			Comparator:   compareSubscriptionSuccess,
 		},
 		{
 			Name: "Subscribe multiple objects",
@@ -93,26 +95,35 @@ func TestSubscribe(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator:   successSubResultComparator,
+			Comparator:   compareSubscriptionSuccess,
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			t.Cleanup(func() {
-				tt.Close()
+
+			tt.Run(t, func() (testconn.TestableSubscriptionCreator, error) {
+				return constructTestConnector(tt.Server)
 			})
-
-			conn, err := constructTestConnector(tt.Server)
-			if err != nil {
-				t.Fatalf("failed to construct test connector: %v", err)
-			}
-
-			result, err := conn.Subscribe(t.Context(), tt.Input)
-			tt.Validate(t, err, result)
 		})
 	}
+}
+
+// compareSubscriptionSuccess verifies the operation returned a successful subscription result.
+func compareSubscriptionSuccess(
+	_ string, actual, _ *common.SubscriptionResult,
+) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+
+	if actual == nil {
+		return result.AddDiff("subscription result is nil")
+	}
+
+	result.Assert("Status", common.SubscriptionStatusSuccess, actual.Status)
+
+	return result
 }
 
 func TestBuildRequestedEventSet(t *testing.T) {
@@ -153,6 +164,18 @@ func TestBuildRequestedEventSet(t *testing.T) {
 			expected:    map[string]bool{"account.application.authorized": true},
 			expectedErr: nil,
 			description: "Test building event set with pass-through event",
+		},
+		{
+			name: "Object with no events is rejected",
+			subscriptionEvents: map[common.ObjectName]common.ObjectEvents{
+				"account": {
+					Events: []common.SubscriptionEventType{common.SubscriptionEventTypeCreate},
+				},
+				"charge": {},
+			},
+			expected:    nil,
+			expectedErr: errMissingParams,
+			description: "An object resolving to zero events must error instead of silently reporting success",
 		},
 		{
 			name: "Multiple objects, multiple events",
@@ -317,303 +340,35 @@ func TestBuildSubscriptionResult(t *testing.T) {
 	}
 }
 
-// computeTestSignature computes a Stripe signature for testing purposes.
-func computeTestSignature(secret, timestamp string, body []byte) string {
-	signedPayload := fmt.Sprintf("%s.%s", timestamp, string(body))
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(signedPayload))
-	return hex.EncodeToString(mac.Sum(nil))
-}
-
-func TestVerifyWebhookMessage(t *testing.T) {
+func TestBuildSubscriptionResultDedup(t *testing.T) {
 	t.Parallel()
 
-	secret := "whsec_test_secret"
-	// Use a recent timestamp (current time) for valid tests
-	recentTimestamp := fmt.Sprintf("%d", time.Now().Unix())
-	body := []byte(`{"id":"evt_test_123","type":"charge.succeeded"}`)
+	response := &WebhookResponse{
+		ID:            "we_123",
+		EnabledEvents: []string{"account.updated"},
+	}
 
-	validSignature := computeTestSignature(secret, recentTimestamp, body)
-	validSignatureHeader := fmt.Sprintf("t=%s,v1=%s", recentTimestamp, validSignature)
-
-	conn := &Connector{}
-
-	tests := []struct {
-		name          string
-		request       *common.WebhookRequest
-		params        *common.VerificationParams
-		expectedValid bool
-		expectedError error
-	}{
-		{
-			name: "Valid signature",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{validSignatureHeader},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: true,
-			expectedError: nil,
-		},
-
-		{
-			name: "Invalid signature",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{fmt.Sprintf("t=%s,v1=%s", recentTimestamp, "invalid_signature")},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errInvalidSignature,
-		},
-		{
-			name: "Missing signature header",
-			request: &common.WebhookRequest{
-				Headers: http.Header{},
-				Body:    body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errMissingSignature,
-		},
-		{
-			name:    "Nil request",
-			request: nil,
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errMissingParams,
-		},
-		{
-			name: "Empty secret",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{validSignatureHeader},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: "",
-				},
-			},
-			expectedValid: false,
-			expectedError: errMissingParams,
-		},
-		{
-			name: "Wrong timestamp (signature mismatch)",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					// Use a valid recent timestamp but with a signature computed for a different timestamp
-					"Stripe-Signature": []string{fmt.Sprintf("t=%s,v1=%s", recentTimestamp, computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-10), body))},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errInvalidSignature,
-		},
-		{
-			name: "Timestamp too old (replay attack)",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{fmt.Sprintf("t=%d,v1=%s", time.Now().Unix()-600, computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-600), body))},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errTimestampTooOld,
-		},
-		{
-			name: "Timestamp too far in the future",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{fmt.Sprintf("t=%d,v1=%s", time.Now().Unix()+600, computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()+600), body))},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: secret,
-				},
-			},
-			expectedValid: false,
-			expectedError: errTimestampTooFarInFuture,
-		},
-		{
-			name: "Invalid tolerance (zero)",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{validSignatureHeader},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret:    secret,
-					Tolerance: 0,
-				},
-			},
-			expectedValid: true,
-			expectedError: nil,
-		},
-		{
-			name: "Invalid tolerance (negative)",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{validSignatureHeader},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret:    secret,
-					Tolerance: -1 * time.Minute,
-				},
-			},
-			expectedValid: false,
-			expectedError: errInvalidTolerance,
-		},
-		{
-			name: "Custom tolerance within limit",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{fmt.Sprintf("t=%d,v1=%s", time.Now().Unix()-120, computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-120), body))},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret:    secret,
-					Tolerance: 5 * time.Minute, // 5 minutes tolerance
-				},
-			},
-			expectedValid: true,
-			expectedError: nil,
-		},
-		{
-			name: "Custom tolerance exceeded",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{fmt.Sprintf("t=%d,v1=%s", time.Now().Unix()-120, computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-120), body))},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret:    secret,
-					Tolerance: 1 * time.Minute, // Only 1 minute tolerance, but timestamp is 2 minutes old
-				},
-			},
-			expectedValid: false,
-			expectedError: errTimestampTooOld,
-		},
-		{
-			name: "Wrong secret",
-			request: &common.WebhookRequest{
-				Headers: http.Header{
-					"Stripe-Signature": []string{validSignatureHeader},
-				},
-				Body: body,
-			},
-			params: &common.VerificationParams{
-				Param: &VerificationParams{
-					Secret: "wrong_secret",
-				},
-			},
-			expectedValid: false,
-			expectedError: errInvalidSignature,
+	// The same Stripe event expressed through both Events and PassThroughEvents
+	// must be stored once, matching the deduplicated enabled_events sent to Stripe.
+	subscriptionEvents := map[common.ObjectName]common.ObjectEvents{
+		"account": {
+			Events:            []common.SubscriptionEventType{common.SubscriptionEventTypeUpdate},
+			PassThroughEvents: []string{"account.updated"},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			valid, err := conn.VerifyWebhookMessage(context.Background(), tt.request, tt.params)
-
-			if tt.expectedError != nil {
-				assert.ErrorIs(t, err, tt.expectedError, "should return expected error")
-				assert.Equal(t, valid, false, "should return false for invalid verification")
-			} else {
-				assert.NilError(t, err, "should not return error")
-				assert.Equal(t, valid, tt.expectedValid, "verification result should match expected")
-			}
-		})
-	}
-}
-
-func TestParseStripeSignature(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		header        string
-		expectedTS    string
-		expectedSigs  []string
-		expectedError string
-	}{
-
-		{
-			name:         "Parse signature header",
-			header:       "t=1766887044,v1=08ddffb964639dd31625fa74a9fcb8e95daaef2220ebd8e493127cf2a06320f7,v0=2c1d2ba92e6f80203fbbd6b46b9b2386693bb0d4a1987432c4646e817583201d",
-			expectedTS:   "1766887044",
-			expectedSigs: []string{"08ddffb964639dd31625fa74a9fcb8e95daaef2220ebd8e493127cf2a06320f7", "2c1d2ba92e6f80203fbbd6b46b9b2386693bb0d4a1987432c4646e817583201d"},
-		},
+	result, err := buildSubscriptionResult(response, subscriptionEvents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ts, sigs, err := parseStripeSignature(tt.header)
-
-			if tt.expectedError != "" {
-				assert.ErrorContains(t, err, tt.expectedError, "should return expected error")
-			} else {
-				assert.NilError(t, err, "should not return error")
-				assert.Equal(t, ts, tt.expectedTS, "timestamp should match")
-				assert.DeepEqual(t, sigs, tt.expectedSigs)
-			}
-		})
-	}
-}
-
-func successSubResultComparator(url string,
-	actual *common.SubscriptionResult,
-	expected *common.SubscriptionResult,
-) *testutils.CompareResult {
-	result := testutils.NewCompareResult()
-	if actual == nil {
-		result.AddDiff("actual SubscriptionResult cannot be nil")
-		return result
+	subResult, ok := result.Result.(*SubscriptionResult)
+	if !ok {
+		t.Fatalf("expected SubscriptionResult, got %T", result.Result)
 	}
 
-	result.Assert("Status", common.SubscriptionStatusSuccess, actual.Status)
-
-	return result
+	enabledEvents := subResult.Subscriptions["account"].EnabledEvents
+	if len(enabledEvents) != 1 || enabledEvents[0] != "account.updated" {
+		t.Errorf("expected deduplicated [account.updated], got %v", enabledEvents)
+	}
 }

--- a/providers/stripe/subscriptionEvent.go
+++ b/providers/stripe/subscriptionEvent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -61,6 +62,9 @@ func (evt SubscriptionEvent) UpdatedFields() ([]string, error) {
 	for field := range previousAttrs {
 		updatedFields = append(updatedFields, field)
 	}
+
+	// Map iteration order is random; sort for deterministic output.
+	sort.Strings(updatedFields)
 
 	return updatedFields, nil
 }

--- a/providers/stripe/subscriptionEvent_test.go
+++ b/providers/stripe/subscriptionEvent_test.go
@@ -3,14 +3,14 @@ package stripe
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
-	"gotest.tools/v3/assert"
 )
 
-//nolint:funlen
-func TestCollapsedSubscriptionEvent_Created(t *testing.T) {
+func TestSubscriptionEvents(t *testing.T) {
 	t.Parallel()
 
 	data := testutils.DataFromFile(t, "subscribe/setup_intent-created.json")
@@ -22,44 +22,28 @@ func TestCollapsedSubscriptionEvent_Created(t *testing.T) {
 		t.Fatalf("failed to unmarshal event: %v", err)
 	}
 
-	rawMap, err := evt.RawMap()
-	assert.NilError(t, err, "RawMap should not return error")
-	assert.Assert(t, rawMap != nil, "RawMap should not be nil")
+	tests := []testconn.TestCaseSubscriptionEvent{
+		{
+			Name:  "Setup intent created event",
+			Input: evt,
+			Expected: []testconn.SubscriptionEventExpected{{
+				Data: testconn.SubscriptionEventExpectedData{
+					EventType:          common.SubscriptionEventTypeCreate,
+					RawEventName:       "setup_intent.created",
+					ObjectName:         "setup_intent",
+					Workspace:          "",
+					RecordId:           "seti_1NG8Du2eZvKYlo2C9XMqbR0x",
+					EventTimeStampNano: time.Unix(1686089970, 0).UnixNano(),
+					UpdatedFields:      []string{},
+				},
+			}},
+		},
+	}
 
-	events, err := evt.SubscriptionEventList()
-	assert.NilError(t, err, "SubscriptionEventList should not return error")
-	assert.Equal(t, len(events), 1, "should have exactly one event")
-
-	subEvt := events[0]
-
-	eventType, err := subEvt.EventType()
-	assert.NilError(t, err, "EventType should not return error")
-	assert.Equal(t, eventType, common.SubscriptionEventTypeCreate, "EventType should be Create")
-
-	rawEventName, err := subEvt.RawEventName()
-	assert.NilError(t, err, "RawEventName should not return error")
-	assert.Equal(t, rawEventName, "setup_intent.created", "RawEventName should be setup_intent.created")
-
-	objectName, err := subEvt.ObjectName()
-	assert.NilError(t, err, "ObjectName should not return error")
-	assert.Equal(t, objectName, "setup_intent", "ObjectName should be setup_intent")
-
-	recordID, err := subEvt.RecordId()
-	assert.NilError(t, err, "RecordId should not return error")
-	assert.Equal(t, recordID, "seti_1NG8Du2eZvKYlo2C9XMqbR0x", "RecordId should be seti_1NG8Du2eZvKYlo2C9XMqbR0x")
-
-	workspace, err := subEvt.Workspace()
-	assert.NilError(t, err, "Workspace should not return error")
-	assert.Equal(t, workspace, "", "Workspace should be empty")
-
-	timestamp, err := subEvt.EventTimeStampNano()
-	assert.NilError(t, err, "EventTimeStampNano should not return error")
-	assert.Assert(t, timestamp > 0, "EventTimeStampNano should be positive")
-
-	updateEvt, ok := subEvt.(common.SubscriptionUpdateEvent)
-	assert.Assert(t, ok, "should implement SubscriptionUpdateEvent")
-
-	fields, err := updateEvt.UpdatedFields()
-	assert.NilError(t, err, "UpdatedFields should not return error")
-	assert.Equal(t, len(fields), 0, "created events should have no updated fields")
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			tt.Run(t)
+		})
+	}
 }

--- a/providers/stripe/verify.go
+++ b/providers/stripe/verify.go
@@ -1,0 +1,152 @@
+package stripe
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+)
+
+var _ connectors.WebhookVerifierConnector = &Connector{}
+
+const (
+	stripeSignatureHeader = "Stripe-Signature"
+	keyValuePairParts     = 2
+	defaultTolerance      = 5 * time.Minute
+)
+
+// VerifyWebhookMessage verifies the signature of a webhook message from Stripe.
+// Stripe uses HMAC-SHA256 with the format: signed_payload = timestamp + "." + requestBody.
+func (c *Connector) VerifyWebhookMessage(
+	_ context.Context,
+	request *common.WebhookRequest,
+	params *common.VerificationParams,
+) (bool, error) {
+	if request == nil || params == nil {
+		return false, fmt.Errorf("%w: request and params cannot be nil", errMissingParams)
+	}
+
+	verificationParams, err := common.AssertType[*VerificationParams](params.Param)
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", errMissingParams, err)
+	}
+
+	if verificationParams.Secret == "" {
+		return false, fmt.Errorf("%w: secret cannot be empty", errMissingParams)
+	}
+
+	// Determine tolerance: use provided value or default to 5 minutes
+	tolerance := verificationParams.Tolerance
+	if tolerance == 0 {
+		tolerance = defaultTolerance
+	} else if tolerance < 0 {
+		return false, fmt.Errorf("%w", errInvalidTolerance)
+	}
+
+	signatureHeader := request.Headers.Get(stripeSignatureHeader)
+	if signatureHeader == "" {
+		return false, fmt.Errorf("%w: missing %s header", errMissingSignature, stripeSignatureHeader)
+	}
+
+	timestampStr, signatures, err := parseStripeSignature(signatureHeader)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse Stripe signature: %w", err)
+	}
+
+	if err := validateTimestampRecency(timestampStr, tolerance); err != nil {
+		return false, err
+	}
+
+	return verifySignature(verificationParams.Secret, timestampStr, request.Body, signatures)
+}
+
+// verifySignature computes the expected HMAC-SHA256 signature and compares it with the received signatures.
+func verifySignature(secret, timestampStr string, body []byte, receivedSignatures []string) (bool, error) {
+	// Create signed_payload: timestamp + "." + requestBody
+	signedPayload := fmt.Sprintf("%s.%s", timestampStr, string(body))
+
+	// Compute expected signature using HMAC-SHA256
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signedPayload))
+	expectedSignature := hex.EncodeToString(mac.Sum(nil))
+
+	// Compare signatures using constant-time comparison
+	// Check if any of the received signatures matches the expected signature
+	for _, sig := range receivedSignatures {
+		if hmac.Equal([]byte(expectedSignature), []byte(sig)) {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("%w: signature mismatch", errInvalidSignature)
+}
+
+// validateTimestampRecency validates that the webhook timestamp is within the allowed tolerance.
+func validateTimestampRecency(timestampStr string, tolerance time.Duration) error {
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse timestamp: %w", err)
+	}
+
+	timestampTime := time.Unix(timestamp, 0)
+	now := time.Now()
+	timeDiff := now.Sub(timestampTime)
+
+	if timeDiff < 0 {
+		timeDiff = -timeDiff
+	}
+
+	if timeDiff > tolerance {
+		if timestampTime.Before(now) {
+			return errTimestampTooOld
+		}
+
+		return errTimestampTooFarInFuture
+	}
+
+	return nil
+}
+
+func parseStripeSignature(header string) (string, []string, error) {
+	elements := strings.Split(header, ",")
+
+	var timestamp string
+
+	var signatures []string
+
+	for _, element := range elements {
+		element = strings.TrimSpace(element)
+
+		parts := strings.SplitN(element, "=", keyValuePairParts)
+		if len(parts) != keyValuePairParts {
+			continue
+		}
+
+		prefix := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch prefix {
+		case "t":
+			timestamp = value
+		case "v1", "v2", "v0":
+			signatures = append(signatures, value)
+		}
+	}
+
+	if timestamp == "" {
+		return "", nil, fmt.Errorf("%w", errMissingTimestamp)
+	}
+
+	if len(signatures) == 0 {
+		return "", nil, fmt.Errorf("%w", errNoSignaturesFound)
+	}
+
+	return timestamp, signatures, nil
+}

--- a/providers/stripe/verify_test.go
+++ b/providers/stripe/verify_test.go
@@ -1,0 +1,350 @@
+package stripe
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"gotest.tools/v3/assert"
+)
+
+// computeTestSignature computes a Stripe signature for testing purposes.
+func computeTestSignature(secret, timestamp string, body []byte) string {
+	signedPayload := fmt.Sprintf("%s.%s", timestamp, string(body))
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signedPayload))
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyWebhookMessage(t *testing.T) { // nolint:funlen,maintidx
+	t.Parallel()
+
+	secret := "whsec_test_secret"
+	// Use a recent timestamp (current time) for valid tests
+	recentTimestamp := fmt.Sprintf("%d", time.Now().Unix())
+	body := []byte(`{"id":"evt_test_123","type":"charge.succeeded"}`)
+
+	validSignature := computeTestSignature(secret, recentTimestamp, body)
+	validSignatureHeader := fmt.Sprintf("t=%s,v1=%s", recentTimestamp, validSignature)
+
+	tests := []testconn.TestCaseVerifyWebhookMessage{
+		{
+			Name: "Valid signature",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{validSignatureHeader},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: true,
+		},
+		{
+			Name: "Invalid signature",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{fmt.Sprintf("t=%s,v1=%s", recentTimestamp, "invalid_signature")},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errInvalidSignature},
+		},
+		{
+			Name: "Missing signature header",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{},
+					Body:    body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errMissingSignature},
+		},
+		{
+			Name: "Nil request",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: nil,
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errMissingParams},
+		},
+		{
+			Name: "Empty secret",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{validSignatureHeader},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: "",
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errMissingParams},
+		},
+		{
+			Name: "Wrong timestamp (signature mismatch)",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						// Use a valid recent timestamp but with a signature computed for a different timestamp
+						"Stripe-Signature": []string{fmt.Sprintf(
+							"t=%s,v1=%s",
+							recentTimestamp,
+							computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-10), body),
+						)},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errInvalidSignature},
+		},
+		{
+			Name: "Timestamp too old (replay attack)",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{fmt.Sprintf(
+							"t=%d,v1=%s",
+							time.Now().Unix()-600,
+							computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-600), body),
+						)},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errTimestampTooOld},
+		},
+		{
+			Name: "Timestamp too far in the future",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{fmt.Sprintf(
+							"t=%d,v1=%s",
+							time.Now().Unix()+600,
+							computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()+600), body),
+						)},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: secret,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errTimestampTooFarInFuture},
+		},
+		{
+			Name: "Default tolerance applies when unset (zero)",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{validSignatureHeader},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret:    secret,
+						Tolerance: 0,
+					},
+				},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: true,
+		},
+		{
+			Name: "Invalid tolerance (negative)",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{validSignatureHeader},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret:    secret,
+						Tolerance: -1 * time.Minute,
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errInvalidTolerance},
+		},
+		{
+			Name: "Custom tolerance within limit",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{fmt.Sprintf(
+							"t=%d,v1=%s",
+							time.Now().Unix()-120,
+							computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-120), body),
+						)},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret:    secret,
+						Tolerance: 5 * time.Minute, // 5 minutes tolerance
+					},
+				},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: true,
+		},
+		{
+			Name: "Custom tolerance exceeded",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{fmt.Sprintf(
+							"t=%d,v1=%s",
+							time.Now().Unix()-120,
+							computeTestSignature(secret, fmt.Sprintf("%d", time.Now().Unix()-120), body),
+						)},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret:    secret,
+						Tolerance: 1 * time.Minute, // Only 1 minute tolerance, but timestamp is 2 minutes old
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errTimestampTooOld},
+		},
+		{
+			Name: "Wrong secret",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: &common.WebhookRequest{
+					Headers: http.Header{
+						"Stripe-Signature": []string{validSignatureHeader},
+					},
+					Body: body,
+				},
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{
+						Secret: "wrong_secret",
+					},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			Expected:     false,
+			ExpectedErrs: []error{errInvalidSignature},
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableWebhookMessageVerifier, error) {
+				return &Connector{}, nil
+			})
+		})
+	}
+}
+
+func TestParseStripeSignature(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		header        string
+		expectedTS    string
+		expectedSigs  []string
+		expectedError string
+	}{
+		{
+			name: "Parse signature header",
+			header: "t=1766887044,v1=08ddffb964639dd31625fa74a9fcb8e95daaef2220ebd8e493127cf2a06320f7," +
+				"v0=2c1d2ba92e6f80203fbbd6b46b9b2386693bb0d4a1987432c4646e817583201d",
+			expectedTS: "1766887044",
+			expectedSigs: []string{
+				"08ddffb964639dd31625fa74a9fcb8e95daaef2220ebd8e493127cf2a06320f7",
+				"2c1d2ba92e6f80203fbbd6b46b9b2386693bb0d4a1987432c4646e817583201d",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, sigs, err := parseStripeSignature(tt.header)
+
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError, "should return expected error")
+			} else {
+				assert.NilError(t, err, "should not return error")
+				assert.Equal(t, ts, tt.expectedTS, "timestamp should match")
+				assert.DeepEqual(t, sigs, tt.expectedSigs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Subscribe Action — Stripe — [PR 1: Fix & restructure the merged implementation]

Part of the Subscribe Action stack for `stripe` (CON-2753). See [CONTRIBUTING_SUBSCRIBE_ACTION.md](https://github.com/amp-labs/connectors/blob/main/CONTRIBUTING_SUBSCRIBE_ACTION.md).

**Context:** #2504 merged the original January implementation into main. That code predates the stripe connector rebuild, so **`providers/stripe` currently does not compile on main** (removed `providers/stripe/metadata` package, removed `c.Client`/`c.getURL`, removed `testroutines` test package). This PR — now the bottom of the stack — repairs the build and carries every change we made relative to the original #2504 code. **The diff of this PR is exactly "our version vs the original".**

Build repairs / API drift:
- `JSONHTTPClient()`/`HTTPClient()`/`GetURL()` replace removed `c.Client`/`c.BaseURL`; `internal/metadata` import path; `common.ModuleRoot`; `ParseJSONResponse(ctx, ...)`
- tests migrated from removed `testroutines` to the shared `testconn` suites, with decomposed `TestableSubscription{Creator,Updater,Remover}` assertions

Restructure (per [pr-2-verification.md](https://github.com/amp-labs/connectors/blob/main/docs/subscribe-onboarding/pr-2-verification.md)):
- verification extracted from subscribe.go into `verify.go`/`verify_test.go` with the `WebhookVerifierConnector` compile-time assertion

Behavioral fixes (all reviewed on the pre-merge stack, incl. AI review findings):
- **UpdateSubscription** honors the platform contract: `params.SubscriptionEvents` is the *full desired state* — objects absent from it are unsubscribed (the original merged previous∪new state while the endpoint payload dropped them, so persisted state diverged from remote). Regression test included.
- signing **secret carried over on update** — Stripe returns it only at endpoint creation; without this, verification breaks after any update
- **GetRecordsByIds pluralizes object names** — webhook events carry singular object types ("setup_intent") but retrieve endpoints are plural (`/v1/setup_intents/{id}`); mirrors the hubspot pattern
- **dot-path association extraction** per `common.ReadParams.AssociatedObjects` (https://docs.stripe.com/expand — "Expanding multiple levels")
- sorted `UpdatedFields`; per-object empty-event validation; deduplicated stored `EnabledEvents`; removed dead `ObjectsToDelete`

- [x] Head is green (repairs main's build)
- [x] Provider remains gated off (`Support.Subscribe` stays false)
- [x] Compile-time interface assertions present (`WebhookVerifierConnector`, `SubscribeConnector`, testconn decomposed)
- [x] Unit tests migrated/extended (testconn suites)
- [x] Linked [SUBSCRIBE_REFERENCES.md](https://github.com/amp-labs/connectors/blob/main/SUBSCRIBE_REFERENCES.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
