### PR TITLE
[CON-3436] feat(surveymonkey): Deep Connector Metadata

### DIFF
--- a/connector/new.go
+++ b/connector/new.go
@@ -137,6 +137,7 @@ import (
 	"github.com/amp-labs/connectors/providers/square"
 	"github.com/amp-labs/connectors/providers/stripe"
 	"github.com/amp-labs/connectors/providers/supersend"
+	"github.com/amp-labs/connectors/providers/surveymonkey"
 	"github.com/amp-labs/connectors/providers/talkdesk"
 	"github.com/amp-labs/connectors/providers/teamleader"
 	"github.com/amp-labs/connectors/providers/teamwork"
@@ -297,6 +298,7 @@ var connectorConstructors = map[providers.Provider]outputConstructorFunc{ // nol
 	providers.Square:                    wrapper(newSquareConnector),
 	providers.SquareSandbox:             wrapper(newSquareSandboxConnector),
 	providers.SuperSend:                 wrapper(newSuperSendConnector),
+	providers.SurveyMonkey:              wrapper(newSurveyMonkeyConnector),
 	providers.Talkdesk:                  wrapper(newTalkdeskConnector),
 	providers.Teamleader:                wrapper(newTeamleaderConnector),
 	providers.Teamwork:                  wrapper(newTeamworkConnector),
@@ -1230,6 +1232,10 @@ func newDropboxSignConnector(params common.ConnectorParams) (*dropboxsign.Connec
 
 func newSuperSendConnector(params common.ConnectorParams) (*supersend.Connector, error) {
 	return supersend.NewConnector(params)
+}
+
+func newSurveyMonkeyConnector(params common.ConnectorParams) (*surveymonkey.Connector, error) {
+	return surveymonkey.NewConnector(params)
 }
 
 func newCallRail(params common.ConnectorParams) (*callrail.Connector, error) {

--- a/providers/surveymonkey/connector.go
+++ b/providers/surveymonkey/connector.go
@@ -1,0 +1,31 @@
+package surveymonkey
+
+import (
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/surveymonkey/metadata"
+)
+
+type Connector struct {
+	*components.Connector
+
+	common.RequireAuthenticatedClient
+	components.SchemaProvider
+}
+
+func NewConnector(params common.ConnectorParams) (*Connector, error) {
+	return components.Init(providers.SurveyMonkey, params, constructor)
+}
+
+func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
+	connector := &Connector{Connector: base}
+
+	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
+		connector.ProviderContext.Module(),
+		metadata.Schemas,
+	)
+
+	return connector, nil
+}

--- a/providers/surveymonkey/metadata/README.md
+++ b/providers/surveymonkey/metadata/README.md
@@ -1,0 +1,3 @@
+# Metadata
+
+The static file `schemas.json` was created by manually inspecting the [SurveyMonkey API documentation](https://api.surveymonkey.com/v3/docs) and translating supported list endpoints into our static schema format.

--- a/providers/surveymonkey/metadata/metadata.go
+++ b/providers/surveymonkey/metadata/metadata.go
@@ -1,0 +1,22 @@
+package metadata
+
+import (
+	_ "embed"
+
+	"github.com/amp-labs/connectors/internal/staticschema"
+	"github.com/amp-labs/connectors/tools/fileconv"
+	"github.com/amp-labs/connectors/tools/scrapper"
+)
+
+// nolint:gochecknoglobals
+var (
+	//go:embed schemas.json
+	schemaContent []byte
+
+	FileManager = scrapper.NewMetadataFileManager[staticschema.FieldMetadataMapV2](
+		schemaContent,
+		fileconv.NewSiblingFileLocator(),
+	)
+
+	Schemas = FileManager.MustLoadSchemas()
+)

--- a/providers/surveymonkey/metadata/schemas.json
+++ b/providers/surveymonkey/metadata/schemas.json
@@ -1,0 +1,385 @@
+{
+  "modules": {
+    "root": {
+      "id": "root",
+      "path": "",
+      "objects": {
+        "groups": {
+          "displayName": "Groups",
+          "path": "/groups",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-groups",
+          "fields": {
+            "id": {
+              "displayName": "Group Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "Href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "survey_categories": {
+          "displayName": "Survey Categories",
+          "path": "/survey_categories",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-survey_categories",
+          "fields": {
+            "id": {
+              "displayName": "Category Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "survey_templates": {
+          "displayName": "Survey Templates",
+          "path": "/survey_templates",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-survey_templates",
+          "fields": {
+            "id": {
+              "displayName": "Template Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "category": {
+              "displayName": "Category",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "title": {
+              "displayName": "Title",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "available": {
+              "displayName": "Available",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "num_questions": {
+              "displayName": "Num Questions",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "preview_link": {
+              "displayName": "Preview Link",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "team_survey_templates": {
+          "displayName": "Team Survey Templates",
+          "path": "/team_survey_templates",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-team_survey_templates",
+          "fields": {
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "team_template_id": {
+              "displayName": "Team Template Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "survey_id": {
+              "displayName": "Survey Id",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "survey_languages": {
+          "displayName": "Survey Languages",
+          "path": "/survey_languages",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-survey_languages",
+          "fields": {
+            "id": {
+              "displayName": "Language Code",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "native_name": {
+              "displayName": "Native Name",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "question_bank_questions": {
+          "displayName": "Question Bank Questions",
+          "path": "/question_bank/questions",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-question_bank-questions",
+          "fields": {
+            "question_id": {
+              "displayName": "Question Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "text": {
+              "displayName": "Text",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "locales": {
+              "displayName": "Locales",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "modifiers": {
+              "displayName": "Modifiers",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "survey_folders": {
+          "displayName": "Survey Folders",
+          "path": "/survey_folders",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-survey_folders",
+          "fields": {
+            "id": {
+              "displayName": "Folder Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "title": {
+              "displayName": "Title",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "num_surveys": {
+              "displayName": "Num Surveys",
+              "valueType": "int",
+              "providerType": "integer"
+            },
+            "href": {
+              "displayName": "Href",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "contacts": {
+          "displayName": "Contacts",
+          "path": "/contacts",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-contacts",
+          "fields": {
+            "id": {
+              "displayName": "Contact Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "first_name": {
+              "displayName": "First Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "last_name": {
+              "displayName": "Last Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "email": {
+              "displayName": "Email",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "phone_number": {
+              "displayName": "Phone Number",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "Href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "custom_fields": {
+              "displayName": "Custom Fields",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "status": {
+              "displayName": "Status",
+              "valueType": "singleSelect",
+              "providerType": "string",
+              "values": [
+                {
+                  "value": "active",
+                  "displayValue": "Active"
+                },
+                {
+                  "value": "optout",
+                  "displayValue": "Opt Out"
+                },
+                {
+                  "value": "bounced",
+                  "displayValue": "Bounced"
+                }
+              ]
+            }
+          }
+        },
+        "contact_lists": {
+          "displayName": "Contact Lists",
+          "path": "/contact_lists",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-contact_lists",
+          "fields": {
+            "id": {
+              "displayName": "Contact List Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "Href",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        },
+        "organizations": {
+          "displayName": "Organizations",
+          "path": "/organizations",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-organizations",
+          "fields": {
+            "id": {
+              "displayName": "Organization Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "default_role_id": {
+              "displayName": "Default Role Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "users_can_create_workgroups": {
+              "displayName": "Users Can Create Workgroups",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "updated_at": {
+              "displayName": "Updated At",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            }
+          }
+        },
+        "roles": {
+          "displayName": "Roles",
+          "path": "/roles",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-roles",
+          "fields": {
+            "id": {
+              "displayName": "Role Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "name": {
+              "displayName": "Name",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "Description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "is_enabled": {
+              "displayName": "Is Enabled",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "is_system_role": {
+              "displayName": "Is System Role",
+              "valueType": "boolean",
+              "providerType": "boolean"
+            },
+            "created_at": {
+              "displayName": "Created At",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "updated_at": {
+              "displayName": "Updated At",
+              "valueType": "datetime",
+              "providerType": "datetime"
+            },
+            "privileges": {
+              "displayName": "Privileges",
+              "valueType": "other",
+              "providerType": "array"
+            }
+          }
+        },
+        "benchmark_bundles": {
+          "displayName": "Benchmark Bundles",
+          "path": "/benchmark_bundles",
+          "responseKey": "data",
+          "docs": "https://api.surveymonkey.com/v3/docs#api-endpoints-get-benchmark_bundles",
+          "fields": {
+            "id": {
+              "displayName": "Benchmark Id",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "href": {
+              "displayName": "Href",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "title": {
+              "displayName": "Title",
+              "valueType": "string",
+              "providerType": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/surveymonkey/metadata_test.go
+++ b/providers/surveymonkey/metadata_test.go
@@ -1,0 +1,274 @@
+package surveymonkey
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestListObjectMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []testconn.TestCaseListObjectMetadata{
+		{
+			Name: "Successful metadata for core objects",
+			Input: []string{
+				"groups",
+				"survey_categories",
+				"survey_templates",
+				"team_survey_templates",
+				"survey_languages",
+				"question_bank_questions",
+				"survey_folders",
+				"contacts",
+				"contact_lists",
+				"organizations",
+				"roles",
+				"benchmark_bundles",
+			},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"groups": {
+						DisplayName: "Groups",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Group Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"survey_categories": {
+						DisplayName: "Survey Categories",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Category Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"survey_templates": {
+						DisplayName: "Survey Templates",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Template Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"team_survey_templates": {
+						DisplayName: "Team Survey Templates",
+						Fields: map[string]common.FieldMetadata{
+							"team_template_id": {
+								DisplayName:  "Team Template Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"survey_id": {
+								DisplayName:  "Survey Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"survey_languages": {
+						DisplayName: "Survey Languages",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Language Code",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"question_bank_questions": {
+						DisplayName: "Question Bank Questions",
+						Fields: map[string]common.FieldMetadata{
+							"question_id": {
+								DisplayName:  "Question Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"text": {
+								DisplayName:  "Text",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"survey_folders": {
+						DisplayName: "Survey Folders",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Folder Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"title": {
+								DisplayName:  "Title",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"contacts": {
+						DisplayName: "Contacts",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Contact Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"email": {
+								DisplayName:  "Email",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"contact_lists": {
+						DisplayName: "Contact Lists",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Contact List Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"organizations": {
+						DisplayName: "Organizations",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Organization Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"roles": {
+						DisplayName: "Roles",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Role Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"name": {
+								DisplayName:  "Name",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+					"benchmark_bundles": {
+						DisplayName: "Benchmark Bundles",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Benchmark Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+							"title": {
+								DisplayName:  "Title",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name:         "Empty objects returns missing objects error",
+			Input:        nil,
+			Server:       mockserver.Dummy(),
+			Expected:     nil,
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:       "Unsupported object returns object not supported error",
+			Input:      []string{"groups", "unknown_object"},
+			Server:     mockserver.Dummy(),
+			Comparator: testconn.ComparatorSubsetMetadata,
+			Expected: &common.ListObjectMetadataResult{
+				Result: map[string]common.ObjectMetadata{
+					"groups": {
+						DisplayName: "Groups",
+						Fields: map[string]common.FieldMetadata{
+							"id": {
+								DisplayName:  "Group Id",
+								ValueType:    "string",
+								ProviderType: "string",
+							},
+						},
+					},
+				},
+				Errors: map[string]error{
+					"unknown_object": mockutils.ExpectedSubsetErrors{common.ErrObjectNotSupported},
+				},
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableMetadataReader, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}
+
+func constructTestConnector(serverURL string) (*Connector, error) {
+	connector, err := NewConnector(
+		common.ConnectorParams{
+			Module:              common.ModuleRoot,
+			AuthenticatedClient: mockutils.NewClient(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	connector.SetUnitTestMockServerBaseURL(serverURL)
+
+	return connector, nil
+}

--- a/test/surveymonkey/connector.go
+++ b/test/surveymonkey/connector.go
@@ -1,0 +1,39 @@
+package surveymonkey
+
+import (
+	"context"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/scanning/credscanning"
+	"github.com/amp-labs/connectors/providers"
+	"github.com/amp-labs/connectors/providers/surveymonkey"
+	"github.com/amp-labs/connectors/test/utils"
+	"golang.org/x/oauth2"
+)
+
+func GetSurveyMonkeyConnector(ctx context.Context) *surveymonkey.Connector {
+	filePath := credscanning.LoadPath(providers.SurveyMonkey)
+	reader := utils.MustCreateProvCredJSON(filePath, true)
+
+	conn, err := surveymonkey.NewConnector(common.ConnectorParams{
+		AuthenticatedClient: utils.NewOauth2Client(ctx, reader, getConfig),
+	})
+	if err != nil {
+		utils.Fail("error creating SurveyMonkey connector", "error", err)
+	}
+
+	return conn
+}
+
+func getConfig(reader *credscanning.ProviderCredentials) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     reader.Get(credscanning.Fields.ClientId),
+		ClientSecret: reader.Get(credscanning.Fields.ClientSecret),
+		RedirectURL:  "http://localhost:8080/callbacks/v1/oauth",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://api.surveymonkey.com/oauth/authorize",
+			TokenURL:  "https://api.surveymonkey.com/oauth/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+}

--- a/test/surveymonkey/metadata/main.go
+++ b/test/surveymonkey/metadata/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	connTest "github.com/amp-labs/connectors/test/surveymonkey"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+	conn := connTest.GetSurveyMonkeyConnector(ctx)
+
+	meta, err := conn.ListObjectMetadata(ctx, []string{
+		"groups",
+		"survey_categories",
+		"survey_templates",
+		"team_survey_templates",
+		"survey_languages",
+		"question_bank_questions",
+		"survey_folders",
+		"contacts",
+		"contact_lists",
+		"organizations",
+		"roles",
+		"benchmark_bundles",
+	})
+	if err != nil {
+		log.Fatalf("ListObjectMetadata error: %v", err)
+	}
+
+	for objName, objMeta := range meta.Result {
+		log.Printf("   - %s: %d fields\n", objName, len(objMeta.Fields))
+	}
+
+	utils.DumpJSON(meta, os.Stdout)
+}


### PR DESCRIPTION
## Summary
This PR implements `ListObjectMetadata` for the SurveyMonkey connector, enabling retrieval of object schema information from the connector’s embedded metadata schemas. Users can discover field definitions, types, and metadata for supported SurveyMonkey objects (groups, survey_categories, survey_templates, team_survey_templates, survey_languages, question_bank_questions, survey_folders, contacts, contact_lists, organizations, roles, and benchmark_bundles) using a static, schema-only deep connector backed by `schemas.json`. The connector is registered in `connector/new.go` so the Ampersand server can instantiate it via `providers.SurveyMonkey`. Proxy support already exists; this adds the deep-connector metadata surface.

## Key Features

- **Schema-backed metadata**: Serves object and field metadata from an embedded `schemas.json` via `schema.NewOpenAPISchemaProvider`.
- **Multi-object support**: Fetches metadata for multiple SurveyMonkey objects in one call and returns a consolidated result map.
- **Per-object error handling**: Validates input and returns clear per-object errors for empty object lists and unsupported object names.
- **Metadata-only deep connector**: Implements `ObjectMetadataConnector` only (no read/write/delete yet).
- **No connector-level metadata**: API host is fixed (`api.surveymonkey.com`) and auth is OAuth2; no workspace/tenant install metadata required.
- **Well tested**: Unit tests cover successful metadata retrieval, empty input behavior, and unsupported objects, following existing connector test patterns (`testconn.TestCaseListObjectMetadata`).
- **Live test harness**: Adds `test/surveymonkey/metadata/main.go` for exercising real credentials against `ListObjectMetadata`.

## Testing
```bash
# Run SurveyMonkey unit tests
go test ./providers/surveymonkey -v

# Run with coverage
go test ./providers/surveymonkey -cover

# Run integration-style script to inspect metadata responses (requires creds.json with surveyMonkey OAuth tokens)
go run ./test/surveymonkey/metadata/main.go
```

## Live Tests
<img width="1501" height="846" alt="Screenshot 2026-08-10 at 6 42 31 PM" src="https://github.com/user-attachments/assets/03f44ca4-6afd-4487-87a6-98aabe710bc1" />
<img width="1490" height="866" alt="Screenshot 2026-08-10 at 6 43 29 PM" src="https://github.com/user-attachments/assets/a5034166-d708-4c25-8fb9-09ff2a669b58" />
<img width="1496" height="867" alt="Screenshot 2026-08-10 at 6 43 45 PM" src="https://github.com/user-attachments/assets/620844d4-6e06-4794-aa75-f71c1b4cff1e" />
<img width="1494" height="883" alt="Screenshot 2026-08-10 at 6 43 58 PM" src="https://github.com/user-attachments/assets/a5bedef0-c5e2-40f4-9241-960140eaa508" />
<img width="1490" height="726" alt="Screenshot 2026-08-10 at 6 44 15 PM" src="https://github.com/user-attachments/assets/e87cfe82-628c-4a4e-8a9b-208bf195b1d3" />
<img width="1362" height="728" alt="Screenshot 2026-08-10 at 6 52 13 PM" src="https://github.com/user-attachments/assets/810417f9-281c-467b-9a5f-1b58c0428eea" />
<img width="1487" height="869" alt="Screenshot 2026-08-10 at 6 52 25 PM" src="https://github.com/user-attachments/assets/a169c070-d684-4142-b161-4325ccac0a9f" />
<img width="1495" height="885" alt="Screenshot 2026-08-10 at 6 52 50 PM" src="https://github.com/user-attachments/assets/be33b057-892b-443d-90ce-296290b26320" />
<img width="1496" height="830" alt="Screenshot 2026-08-10 at 6 53 02 PM" src="https://github.com/user-attachments/assets/8877da74-8efd-44cd-8df6-5c8d2d821582" />
<img width="1509" height="883" alt="Screenshot 2026-08-10 at 6 53 12 PM" src="https://github.com/user-attachments/assets/b9b5a09f-0fc4-4b3d-8932-b3e479bab968" />
<img width="36" height="28" alt="Screenshot 2026-08-10 at 6 53 18 PM" src="https://github.com/user-attachments/assets/94a32087-edc2-43b8-9bcb-7db2478a07f5" />
<img width="1346" height="625" alt="Screenshot 2026-08-10 at 6 53 25 PM" src="https://github.com/user-attachments/assets/8fae08a1-62a7-4a18-9f3a-7763bc07edb4" />
<img width="1456" height="865" alt="Screenshot 2026-08-10 at 6 53 32 PM" src="https://github.com/user-attachments/assets/83bc31ce-9d02-43f8-92f0-6b9a061b76c5" />
<img width="1427" height="742" alt="Screenshot 2026-08-10 at 6 53 44 PM" src="https://github.com/user-attachments/assets/aabd71b0-f72d-47ab-a720-adf1f4fdbf35" />
<img width="1502" height="851" alt="Screenshot 2026-08-10 at 6 53 54 PM" src="https://github.com/user-attachments/assets/e3aecf15-3bb4-444f-b14a-9148045a7f8c" />
<img width="1437" height="740" alt="Screenshot 2026-08-10 at 6 54 05 PM" src="https://github.com/user-attachments/assets/f2fac58c-69b7-4bfb-98e0-6f2ea7a302b6" />

