### PR TITLE
feat: add initialAppointment queryParam for jobs

### DIFF
--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -64,13 +64,19 @@ const (
 // includesByObject lists the AccuLynx ?includes= expansions applied
 // unconditionally on every read of the object. Contacts return phone/email as
 // reference-only stubs unless expanded, so we always request them — downstream
-// field filtering still drops fields the caller did not select. Object-scoped
-// (not org-scoped): the connector has no org context. Association-driven
-// includes (e.g. jobs -> contacts) are handled separately in applyIncludes.
+// field filtering still drops fields the caller did not select. Jobs omit
+// initialAppointment from the payload entirely unless expanded; with
+// ?includes=initialAppointment it arrives in full (startDate/endDate/notes).
+// Note the OpenAPI spec types job.initialAppointment as a _link-only stub and
+// documents contacts as the sole expandable property — both are spec bugs; the
+// live API expands initialAppointment. Object-scoped (not org-scoped): the
+// connector has no org context. Association-driven includes (e.g. jobs ->
+// contacts) are handled separately in applyIncludes.
 //
 //nolint:gochecknoglobals
-var includesByObject = map[string]string{
-	objectContacts: "emailAddress,phoneNumber",
+var includesByObject = map[string][]string{
+	objectContacts: {"emailAddress", "phoneNumber"},
+	objectJobs:     {"initialAppointment"},
 }
 
 type nestedSpec struct {
@@ -151,14 +157,23 @@ func (c *Connector) buildInitialURL(params common.ReadParams) (*urlbuilder.URL, 
 // defaults come from includesByObject (always applied). Additionally, jobs
 // request the embedded contacts array only when the Job<->Contact association is
 // requested, so plain jobs reads are not bloated for orgs that did not opt in.
+//
+// AccuLynx takes every expansion as one comma-separated ?includes= value, and
+// urlbuilder's WithQueryParam replaces rather than appends — so the values are
+// collected and written in a single call. Setting the param twice would silently
+// drop the first expansion.
 func applyIncludes(url *urlbuilder.URL, objectName string, params common.ReadParams) {
-	if includes, ok := includesByObject[objectName]; ok {
-		url.WithQueryParam("includes", includes)
-	}
+	includes := slices.Clone(includesByObject[objectName])
 
 	if objectName == objectJobs && slices.Contains(params.AssociatedObjects, jobContactsAssociation) {
-		url.WithQueryParam("includes", jobContactsAssociation)
+		includes = append(includes, jobContactsAssociation)
 	}
+
+	if len(includes) == 0 {
+		return
+	}
+
+	url.WithQueryParam("includes", strings.Join(includes, ","))
 }
 
 func applyPagination(url *urlbuilder.URL, objectName string, params common.ReadParams) {

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -73,6 +73,9 @@ var jobsWithContactsResponse []byte
 //go:embed test/read/contacts-includes.json
 var contactsIncludesResponse []byte
 
+//go:embed test/read/jobs-with-initial-appointment.json
+var jobsWithInitialAppointmentResponse []byte
+
 func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
@@ -134,7 +137,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						If: mockcond.And{
 							mockcond.MethodGET(),
 							mockcond.Path("/api/v2/jobs"),
-							mockcond.QueryParam("includes", "contacts"),
+							mockcond.QueryParam("includes", "initialAppointment,contacts"),
 						},
 						Then: mockserver.Response(http.StatusOK, jobsWithContactsResponse),
 					},
@@ -179,7 +182,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			},
 		},
 		{
-			Name: "Read jobs without association omits includes and attaches no associations",
+			Name: "Read jobs without association still requests initialAppointment and attaches no associations",
 			Input: common.ReadParams{
 				ObjectName: "jobs",
 				Fields:     connectors.Fields("id"),
@@ -191,7 +194,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						If: mockcond.And{
 							mockcond.MethodGET(),
 							mockcond.Path("/api/v2/jobs"),
-							mockcond.QueryParamsMissing("includes"),
+							mockcond.QueryParam("includes", "initialAppointment"),
 						},
 						Then: mockserver.Response(http.StatusOK, jobsWithContactsResponse),
 					},
@@ -212,6 +215,64 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					{Fields: map[string]any{"id": "job-001"}, Raw: map[string]any{"id": "job-001"}},
 					{Fields: map[string]any{"id": "job-002"}, Raw: map[string]any{"id": "job-002"}},
 				},
+				Done: true,
+			},
+		},
+		{
+			// The initialAppointment expansion is what makes startDate/endDate/notes
+			// present at all — without ?includes=initialAppointment AccuLynx omits the
+			// property from the job payload entirely.
+			Name: "Read jobs surfaces the expanded initialAppointment object",
+			Input: common.ReadParams{
+				ObjectName: "jobs",
+				Fields:     connectors.Fields("id", "initialAppointment"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs"),
+							mockcond.QueryParam("includes", "initialAppointment"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobsWithInitialAppointmentResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/company-settings/custom-fields"),
+						},
+						Then: mockserver.Response(http.StatusOK, customFieldDefinitionsEmptyResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"id": "875b28e8-4f10-44e2-9af1-aff90527291e",
+						"initialappointment": map[string]any{
+							"startDate": "2025-03-20T16:30:00Z",
+							"endDate":   "2025-03-20T17:00:00Z",
+							"notes":     "Customer contact information:\nFoobar - McHealy, David\n",
+							"_link": "https://api.acculynx.com/api/v2/jobs/" +
+								"875b28e8-4f10-44e2-9af1-aff90527291e/initial-appointment",
+						},
+					},
+					Raw: map[string]any{
+						"id": "875b28e8-4f10-44e2-9af1-aff90527291e",
+						"initialAppointment": map[string]any{
+							"startDate": "2025-03-20T16:30:00Z",
+							"endDate":   "2025-03-20T17:00:00Z",
+							"notes":     "Customer contact information:\nFoobar - McHealy, David\n",
+							"_link": "https://api.acculynx.com/api/v2/jobs/" +
+								"875b28e8-4f10-44e2-9af1-aff90527291e/initial-appointment",
+						},
+					},
+				}},
 				Done: true,
 			},
 		},

--- a/providers/acculynx/test/read/jobs-with-initial-appointment.json
+++ b/providers/acculynx/test/read/jobs-with-initial-appointment.json
@@ -1,0 +1,19 @@
+{
+  "count": 1,
+  "pageSize": 25,
+  "pageStartIndex": 0,
+  "items": [
+    {
+      "id": "875b28e8-4f10-44e2-9af1-aff90527291e",
+      "initialAppointment": {
+        "startDate": "2025-03-20T16:30:00Z",
+        "endDate": "2025-03-20T17:00:00Z",
+        "notes": "Customer contact information:\nFoobar - McHealy, David\n",
+        "_link": "https://api.acculynx.com/api/v2/jobs/875b28e8-4f10-44e2-9af1-aff90527291e/initial-appointment"
+      },
+      "currentMilestone": "Cancelled",
+      "modifiedDate": "2025-03-19T20:01:27Z",
+      "_link": "https://api.acculynx.com/api/v2/jobs/875b28e8-4f10-44e2-9af1-aff90527291e"
+    }
+  ]
+}


### PR DESCRIPTION
### What this change does?
AccuLynx omits `initialAppointment` from the `/jobs` payload entirely unless the read asks for it via `?includes=initialAppointment`. We never sent it, so the field never reached customers.

- Adds `initialAppointment` to the includes applied on every `jobs` read
- Refactors `applyIncludes` to collect values and write the param **once**, comma-joined  `urlbuilder.WithQueryParam` *replaces* rather than appends, so setting `includes` twice would have silently dropped the existing `contacts` expansion (Hatch's association path)
- Jobs reads with the contacts association now send `includes=initialAppointment,contacts`


## How to test

Unit:
- `go test ./providers/acculynx/` — includes a new regression test asserting the expanded object lands in the row

End-to-end (already verified locally against a real AccuLynx tenant):
1. Point a local server at this branch, enable `jobs` on the install, add `initialAppointment` to `selectedFields`
2. Trigger an on-demand read scoped to a narrow window (`sinceTimestamp: 2025-03-19`, `untilTimestamp: 2025-03-20`)
3. Check `raw.initialAppointment` in the delivered payload


- **Before:** no `initialAppointment` key at all
<img width="962" height="923" alt="Screenshot 2026-08-06 at 16 27 23" src="https://github.com/user-attachments/assets/9040e340-0368-4b4b-a4b1-c90ce095dc35" />

- **After:** 
<img width="1635" height="931" alt="Screenshot 2026-08-06 at 16 31 30" src="https://github.com/user-attachments/assets/8ce83a07-e9d9-4444-af56-3494d67c7537" />
