### PR TITLE
[CON-3464] feat(slack): Exhaustive Unit tests

### DIFF
--- a/providers/slack/support-create_test.go
+++ b/providers/slack/support-create_test.go
@@ -1,0 +1,92 @@
+package slack
+
+import (
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestWriteCreate(t *testing.T) {
+	type writeResponseSpecDuplicate struct {
+		recordKey string
+		idField   string
+	}
+
+	var writeResponseFieldDuplicate = datautils.Map[string, writeResponseSpecDuplicate]{
+		"calls":                  {"call", "id"},
+		"bookmarks":              {"bookmark", "id"},
+		"canvases":               {"", "canvas_id"},
+		"conversations.canvases": {"", "canvas_id"},
+		"conversations":          {"channel", "id"},
+		"files.remote":           {"file", "id"},
+		"slackLists":             {"", "list_id"},
+		"slackLists.items":       {"item", "id"},
+		"usergroups":             {"usergroup", "id"},
+	}
+
+	writeRequestMap := map[string]mockcond.Condition{
+		"bookmarks":              mockcond.Path("/api/bookmarks.add"),
+		"calls":                  mockcond.Path("/api/calls.add"),
+		"canvases":               mockcond.Path("/api/canvases.create"),
+		"conversations":          mockcond.Path("/api/conversations.create"),
+		"conversations.canvases": mockcond.Path("/api/conversations.canvases.create"),
+		"files.remote":           mockcond.Path("/api/files.remote.add"),
+		"slackLists":             mockcond.Path("/api/slackLists.create"),
+		"slackLists.items":       mockcond.Path("/api/slackLists.items.create"),
+		"usergroups":             mockcond.Path("/api/usergroups.create"),
+	}
+
+	objectNames := writeResponseFieldDuplicate.Keys()
+	sort.Strings(objectNames)
+	for _, objectName := range objectNames {
+		spec := writeResponseFieldDuplicate[objectName]
+
+		t.Run(objectName, func(t *testing.T) {
+			inner := map[string]any{spec.idField: "test-id"}
+			body := map[string]any{"ok": true}
+			if spec.recordKey != "" {
+				body[spec.recordKey] = inner
+			} else if spec.idField != "" {
+				body[spec.idField] = "test-id"
+			}
+
+			path := writeRequestMap[objectName]
+			tc := testconn.TestCaseWrite{
+				Name: objectName,
+				Input: common.WriteParams{
+					ObjectName: objectName,
+					RecordData: map[string]any{},
+				},
+				Server: mockserver.Conditional{
+					Setup: mockserver.ContentJSON(),
+					If:    mockcond.And{mockcond.MethodPOST(), path},
+					Then:  mockserver.Response(http.StatusOK, testJSONMarshal(t, body)),
+				}.Server(),
+				Expected: &common.WriteResult{
+					Success:  true,
+					RecordId: "test-id",
+					Data:     inner,
+				},
+			}
+
+			if spec.recordKey == "" {
+				tc.Expected.Data = body
+			}
+
+			if spec.idField == "" {
+				tc.Expected.RecordId = ""
+				tc.Expected.Data = nil
+			}
+
+			tc.Run(t, func() (testconn.TestableWriter, error) {
+				return constructTestConnector(tc.Server)
+			})
+		})
+	}
+}

--- a/providers/slack/support-read-batch_test.go
+++ b/providers/slack/support-read-batch_test.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestBatchReadSupport(t *testing.T) {
+	var readSingleRecordResourceNameToQueryParamDuplicate = datautils.Map[string, string]{ // nolint:gochecknoglobals
+		"bots.info":          "bot",
+		"calls.info":         "id",
+		"conversations.info": "channel",
+		"files.info":         "file",
+		"users.info":         "user",
+	}
+
+	var readSingleRecordResourceNameToResponseFieldDuplicate = datautils.Map[string, string]{ // nolint:gochecknoglobals
+		"bots.info":          "bot",
+		"calls.info":         "call",
+		"conversations.info": "channel",
+		"files.info":         "file",
+		"users.info":         "user",
+	}
+
+	objectNames := []string{
+		"bots",
+		"calls",
+		"conversations",
+		"files",
+		"users",
+	}
+
+	for _, objectName := range objectNames {
+		t.Run(objectName, func(t *testing.T) {
+			operationName := objectName + ".info"
+			queryParam := readSingleRecordResourceNameToQueryParamDuplicate[operationName]
+			fieldKey := readSingleRecordResourceNameToResponseFieldDuplicate[operationName]
+
+			tc := testconn.TestCaseGetRecordsByIds{
+				Name: objectName,
+				Input: testconn.ReadByIdsParams{
+					ObjectName: objectName,
+					RecordIds:  []string{"test-id"},
+					Fields:     []string{"id"},
+				},
+				Server: mockserver.Conditional{
+					Setup: mockserver.ContentJSON(),
+					If: mockcond.And{
+						mockcond.MethodGET(),
+						mockcond.Path("/api/" + operationName),
+						mockcond.QueryParam(queryParam, "test-id"),
+					},
+					Then: mockserver.Response(http.StatusOK, testJSONMarshal(t, map[string]any{
+						"ok":     true,
+						fieldKey: map[string]any{"id": "test-id"},
+					})),
+				}.Server(),
+				Expected: []common.ReadResultRow{{
+					Fields: map[string]any{"id": "test-id"},
+					Raw:    map[string]any{"id": "test-id"},
+					Id:     "test-id",
+				}},
+			}
+
+			tc.Run(t, func() (testconn.TestableBatchReader, error) {
+				return constructTestConnector(tc.Server)
+			})
+		})
+	}
+}

--- a/providers/slack/support-read_test.go
+++ b/providers/slack/support-read_test.go
@@ -1,0 +1,137 @@
+package slack
+
+import (
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestObjectResponseField(t *testing.T) {
+	var objectResponseFieldDuplicate = datautils.Map[string, string]{
+		"auth.teams":                        "teams",
+		"chat.scheduledMessages":            "scheduled_messages",
+		"conversations":                     "channels",
+		"conversations.listConnectInvites":  "invites",
+		"conversations.requestSharedInvite": "invites",
+		"files":                             "files",
+		"files.remote":                      "files",
+		"reactions":                         "items",
+		"team.externalTeams":                "external_teams",
+		"usergroups":                        "usergroups",
+		"users":                             "members",
+		"users.conversations":               "channels",
+	}
+
+	var objectsWithConnectorSideFilterDuplicate = datautils.Map[string, string]{
+		"conversations": "updated",
+		"files":         "created",
+		"usergroups":    "date_update",
+		"users":         "updated",
+	}
+
+	readRequestMap := map[string]mockcond.Condition{
+		"auth.teams": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/auth.teams.list"),
+		},
+		"chat.scheduledMessages": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/chat.scheduledMessages.list"),
+		},
+		"conversations": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/conversations.list"),
+		},
+		"files": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/files.list"),
+		},
+		"files.remote": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/files.remote.list"),
+		},
+		"reactions": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/reactions.list"),
+		},
+		"team.externalTeams": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/team.externalTeams.list"),
+		},
+		"usergroups": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/usergroups.list"),
+		},
+		"users": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/users.list"),
+		},
+		"users.conversations": mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path("/api/users.conversations"),
+		},
+		"conversations.listConnectInvites": mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/api/conversations.listConnectInvites"),
+		},
+		"conversations.requestSharedInvite": mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/api/conversations.requestSharedInvite.list"),
+		},
+	}
+
+	tests := make([]testconn.TestCaseRead, 0, len(objectResponseFieldDuplicate))
+	objectNames := objectResponseFieldDuplicate.Keys()
+	sort.Strings(objectNames)
+
+	for _, objectName := range objectNames {
+		arrayKey := objectResponseFieldDuplicate[objectName]
+		record1 := map[string]any{"id": "test1"}
+		record2 := map[string]any{"id": "test2"}
+		array := []map[string]any{record1, record2}
+		expectedRows := int64(2)
+		if tsField, ok := objectsWithConnectorSideFilterDuplicate[objectName]; ok {
+			record1[tsField] = 1000
+			record2[tsField] = 2000
+			expectedRows = 1
+		}
+
+		tests = append(tests, testconn.TestCaseRead{
+			Name: objectName,
+			Input: common.ReadParams{
+				ObjectName: objectName,
+				Fields:     connectors.Fields("id"),
+				Since:      time.Unix(1050, 0), // between 1000 and 2000.
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    readRequestMap[objectName],
+				Then: mockserver.Response(http.StatusOK, testJSONMarshal(t, map[string]any{
+					"ok":     true,
+					arrayKey: array,
+				})),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows: expectedRows,
+				Done: true,
+			},
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			tt.Run(t, func() (testconn.TestableReader, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/slack/support-update_test.go
+++ b/providers/slack/support-update_test.go
@@ -1,0 +1,128 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestWriteUpdate(t *testing.T) {
+	var writeUpdateSuffixDuplicate = datautils.Map[string, string]{
+		"bookmarks":    ".edit",
+		"calls":        ".update",
+		"canvases":     ".edit",
+		"files.remote": ".update",
+		"slackLists":   ".update",
+		"usergroups":   ".update",
+	}
+
+	var writeUpdateIdFieldDuplicate = datautils.Map[string, string]{
+		"bookmarks":    "bookmark_id",
+		"calls":        "id",
+		"canvases":     "canvas_id",
+		"files.remote": "file",
+		"slackLists":   "id",
+		"usergroups":   "usergroup",
+	}
+
+	type writeResponseSpecDuplicate struct {
+		recordKey string
+		idField   string
+	}
+
+	var writeResponseFieldDuplicate = datautils.Map[string, writeResponseSpecDuplicate]{
+		"calls":                  {"call", "id"},
+		"bookmarks":              {"bookmark", "id"},
+		"canvases":               {"", "canvas_id"},
+		"conversations.canvases": {"", "canvas_id"},
+		"conversations":          {"channel", "id"},
+		"files.remote":           {"file", "id"},
+		"slackLists":             {"", "list_id"},
+		"slackLists.items":       {"item", "id"},
+		"usergroups":             {"usergroup", "id"},
+	}
+
+	writeRequestMap := map[string]mockcond.Condition{
+		"bookmarks":    mockcond.Path("/api/bookmarks.edit"),
+		"calls":        mockcond.Path("/api/calls.update"),
+		"canvases":     mockcond.Path("/api/canvases.edit"),
+		"files.remote": mockcond.Path("/api/files.remote.update"),
+		"slackLists":   mockcond.Path("/api/slackLists.update"),
+		"usergroups":   mockcond.Path("/api/usergroups.update"),
+	}
+	objectNames := writeUpdateSuffixDuplicate.Keys()
+	sort.Strings(objectNames)
+
+	for _, objectName := range objectNames {
+		if objectName == "files.remote" {
+			fmt.Println("")
+		}
+
+		t.Run(objectName, func(t *testing.T) {
+			spec := writeResponseFieldDuplicate[objectName]
+			idField := writeUpdateIdFieldDuplicate[objectName]
+
+			inner := map[string]any{spec.idField: "test-id"}
+			body := map[string]any{"ok": true}
+			if spec.recordKey != "" {
+				body[spec.recordKey] = inner
+			} else if spec.idField != "" {
+				body[spec.idField] = "test-id"
+			}
+
+			expectedBody := map[string]any{}
+			if idField != "" {
+				expectedBody[idField] = "test-id"
+			}
+
+			path := writeRequestMap[objectName]
+			tc := testconn.TestCaseWrite{
+				Name: objectName,
+				Input: common.WriteParams{
+					ObjectName: objectName,
+					RecordId:   "test-id",
+					RecordData: map[string]any{},
+				},
+				Server: mockserver.Conditional{
+					Setup: mockserver.ContentJSON(),
+					If: mockcond.And{
+						mockcond.MethodPOST(),
+						path,
+						mockcond.BodyBytes(testJSONMarshal(t, expectedBody)),
+					},
+					Then: mockserver.Response(http.StatusOK, testJSONMarshal(t, body)),
+				}.Server(),
+				Expected: &common.WriteResult{
+					Success:  true,
+					RecordId: "test-id",
+					Data:     inner,
+				},
+			}
+
+			if spec.recordKey == "" {
+				tc.Expected.Data = body
+			}
+
+			tc.Run(t, func() (testconn.TestableWriter, error) {
+				return constructTestConnector(tc.Server)
+			})
+		})
+	}
+}
+
+func testJSONMarshal(t *testing.T, body any) []byte {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal body: %v", err)
+	}
+	return b
+}

--- a/providers/slack/support.go
+++ b/providers/slack/support.go
@@ -110,11 +110,12 @@ var writeUpdateSuffix = datautils.Map[string, string]{
 //
 //nolint:gochecknoglobals
 var writeUpdateIdField = datautils.Map[string, string]{
-	"calls":      "id",
-	"bookmarks":  "bookmark_id",
-	"canvases":   "canvas_id",
-	"slackLists": "id",
-	"usergroups": "usergroup",
+	"bookmarks":    "bookmark_id",
+	"calls":        "id",
+	"canvases":     "canvas_id",
+	"files.remote": "file",
+	"slackLists":   "id",
+	"usergroups":   "usergroup",
 }
 
 // readSingleRecordResourceNameToQueryParam maps Slack API resources that read single records


### PR DESCRIPTION
# Background

This PR is the first in a series that introduces the **Slack for user** connector. The new connector reuses the existing **Slack for bot** implementation rather than duplicating it. The two connectors differ only in the endpoints they can access (response parsing, payload construction, query parameters, and REST methods). All other logic and structure is shared.

Before refactoring the shared code (actually a data structure/mapping), we need a comprehensive test suite to guarantee that subsequent changes do not degrade the existing Slack for bot connector's functionality.

In upcoming PRs, `support.go` will be removed and replaced with a unified registry that serves both `slack` (bot) and `slackUserScope` (user) connectors.

The business logic remains shared. *Only the data layer is extended to support both scopes*!

# Description

This PR adds exhaustive unit tests for every object and mapping currently defined in `support.go`. Specifically:

- Created unit test files covering **read**, **read batch**, **create**, and **update** operations.
- Duplicated the maps from `support.go` into the test suite to assert their contents.
- Tests invoke high-level connector functions rather than internal helpers, which are subject to change and tests must be useful in later PRs.
- Tests are fully self-sustained and do not reference any data structures. Duplication in tests makes it independent.

## Test coverage validation

To verify that the tests are exhaustive, I used the following approach:

1. Ran the new test suite.
2. Removed each entry in `support.go` one by one.
3. Confirmed that the tests fail whenever any line is removed.

This proves that the test suite fully captures the behavior provided by `support.go`.

# Future PRs

Going forward, all tests in this suite must pass to ensure no functional regression. If a future PR requires changing or removing any of these tests, the PR description will explicitly explain why and what functionality is being altered or deprecated. This ensures that:

- **Expectations** of existing functionality are **fully documented**.
- Any **outdated** or superseded **behavior** is clearly **identified**.
- Customers experience **no degradation in service**.