### PR TITLE
[ENG-4141] feat(zohoMail): enable subscribe support

### DIFF
--- a/providers/zoho.go
+++ b/providers/zoho.go
@@ -132,7 +132,7 @@ func init() {
 				DisplayName: "Zoho Mail",
 				Support: Support{
 					Read:      true,
-					Subscribe: false,
+					Subscribe: true,
 					Write:     true,
 				},
 				// Zoho Mail has no API to create/manage webhook subscriptions; the

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -105,7 +105,8 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 	},
 	providers.Zoho: {
 		Modules: map[common.ModuleID]*ProviderConfig{
-			providers.ModuleZohoCRM: &zohoConfig,
+			providers.ModuleZohoCRM:  &zohoConfig,
+			providers.ModuleZohoMail: &zohoMailConfig,
 		},
 	},
 	providers.Outreach:  {DefaultModuleConfig: &outreachConfig},

--- a/subscribe/zoho.go
+++ b/subscribe/zoho.go
@@ -74,3 +74,20 @@ func getZohoRequest(
 		Duration:        &dur,
 	}, nil
 }
+
+// zohoMailConfig is the per-module subscribe-config bundle for the Zoho Mail module. Zoho Mail
+// has no API to create/manage webhook subscriptions (SubscribeByAPI: false in the catalog) — the
+// outgoing webhook is configured by hand in the Zoho Mail console, so there are no
+// registration, subscription, or maintenance declarations; the platform only persists
+// subscription lookups and processes delivered events. Signature verification is bypassed for
+// now: the HMAC signing secret (x-hook-secret) is delivered only on the first webhook request
+// and its plumbing into connection metadata is not yet in place. The verifier connector is
+// declared so the wiring is ready once verification is enabled; note a zero-value
+// zoho.Connector routes VerifyWebhookMessage down the CRM echo-token path, so lifting the
+// bypass requires a mail-module-bound verifier.
+var zohoMailConfig = ProviderConfig{
+	Verification: VerificationConfig{
+		verifierConnector: &zoho.Connector{},
+		bypassed:          true,
+	},
+}


### PR DESCRIPTION
## Summary

Zoho Mail webhook event parsing and verification routing already landed (#3196); this wires up the remaining declarative pieces so the subscribe action can be enabled end to end:

- **Catalog** (`providers/zoho.go`): flip `Support.Subscribe` to `true` for the mail module. Zoho Mail has no webhook-subscription API (`SubscribeByAPI` stays `false`), so the platform treats it as look-up-only — the outgoing webhook is configured by hand in the Zoho Mail console (Settings > Developer Space > Webhooks > Outgoing Webhooks), and Ampersand persists subscription lookups and processes delivered events (same pattern as Gong).
- **Subscribe registry** (`subscribe/zoho.go`, `subscribe/config.go`): register a `ModuleZohoMail` entry with a verification-only `zohoMailConfig`. Signature verification is `bypassed` for now: the HMAC signing secret (`x-hook-secret`) is only delivered on the first webhook request and its plumbing into connection metadata is not yet in place (`mail/verify.go` stub). The comment on the config documents that lifting the bypass requires a mail-module-bound verifier, since a zero-value `zoho.Connector` routes `VerifyWebhookMessage` down the CRM echo-token path.

No server-side change is needed: the ENG-4090 cutover (amp-labs/server#6924) made this package the sole source of truth, so this takes effect once the server's connectors dependency is bumped past this PR.

Companion PRs: amp-labs/docs#689 (provider + customer guides), amp-labs/samples#154 (example manifest).

## Test plan

- [x] `go build ./...`
- [x] `go test ./subscribe/... ./providers/zoho/... ./providers`
- [x] `./custom-gcl run -c .golangci.yml` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
