### PR TITLE
[CON-3458] feat(monaco): add Write action

### DIFF
--- a/providers/monaco.go
+++ b/providers/monaco.go
@@ -36,7 +36,7 @@ func init() {
 			Proxy:     true,
 			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 			// Monaco's list endpoints double as search endpoints, filtering on
 			// a `filters` array. Only equality maps onto common.FilterOperator
 			// today; Monaco itself also accepts contains/greater_than/less_than/is.

--- a/providers/monaco/connector.go
+++ b/providers/monaco/connector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
+	"github.com/amp-labs/connectors/internal/components/writer"
 	"github.com/amp-labs/connectors/providers"
 	"github.com/amp-labs/connectors/providers/monaco/metadata"
 )
@@ -16,6 +17,7 @@ type Connector struct {
 	common.RequireAuthenticatedClient
 	components.SchemaProvider
 	components.Reader
+	components.Writer
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -43,6 +45,17 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 		operations.ReadHandlers{
 			BuildRequest:  connector.buildReadRequest,
 			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Writer = writer.NewHTTPWriter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.WriteHandlers{
+			BuildRequest:  connector.buildWriteRequest,
+			ParseResponse: connector.parseWriteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/monaco/read.go
+++ b/providers/monaco/read.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/readhelper"
-	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/providers/monaco/metadata"
 	"github.com/spyzhov/ajson"
@@ -119,24 +117,10 @@ func (c *Connector) buildReadURL(objectName string) (string, error) {
 
 	modulePath := metadata.Schemas.LookupModuleURLPath(c.ProviderContext.Module())
 
-	endpointURL, err := urlbuilder.New(c.ProviderInfo().BaseURL, modulePath, path)
-	if err != nil {
-		return "", err
-	}
-
-	result := endpointURL.String()
-
-	// urlbuilder normalizes trailing slashes away, but Monaco's routes are
-	// slash-exact: GET /v1/tags/ and /v1/users/ are served directly, while
-	// /v1/tags and /v1/users answer 307 pointing at the slashed form. Restore
-	// the slash rather than depend on the client following a redirect.
-	// /v1/sequence-templates is the reverse -- unslashed is the real route --
-	// which is why this keys off the recorded path instead of the object kind.
-	if strings.HasSuffix(path, "/") && !strings.HasSuffix(result, "/") {
-		result += "/"
-	}
-
-	return result, nil
+	// buildURL preserves the trailing slash recorded in schemas.json, which is
+	// load-bearing on GET /v1/tags/ and /v1/users/ but must stay off
+	// /v1/sequence-templates. See url.go.
+	return buildURL(c.ProviderInfo().BaseURL, modulePath, path)
 }
 
 func newGetRequest(ctx context.Context, endpointURL string) (*http.Request, error) {

--- a/providers/monaco/test/write/account-upsert.json
+++ b/providers/monaco/test/write/account-upsert.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "id": "acc_def456",
+    "name": "Acme Corp",
+    "status": "active",
+    "company": { "domain": "acme.com" },
+    "created_at": "2025-01-02T00:00:00Z",
+    "updated_at": "2026-08-07T09:10:00Z"
+  },
+  "meta": {
+    "timestamp": "2026-08-07T09:10:00Z"
+  }
+}

--- a/providers/monaco/test/write/contact-create.json
+++ b/providers/monaco/test/write/contact-create.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "con_new001",
+    "account_id": null,
+    "first_name": "Grace",
+    "last_name": "Hopper",
+    "email": "grace@acme.com",
+    "title": "Rear Admiral",
+    "created_at": "2026-08-07T09:00:00Z",
+    "updated_at": "2026-08-07T09:00:00Z"
+  },
+  "meta": {
+    "timestamp": "2026-08-07T09:00:00Z"
+  }
+}

--- a/providers/monaco/test/write/contact-update.json
+++ b/providers/monaco/test/write/contact-update.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "con_abc123",
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "email": "jane@acme.com",
+    "title": "CTO",
+    "created_at": "2025-06-15T10:30:00Z",
+    "updated_at": "2026-08-07T09:05:00Z"
+  },
+  "meta": {
+    "timestamp": "2026-08-07T09:05:00Z"
+  }
+}

--- a/providers/monaco/test/write/sequence-template-create.json
+++ b/providers/monaco/test/write/sequence-template-create.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "seqt_001",
+    "name": "Outbound v2",
+    "description": "Three-touch outbound",
+    "status": "draft",
+    "is_default": false,
+    "created_at": "2026-08-07T09:15:00Z",
+    "updated_at": "2026-08-07T09:15:00Z"
+  },
+  "meta": {
+    "timestamp": "2026-08-07T09:15:00Z"
+  }
+}

--- a/providers/monaco/url.go
+++ b/providers/monaco/url.go
@@ -1,0 +1,44 @@
+package monaco
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// buildURL joins path segments onto the base URL, preserving a trailing slash
+// on the last segment when it has one.
+//
+// Monaco's routes are slash-exact and inconsistent about it. Probing the live
+// API: /v1/contacts/, /v1/tags/, /v1/tasks/, /v1/campaigns/, /v1/opportunities/
+// and /v1/accounts/ are served directly while their unslashed forms answer 307,
+// and /v1/audiences and /v1/sequence-templates are the exact reverse. urlbuilder
+// normalizes trailing slashes away unconditionally, so without this the
+// connector would lean on redirects for roughly half its endpoints.
+func buildURL(baseURL string, parts ...string) (string, error) {
+	endpointURL, err := urlbuilder.New(baseURL, parts...)
+	if err != nil {
+		return "", err
+	}
+
+	result := endpointURL.String()
+
+	if wantsTrailingSlash(parts) && !strings.HasSuffix(result, "/") {
+		result += "/"
+	}
+
+	return result, nil
+}
+
+func wantsTrailingSlash(parts []string) bool {
+	for _, part := range slices.Backward(parts) {
+		if part == "" {
+			continue
+		}
+
+		return strings.HasSuffix(part, "/")
+	}
+
+	return false
+}

--- a/providers/monaco/write.go
+++ b/providers/monaco/write.go
@@ -1,0 +1,196 @@
+package monaco
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/monaco/metadata"
+)
+
+// dataKey is where Monaco nests the written record in a write response:
+// {"data": {...record...}, "meta": {...}}.
+const dataKey = "data"
+
+// writeConfig describes how one object is written. Monaco's write paths do not
+// follow from its read paths -- reads go to /v1/contacts/list while writes go to
+// /v1/contacts/ -- so they are spelled out rather than derived from schemas.json.
+//
+// Trailing slashes are reproduced exactly as the live API wants them; see url.go.
+type writeConfig struct {
+	// createPath is the collection endpoint used when RecordId is empty.
+	// Empty means the object cannot be created.
+	createPath string
+
+	// createMethod is the verb for createPath. Normally POST.
+	createMethod string
+
+	// updatePath is the collection the RecordId is appended to, always via PATCH.
+	// Empty means the object cannot be updated.
+	updatePath string
+}
+
+//nolint:gochecknoglobals
+var writeConfigs = map[string]writeConfig{
+	objectAccounts: {
+		// Accounts have no create endpoint -- POST /v1/accounts/ answers 405.
+		// PUT is an upsert keyed on `domain`, which is the only way to insert
+		// one, so a create is routed there. It will update an existing account
+		// when the domain already exists rather than failing as a create would.
+		createPath:   "/accounts/",
+		createMethod: http.MethodPut,
+		updatePath:   "/accounts",
+	},
+	objectAudiences: {
+		createPath:   "/audiences",
+		createMethod: http.MethodPost,
+		// No update endpoint.
+	},
+	objectCampaigns: {
+		createPath:   "/campaigns/",
+		createMethod: http.MethodPost,
+		updatePath:   "/campaigns",
+	},
+	objectContacts: {
+		createPath:   "/contacts/",
+		createMethod: http.MethodPost,
+		updatePath:   "/contacts",
+	},
+	objectOpportunities: {
+		createPath:   "/opportunities/",
+		createMethod: http.MethodPost,
+		updatePath:   "/opportunities",
+	},
+	objectSequenceTemplates: {
+		createPath:   "/sequence-templates",
+		createMethod: http.MethodPost,
+		updatePath:   "/sequence-templates",
+	},
+	objectSequences: {
+		// No create endpoint; sequences are produced by Monaco, not by callers.
+		// PATCH takes an `action` rather than field values.
+		updatePath: "/sequences",
+	},
+	objectTags: {
+		createPath:   "/tags/",
+		createMethod: http.MethodPost,
+		updatePath:   "/tags",
+	},
+	objectTasks: {
+		createPath:   "/tasks/",
+		createMethod: http.MethodPost,
+		updatePath:   "/tasks",
+	},
+}
+
+func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
+	if err := params.ValidateParams(); err != nil {
+		return nil, err
+	}
+
+	endpointURL, method, err := c.buildWriteURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := common.RecordDataToMap(params.RecordData)
+	if err != nil {
+		return nil, err
+	}
+
+	// `id` is server-assigned and appears in no request schema. Dropping it
+	// lets a record read back from Monaco be handed straight to Write.
+	delete(record, "id")
+
+	body, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpointURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+func (c *Connector) buildWriteURL(params common.WriteParams) (string, string, error) {
+	config, ok := writeConfigs[params.ObjectName]
+	if !ok {
+		return "", "", common.ErrOperationNotSupportedForObject
+	}
+
+	modulePath := metadata.Schemas.LookupModuleURLPath(c.ProviderContext.Module())
+
+	if params.IsCreate() {
+		if config.createPath == "" {
+			return "", "", common.ErrOperationNotSupportedForObject
+		}
+
+		url, err := buildURL(c.ProviderInfo().BaseURL, modulePath, config.createPath)
+
+		return url, config.createMethod, err
+	}
+
+	if config.updatePath == "" {
+		return "", "", common.ErrOperationNotSupportedForObject
+	}
+
+	url, err := buildURL(c.ProviderInfo().BaseURL, modulePath, config.updatePath, params.RecordId)
+
+	return url, http.MethodPatch, err
+}
+
+// parseWriteResponse reads the record back out of the `data` envelope. Monaco
+// answers 200 for most writes and 201 for sequence template creation; both
+// carry the same shape.
+func (c *Connector) parseWriteResponse(
+	_ context.Context,
+	params common.WriteParams,
+	_ *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.WriteResult, error) {
+	body, ok := response.Body()
+	if !ok || body == nil {
+		return &common.WriteResult{
+			Success:  true,
+			RecordId: params.RecordId,
+		}, nil
+	}
+
+	record, err := jsonquery.New(body).ObjectOptional(dataKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if record == nil {
+		// No `data` envelope: report success without inventing a record.
+		return &common.WriteResult{
+			Success:  true,
+			RecordId: params.RecordId,
+		}, nil
+	}
+
+	recordID, err := jsonquery.New(record).TextWithDefault("id", params.RecordId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := jsonquery.Convertor.ObjectToMap(record)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.WriteResult{
+		Success:  true,
+		RecordId: recordID,
+		Data:     data,
+	}, nil
+}

--- a/providers/monaco/write_test.go
+++ b/providers/monaco/write_test.go
@@ -1,0 +1,280 @@
+package monaco
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestWrite(t *testing.T) { //nolint:funlen,maintidx
+	t.Parallel()
+
+	responseContactCreate := testutils.DataFromFile(t, "write/contact-create.json")
+	responseContactUpdate := testutils.DataFromFile(t, "write/contact-update.json")
+	responseAccountUpsert := testutils.DataFromFile(t, "write/account-upsert.json")
+	responseSequenceTemplate := testutils.DataFromFile(t, "write/sequence-template-create.json")
+
+	tests := []testconn.TestCaseWrite{
+		{
+			Name:         "Write object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write needs record data",
+			Input:        common.WriteParams{ObjectName: objectContacts},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordData},
+		},
+		{
+			Name: "Unsupported object is rejected",
+			Input: common.WriteParams{
+				ObjectName: objectUsers,
+				RecordData: map[string]any{"email": "x@y.com"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Meetings are read-only",
+			Input: common.WriteParams{
+				ObjectName: objectMeetings,
+				RecordData: map[string]any{"title": "Kickoff"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Sequences cannot be created, only updated",
+			Input: common.WriteParams{
+				ObjectName: objectSequences,
+				RecordData: map[string]any{"action": "start"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Audiences cannot be updated, only created",
+			Input: common.WriteParams{
+				ObjectName: objectAudiences,
+				RecordId:   "aud_001",
+				RecordData: map[string]any{"name": "Renamed"},
+			},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Create contact POSTs to the slash-terminated collection",
+			Input: common.WriteParams{
+				ObjectName: objectContacts,
+				RecordData: map[string]any{
+					"email":      "grace@acme.com",
+					"first_name": "Grace",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					// /v1/contacts would answer 307.
+					mockcond.Path("/v1/contacts/"),
+					mockcond.Body(`{"email":"grace@acme.com","first_name":"Grace"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactCreate),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "con_new001",
+				Errors:   nil,
+				Data: map[string]any{
+					"id":    "con_new001",
+					"email": "grace@acme.com",
+				},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update contact PATCHes the record path",
+			Input: common.WriteParams{
+				ObjectName: objectContacts,
+				RecordId:   "con_abc123",
+				RecordData: map[string]any{"title": "CTO"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPATCH(),
+					mockcond.Path("/v1/contacts/con_abc123"),
+					mockcond.Body(`{"title":"CTO"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactUpdate),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "con_abc123",
+				Errors:   nil,
+				Data:     map[string]any{"title": "CTO"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Server-assigned id is stripped from the request body",
+			Input: common.WriteParams{
+				ObjectName: objectContacts,
+				RecordId:   "con_abc123",
+				RecordData: map[string]any{"id": "con_abc123", "title": "CTO"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPATCH(),
+					// No "id" key -- it appears in no Monaco request schema.
+					mockcond.Body(`{"title":"CTO"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContactUpdate),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "con_abc123",
+				Errors:   nil,
+				Data:     map[string]any{"title": "CTO"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Create account falls back to PUT upsert",
+			Input: common.WriteParams{
+				ObjectName: objectAccounts,
+				RecordData: map[string]any{
+					"domain": "acme.com",
+					"name":   "Acme Corp",
+				},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					// POST /v1/accounts/ answers 405; PUT is the only insert path.
+					mockcond.MethodPUT(),
+					mockcond.Path("/v1/accounts/"),
+					mockcond.Body(`{"domain":"acme.com","name":"Acme Corp"}`),
+				},
+				Then: mockserver.Response(http.StatusOK, responseAccountUpsert),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "acc_def456",
+				Errors:   nil,
+				Data:     map[string]any{"name": "Acme Corp"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Update account still uses PATCH",
+			Input: common.WriteParams{
+				ObjectName: objectAccounts,
+				RecordId:   "acc_def456",
+				RecordData: map[string]any{"status": "active"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPATCH(),
+					mockcond.Path("/v1/accounts/acc_def456"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseAccountUpsert),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "acc_def456",
+				Errors:   nil,
+				Data:     map[string]any{"status": "active"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Sequence templates create on the unslashed route and answer 201",
+			Input: common.WriteParams{
+				ObjectName: objectSequenceTemplates,
+				RecordData: map[string]any{"name": "Outbound v2"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					// Mirror image of contacts: the slashed form is the redirect.
+					mockcond.Path("/v1/sequence-templates"),
+				},
+				Then: mockserver.Response(http.StatusCreated, responseSequenceTemplate),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "seqt_001",
+				Errors:   nil,
+				Data:     map[string]any{"name": "Outbound v2"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Audiences create on the unslashed route",
+			Input: common.WriteParams{
+				ObjectName: objectAudiences,
+				RecordData: map[string]any{"name": "Q3 targets"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/v1/audiences"),
+				},
+				Then: mockserver.Response(http.StatusOK, []byte(`{"data":{"id":"aud_001","name":"Q3 targets"}}`)),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetWrite,
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "aud_001",
+				Errors:   nil,
+				Data:     map[string]any{"name": "Q3 targets"},
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Response without a data envelope still reports success",
+			Input: common.WriteParams{
+				ObjectName: objectTags,
+				RecordId:   "tag_001",
+				RecordData: map[string]any{"name": "Hot"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.MethodPATCH(),
+				Then:  mockserver.Response(http.StatusOK, []byte(`{"meta":{}}`)),
+			}.Server(),
+			Expected: &common.WriteResult{
+				Success:  true,
+				RecordId: "tag_001",
+			},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableWriter, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/test/monaco/write/main.go
+++ b/test/monaco/write/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/monaco"
+	connTest "github.com/amp-labs/connectors/test/monaco"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := connTest.GetMonacoConnector(ctx)
+
+	// Create then update a tag: the cheapest round trip that exercises both
+	// halves of Write, and the least intrusive object to leave behind.
+	created, err := testWrite(ctx, conn, common.WriteParams{
+		ObjectName: "tags",
+		RecordData: map[string]any{
+			"object": "contact",
+			"name":   "ampersand-smoke-test",
+			"color":  "#22c55e",
+		},
+	})
+	if err != nil {
+		slog.Error(err.Error())
+
+		return
+	}
+
+	if _, err := testWrite(ctx, conn, common.WriteParams{
+		ObjectName: "tags",
+		RecordId:   created.RecordId,
+		RecordData: map[string]any{"name": "ampersand-smoke-test-renamed"},
+	}); err != nil {
+		slog.Error(err.Error())
+	}
+
+	// Accounts have no create endpoint, so this must go out as PUT (upsert).
+	// `domain` is the required key it matches on. Expect an update rather than
+	// an insert if the domain already exists.
+	if _, err := testWrite(ctx, conn, common.WriteParams{
+		ObjectName: "accounts",
+		RecordData: map[string]any{
+			"domain": "ampersand-smoke-test.example.com",
+			"name":   "Ampersand Smoke Test",
+		},
+	}); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func testWrite(
+	ctx context.Context, conn *monaco.Connector, params common.WriteParams,
+) (*common.WriteResult, error) {
+	res, err := conn.Write(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("error writing %s: %w", params.ObjectName, err)
+	}
+
+	slog.Info("write",
+		"object", params.ObjectName,
+		"create", params.RecordId == "",
+		"success", res.Success,
+		"recordId", res.RecordId,
+	)
+
+	jsonStr, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling %s result: %w", params.ObjectName, err)
+	}
+
+	slog.Debug(string(jsonStr))
+
+	return res, nil
+}


### PR DESCRIPTION
Context:
Adds create/update support for the 9 Monaco objects that allow writes. meetings and users are read-only, audiences are create-only, sequences are update-only, and everything else returns ErrOperationNotSupportedForObject upfront. Write URLs don't derive from read URLs, so each object gets an explicit writeConfig.

Notable quirks handled: accounts have no POST endpoint, so creates route to the PUT upsert keyed on domain — meaning a create against an existing domain silently updates it. Trailing-slash rules are inconsistent per object, now centralised in url.go and verified live. Responses nest records under data (with 201 for sequence templates vs 200 elsewhere), and a missing envelope still counts as success. id is stripped from request bodies since it's server-assigned, so a read-back record can be written directly.

# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [ ] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [ ] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)
