### PR TITLE
[ENG-4159] chore: update cdcOptimization dependency interface

### DIFF
--- a/docs/subscribe-onboarding/pr-6-provider-config.md
+++ b/docs/subscribe-onboarding/pr-6-provider-config.md
@@ -66,7 +66,7 @@ Some per-provider functions need data that only the Ampersand server can resolve
 ```go
 type Dependencies struct {
     Project         ProjectResolver          // project attributes (Salesforce CDC event-flag field naming)
-    CDCOptimization CDCOptimizationResolver  // per-(project, group) Salesforce CDC quota opt-in
+    CDCOptimization CDCOptimizationResolver  // an installation's Salesforce CDC quota opt-in
     Subscriptions   SubscriptionResultLister // stored subscription results (Attio signing secret recovery)
 }
 ```

--- a/subscribe/deps/cdcoptimization.go
+++ b/subscribe/deps/cdcoptimization.go
@@ -3,20 +3,34 @@ package deps
 import (
 	"context"
 
+	"github.com/amp-labs/amp-common/openapi"
 	"github.com/amp-labs/connectors/common"
 )
 
-// CDCOptimizationResolver resolves the Salesforce CDC quota-optimization opt-in configuration
-// for a (project, group) pair.
+// CDCOptimizationResolver resolves the Salesforce CDC quota-optimization opt-in for one
+// installation.
+//
+// The opt-in is expressed per subscribe object in the installation config, so answering takes
+// the caller's config-over-revision resolution — which is why this is a seam rather than
+// something this package derives from the installation itself.
 type CDCOptimizationResolver interface {
-	// GetCDCOptimizationConfig returns the CDC optimization config for the given project and
-	// group, falling back to the project default when the group has no specific entry. Returns
-	// nil when the project has no CDC optimization configured.
-	GetCDCOptimizationConfig(ctx context.Context, projectID, groupRef string) *CDCOptimizationConfig
+	// GetCDCOptimizationConfig returns the resolved CDC optimization config for an installation.
+	//
+	// Nil means the caller has no opinion: leave whatever is provisioned at the provider alone.
+	// A non-nil config is the authoritative desired state, so one listing no objects is an
+	// instruction to tear existing quota optimization down — not the same answer as nil.
+	//
+	// An error means resolution failed and the desired state is unknown. Callers must not read
+	// that as "nothing enabled", or a transient failure would deprovision a live optimization.
+	GetCDCOptimizationConfig(
+		ctx context.Context,
+		inst *openapi.Installation,
+		rev *openapi.Revision,
+	) (*CDCOptimizationConfig, error)
 }
 
-// CDCOptimizationConfig is the Salesforce CDC quota-optimization opt-in configuration for a
-// group or a project. Mirrors the server's customer.CDCOptimizationConfig.
+// CDCOptimizationConfig is the resolved Salesforce CDC quota-optimization desired state for one
+// installation.
 type CDCOptimizationConfig struct {
 	// ManualCheckboxManagement reports whether the customer manually manages the checkbox field.
 	ManualCheckboxManagement bool
@@ -24,6 +38,8 @@ type CDCOptimizationConfig struct {
 	// ManualApexTriggerManagement reports whether the customer manually manages the Apex trigger.
 	ManualApexTriggerManagement bool
 
-	// ObjectEnabled maps object names to whether CDC optimization is enabled for them.
-	ObjectEnabled map[common.ObjectName]bool
+	// EnabledObjects lists the objects opted into CDC quota optimization. Only enabled objects
+	// are represented: once the caller has resolved the config, "explicitly disabled" and "never
+	// mentioned" are the same desired state, and an object's absence here is what drives teardown.
+	EnabledObjects []common.ObjectName
 }

--- a/subscribe/deps/types.go
+++ b/subscribe/deps/types.go
@@ -23,8 +23,8 @@ type Dependencies struct {
 	// builder to read the project's app name for CDC event-flag field naming.
 	Project ProjectResolver
 
-	// CDCOptimization resolves the per-(project, group) Salesforce CDC quota-optimization
-	// opt-in configuration. Used by the Salesforce subscribe-request builder.
+	// CDCOptimization resolves an installation's Salesforce CDC quota-optimization opt-in.
+	// Used by the Salesforce subscribe-request builder.
 	CDCOptimization CDCOptimizationResolver
 
 	// Subscriptions lists the stored subscription results for an installation. Used by the

--- a/subscribe/deps_test.go
+++ b/subscribe/deps_test.go
@@ -129,15 +129,16 @@ func (s stubProjectResolver) GetProjectAppName(_ context.Context, _ string) (str
 	return s.appName, s.err
 }
 
-// stubCDCOptimizationResolver returns a canned CDC config.
+// stubCDCOptimizationResolver returns a canned CDC config, or a canned resolution failure.
 type stubCDCOptimizationResolver struct {
 	cfg *deps.CDCOptimizationConfig
+	err error
 }
 
 func (s stubCDCOptimizationResolver) GetCDCOptimizationConfig(
-	_ context.Context, _, _ string,
-) *deps.CDCOptimizationConfig {
-	return s.cfg
+	_ context.Context, _ *openapi.Installation, _ *openapi.Revision,
+) (*deps.CDCOptimizationConfig, error) {
+	return s.cfg, s.err
 }
 
 // TestGetSalesforceRequestWithCDCOptIn verifies the full resolver-seam happy path: the Salesforce
@@ -150,7 +151,7 @@ func TestGetSalesforceRequestWithCDCOptIn(t *testing.T) {
 		Project: stubProjectResolver{appName: "My App"},
 		CDCOptimization: stubCDCOptimizationResolver{cfg: &deps.CDCOptimizationConfig{
 			ManualCheckboxManagement: true,
-			ObjectEnabled:            map[common.ObjectName]bool{"Account": true},
+			EnabledObjects:           []common.ObjectName{"Account"},
 		}},
 	}
 

--- a/subscribe/salesforce.go
+++ b/subscribe/salesforce.go
@@ -81,24 +81,20 @@ func getSalesforceRequest(
 	ctx context.Context,
 	deps deps.Dependencies,
 	inst *openapi.Installation,
-	_ *openapi.Revision,
+	rev *openapi.Revision,
 	_ *common.RegistrationResult,
 	_ *openapi.Connection,
 	_ string,
 ) (any, error) {
-	// GroupRef lives under Group on the wire type.
-	groupRef := ""
-	if inst.Group != nil {
-		groupRef = inst.Group.GroupRef
-	}
-
-	// Resolve the CDC optimization config for this installation's (project, group).
-	// Falls back to the project default when the group has no specific entry.
 	if deps.CDCOptimization == nil {
 		return nil, nil //nolint:nilnil // documented contract: no CDC opt-in → no custom payload.
 	}
 
-	optInConfig := deps.CDCOptimization.GetCDCOptimizationConfig(ctx, inst.ProjectId, groupRef)
+	optInConfig, err := deps.CDCOptimization.GetCDCOptimizationConfig(ctx, inst, rev)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve CDC optimization config: %w", err)
+	}
+
 	if optInConfig == nil {
 		return nil, nil //nolint:nilnil // documented contract: no CDC opt-in → no custom payload.
 	}
@@ -112,8 +108,8 @@ func getSalesforceRequest(
 		return nil, fmt.Errorf("failed to get project app name: %w", err)
 	}
 
-	// Build CDC event flag fields for the opted-in objects in this project's group.
-	cdcEventFlagFields, err := buildCDCEventFlagFields(appName, optInConfig.ObjectEnabled)
+	// Build CDC event flag fields for the objects this installation opted in.
+	cdcEventFlagFields, err := buildCDCEventFlagFields(appName, optInConfig.EnabledObjects)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build CDC event flag fields: %w", err)
 	}
@@ -133,9 +129,12 @@ var ErrAppNameInvalid = errors.New("app name is invalid")
 
 // buildCDCEventFlagFields maps each opted-in object name to a CDC event flag custom field name,
 // using the sanitized app name as a prefix (e.g. "myapp_cdc_event_flag__c").
+//
+// No objects yields an empty (non-nil) map, which is the teardown instruction — see
+// getSalesforceRequest.
 func buildCDCEventFlagFields(
 	appName string,
-	objectEnabled map[common.ObjectName]bool,
+	enabledObjects []common.ObjectName,
 ) (map[common.ObjectName]string, error) {
 	if appName == "" {
 		return nil, ErrAppNameRequired
@@ -147,13 +146,9 @@ func buildCDCEventFlagFields(
 	}
 
 	fieldName := sanitizedAppName + "_cdc_event_flag__c"
-	result := make(map[common.ObjectName]string, len(objectEnabled))
+	result := make(map[common.ObjectName]string, len(enabledObjects))
 
-	for objectName, enabled := range objectEnabled {
-		if !enabled {
-			continue
-		}
-
+	for _, objectName := range enabledObjects {
 		result[objectName] = fieldName
 	}
 

--- a/subscribe/salesforce_test.go
+++ b/subscribe/salesforce_test.go
@@ -17,89 +17,66 @@ func TestBuildCDCEventFlagFields(t *testing.T) {
 	tests := []struct {
 		name           string
 		appName        string
-		objectNames    map[common.ObjectName]bool
+		enabledObjects []common.ObjectName
 		expectedResult map[common.ObjectName]string
 		expectedErr    error
 	}{
 		{
-			name:    "empty appName returns error",
-			appName: "",
-			objectNames: map[common.ObjectName]bool{
-				"obj1": true,
-			},
-			expectedErr: ErrAppNameRequired,
+			name:           "empty appName returns error",
+			appName:        "",
+			enabledObjects: []common.ObjectName{"obj1"},
+			expectedErr:    ErrAppNameRequired,
 		},
 		{
-			name:    "appName that sanitizes to empty returns invalid error",
-			appName: "!@#$%",
-			objectNames: map[common.ObjectName]bool{
-				"Account": true,
-			},
-			expectedErr: ErrAppNameInvalid,
+			name:           "appName that sanitizes to empty returns invalid error",
+			appName:        "!@#$%",
+			enabledObjects: []common.ObjectName{"Account"},
+			expectedErr:    ErrAppNameInvalid,
 		},
 		{
-			name:           "empty objectNames returns empty map",
+			name:           "empty enabledObjects returns empty map",
 			appName:        "myapp",
-			objectNames:    map[common.ObjectName]bool{},
+			enabledObjects: []common.ObjectName{},
 			expectedResult: map[common.ObjectName]string{},
 		},
 		{
-			name:           "nil objectNames returns empty map",
+			name:           "nil enabledObjects returns empty map",
 			appName:        "myapp",
-			objectNames:    nil,
+			enabledObjects: nil,
 			expectedResult: map[common.ObjectName]string{},
 		},
 		{
-			name:    "single object name produces field with sanitized appName prefix",
-			appName: "myapp",
-			objectNames: map[common.ObjectName]bool{
-				"Account": true,
-			},
+			name:           "single object name produces field with sanitized appName prefix",
+			appName:        "myapp",
+			enabledObjects: []common.ObjectName{"Account"},
 			expectedResult: map[common.ObjectName]string{
 				"Account": "myapp_cdc_event_flag__c",
 			},
 		},
 		{
-			name:    "appName with special characters is sanitized in field value",
-			appName: "My App-Name!",
-			objectNames: map[common.ObjectName]bool{
-				"Account": true,
-			},
+			name:           "appName with special characters is sanitized in field value",
+			appName:        "My App-Name!",
+			enabledObjects: []common.ObjectName{"Account"},
 			expectedResult: map[common.ObjectName]string{
 				"Account": "my_app_name_cdc_event_flag__c",
 			},
 		},
 		{
-			name:    "multiple object names",
-			appName: "myapp",
-			objectNames: map[common.ObjectName]bool{
-				"Account": true,
-				"Contact": true,
-			},
+			name:           "multiple object names share the one app-derived field",
+			appName:        "myapp",
+			enabledObjects: []common.ObjectName{"Account", "Contact"},
 			expectedResult: map[common.ObjectName]string{
 				"Account": "myapp_cdc_event_flag__c",
 				"Contact": "myapp_cdc_event_flag__c",
 			},
 		},
 		{
-			name:    "objects mapped to false are omitted",
-			appName: "myapp",
-			objectNames: map[common.ObjectName]bool{
-				"Account": true,
-				"Contact": false,
-			},
+			name:           "repeated object name collapses to one entry",
+			appName:        "myapp",
+			enabledObjects: []common.ObjectName{"Account", "Account"},
 			expectedResult: map[common.ObjectName]string{
 				"Account": "myapp_cdc_event_flag__c",
 			},
-		},
-		{
-			name:    "all objects mapped to false returns empty map",
-			appName: "myapp",
-			objectNames: map[common.ObjectName]bool{
-				"Account": false,
-				"Contact": false,
-			},
-			expectedResult: map[common.ObjectName]string{},
 		},
 	}
 
@@ -107,7 +84,7 @@ func TestBuildCDCEventFlagFields(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := buildCDCEventFlagFields(testCase.appName, testCase.objectNames)
+			result, err := buildCDCEventFlagFields(testCase.appName, testCase.enabledObjects)
 
 			if testCase.expectedErr != nil {
 				if !errors.Is(err, testCase.expectedErr) {
@@ -269,21 +246,19 @@ func TestGetSalesforceRequestNilConfig(t *testing.T) {
 func TestGetSalesforceRequestExplicitDisable(t *testing.T) {
 	t.Parallel()
 
+	// An object the caller resolved to disabled reaches here the same way one that was never
+	// configured does — absent from EnabledObjects — so both arrive as one of the cases below.
 	tests := []struct {
-		name          string
-		objectEnabled map[common.ObjectName]bool
+		name           string
+		enabledObjects []common.ObjectName
 	}{
 		{
-			name:          "empty opt-in map",
-			objectEnabled: map[common.ObjectName]bool{},
+			name:           "empty opt-in list",
+			enabledObjects: []common.ObjectName{},
 		},
 		{
-			name:          "nil opt-in map",
-			objectEnabled: nil,
-		},
-		{
-			name:          "every object explicitly disabled",
-			objectEnabled: map[common.ObjectName]bool{"Account": false, "Contact": false},
+			name:           "nil opt-in list",
+			enabledObjects: nil,
 		},
 	}
 
@@ -296,7 +271,7 @@ func TestGetSalesforceRequestExplicitDisable(t *testing.T) {
 				CDCOptimization: stubCDCOptimizationResolver{cfg: &deps.CDCOptimizationConfig{
 					ManualCheckboxManagement:    true,
 					ManualApexTriggerManagement: true,
-					ObjectEnabled:               testCase.objectEnabled,
+					EnabledObjects:              testCase.enabledObjects,
 				}},
 			}
 
@@ -332,16 +307,16 @@ func TestGetSalesforceRequestExplicitDisable(t *testing.T) {
 	}
 }
 
-// TestGetSalesforceRequestPartialOptIn verifies that only objects with enabled:true appear in
-// QuotaOptimizationObjectFields. Objects set to enabled:false are omitted so UpdateSubscription
-// can tear down their CDC quota-optimization artifacts without re-enabling them.
-func TestGetSalesforceRequestPartialOptIn(t *testing.T) {
+// TestGetSalesforceRequestEnabledObjects verifies that exactly the enabled objects appear in
+// QuotaOptimizationObjectFields, each pointing at the one app-derived checkbox field. Objects the
+// caller left out are absent, which is what lets UpdateSubscription tear their artifacts down.
+func TestGetSalesforceRequestEnabledObjects(t *testing.T) {
 	t.Parallel()
 
 	dependencies := deps.Dependencies{
 		Project: stubProjectResolver{appName: "My App"},
 		CDCOptimization: stubCDCOptimizationResolver{cfg: &deps.CDCOptimizationConfig{
-			ObjectEnabled: map[common.ObjectName]bool{"Account": true, "Contact": false},
+			EnabledObjects: []common.ObjectName{"Account", "Contact"},
 		}},
 	}
 
@@ -357,7 +332,10 @@ func TestGetSalesforceRequestPartialOptIn(t *testing.T) {
 		t.Fatalf("getSalesforceRequest() = %T, want *salesforce.SubscriptionRequest", got)
 	}
 
-	want := map[common.ObjectName]string{"Account": "my_app_cdc_event_flag__c"}
+	want := map[common.ObjectName]string{
+		"Account": "my_app_cdc_event_flag__c",
+		"Contact": "my_app_cdc_event_flag__c",
+	}
 	if len(req.QuotaOptimizationObjectFields) != len(want) {
 		t.Fatalf("QuotaOptimizationObjectFields = %v, want %v", req.QuotaOptimizationObjectFields, want)
 	}
@@ -367,5 +345,30 @@ func TestGetSalesforceRequestPartialOptIn(t *testing.T) {
 			t.Errorf("QuotaOptimizationObjectFields[%s] = %q, want %q",
 				objName, req.QuotaOptimizationObjectFields[objName], fieldName)
 		}
+	}
+}
+
+// TestGetSalesforceRequestResolverError verifies that a failed resolution propagates instead of
+// degrading to an empty payload. An empty payload would read as an explicit disable and tear down
+// a live optimization on what may be a transient failure.
+func TestGetSalesforceRequestResolverError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("resolving subscribe objects")
+
+	dependencies := deps.Dependencies{
+		Project:         stubProjectResolver{appName: "My App"},
+		CDCOptimization: stubCDCOptimizationResolver{err: wantErr},
+	}
+
+	got, err := getSalesforceRequest(
+		context.Background(), dependencies, &openapi.Installation{Id: "inst-1", ProjectId: "proj-1"},
+		nil, nil, nil, "")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("getSalesforceRequest() error = %v, want %v", err, wantErr)
+	}
+
+	if got != nil {
+		t.Errorf("getSalesforceRequest() = %v, want nil", got)
 	}
 }


### PR DESCRIPTION
Updates the `GetCDCOptimizationConfig` dependency to have parameters `inst`, `rev`, so that it can fetch the resolved quota-optimization config instead of the hard-coded map which was keyed on (`projectId`, `groupRef`).  