### PR TITLE
[CON-3457] feat(monaco): add Read & Search action

### DIFF
--- a/providers/monaco.go
+++ b/providers/monaco.go
@@ -34,7 +34,7 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
 			Write:     false,
 		},

--- a/providers/monaco.go
+++ b/providers/monaco.go
@@ -37,6 +37,14 @@ func init() {
 			Read:      true,
 			Subscribe: false,
 			Write:     false,
+			// Monaco's list endpoints double as search endpoints, filtering on
+			// a `filters` array. Only equality maps onto common.FilterOperator
+			// today; Monaco itself also accepts contains/greater_than/less_than/is.
+			Search: SearchSupport{
+				Operators: SearchOperators{
+					Equals: true,
+				},
+			},
 		},
 		//nolint:lll
 		Media: &Media{

--- a/providers/monaco/connector.go
+++ b/providers/monaco/connector.go
@@ -3,6 +3,8 @@ package monaco
 import (
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/monaco/metadata"
@@ -13,6 +15,7 @@ type Connector struct {
 
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -31,6 +34,17 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(
 		connector.Module(),
 		metadata.Schemas,
+	)
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
 	)
 
 	return connector, nil

--- a/providers/monaco/objects.go
+++ b/providers/monaco/objects.go
@@ -49,7 +49,7 @@ var getListObjects = datautils.NewStringSet(
 // so `updated_at` being a filterable field with a `greater_than` operator is
 // unverified for all six. The one directly documented example is accounts
 // filtering on `created_at` with `greater_than`. Confirm against
-// GET /v1/schemas/{entity} once credentials exist; see metadata/README.md.
+// GET /v1/schemas/{entity} once credentials exist.
 //
 //nolint:gochecknoglobals
 var incrementalObjects = datautils.NewStringSet(

--- a/providers/monaco/objects.go
+++ b/providers/monaco/objects.go
@@ -17,10 +17,12 @@ const (
 	objectUsers             = "users"
 )
 
-// getListObjects are served over GET and return the whole collection in a
-// single response: the body carries `data` but no `pagination` object, so there
-// is never a next page. Everything else is listed over POST <path> with a JSON
-// body and responds with `{data, pagination, meta}`.
+// getListObjects are served over GET: the body carries `data` but no
+// `pagination` object. Users and sequence templates arrive whole in a single
+// response; tags additionally require an `object` query param and are walked
+// one object type per page (see tagObjectTypes). Everything else is listed
+// over POST <path> with a JSON body and responds with `{data, pagination,
+// meta}`.
 //
 //nolint:gochecknoglobals
 var getListObjects = datautils.NewStringSet(
@@ -28,6 +30,19 @@ var getListObjects = datautils.NewStringSet(
 	objectTags,
 	objectUsers,
 )
+
+// tagObjectTypes are the values of the required `object` query param of
+// GET /v1/tags/ (the TagObject enum), in the fixed order Read pages through
+// them: the first read (empty token) fetches contacts and each next-page token
+// names the type to fetch next, so one full read returns the tags of every
+// type. The enum values happen to coincide with our object name constants.
+//
+//nolint:gochecknoglobals
+var tagObjectTypes = []string{
+	objectContacts,
+	objectAccounts,
+	objectOpportunities,
+}
 
 // incrementalObjects are the objects where Since/Until are pushed to the server
 // as `updated_at` filter rules.

--- a/providers/monaco/objects.go
+++ b/providers/monaco/objects.go
@@ -1,0 +1,62 @@
+package monaco
+
+import "github.com/amp-labs/connectors/internal/datautils"
+
+// Object names for read routing. These match the keys in metadata/schemas.json.
+const (
+	objectAccounts          = "accounts"
+	objectAudiences         = "audiences"
+	objectCampaigns         = "campaigns"
+	objectContacts          = "contacts"
+	objectMeetings          = "meetings"
+	objectOpportunities     = "opportunities"
+	objectSequenceTemplates = "sequenceTemplates"
+	objectSequences         = "sequences"
+	objectTags              = "tags"
+	objectTasks             = "tasks"
+	objectUsers             = "users"
+)
+
+// getListObjects are served over GET and return the whole collection in a
+// single response: the body carries `data` but no `pagination` object, so there
+// is never a next page. Everything else is listed over POST <path> with a JSON
+// body and responds with `{data, pagination, meta}`.
+//
+//nolint:gochecknoglobals
+var getListObjects = datautils.NewStringSet(
+	objectSequenceTemplates,
+	objectTags,
+	objectUsers,
+)
+
+// incrementalObjects are the objects where Since/Until are pushed to the server
+// as `updated_at` filter rules.
+//
+// Membership is deliberately narrow. Monaco documents that valid filter fields
+// and operators per entity come from GET /v1/schemas/{entity}, and that endpoint
+// covers exactly these six. The two remaining POST-list objects are excluded:
+//
+//   - audiences: AudienceListRequest has no `filters` property at all, so there
+//     is nothing to push down.
+//   - campaigns: PublicListRequest does have `filters`, but campaigns has no
+//     field-schema endpoint and the spec ships no filter example for it, so the
+//     filterable field names are unknown.
+//
+// For those two, Since/Until are accepted and ignored -- the read returns the
+// full collection rather than failing.
+//
+// NOTE: this is inferred from the spec, not observed. We have no Monaco API key,
+// so `updated_at` being a filterable field with a `greater_than` operator is
+// unverified for all six. The one directly documented example is accounts
+// filtering on `created_at` with `greater_than`. Confirm against
+// GET /v1/schemas/{entity} once credentials exist; see metadata/README.md.
+//
+//nolint:gochecknoglobals
+var incrementalObjects = datautils.NewStringSet(
+	objectAccounts,
+	objectContacts,
+	objectMeetings,
+	objectOpportunities,
+	objectSequences,
+	objectTasks,
+)

--- a/providers/monaco/read.go
+++ b/providers/monaco/read.go
@@ -207,17 +207,16 @@ func (c *Connector) parseReadResponse(
 
 	return common.ParseResult(
 		resp,
-		extractRecords(recordsKey),
+		// Records are required, not optional: `data` is mandatory in Monaco's
+		// response schema for both the paginated and unpaginated envelopes, so
+		// its absence is a contract violation. Treating it as optional would
+		// report "zero records, read complete" and let a sync end early and
+		// silently; an error is louder and safer.
+		common.MakeRecordsFunc(recordsKey),
 		makeNextPageFunc(params.ObjectName),
 		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
 		params.Fields,
 	)
-}
-
-func extractRecords(recordsKey string) common.NodeRecordsFunc {
-	return func(node *ajson.Node) ([]*ajson.Node, error) {
-		return jsonquery.New(node).ArrayOptional(recordsKey)
-	}
 }
 
 func makeNextPageFunc(objectName string) common.NextPageFunc {

--- a/providers/monaco/read.go
+++ b/providers/monaco/read.go
@@ -33,8 +33,14 @@ const (
 	// incrementalField is the record timestamp Since/Until are applied to.
 	incrementalField = "updated_at"
 
-	conditionGreaterThan = "greater_than"
-	conditionLessThan    = "less_than"
+	// Since is documented as strictly-after while Until is up-to-and-including,
+	// hence the asymmetric pair of operators.
+	conditionGreaterThan      = "greater_than"
+	conditionLessThanOrEquals = "less_than_or_equals"
+
+	// tagObjectKey is the required query param of GET /v1/tags/ naming which
+	// object type's tags to list.
+	tagObjectKey = "object"
 
 	paginationKey = "pagination"
 	pageField     = "page"
@@ -54,10 +60,55 @@ func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadPara
 	}
 
 	if getListObjects.Has(params.ObjectName) {
+		if params.ObjectName == objectTags {
+			endpointURL, err = withTagObjectParam(endpointURL, params.NextPage)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		return newGetRequest(ctx, endpointURL)
 	}
 
 	return newListRequest(ctx, endpointURL, params)
+}
+
+// withTagObjectParam appends the required `object` query param to the tags
+// URL. Tags are read one object type per page: an empty token starts at the
+// first type, and each response's next-page token names the type to fetch
+// next, so a full read walks all of tagObjectTypes without Read holding state.
+func withTagObjectParam(endpointURL string, token common.NextPageToken) (string, error) {
+	objType, err := resolveTagObject(token)
+	if err != nil {
+		return "", err
+	}
+
+	// The types are a fixed lowercase enum, so plain concatenation is safe.
+	return endpointURL + "?" + tagObjectKey + "=" + objType, nil
+}
+
+// resolveTagObject maps a next-page token onto the tag object type to fetch.
+func resolveTagObject(token common.NextPageToken) (string, error) {
+	if token == "" {
+		return tagObjectTypes[0], nil
+	}
+
+	objType := token.String()
+	if tagObjectIndex(objType) == -1 {
+		return "", fmt.Errorf("%w: expected one of %v, got %q", ErrInvalidNextPage, tagObjectTypes, token)
+	}
+
+	return objType, nil
+}
+
+func tagObjectIndex(objType string) int {
+	for index, candidate := range tagObjectTypes {
+		if candidate == objType {
+			return index
+		}
+	}
+
+	return -1
 }
 
 func (c *Connector) buildReadURL(objectName string) (string, error) {
@@ -151,7 +202,7 @@ func buildTimeFilters(params common.ReadParams) []map[string]any {
 	}
 
 	if !params.Until.IsZero() {
-		filters = append(filters, filterRule(incrementalField, conditionLessThan, params.Until))
+		filters = append(filters, filterRule(incrementalField, conditionLessThanOrEquals, params.Until))
 	}
 
 	return filters
@@ -200,7 +251,7 @@ func clampPageSize(size int) int {
 func (c *Connector) parseReadResponse(
 	_ context.Context,
 	params common.ReadParams,
-	_ *http.Request,
+	req *http.Request,
 	resp *common.JSONHTTPResponse,
 ) (*common.ReadResult, error) {
 	recordsKey := metadata.Schemas.LookupArrayFieldName(c.ProviderContext.Module(), params.ObjectName)
@@ -213,20 +264,37 @@ func (c *Connector) parseReadResponse(
 		// report "zero records, read complete" and let a sync end early and
 		// silently; an error is louder and safer.
 		common.MakeRecordsFunc(recordsKey),
-		makeNextPageFunc(params.ObjectName),
+		makeNextPageFunc(params.ObjectName, req),
 		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
 		params.Fields,
 	)
 }
 
-func makeNextPageFunc(objectName string) common.NextPageFunc {
-	if getListObjects.Has(objectName) {
+func makeNextPageFunc(objectName string, req *http.Request) common.NextPageFunc {
+	switch {
+	case objectName == objectTags:
+		return makeTagsNextPage(req)
+	case getListObjects.Has(objectName):
 		// The whole collection arrives in one response; there is no pagination
 		// object to advance.
 		return noNextPage
+	default:
+		return nextPageFromPagination
 	}
+}
 
-	return nextPageFromPagination
+// makeTagsNextPage advances through tagObjectTypes. The tags response carries
+// no pagination block, so the page just fetched is identified by the request's
+// own `object` query param and the token returned is simply the next type.
+func makeTagsNextPage(req *http.Request) common.NextPageFunc {
+	return func(*ajson.Node) (string, error) {
+		index := tagObjectIndex(req.URL.Query().Get(tagObjectKey))
+		if index == -1 || index+1 == len(tagObjectTypes) {
+			return "", nil
+		}
+
+		return tagObjectTypes[index+1], nil
+	}
 }
 
 func noNextPage(*ajson.Node) (string, error) {

--- a/providers/monaco/read.go
+++ b/providers/monaco/read.go
@@ -100,7 +100,7 @@ func newGetRequest(ctx context.Context, endpointURL string) (*http.Request, erro
 }
 
 func newListRequest(ctx context.Context, endpointURL string, params common.ReadParams) (*http.Request, error) {
-	page, err := readPage(params)
+	page, err := resolvePage(params.NextPage)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func newListRequest(ctx context.Context, endpointURL string, params common.ReadP
 func buildListRequestBody(params common.ReadParams, page int) map[string]any {
 	body := map[string]any{
 		pageKey:     page,
-		pageSizeKey: readPageSize(params),
+		pageSizeKey: clampPageSize(params.PageSize),
 	}
 
 	if filters := buildTimeFilters(params); len(filters) != 0 {
@@ -165,16 +165,17 @@ func filterRule(field, condition string, value time.Time) map[string]any {
 	}
 }
 
-// readPage resolves which page to request. Monaco paginates by page number
-// rather than by cursor, so the next-page token is just the number.
-func readPage(params common.ReadParams) (int, error) {
-	if params.NextPage == "" {
+// resolvePage turns a next-page token into the page to request. Monaco
+// paginates by page number rather than by cursor, so the token is just the
+// number. Shared with Search, which pages the same endpoints.
+func resolvePage(token common.NextPageToken) (int, error) {
+	if token == "" {
 		return firstPage, nil
 	}
 
-	page, err := strconv.Atoi(params.NextPage.String())
+	page, err := strconv.Atoi(token.String())
 	if err != nil {
-		return 0, fmt.Errorf("%w: expected a page number, got %q", ErrInvalidNextPage, params.NextPage)
+		return 0, fmt.Errorf("%w: expected a page number, got %q", ErrInvalidNextPage, token)
 	}
 
 	if page < firstPage {
@@ -184,14 +185,15 @@ func readPage(params common.ReadParams) (int, error) {
 	return page, nil
 }
 
-func readPageSize(params common.ReadParams) int {
+// clampPageSize keeps the requested size inside Monaco's 1..500 range.
+func clampPageSize(size int) int {
 	switch {
-	case params.PageSize <= 0:
+	case size <= 0:
 		return defaultPageSize
-	case params.PageSize > maxPageSize:
+	case size > maxPageSize:
 		return maxPageSize
 	default:
-		return params.PageSize
+		return size
 	}
 }
 

--- a/providers/monaco/read.go
+++ b/providers/monaco/read.go
@@ -1,0 +1,259 @@
+package monaco
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/monaco/metadata"
+	"github.com/spyzhov/ajson"
+)
+
+const (
+	// Monaco pages are 1-indexed. page_size accepts 1..500 and defaults to 50;
+	// we ask for more per round trip but stay inside the cap.
+	firstPage       = 1
+	defaultPageSize = 100
+	maxPageSize     = 500
+
+	pageKey     = "page"
+	pageSizeKey = "page_size"
+	filtersKey  = "filters"
+
+	// incrementalField is the record timestamp Since/Until are applied to.
+	incrementalField = "updated_at"
+
+	conditionGreaterThan = "greater_than"
+	conditionLessThan    = "less_than"
+
+	paginationKey = "pagination"
+	pageField     = "page"
+	totalPagesKey = "total_pages"
+)
+
+var ErrInvalidNextPage = errors.New("invalid next page token")
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	endpointURL, err := c.buildReadURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	if getListObjects.Has(params.ObjectName) {
+		return newGetRequest(ctx, endpointURL)
+	}
+
+	return newListRequest(ctx, endpointURL, params)
+}
+
+func (c *Connector) buildReadURL(objectName string) (string, error) {
+	path, err := metadata.Schemas.FindURLPath(c.ProviderContext.Module(), objectName)
+	if err != nil {
+		return "", err
+	}
+
+	modulePath := metadata.Schemas.LookupModuleURLPath(c.ProviderContext.Module())
+
+	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, modulePath, path)
+	if err != nil {
+		return "", err
+	}
+
+	result := endpointURL.String()
+
+	// urlbuilder normalizes trailing slashes away, but Monaco's routes are
+	// slash-exact: GET /v1/tags/ and /v1/users/ are served directly, while
+	// /v1/tags and /v1/users answer 307 pointing at the slashed form. Restore
+	// the slash rather than depend on the client following a redirect.
+	// /v1/sequence-templates is the reverse -- unslashed is the real route --
+	// which is why this keys off the recorded path instead of the object kind.
+	if strings.HasSuffix(path, "/") && !strings.HasSuffix(result, "/") {
+		result += "/"
+	}
+
+	return result, nil
+}
+
+func newGetRequest(ctx context.Context, endpointURL string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+func newListRequest(ctx context.Context, endpointURL string, params common.ReadParams) (*http.Request, error) {
+	page, err := readPage(params)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(buildListRequestBody(params, page))
+	if err != nil {
+		return nil, fmt.Errorf("marshal list request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+// buildListRequestBody assembles the POST body. `sort` is deliberately omitted
+// so each endpoint keeps its documented default ordering, and
+// `include_custom_fields` is omitted so it keeps its default of true on the
+// three objects that accept it -- custom fields are not in schemas.json, but
+// dropping them from the payload would lose data the caller may want.
+func buildListRequestBody(params common.ReadParams, page int) map[string]any {
+	body := map[string]any{
+		pageKey:     page,
+		pageSizeKey: readPageSize(params),
+	}
+
+	if filters := buildTimeFilters(params); len(filters) != 0 {
+		body[filtersKey] = filters
+	}
+
+	return body
+}
+
+func buildTimeFilters(params common.ReadParams) []map[string]any {
+	if !incrementalObjects.Has(params.ObjectName) {
+		return nil
+	}
+
+	filters := make([]map[string]any, 0, 2) //nolint:mnd
+
+	if !params.Since.IsZero() {
+		filters = append(filters, filterRule(incrementalField, conditionGreaterThan, params.Since))
+	}
+
+	if !params.Until.IsZero() {
+		filters = append(filters, filterRule(incrementalField, conditionLessThan, params.Until))
+	}
+
+	return filters
+}
+
+func filterRule(field, condition string, value time.Time) map[string]any {
+	return map[string]any{
+		"field":     field,
+		"condition": condition,
+		"value":     value.UTC().Format(time.RFC3339),
+	}
+}
+
+// readPage resolves which page to request. Monaco paginates by page number
+// rather than by cursor, so the next-page token is just the number.
+func readPage(params common.ReadParams) (int, error) {
+	if params.NextPage == "" {
+		return firstPage, nil
+	}
+
+	page, err := strconv.Atoi(params.NextPage.String())
+	if err != nil {
+		return 0, fmt.Errorf("%w: expected a page number, got %q", ErrInvalidNextPage, params.NextPage)
+	}
+
+	if page < firstPage {
+		return 0, fmt.Errorf("%w: pages start at %d, got %d", ErrInvalidNextPage, firstPage, page)
+	}
+
+	return page, nil
+}
+
+func readPageSize(params common.ReadParams) int {
+	switch {
+	case params.PageSize <= 0:
+		return defaultPageSize
+	case params.PageSize > maxPageSize:
+		return maxPageSize
+	default:
+		return params.PageSize
+	}
+}
+
+func (c *Connector) parseReadResponse(
+	_ context.Context,
+	params common.ReadParams,
+	_ *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	recordsKey := metadata.Schemas.LookupArrayFieldName(c.ProviderContext.Module(), params.ObjectName)
+
+	return common.ParseResult(
+		resp,
+		extractRecords(recordsKey),
+		makeNextPageFunc(params.ObjectName),
+		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
+		params.Fields,
+	)
+}
+
+func extractRecords(recordsKey string) common.NodeRecordsFunc {
+	return func(node *ajson.Node) ([]*ajson.Node, error) {
+		return jsonquery.New(node).ArrayOptional(recordsKey)
+	}
+}
+
+func makeNextPageFunc(objectName string) common.NextPageFunc {
+	if getListObjects.Has(objectName) {
+		// The whole collection arrives in one response; there is no pagination
+		// object to advance.
+		return noNextPage
+	}
+
+	return nextPageFromPagination
+}
+
+func noNextPage(*ajson.Node) (string, error) {
+	return "", nil
+}
+
+// nextPageFromPagination advances while the response says more pages exist.
+// A missing or malformed pagination block ends the read rather than erroring,
+// so an unexpected payload degrades to a single page instead of a failure.
+func nextPageFromPagination(node *ajson.Node) (string, error) {
+	pagination, err := jsonquery.New(node).ObjectOptional(paginationKey)
+	if err != nil || pagination == nil {
+		return "", nil //nolint:nilerr
+	}
+
+	page, err := jsonquery.New(pagination).IntegerWithDefault(pageField, 0)
+	if err != nil {
+		return "", nil //nolint:nilerr
+	}
+
+	totalPages, err := jsonquery.New(pagination).IntegerWithDefault(totalPagesKey, 0)
+	if err != nil {
+		return "", nil //nolint:nilerr
+	}
+
+	if page < firstPage || page >= totalPages {
+		return "", nil
+	}
+
+	return strconv.FormatInt(page+1, 10), nil
+}

--- a/providers/monaco/read_test.go
+++ b/providers/monaco/read_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
@@ -235,6 +236,23 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			}.Server(),
 			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
 			ExpectedErrs: nil,
+		},
+		{
+			// Records are extracted with required semantics. A response missing
+			// `data` violates Monaco's schema, and reporting it as an empty page
+			// would let a sync finish early and silently.
+			Name: "Missing data envelope is an error, not an empty page",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v1/contacts/list"),
+				Then: mockserver.Response(http.StatusOK,
+					[]byte(`{"pagination":{"page":1,"page_size":100,"total_count":0,"total_pages":1},"meta":{}}`)),
+			}.Server(),
+			ExpectedErrs: []error{jsonquery.ErrKeyNotFound},
 		},
 		{
 			Name: "Malformed NextPage is rejected",

--- a/providers/monaco/read_test.go
+++ b/providers/monaco/read_test.go
@@ -1,0 +1,260 @@
+package monaco
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,maintidx
+	t.Parallel()
+
+	responseContacts := testutils.DataFromFile(t, "read/contacts.json")
+	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts-last-page.json")
+	responseContactsEmpty := testutils.DataFromFile(t, "read/contacts-empty.json")
+	responseTags := testutils.DataFromFile(t, "read/tags.json")
+
+	tests := []testconn.TestCaseRead{
+		{
+			Name:         "Read object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: objectContacts},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:         "Unknown object is not supported",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: connectors.Fields("id")},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrResolvingURLPathForObject},
+		},
+		{
+			Name: "Contacts list is a POST carrying page and page_size",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id", "email"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/contacts/list"),
+					mockcond.Body(`{"page":1,"page_size":100}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "con_abc123", "email": "jane@acme.com"},
+					Raw:    map[string]any{"first_name": "Jane", "title": "VP Engineering"},
+					Id:     "con_abc123",
+				}, {
+					Fields: map[string]any{"id": "con_xyz789", "email": "john@globex.com"},
+					Raw:    map[string]any{"first_name": "John", "do_not_contact": true},
+					Id:     "con_xyz789",
+				}},
+				// page 1 of 2 -> the token is simply the next page number.
+				NextPage: "2",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "NextPage token is fed back as the page number",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				NextPage:   "2",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/contacts/list"),
+					mockcond.Body(`{"page":2,"page_size":100}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsLastPage),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "con_lmn456"},
+					Raw:    map[string]any{"email": "ada@acme.com"},
+					Id:     "con_lmn456",
+				}},
+				// page == total_pages, so the read is finished.
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Empty page reports done",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v1/contacts/list"),
+				Then:  mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected: &common.ReadResult{
+				Rows: 0,
+				Data: []common.ReadResultRow{},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Since and Until become updated_at filter rules",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				Since:      time.Date(2025, time.June, 1, 0, 0, 0, 0, time.UTC),
+				Until:      time.Date(2025, time.July, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/contacts/list"),
+					mockcond.Body(`{
+						"page": 1,
+						"page_size": 100,
+						"filters": [
+							{"field":"updated_at","condition":"greater_than","value":"2025-06-01T00:00:00Z"},
+							{"field":"updated_at","condition":"less_than","value":"2025-07-01T00:00:00Z"}
+						]
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Audiences ignores Since because its list request has no filters",
+			Input: common.ReadParams{
+				ObjectName: objectAudiences,
+				Fields:     connectors.Fields("id"),
+				Since:      time.Date(2025, time.June, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/audiences/list"),
+					// No filters key -- pushing one down would be rejected.
+					mockcond.Body(`{"page":1,"page_size":100}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "PageSize is clamped to Monaco's maximum of 500",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				PageSize:   5000,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Body(`{"page":1,"page_size":500}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Tags is a GET on the slash-terminated route and never paginates",
+			Input: common.ReadParams{
+				ObjectName: objectTags,
+				Fields:     connectors.Fields("id", "name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					// The trailing slash is load-bearing: /v1/tags answers 307.
+					mockcond.Path("/v1/tags/"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseTags),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "tag_001", "name": "Interested"},
+					Raw:    map[string]any{"color": "#22c55e"},
+					Id:     "tag_001",
+				}, {
+					Fields: map[string]any{"id": "tag_002", "name": "Decision Maker"},
+					Raw:    map[string]any{"color": "#3b82f6"},
+					Id:     "tag_002",
+				}},
+				// No pagination block in the response.
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Sequence templates keep the unslashed route",
+			Input: common.ReadParams{
+				ObjectName: objectSequenceTemplates,
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					// Mirror image of tags: here the slashed form is the redirect.
+					mockcond.Path("/v1/sequence-templates"),
+				},
+				Then: mockserver.Response(http.StatusOK, []byte(`{"data":[]}`)),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Malformed NextPage is rejected",
+			Input: common.ReadParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				NextPage:   "not-a-page",
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrInvalidNextPage},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableReader, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/monaco/read_test.go
+++ b/providers/monaco/read_test.go
@@ -139,7 +139,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 						"page_size": 100,
 						"filters": [
 							{"field":"updated_at","condition":"greater_than","value":"2025-06-01T00:00:00Z"},
-							{"field":"updated_at","condition":"less_than","value":"2025-07-01T00:00:00Z"}
+							{"field":"updated_at","condition":"less_than_or_equals","value":"2025-07-01T00:00:00Z"}
 						]
 					}`),
 				},
@@ -187,7 +187,10 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			ExpectedErrs: nil,
 		},
 		{
-			Name: "Tags is a GET on the slash-terminated route and never paginates",
+			// Tags pages through object types rather than page numbers: each GET
+			// returns every tag of one type, and the next-page token names the
+			// type to fetch next.
+			Name: "Tags first page is a GET for contacts tags and points at accounts",
 			Input: common.ReadParams{
 				ObjectName: objectTags,
 				Fields:     connectors.Fields("id", "name"),
@@ -198,6 +201,9 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					mockcond.MethodGET(),
 					// The trailing slash is load-bearing: /v1/tags answers 307.
 					mockcond.Path("/v1/tags/"),
+					// `object` is a required query param; an empty NextPage
+					// token starts the walk at contacts.
+					mockcond.QueryParam("object", "contacts"),
 				},
 				Then: mockserver.Response(http.StatusOK, responseTags),
 			}.Server(),
@@ -213,10 +219,103 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					Raw:    map[string]any{"color": "#3b82f6"},
 					Id:     "tag_002",
 				}},
-				// No pagination block in the response.
+				NextPage: "accounts",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Tags token names the object type to fetch and advances to the next",
+			Input: common.ReadParams{
+				ObjectName: objectTags,
+				Fields:     connectors.Fields("id"),
+				NextPage:   "accounts",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/tags/"),
+					mockcond.QueryParam("object", "accounts"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseTags),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "tag_001"},
+					Raw:    map[string]any{"name": "Interested"},
+					Id:     "tag_001",
+				}, {
+					Fields: map[string]any{"id": "tag_002"},
+					Raw:    map[string]any{"name": "Decision Maker"},
+					Id:     "tag_002",
+				}},
+				NextPage: "opportunities",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Tags last object type finishes the read",
+			Input: common.ReadParams{
+				ObjectName: objectTags,
+				Fields:     connectors.Fields("id"),
+				NextPage:   "opportunities",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/tags/"),
+					mockcond.QueryParam("object", "opportunities"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseTags),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "tag_001"},
+					Raw:    map[string]any{"name": "Interested"},
+					Id:     "tag_001",
+				}, {
+					Fields: map[string]any{"id": "tag_002"},
+					Raw:    map[string]any{"name": "Decision Maker"},
+					Id:     "tag_002",
+				}},
 				NextPage: "",
 				Done:     true,
 			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Tags rejects a token that is not an object type",
+			Input: common.ReadParams{
+				ObjectName: objectTags,
+				Fields:     connectors.Fields("id"),
+				NextPage:   "2",
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrInvalidNextPage},
+		},
+		{
+			Name: "Users is a GET without the tags object param and never paginates",
+			Input: common.ReadParams{
+				ObjectName: objectUsers,
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/users/"),
+					mockcond.QueryParamsMissing("object"),
+				},
+				Then: mockserver.Response(http.StatusOK, []byte(`{"data":[]}`)),
+			}.Server(),
+			Expected:     &common.ReadResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
 			ExpectedErrs: nil,
 		},
 		{

--- a/providers/monaco/search.go
+++ b/providers/monaco/search.go
@@ -20,7 +20,7 @@ import (
 // GET /v1/schemas/{entity} under `allowed_operators`, and we have no API key to
 // read it. `equals` is chosen because it is the operator the spec uses for the
 // plainest equality example (contacts by email). If a field turns out to accept
-// only `is`, searching on it will 400;
+// only `is`, searching on it will 400 and this mapping has to become per-field.
 const conditionEquals = "equals"
 
 // ErrUnsupportedSearchOperator is returned for any operator the framework may
@@ -81,7 +81,7 @@ func (c *Connector) Search(ctx context.Context, params *common.SearchParams) (*c
 
 	return common.ParseResult(
 		resp,
-		extractRecords(recordsKey),
+		common.MakeRecordsFunc(recordsKey),
 		nextPageFromPagination,
 		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
 		params.Fields,

--- a/providers/monaco/search.go
+++ b/providers/monaco/search.go
@@ -1,0 +1,139 @@
+package monaco
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/providers/monaco/metadata"
+)
+
+// conditionEquals is what common.FilterOperatorEQ maps onto.
+//
+// Monaco also accepts `is`, and its own examples use both against what look
+// like the same kinds of field -- sequences filters contact_id with `equals`
+// while meetings filters account_id with `is`, both UUIDs. Which operators a
+// given field actually accepts is reported per-field by
+// GET /v1/schemas/{entity} under `allowed_operators`, and we have no API key to
+// read it. `equals` is chosen because it is the operator the spec uses for the
+// plainest equality example (contacts by email). If a field turns out to accept
+// only `is`, searching on it will 400;
+const conditionEquals = "equals"
+
+// ErrUnsupportedSearchOperator is returned for any operator the framework may
+// grow that Monaco has no equivalent for.
+var ErrUnsupportedSearchOperator = errors.New("unsupported search operator")
+
+// searchableObjects are the objects whose list request schema carries a
+// `filters` property.
+//
+// This is the read set of POST-list objects minus audiences, whose
+// AudienceListRequest exposes only page and page_size. The three GET-list
+// objects (tags, users, sequenceTemplates) have no request body at all and so
+// cannot be filtered either.
+//
+//nolint:gochecknoglobals
+var searchableObjects = datautils.NewStringSet(
+	objectAccounts,
+	objectCampaigns,
+	objectContacts,
+	objectMeetings,
+	objectOpportunities,
+	objectSequences,
+	objectTasks,
+)
+
+// Search runs a filtered list against the same POST /v1/<object>/list endpoint
+// Read uses -- in Monaco the list endpoint *is* the search endpoint, and the
+// only difference is whether `filters` is populated. Pagination, the response
+// envelope and record extraction are therefore shared with Read verbatim.
+//
+// A flat filters array is implicitly AND-joined by Monaco, which matches the
+// contract of common.SearchFilter.
+func (c *Connector) Search(ctx context.Context, params *common.SearchParams) (*common.SearchResult, error) {
+	if err := params.ValidateParams(true); err != nil {
+		return nil, err
+	}
+
+	if !searchableObjects.Has(params.ObjectName) {
+		return nil, common.ErrOperationNotSupportedForObject
+	}
+
+	endpointURL, err := c.buildReadURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := buildSearchRequestBody(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.JSONHTTPClient().Post(ctx, endpointURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	recordsKey := metadata.Schemas.LookupArrayFieldName(c.ProviderContext.Module(), params.ObjectName)
+
+	return common.ParseResult(
+		resp,
+		extractRecords(recordsKey),
+		nextPageFromPagination,
+		readhelper.MakeMarshaledDataFuncWithId(nil, readhelper.NewIdField("id")),
+		params.Fields,
+	)
+}
+
+func buildSearchRequestBody(params *common.SearchParams) (map[string]any, error) {
+	page, err := resolvePage(params.NextPage)
+	if err != nil {
+		return nil, err
+	}
+
+	filters, err := buildSearchFilters(params.Filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		pageKey:     page,
+		pageSizeKey: clampPageSize(int(params.Limit)),
+		filtersKey:  filters,
+	}, nil
+}
+
+func buildSearchFilters(filter common.SearchFilter) ([]map[string]any, error) {
+	rules := make([]map[string]any, 0, len(filter.FieldFilters))
+
+	for _, fieldFilter := range filter.FieldFilters {
+		condition, err := searchCondition(fieldFilter.Operator)
+		if err != nil {
+			return nil, err
+		}
+
+		rules = append(rules, map[string]any{
+			"field":     fieldFilter.FieldName,
+			"condition": condition,
+			"value":     fieldFilter.Value,
+		})
+	}
+
+	return rules, nil
+}
+
+// searchCondition maps a framework operator onto a Monaco condition. The
+// framework currently defines exactly one (FilterOperatorEQ), so Monaco's
+// richer vocabulary -- contains, greater_than, less_than, is -- is not
+// reachable through SearchParams today.
+func searchCondition(operator common.FilterOperator) (string, error) {
+	switch operator {
+	case common.FilterOperatorEQ:
+		return conditionEquals, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnsupportedSearchOperator, operator)
+	}
+}

--- a/providers/monaco/search_test.go
+++ b/providers/monaco/search_test.go
@@ -1,0 +1,237 @@
+package monaco
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+// Monaco must satisfy the SearchConnector interface, not merely have a method
+// with the right shape -- that interface is how the action is dispatched.
+var _ connectors.SearchConnector = &Connector{}
+
+func equalsFilter(field string, value any) common.SearchFilter {
+	return common.SearchFilter{
+		FieldFilters: []common.FieldFilter{{
+			FieldName: field,
+			Operator:  common.FilterOperatorEQ,
+			Value:     value,
+		}},
+	}
+}
+
+func TestSearch(t *testing.T) { //nolint:funlen,maintidx
+	t.Parallel()
+
+	responseContacts := testutils.DataFromFile(t, "read/contacts.json")
+	responseContactsEmpty := testutils.DataFromFile(t, "read/contacts-empty.json")
+
+	tests := []testconn.TestCaseSearch{
+		{
+			Name:         "Search object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name: "At least one field is requested",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Filter:     equalsFilter("email", "jane@acme.com"),
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name: "A filter is required",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingSearchFilters},
+		},
+		{
+			Name: "Audiences cannot be searched, its list request has no filters",
+			Input: common.SearchParams{
+				ObjectName: objectAudiences,
+				Fields:     connectors.Fields("id"),
+				Filter:     equalsFilter("name", "Q3"),
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Tags cannot be searched, it is a plain GET collection",
+			Input: common.SearchParams{
+				ObjectName: objectTags,
+				Fields:     connectors.Fields("id"),
+				Filter:     equalsFilter("name", "Hot"),
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Equality filter becomes an equals condition",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id", "email"),
+				Filter:     equalsFilter("email", "jane@acme.com"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					// Same endpoint Read uses; only `filters` differs.
+					mockcond.Path("/v1/contacts/list"),
+					mockcond.Body(`{
+						"page": 1,
+						"page_size": 100,
+						"filters": [
+							{"field":"email","condition":"equals","value":"jane@acme.com"}
+						]
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.SearchResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "con_abc123", "email": "jane@acme.com"},
+					Raw:    map[string]any{"first_name": "Jane"},
+					Id:     "con_abc123",
+				}, {
+					Fields: map[string]any{"id": "con_xyz789", "email": "john@globex.com"},
+					Raw:    map[string]any{"first_name": "John"},
+					Id:     "con_xyz789",
+				}},
+				NextPage: "2",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Multiple filters are sent as a flat array, AND-joined by Monaco",
+			Input: common.SearchParams{
+				ObjectName: objectOpportunities,
+				Fields:     connectors.Fields("id"),
+				Filter: common.SearchFilter{
+					FieldFilters: []common.FieldFilter{{
+						FieldName: "name",
+						Operator:  common.FilterOperatorEQ,
+						Value:     "Acme renewal",
+					}, {
+						FieldName: "stage",
+						Operator:  common.FilterOperatorEQ,
+						Value:     "negotiation",
+					}},
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/opportunities/list"),
+					mockcond.Body(`{
+						"page": 1,
+						"page_size": 100,
+						"filters": [
+							{"field":"name","condition":"equals","value":"Acme renewal"},
+							{"field":"stage","condition":"equals","value":"negotiation"}
+						]
+					}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.SearchResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Limit maps to page_size and is clamped at 500",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				Filter:     equalsFilter("email", "jane@acme.com"),
+				Limit:      5000,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.Body(`{
+					"page": 1,
+					"page_size": 500,
+					"filters": [
+						{"field":"email","condition":"equals","value":"jane@acme.com"}
+					]
+				}`),
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.SearchResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "NextPage carries the page number, as in Read",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				Filter:     equalsFilter("email", "jane@acme.com"),
+				NextPage:   "3",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.Body(`{
+					"page": 3,
+					"page_size": 100,
+					"filters": [
+						{"field":"email","condition":"equals","value":"jane@acme.com"}
+					]
+				}`),
+				Then: mockserver.Response(http.StatusOK, responseContactsEmpty),
+			}.Server(),
+			Expected:     &common.SearchResult{Rows: 0, Data: []common.ReadResultRow{}, Done: true},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Malformed NextPage is rejected",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				Filter:     equalsFilter("email", "jane@acme.com"),
+				NextPage:   "not-a-page",
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrInvalidNextPage},
+		},
+		{
+			Name: "Unknown operator is rejected before any request",
+			Input: common.SearchParams{
+				ObjectName: objectContacts,
+				Fields:     connectors.Fields("id"),
+				Filter: common.SearchFilter{
+					FieldFilters: []common.FieldFilter{{
+						FieldName: "email",
+						Operator:  common.FilterOperator("contains"),
+						Value:     "acme",
+					}},
+				},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{ErrUnsupportedSearchOperator},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableSearcher, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/monaco/test/read/contacts-empty.json
+++ b/providers/monaco/test/read/contacts-empty.json
@@ -1,0 +1,12 @@
+{
+  "data": [],
+  "pagination": {
+    "page": 1,
+    "page_size": 100,
+    "total_count": 0,
+    "total_pages": 0
+  },
+  "meta": {
+    "timestamp": "2026-08-06T00:00:00Z"
+  }
+}

--- a/providers/monaco/test/read/contacts-last-page.json
+++ b/providers/monaco/test/read/contacts-last-page.json
@@ -1,0 +1,22 @@
+{
+  "data": [
+    {
+      "id": "con_lmn456",
+      "account_id": "acc_def456",
+      "first_name": "Ada",
+      "last_name": "Lovelace",
+      "email": "ada@acme.com",
+      "created_at": "2025-06-17T12:00:00Z",
+      "updated_at": "2025-06-22T10:00:00Z"
+    }
+  ],
+  "pagination": {
+    "page": 2,
+    "page_size": 2,
+    "total_count": 3,
+    "total_pages": 2
+  },
+  "meta": {
+    "timestamp": "2026-08-06T00:00:00Z"
+  }
+}

--- a/providers/monaco/test/read/contacts.json
+++ b/providers/monaco/test/read/contacts.json
@@ -1,0 +1,39 @@
+{
+  "data": [
+    {
+      "id": "con_abc123",
+      "account_id": "acc_def456",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "email": "jane@acme.com",
+      "title": "VP Engineering",
+      "phone_number": null,
+      "do_not_contact": false,
+      "tags": ["Interested", "Decision Maker"],
+      "created_at": "2025-06-15T10:30:00Z",
+      "updated_at": "2025-06-20T08:00:00Z"
+    },
+    {
+      "id": "con_xyz789",
+      "account_id": null,
+      "first_name": "John",
+      "last_name": "Smith",
+      "email": "john@globex.com",
+      "title": null,
+      "phone_number": "+1-555-0100",
+      "do_not_contact": true,
+      "tags": [],
+      "created_at": "2025-06-16T11:00:00Z",
+      "updated_at": "2025-06-21T09:15:00Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 2,
+    "total_count": 3,
+    "total_pages": 2
+  },
+  "meta": {
+    "timestamp": "2026-08-06T00:00:00Z"
+  }
+}

--- a/providers/monaco/test/read/tags.json
+++ b/providers/monaco/test/read/tags.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    { "id": "tag_001", "name": "Interested", "color": "#22c55e" },
+    { "id": "tag_002", "name": "Decision Maker", "color": "#3b82f6" }
+  ],
+  "meta": {
+    "timestamp": "2026-08-06T00:00:00Z"
+  }
+}

--- a/test/monaco/read/main.go
+++ b/test/monaco/read/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/monaco"
+	connTest "github.com/amp-labs/connectors/test/monaco"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetMonacoConnector(ctx)
+
+	// One POST-list object and one GET-list object, to cover both read shapes.
+	for _, objectName := range []string{"contacts", "accounts", "tags", "users"} {
+		if err := testRead(ctx, conn, objectName, time.Time{}); err != nil {
+			slog.Error(err.Error())
+		}
+	}
+
+	// Incremental read. contacts is in incrementalObjects, so this should send
+	// an updated_at/greater_than filter rule. Watch for a 4xx here: it is the
+	// signal that updated_at is not a filterable field, which we could not
+	// verify without credentials.
+	if err := testRead(ctx, conn, "contacts", time.Now().AddDate(0, -1, 0)); err != nil {
+		slog.Error(err.Error())
+	}
+
+	// audiences deliberately ignores Since -- expect a full first page, not an error.
+	if err := testRead(ctx, conn, "audiences", time.Now().AddDate(0, -1, 0)); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func testRead(ctx context.Context, conn *monaco.Connector, objectName string, since time.Time) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields("id"),
+		Since:      since,
+		PageSize:   5,
+	})
+	if err != nil {
+		return fmt.Errorf("error reading %s: %w", objectName, err)
+	}
+
+	slog.Info("read",
+		"object", objectName,
+		"since", since,
+		"rows", res.Rows,
+		"done", res.Done,
+		"nextPage", res.NextPage,
+	)
+
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling %s result: %w", objectName, err)
+	}
+
+	slog.Debug(string(jsonStr))
+
+	return nil
+}

--- a/test/monaco/search/main.go
+++ b/test/monaco/search/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/monaco"
+	connTest "github.com/amp-labs/connectors/test/monaco"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetMonacoConnector(ctx)
+
+	// The spec's own example: look a contact up by exact email. This is the
+	// case most likely to be accepted, since `equals` on email is the one
+	// equality example Monaco documents.
+	if err := testSearch(ctx, conn, "contacts", "email", "jane@acme.com"); err != nil {
+		slog.Error(err.Error())
+	}
+
+	// A UUID-valued field. Watch for a 4xx here specifically: Monaco's examples
+	// use `equals` for sequences.contact_id but `is` for meetings.account_id,
+	// and which operators a field accepts is only discoverable from
+	// GET /v1/schemas/{entity}, which we cannot call without a key. A failure
+	// here means the eq -> equals mapping needs to become per-field.
+	if err := testSearch(ctx, conn, "meetings", "account_id",
+		"550e8400-e29b-41d4-a716-446655440000"); err != nil {
+		slog.Error(err.Error())
+	}
+
+	// Not searchable: its list request carries no filters at all.
+	if err := testSearch(ctx, conn, "audiences", "name", "Q3 targets"); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func testSearch(ctx context.Context, conn *monaco.Connector, objectName, field string, value any) error {
+	res, err := conn.Search(ctx, &common.SearchParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields("id"),
+		Filter: common.SearchFilter{
+			FieldFilters: []common.FieldFilter{{
+				FieldName: field,
+				Operator:  common.FilterOperatorEQ,
+				Value:     value,
+			}},
+		},
+		Limit: 5,
+	})
+	if err != nil {
+		return fmt.Errorf("error searching %s on %s: %w", objectName, field, err)
+	}
+
+	slog.Info("search",
+		"object", objectName,
+		"filter", fmt.Sprintf("%s eq %v", field, value),
+		"rows", res.Rows,
+		"done", res.Done,
+		"nextPage", res.NextPage,
+	)
+
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshalling %s result: %w", objectName, err)
+	}
+
+	slog.Debug(string(jsonStr))
+
+	return nil
+}


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [ ] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
