### PR TITLE
[CON-2753][PR5] Stripe subscribe: enable the provider (merge last)

### DIFF
--- a/providers/stripe.go
+++ b/providers/stripe.go
@@ -24,7 +24,7 @@ func init() {
 			},
 			Proxy:     true,
 			Read:      true,
-			Subscribe: false, // the gate; flipped to true in the final Enable PR of the subscribe stack
+			Subscribe: true,
 			Write:     true,
 		},
 		SubscribeRequirements: &SubscribeRequirements{


### PR DESCRIPTION
## Subscribe Action — Stripe — [PR 5: Enable the provider]

Part of the Subscribe Action stack for `stripe` (CON-2753); this is rung 7 (top) of [CONTRIBUTING_SUBSCRIBE_ACTION.md](https://github.com/amp-labs/connectors/blob/main/CONTRIBUTING_SUBSCRIBE_ACTION.md). See [pr-7-enable.md](https://github.com/amp-labs/connectors/blob/main/docs/subscribe-onboarding/pr-7-enable.md).

One-line flip of `Support.Subscribe` for Stripe. **Merge last**, after everything below in the stack.

⚠️ **Do not merge until the required live verification is done** (per the guide):

- [ ] All prerequisite PRs merged (PR 1–4 of this stack)
- [ ] Live-tested on Ampersand: installed (e.g. MailMonkey demo app), created an installation, subscribed, and received a **real webhook** end-to-end (Svix Play works as the receiver)
- [ ] **Screenshot of the actual delivered webhook attached to this PR**
- [x] Change is just the `Support.Subscribe` flip, trivial to revert

The original #2504 carried screenshots of a working subscribe/verify flow from January; they predate the connector rebuild and the reconciliation fixes in this stack, so a fresh verification run is required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
