### PR TITLE
[CON-2753][PR4] Stripe subscribe: ProviderConfig declaration

### DIFF
--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -125,6 +125,7 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 	providers.Slack:        {DefaultModuleConfig: &slackConfig},
 	providers.Microsoft:    {DefaultModuleConfig: &microsoftConfig},
 	providers.Attio:        {DefaultModuleConfig: &attioConfig},
+	providers.Stripe:       {DefaultModuleConfig: &stripeConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in

--- a/subscribe/events.go
+++ b/subscribe/events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/amp-labs/connectors/providers/salesforce"
 	"github.com/amp-labs/connectors/providers/salesloft"
 	"github.com/amp-labs/connectors/providers/slack"
+	"github.com/amp-labs/connectors/providers/stripe"
 	"github.com/amp-labs/connectors/providers/zoho"
 )
 
@@ -68,6 +69,8 @@ func GetObjectTypeSubscribeEventsList(
 		collapsedEvents = microsoft.CollapsedSubscriptionEvent(rawEvent)
 	case providers.Attio:
 		collapsedEvents = attio.CollapsedSubscriptionEvent(rawEvent)
+	case providers.Stripe:
+		collapsedEvents = stripe.CollapsedSubscriptionEvent(rawEvent)
 	default:
 		return nil, fmt.Errorf("%w with non-array object webhook message: %s", errUnsupportedProvider, provider)
 	}

--- a/subscribe/stripe.go
+++ b/subscribe/stripe.go
@@ -1,0 +1,112 @@
+package subscribe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/amp-common/openapi"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/stripe"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+// errStripeWebhookSecretNotFound is returned when no stored subscription result carries the
+// endpoint signing secret needed to verify an incoming Stripe webhook.
+var errStripeWebhookSecretNotFound = errors.New("stripe webhook signing secret not found for installation")
+
+// stripeConfig is the per-provider subscribe-config bundle for Stripe. Stripe subscribes via
+// API and builds a subscribe-time request payload (the webhook endpoint URL), so a
+// buildRequestFn is declared. Stripe sends one event per webhook delivery; the payload is
+// fanned out by stripe.CollapsedSubscriptionEvent (registered in
+// GetObjectTypeSubscribeEventsList).
+//
+// Webhook signatures are verified: Stripe generates a signing secret when the webhook
+// endpoint is created and the connector stores it in the SubscriptionResult.
+// getStripeVerificationParams recovers that stored secret (via
+// deps.Dependencies.Subscriptions) so the connector's VerifyWebhookMessage can HMAC-check
+// the Stripe-Signature header.
+var stripeConfig = ProviderConfig{
+	Subscription: SubscriptionConfig{
+		buildRequestFn: getStripeRequest,
+	},
+	Verification: VerificationConfig{
+		paramsFn:          getStripeVerificationParams,
+		verifierConnector: &stripe.Connector{},
+		eventCaster:       CastSubscriptionEvents[stripe.SubscriptionEvent],
+	},
+}
+
+func getStripeRequest(
+	_ context.Context,
+	_ deps.Dependencies,
+	_ *openapi.Installation,
+	_ *openapi.Revision,
+	_ *common.RegistrationResult,
+	_ *openapi.Connection,
+	webhookURL string,
+) (any, error) {
+	return &stripe.SubscriptionRequest{
+		WebhookEndPoint: webhookURL,
+	}, nil
+}
+
+// getStripeVerificationParams supplies the signing secret Stripe generated for the
+// installation's webhook endpoint so the connector can verify the incoming signature.
+func getStripeVerificationParams(
+	ctx context.Context,
+	deps deps.Dependencies,
+	req *deps.VerificationRequest,
+) (*common.VerificationParams, error) {
+	if req == nil || req.Installation == nil {
+		return nil, errInstallationNotFound
+	}
+
+	if deps.Subscriptions == nil {
+		return nil, errSubscriptionListerNotConfigured
+	}
+
+	secret, err := stripeWebhookSecret(ctx, deps, req.Installation.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.VerificationParams{
+		Param: &stripe.VerificationParams{Secret: secret},
+	}, nil
+}
+
+// stripeWebhookSecret returns the signing secret for the installation's webhook endpoint.
+// Stripe returns the secret once, at endpoint-creation time, and the connector persists it
+// in the SubscriptionResult; all of an installation's object subscriptions share a single
+// endpoint (composite IDs "endpointID:objectName"), so the first stored secret applies.
+func stripeWebhookSecret(
+	ctx context.Context, deps deps.Dependencies, installationID string,
+) (string, error) {
+	results, err := deps.Subscriptions.ListSubscriptionResults(ctx, installationID,
+		func() *common.SubscriptionResult {
+			return &common.SubscriptionResult{Result: &stripe.SubscriptionResult{}}
+		})
+	if err != nil {
+		return "", fmt.Errorf("error listing subscription results for installation %q: %w", installationID, err)
+	}
+
+	for _, full := range results {
+		if full == nil {
+			continue
+		}
+
+		result, ok := full.Result.(*stripe.SubscriptionResult)
+		if !ok {
+			continue
+		}
+
+		for _, endpoint := range result.Subscriptions {
+			if endpoint.Secret != "" {
+				return endpoint.Secret, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("%w: %q", errStripeWebhookSecretNotFound, installationID)
+}


### PR DESCRIPTION
## Subscribe Action — Stripe — [PR 4: ProviderConfig declaration]

Part of the Subscribe Action stack for `stripe` (CON-2753); this is rung 6 of [CONTRIBUTING_SUBSCRIBE_ACTION.md](https://github.com/amp-labs/connectors/blob/main/CONTRIBUTING_SUBSCRIBE_ACTION.md) (Maintenance rung skipped — Stripe endpoints do not expire). See [pr-6-provider-config.md](https://github.com/amp-labs/connectors/blob/main/docs/subscribe-onboarding/pr-6-provider-config.md).

This rung did not exist in the original #2504 — the `subscribe/` registry landed after that PR was written — so it is authored fresh per the guide:

- `subscribe/stripe.go` — `stripeConfig` with:
  - `Subscription.buildRequestFn` supplying the caller-constructed webhook URL as `stripe.SubscriptionRequest`.
  - `Verification.paramsFn` recovering the endpoint **signing secret from the stored `SubscriptionResult`** via `deps.Subscriptions` (Stripe hands the secret out once, at endpoint creation — same recovery pattern as Attio); `verifierConnector: &stripe.Connector{}` (zero-value, as required); `eventCaster: CastSubscriptionEvents[stripe.SubscriptionEvent]`.
- `subscribe/config.go` — registry entry under `DefaultModuleConfig` (module-agnostic provider).
- `subscribe/events.go` — `providers.Stripe` case in `GetObjectTypeSubscribeEventsList` so raw payloads cast to `stripe.CollapsedSubscriptionEvent`.

- [x] Scope limited to this stack rung (one interface / concern)
- [x] Provider remains gated off (`Support.Subscribe` stays false)
- [x] Config shape matches PR 2–3 capabilities (no registration/maintenance declared)
- [x] Builders use only wire types and `deps.Dependencies`; secrets come from stored results, never hardcoded
- [x] Unit tests: existing subscribe-package suites pass; registry resolution covered by `config_test.go` patterns
- [ ] Live testing before the flip: recommended under `connectors-test-project` per the guide (bypasses the gate)
- [x] Linked the relevant [SUBSCRIBE_REFERENCES.md](https://github.com/amp-labs/connectors/blob/main/SUBSCRIBE_REFERENCES.md) section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
