### PR TITLE
fix(stripe): repair build after reader-strategy refactor

### DIFF
--- a/providers/stripe/record.go
+++ b/providers/stripe/record.go
@@ -74,7 +74,7 @@ func (c *Connector) fetchSingleRecord(
 		return nil, err
 	}
 
-	res, err := c.Client.Get(ctx, url.String())
+	res, err := c.JSONHTTPClient().Get(ctx, url.String())
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (c *Connector) fetchSingleRecord(
 // Format: /v1/{objectName}/{id}
 // Supports expand[] query parameters for associated objects.
 func (c *Connector) buildGetRecordURL(objectName string, id string, associations []string) (*urlbuilder.URL, error) {
-	url, err := c.getURL(objectName)
+	url, err := c.GetURL(objectName)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/stripe/record_test.go
+++ b/providers/stripe/record_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -22,7 +22,7 @@ type GetRecordsByIdsInput struct {
 	Associations []string
 }
 
-type GetRecordsByIdsTestCase = testroutines.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]
+type GetRecordsByIdsTestCase = testconn.TestCase[GetRecordsByIdsInput, []common.ReadResultRow]
 
 func TestGetRecordsByIds(t *testing.T) {
 	t.Parallel()
@@ -79,8 +79,7 @@ func TestGetRecordsByIds(t *testing.T) {
 				If: mockcond.And{
 					mockcond.MethodGET(),
 					mockcond.Path("/v1/payment_intents/pi_3SsAwzF6iHem4voo03GfTErP"),
-					mockcond.QueryParam("expand[]", "payment_method"),
-					mockcond.QueryParam("expand[]", "latest_charge"),
+					mockcond.QueryParam("expand[]", "payment_method", "latest_charge"),
 				},
 				Then: mockserver.Response(http.StatusOK, paymentIntentWithAssociations),
 			}.Server(),
@@ -121,7 +120,7 @@ func TestGetRecordsByIds(t *testing.T) {
 				tt.Close()
 			})
 
-			conn, err := constructTestConnector(tt.Server.URL)
+			conn, err := constructTestConnector(tt.Server)
 			if err != nil {
 				t.Fatalf("failed to construct test connector: %v", err)
 			}
@@ -141,13 +140,22 @@ func TestGetRecordsByIds(t *testing.T) {
 
 // compareReadResultRows compares two slices of ReadResultRow by wrapping them
 // into ReadResult and using existing utilities for Fields and Raw, plus association validation.
-func compareReadResultRows(_ string, actual, expected []common.ReadResultRow) bool {
+func compareReadResultRows(_ string, actual, expected []common.ReadResultRow) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+	if !readResultRowsMatch(actual, expected) {
+		result.AddDiff("read result rows do not match expectation")
+	}
+
+	return result
+}
+
+func readResultRowsMatch(actual, expected []common.ReadResultRow) bool {
 	// Wrap slices into ReadResult to use existing utilities
 	actualResult := &common.ReadResult{Data: actual}
 	expectedResult := &common.ReadResult{Data: expected}
 
 	// Use existing utilities for Fields and Raw
-	if !mockutils.ReadResultComparator.SubsetFields(actualResult, expectedResult) {
+	if !mockutils.ReadResultComparator.SubsetFields(actualResult, expectedResult).OK {
 		return false
 	}
 

--- a/providers/stripe/subscribe.go
+++ b/providers/stripe/subscribe.go
@@ -15,7 +15,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/urlbuilder"
-	"github.com/amp-labs/connectors/providers/stripe/metadata"
+	"github.com/amp-labs/connectors/providers/stripe/internal/metadata"
 	"github.com/go-playground/validator"
 )
 
@@ -195,7 +195,7 @@ func (c *Connector) GetWebhookEndpoint(ctx context.Context, endpointID string) (
 
 	endpointURL.AddPath(endpointID)
 
-	resp, err := c.Client.Get(ctx, endpointURL.String())
+	resp, err := c.JSONHTTPClient().Get(ctx, endpointURL.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get webhook endpoint: %w", err)
 	}
@@ -231,7 +231,7 @@ func (c *Connector) deleteWebhookEndpoint(ctx context.Context, endpointID string
 
 	url.AddPath(endpointID)
 
-	_, err = c.Client.Delete(ctx, url.String())
+	_, err = c.JSONHTTPClient().Delete(ctx, url.String())
 	if err != nil {
 		return err
 	}
@@ -280,9 +280,9 @@ func getExpectedObjectTypeFromMetadata(objectName string) (string, error) {
 }
 
 // parseWebhookEndpointResponse parses and validates the webhook endpoint response.
-func parseWebhookEndpointResponse(httpResp *http.Response, bodyBytes []byte) (*WebhookResponse, error) {
+func parseWebhookEndpointResponse(ctx context.Context, httpResp *http.Response, bodyBytes []byte) (*WebhookResponse, error) {
 	// Use common JSON parsing utilities
-	jsonResp, err := common.ParseJSONResponse(httpResp, bodyBytes)
+	jsonResp, err := common.ParseJSONResponse(ctx, httpResp, bodyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
 	}
@@ -322,11 +322,11 @@ func (c *Connector) createWebhookEndpoint(
 	}
 	defer httpResp.Body.Close()
 
-	return parseWebhookEndpointResponse(httpResp, bodyBytes)
+	return parseWebhookEndpointResponse(ctx, httpResp, bodyBytes)
 }
 
 func (c *Connector) getWebhookEndpointURL() (*urlbuilder.URL, error) {
-	return urlbuilder.New(c.BaseURL, apiVersion, "webhook_endpoints")
+	return c.GetURL("webhook_endpoints")
 }
 
 func (c *Connector) updateWebhookEndpoint(
@@ -350,7 +350,7 @@ func (c *Connector) updateWebhookEndpoint(
 
 	defer httpResp.Body.Close()
 
-	return parseWebhookEndpointResponse(httpResp, bodyBytes)
+	return parseWebhookEndpointResponse(ctx, httpResp, bodyBytes)
 }
 
 // executeFormPostRequest executes a POST request with form-encoded data using HTTPClient.Post.
@@ -363,7 +363,7 @@ func (c *Connector) executeFormPostRequest(
 	formEncoded := formData.Encode()
 	formBytes := []byte(formEncoded)
 
-	httpResp, bodyBytes, err := c.Client.HTTPClient.Post(ctx, endpointURL.String(), formBytes, common.Header{
+	httpResp, bodyBytes, err := c.HTTPClient().Post(ctx, endpointURL.String(), formBytes, common.Header{
 		Key:   "Content-Type",
 		Value: "application/x-www-form-urlencoded",
 		Mode:  common.HeaderModeOverwrite,

--- a/providers/stripe/subscribeDelete_test.go
+++ b/providers/stripe/subscribeDelete_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 )
 
 func TestDeleteSubscription(t *testing.T) {
 	t.Parallel()
 
-	tests := []testroutines.TestCase[common.SubscriptionResult, error]{
+	tests := []testconn.TestCase[common.SubscriptionResult, error]{
 		{
 			Name:         "Nil result",
 			Input:        common.SubscriptionResult{Result: nil},
@@ -66,7 +66,7 @@ func TestDeleteSubscription(t *testing.T) {
 				tt.Close()
 			})
 
-			conn, err := constructTestConnector(tt.Server.URL)
+			conn, err := constructTestConnector(tt.Server)
 			if err != nil {
 				t.Fatalf("failed to construct test connector: %v", err)
 			}

--- a/providers/stripe/subscribeUpdate_test.go
+++ b/providers/stripe/subscribeUpdate_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestUpdateSubscription(t *testing.T) {
 
 	webhookEndpointUpdatedResponse := testutils.DataFromFile(t, "subscribe/webhook-endpoint-updated-response.json")
 
-	tests := []testroutines.TestCase[UpdateSubscriptionInput, *common.SubscriptionResult]{
+	tests := []testconn.TestCase[UpdateSubscriptionInput, *common.SubscriptionResult]{
 		{
 			Name: "Missing previous result",
 			Input: UpdateSubscriptionInput{
@@ -109,9 +109,7 @@ func TestUpdateSubscription(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointUpdatedResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator: func(_ string, actual, expected *common.SubscriptionResult) bool {
-				return actual != nil && actual.Status == common.SubscriptionStatusSuccess
-			},
+			Comparator: comparatorSubscriptionSuccess,
 		},
 		{
 			Name: "Update multiple objects with different events",
@@ -154,9 +152,7 @@ func TestUpdateSubscription(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointUpdatedResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator: func(_ string, actual, expected *common.SubscriptionResult) bool {
-				return actual != nil && actual.Status == common.SubscriptionStatusSuccess
-			},
+			Comparator: comparatorSubscriptionSuccess,
 		},
 	}
 
@@ -167,7 +163,7 @@ func TestUpdateSubscription(t *testing.T) {
 				tt.Close()
 			})
 
-			conn, err := constructTestConnector(tt.Server.URL)
+			conn, err := constructTestConnector(tt.Server)
 			if err != nil {
 				t.Fatalf("failed to construct test connector: %v", err)
 			}

--- a/providers/stripe/subscribe_test.go
+++ b/providers/stripe/subscribe_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
-	"github.com/amp-labs/connectors/test/utils/testroutines"
+	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
 	"gotest.tools/v3/assert"
 )
@@ -24,7 +24,7 @@ func TestSubscribe(t *testing.T) {
 
 	webhookEndpointResponse := testutils.DataFromFile(t, "subscribe/webhook-endpoint-response.json")
 
-	tests := []testroutines.TestCase[common.SubscribeParams, *common.SubscriptionResult]{
+	tests := []testconn.TestCase[common.SubscribeParams, *common.SubscriptionResult]{
 
 		{
 			Name: "Empty events",
@@ -61,9 +61,7 @@ func TestSubscribe(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator: func(_ string, actual, expected *common.SubscriptionResult) bool {
-				return actual != nil && actual.Status == common.SubscriptionStatusSuccess
-			},
+			Comparator: comparatorSubscriptionSuccess,
 		},
 		{
 			Name: "Subscribe multiple objects",
@@ -96,9 +94,7 @@ func TestSubscribe(t *testing.T) {
 				Then: mockserver.Response(http.StatusOK, webhookEndpointResponse),
 			}.Server(),
 			ExpectedErrs: nil,
-			Comparator: func(_ string, actual, expected *common.SubscriptionResult) bool {
-				return actual != nil && actual.Status == common.SubscriptionStatusSuccess
-			},
+			Comparator: comparatorSubscriptionSuccess,
 		},
 	}
 
@@ -109,7 +105,7 @@ func TestSubscribe(t *testing.T) {
 				tt.Close()
 			})
 
-			conn, err := constructTestConnector(tt.Server.URL)
+			conn, err := constructTestConnector(tt.Server)
 			if err != nil {
 				t.Fatalf("failed to construct test connector: %v", err)
 			}
@@ -606,4 +602,14 @@ func TestParseStripeSignature(t *testing.T) {
 			}
 		})
 	}
+}
+
+// comparatorSubscriptionSuccess asserts that a subscription operation succeeded.
+func comparatorSubscriptionSuccess(_ string, actual, _ *common.SubscriptionResult) *testutils.CompareResult {
+	result := testutils.NewCompareResult()
+	if actual == nil || actual.Status != common.SubscriptionStatusSuccess {
+		result.AddDiff("expected subscription status %v, got %v", common.SubscriptionStatusSuccess, actual)
+	}
+
+	return result
 }


### PR DESCRIPTION
## Problem

`main` does not build. The stripe subscription support PR (#2504) was written against the pre-refactor connector and merged after the reader-strategy refactor (#3176 / #3177) without a rebase, so everything it added references APIs that no longer exist.

```
providers/stripe/subscribe.go:18:2: cannot find module providing package
  github.com/amp-labs/connectors/providers/stripe/metadata
providers/stripe/record.go:77:16: c.Client undefined
providers/stripe/record.go:121:16: c.getURL undefined
providers/stripe/subscribe.go:285:54: not enough arguments in call to common.ParseJSONResponse
providers/stripe/subscribe.go:329:26: c.BaseURL undefined
providers/stripe/subscribe.go:329:35: undefined: apiVersion
providers/stripe/record_test.go:13:2: cannot find module providing package
  github.com/amp-labs/connectors/test/utils/testroutines
```

## Fix

| Broken | Fixed to |
|---|---|
| `providers/stripe/metadata` import | `providers/stripe/internal/metadata` |
| `c.Client.Get` / `.Delete` | `c.JSONHTTPClient().Get` / `.Delete` |
| `c.Client.HTTPClient.Post` | `c.HTTPClient().Post` |
| `c.getURL` | `c.GetURL` |
| `common.ParseJSONResponse(resp, body)` | now takes `ctx` first — threaded through `parseWebhookEndpointResponse` |
| `urlbuilder.New(c.BaseURL, apiVersion, ...)` | `c.GetURL("webhook_endpoints")` |
| `testroutines` (4 test files) | `testconn` |
| `constructTestConnector(tt.Server.URL)` | `constructTestConnector(tt.Server)` |
| comparators returning `bool` | return `*testutils.CompareResult` |
| two `QueryParam("expand[]", ...)` conditions | one `QueryParam("expand[]", "payment_method", "latest_charge")` — the matcher now requires the value list to match exactly, so two single-value conditions can never both pass |

Also collapsed the four identical inline subscription comparators into a single `comparatorSubscriptionSuccess` helper.

No behavior changes — this is purely catching the subscribe code up to the current connector API.

## Verification

```
go build ./...   # clean
go vet ./...     # clean
go test ./...    # all pass
```