### PR TITLE
[ENG-4179] fix(microsoft): stop retrying Graph's bodyless 500s

### DIFF
--- a/common/errorclass.go
+++ b/common/errorclass.go
@@ -58,6 +58,10 @@ const (
 	// ErrorClassProvider5xx — 5xx server error on the provider side. Retryable.
 	ErrorClassProvider5xx ErrorClass = "provider_5xx"
 
+	// ErrorClassProvider5xxPermanent — a 5xx that a connector has positively
+	// identified as permanent. Non-retryable.
+	ErrorClassProvider5xxPermanent ErrorClass = "provider_5xx_permanent"
+
 	// ErrorClassRetryable — generic retryable error where a finer class isn't known.
 	ErrorClassRetryable ErrorClass = "retryable"
 )
@@ -143,6 +147,8 @@ func classOfMessage(raw string) ErrorClass {
 		strings.Contains(msg, "precondition check failed"),
 		strings.Contains(msg, "missing secret"):
 		return ErrorClassBadRequest
+	case strings.Contains(msg, "non-retryable server error"):
+		return ErrorClassProvider5xxPermanent
 	case strings.Contains(msg, "http status 5"),
 		strings.Contains(msg, "internal server error"),
 		strings.Contains(msg, "unexpected server error"):

--- a/common/interpreter/error.go
+++ b/common/interpreter/error.go
@@ -22,6 +22,13 @@ type ErrorHandler struct {
 	XML    FaultyResponseHandler
 	HTML   FaultyResponseHandler
 	Custom map[Mime]FaultyResponseHandler
+
+	// Fallback handles responses no handler above claimed: missing or
+	// unparseable Content-Type, or a media type with none registered.
+	// Nil defers to common.InterpretError. A Fallback that recognizes only
+	// certain responses should return common.InterpretError(res, body) for
+	// the rest, leaving them unchanged.
+	Fallback FaultyResponseHandler
 }
 
 func (h ErrorHandler) Handle(res *http.Response, body []byte) error { // nolint:cyclop
@@ -42,6 +49,10 @@ func (h ErrorHandler) Handle(res *http.Response, body []byte) error { // nolint:
 		if customHandler, ok := h.Custom[mediaType]; ok {
 			return customHandler.HandleErrorResponse(res, body)
 		}
+	}
+
+	if h.Fallback != nil {
+		return h.Fallback.HandleErrorResponse(res, body)
 	}
 
 	// Default fallback, which treats body as opaque string to produce golang error.

--- a/common/interpreter/error_test.go
+++ b/common/interpreter/error_test.go
@@ -18,9 +18,10 @@ func TestErrorHandler(t *testing.T) { //nolint:funlen
 	var (
 		// These errors imitate what each error handler would return after response is parsed.
 		// NOTE: we are not interested in parsing itself, rather that the right branches are visited.
-		ErrCustomJSON = errors.New("custom JSON error response")
-		ErrCustomXML  = errors.New("custom XML error response")
-		ErrCustomHTML = errors.New("custom HTML error response")
+		ErrCustomJSON     = errors.New("custom JSON error response")
+		ErrCustomXML      = errors.New("custom XML error response")
+		ErrCustomHTML     = errors.New("custom HTML error response")
+		ErrCustomFallback = errors.New("custom fallback error response")
 	)
 
 	tests := []struct {
@@ -107,6 +108,48 @@ func TestErrorHandler(t *testing.T) { //nolint:funlen
 				},
 			},
 			expectedErr: []error{ErrCustomJSON},
+		},
+		{
+			// A provider that returns errors without Content-Type would
+			// otherwise never get to classify its own failures.
+			name:   "Missing media type is handled using Fallback handler",
+			server: mockserver.Dummy(), // no media
+			handler: ErrorHandler{
+				JSON:     handlerReturningError(ErrCustomJSON),
+				Fallback: handlerReturningError(ErrCustomFallback),
+			},
+			expectedErr: []error{ErrCustomFallback},
+		},
+		{
+			name: "Unregistered media type is handled using Fallback handler",
+			server: mockserver.Fixed{
+				Setup:  mockserver.ContentMIME("application/special-media"),
+				Always: mockserver.Response(http.StatusNotFound),
+			}.Server(),
+			handler: ErrorHandler{
+				Fallback: handlerReturningError(ErrCustomFallback),
+			},
+			expectedErr: []error{ErrCustomFallback},
+		},
+		{
+			// Fallback must not shadow a matching media-type handler.
+			name: "JSON handler takes precedence over Fallback",
+			server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusNotFound),
+			}.Server(),
+			handler: ErrorHandler{
+				JSON:     handlerReturningError(ErrCustomJSON),
+				Fallback: handlerReturningError(ErrCustomFallback),
+			},
+			expectedErr: []error{ErrCustomJSON},
+		},
+		{
+			// Nil Fallback keeps the historical behaviour.
+			name:        "Missing media type with no Fallback still uses default",
+			server:      mockserver.Dummy(),
+			handler:     ErrorHandler{JSON: handlerReturningError(ErrCustomJSON)},
+			expectedErr: []error{common.ErrCaller},
 		},
 	}
 

--- a/common/types.go
+++ b/common/types.go
@@ -41,8 +41,15 @@ var (
 	// ErrCaller represents non-retryable errors caused by bad input from the caller.
 	ErrCaller error = newClassedErr("caller error", ErrorClassBadRequest)
 
-	// ErrServer represents non-retryable errors caused by something on the server.
+	// ErrServer represents errors caused by something on the provider's side
+	// (any 5xx). Retryable: most 5xx responses are transient.
 	ErrServer error = newClassedErr("server error", ErrorClassProvider5xx)
+
+	// ErrServerNonRetryable represents a 5xx response that a connector has
+	// positively identified as permanent for this request, so retrying it
+	// cannot succeed.
+	ErrServerNonRetryable error = newClassedErr(
+		"non-retryable server error", ErrorClassProvider5xxPermanent)
 
 	// ErrUnknown represents an unknown status code response.
 	ErrUnknown error = newClassedErr("unknown error", ErrorClassUnknown)

--- a/providers/microsoft/connector.go
+++ b/providers/microsoft/connector.go
@@ -79,8 +79,10 @@ func constructor(base *components.Connector) (*Connector, error) {
 	// handleErrorResponse needs WWW-Authenticate to detect CAE / step-up
 	// claim challenges on 401s; see providers/microsoft/errors.go for the
 	// classification logic and known limitations.
+	// Fallback catches Graph's bodyless 500s, which arrive with no Content-Type.
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.DirectFaultyResponder{Callback: handleErrorResponse},
+		JSON:     interpreter.DirectFaultyResponder{Callback: handleErrorResponse},
+		Fallback: interpreter.DirectFaultyResponder{Callback: handleNonJSONErrorResponse},
 	}.Handle
 
 	connector.Reader = reader.NewHTTPReader(

--- a/providers/microsoft/errors.go
+++ b/providers/microsoft/errors.go
@@ -1,6 +1,7 @@
 package microsoft
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -74,6 +75,32 @@ func handleErrorResponse(res *http.Response, body []byte) error {
 	}
 
 	return defaultJSONResponder.HandleErrorResponse(res, body)
+}
+
+// handleNonJSONErrorResponse is the Fallback handler: responses with no
+// Content-Type, or a media type with none registered. Graph sends its bodyless
+// 500 this way, so it lands here rather than at handleErrorResponse.
+//
+// Graph reports genuine transient failures through its documented envelope
+// (`{"error": {"code": "InternalServerError", ...}}`), so a 500 with an empty
+// body never took that path; in production this signature has only been
+// observed as a permanent, connection-specific failure. Narrow on purpose — a
+// bodyless 502/503/504 is an ordinary gateway failure and stays retryable, and
+// any envelope at all may still be transient. Everything else goes to
+// common.InterpretError, unchanged from before the Fallback existed.
+func handleNonJSONErrorResponse(res *http.Response, body []byte) error {
+	if res.StatusCode != http.StatusInternalServerError || len(bytes.TrimSpace(body)) != 0 {
+		return common.InterpretError(res, body)
+	}
+
+	// The response carries no other detail, so name the failing request.
+	detail := ""
+	if res.Request != nil && res.Request.URL != nil {
+		detail = fmt.Sprintf(" [%s %s]", res.Request.Method, res.Request.URL)
+	}
+
+	return fmt.Errorf("%w: microsoft returned 500 with no error body%s",
+		common.ErrServerNonRetryable, detail)
 }
 
 // claimsChallengeReason detects CAE (insufficient_claims) and step-up

--- a/providers/microsoft/errors_test.go
+++ b/providers/microsoft/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
 )
 
 func TestHandleErrorResponse(t *testing.T) { //nolint:funlen
@@ -127,6 +128,128 @@ func TestHandleErrorResponse(t *testing.T) { //nolint:funlen
 				t.Errorf("expected error to contain %q, got %v", tt.wantErrSubstring, err)
 			}
 		})
+	}
+}
+
+// TestFallbackDispatch calls ErrorHandler.Handle rather than the callbacks
+// directly. Graph sends its bodyless 500 with no Content-Type, so media-type
+// dispatch is the part that decides which callback runs.
+func TestFallbackDispatch(t *testing.T) {
+	t.Parallel()
+
+	handler := interpreter.ErrorHandler{
+		JSON:     interpreter.DirectFaultyResponder{Callback: handleErrorResponse},
+		Fallback: interpreter.DirectFaultyResponder{Callback: handleNonJSONErrorResponse},
+	}
+
+	tests := []struct {
+		name             string
+		contentType      string
+		status           int
+		body             string
+		wantNonRetryable bool
+		wantHTTPError    bool
+		wantClass        common.ErrorClass
+	}{
+		{
+			// The exact production shape: 500, Content-Length 0, no Content-Type.
+			name:             "bodyless 500 with no content-type is non-retryable",
+			status:           http.StatusInternalServerError,
+			wantNonRetryable: true,
+			wantClass:        common.ErrorClassProvider5xxPermanent,
+		},
+		{
+			// The critical negative: an error envelope means Graph took its
+			// normal path, so the failure may be transient.
+			name:          "500 with an error envelope stays retryable",
+			status:        http.StatusInternalServerError,
+			body:          `{"error":{"code":"InternalServerError","message":"An internal server error occurred."}}`,
+			wantHTTPError: true,
+			wantClass:     common.ErrorClassProvider5xx,
+		},
+		{
+			name:          "bodyless 503 stays retryable",
+			status:        http.StatusServiceUnavailable,
+			wantHTTPError: true,
+			wantClass:     common.ErrorClassProvider5xx,
+		},
+		{
+			// Regression guard: wiring a Fallback must not degrade non-JSON
+			// errors, which previously reached common.InterpretError and kept
+			// their HTTPError wrapper.
+			name:          "html error response keeps its HTTPError wrapper",
+			contentType:   "text/html",
+			status:        http.StatusInternalServerError,
+			body:          "<html>oops</html>",
+			wantHTTPError: true,
+			wantClass:     common.ErrorClassProvider5xx,
+		},
+		{
+			name:          "401 with no content-type still reports auth failure",
+			status:        http.StatusUnauthorized,
+			wantHTTPError: true,
+			wantClass:     common.ErrorClassAuthInvalidated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &http.Response{StatusCode: tt.status, Header: http.Header{}}
+			if tt.contentType != "" {
+				res.Header.Set("Content-Type", tt.contentType)
+			}
+
+			err := handler.Handle(res, []byte(tt.body))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if got := errors.Is(err, common.ErrServerNonRetryable); got != tt.wantNonRetryable {
+				t.Errorf("errors.Is(err, ErrServerNonRetryable): got %v, want %v (err=%v)",
+					got, tt.wantNonRetryable, err)
+			}
+
+			var httpErr *common.HTTPError
+			if got := errors.As(err, &httpErr); got != tt.wantHTTPError {
+				t.Errorf("errors.As(err, *HTTPError): got %v, want %v (err=%v)",
+					got, tt.wantHTTPError, err)
+			}
+
+			if got := common.ClassOf(err); got != tt.wantClass {
+				t.Errorf("ClassOf: got %q, want %q (err=%v)", got, tt.wantClass, err)
+			}
+		})
+	}
+}
+
+// TestBodylessServerErrorSurvivesFlattening covers the Temporal boundary: the
+// typed chain is serialized away, so the class has to be recoverable from the
+// message alone via classOfMessage.
+func TestBodylessServerErrorSurvivesFlattening(t *testing.T) {
+	t.Parallel()
+
+	reqURL, err := url.Parse("https://graph.microsoft.com/v1.0/me/messages")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	res := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{},
+		Request:    &http.Request{Method: http.MethodGet, URL: reqURL},
+	}
+
+	returned := handleNonJSONErrorResponse(res, nil)
+
+	if !strings.Contains(returned.Error(), "GET https://graph.microsoft.com/v1.0/me/messages") {
+		t.Errorf("expected error to name the failing request, got %v", returned)
+	}
+
+	flattened := errors.New(returned.Error()) //nolint:err113
+	if got := common.ClassOf(flattened); got != common.ErrorClassProvider5xxPermanent {
+		t.Errorf("ClassOf(flattened): got %q, want %q", got, common.ErrorClassProvider5xxPermanent)
 	}
 }
 


### PR DESCRIPTION
In production we are observing Microsoft Graph returning a 500 with an empty body and **no** **`Content-Type`** **header** for an Artisan connection ([Example log](https://console.cloud.google.com/logs/query;cursorTimestamp=2026-08-10T18:31:00.908336867Z;duration=PT15M;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22ampersand-prod%22%0Aresource.labels.location%3D%22us-west1%22%0Aresource.labels.cluster_name%3D%22default%22%0Aresource.labels.namespace_name%3D%22default%22%0Aseverity%3E%3DDEFAULT%0ASEARCH%2528%22%6071cf8e96-01d5-4006-bfca-5d29c7dd3d19%60%22%2529%0Atimestamp%3D%222026-08-10T18:31:00.908336867Z%22%0AinsertId%3D%22a1uhfvg1iwj2ri%22?project=ampersand-prod) of Microsoft's response, [Failing Temporal schedule](https://cloud.temporal.io/namespaces/ampersand-prod.jxjul/schedules/schedule%2Fread%2Finstallation%2F71cf8e96-01d5-4006-bfca-5d29c7dd3d19%2Fme%2Fmessages) stuck in retries ). This request is failing identically on every retry and every scheduled run. Graph reports genuinely transient failures through its [documented error envelope](https://learn.microsoft.com/en-us/graph/errors), so an empty body means it never took that path. We should treat this error as non-retryable.   


In this PR we added a new `Fallback FaultyResponseHandler` field on `interpreter.ErrorHandler`, consulted after media-type matching fails. A nil `Fallback` preserves existing behavior exactly, so no other connector is affected.

Microsoft Graph now registers `handleNonJSONErrorResponse` which classifies 500s with an empty body as `ErrServerNonRetryable`. In the server repo, we will match on this error and mark it as non-retryable after this PR lands.