### PR TITLE
feat(salesforce): add CancelDeploy for Metadata API deployments

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -79,6 +79,9 @@ type ApexTriggerResult struct {
 // DeployResult contains the outcome of a Salesforce Metadata API deployment.
 type DeployResult = metadata.DeployResult
 
+// CancelDeployResult is an alias, see internal package for implementation.
+type CancelDeployResult = metadata.CancelDeployResult
+
 const (
 	deployPollInterval = 10 * time.Second
 	deployPollTimeout  = 15 * time.Minute
@@ -298,6 +301,19 @@ func (c *Connector) DeployMetadataZipWithTests(
 func (c *Connector) CheckDeployStatus(ctx context.Context, deployID string) (*DeployResult, error) {
 	if c.crmAdapter != nil {
 		return c.crmAdapter.CheckDeployStatus(ctx, deployID)
+	}
+
+	return nil, common.ErrNotImplemented
+}
+
+// CancelDeploy requests cancellation of a queued (Pending) or InProgress deployment
+// via the Metadata API cancelDeploy operation. Cancellation is asynchronous: when the
+// returned result's Done is false, poll CheckDeployStatus until the deploy reports
+// Done (final status "Canceled"). A deploy that has already finished cannot be
+// canceled; Salesforce returns a SOAP fault, surfaced as an error.
+func (c *Connector) CancelDeploy(ctx context.Context, deployID string) (*CancelDeployResult, error) {
+	if c.crmAdapter != nil {
+		return c.crmAdapter.CancelDeploy(ctx, deployID)
 	}
 
 	return nil, common.ErrNotImplemented

--- a/providers/salesforce/internal/crm/adapter.go
+++ b/providers/salesforce/internal/crm/adapter.go
@@ -109,6 +109,11 @@ func (a Adapter) CheckDeployStatus(ctx context.Context, deployID string) (*metad
 	return a.customAdapter.CheckDeployStatus(ctx, deployID)
 }
 
+func (a Adapter) CancelDeploy(ctx context.Context, deployID string) (*metadata.CancelDeployResult, error) {
+	// Delegated.
+	return a.customAdapter.CancelDeploy(ctx, deployID)
+}
+
 // Gateway access to URLs.
 func (a Adapter) getModuleURL() string {
 	return a.ModuleInfo().BaseURL

--- a/providers/salesforce/internal/crm/metadata/deploy.go
+++ b/providers/salesforce/internal/crm/metadata/deploy.go
@@ -44,6 +44,15 @@ type DeployResult struct {
 	CodeCoverage []CodeCoverage
 }
 
+// CancelDeployResult contains the immediate outcome of a Salesforce Metadata API
+// cancelDeploy call. Done=false means the cancellation is still being processed
+// org-side; the caller polls CheckDeployStatus until the deploy reports Done
+// (final status "Canceled").
+type CancelDeployResult struct {
+	Done bool
+	ID   string
+}
+
 // ComponentFailure describes a single component failure in a deployment.
 type ComponentFailure struct {
 	ComponentType string
@@ -154,6 +163,30 @@ func (a *Adapter) CheckDeployStatus(ctx context.Context, deployID string) (*Depl
 	}, nil
 }
 
+// CancelDeploy requests cancellation of a queued (Pending) or InProgress
+// deployment via the Metadata API SOAP cancelDeploy operation. Cancellation is
+// asynchronous: when the returned result's Done is false, the caller polls
+// CheckDeployStatus until the deploy reports Done (final status "Canceled").
+// A deploy that has already finished cannot be canceled; Salesforce returns a
+// SOAP fault, surfaced here as an error.
+func (a *Adapter) CancelDeploy(ctx context.Context, deployID string) (*CancelDeployResult, error) {
+	payload := fmt.Sprintf(`<md:cancelDeploy xmlns:md="http://soap.sforce.com/2006/04/metadata">
+  <md:asyncProcessId>%s</md:asyncProcessId>
+</md:cancelDeploy>`, deployID)
+
+	resp, err := performDeploySOAPRequest[cancelDeployResponse](ctx, a, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cancel deploy response: %w", err)
+	}
+
+	result := &resp.CancelDeployResponse.Result
+
+	return &CancelDeployResult{
+		Done: result.Done,
+		ID:   result.ID,
+	}, nil
+}
+
 // deploy sends a SOAP deploy request with the base64-encoded zip to the Metadata API.
 // Returns the async deployment ID for status polling.
 //
@@ -217,6 +250,15 @@ type deployResponse struct {
 			Done bool   `xml:"done"`
 		} `xml:"result"`
 	} `xml:"deployResponse"`
+}
+
+type cancelDeployResponse struct {
+	CancelDeployResponse struct {
+		Result struct {
+			Done bool   `xml:"done"`
+			ID   string `xml:"id"`
+		} `xml:"result"`
+	} `xml:"cancelDeployResponse"`
 }
 
 type checkDeployStatusResponse struct {


### PR DESCRIPTION
## Why

The server's `salesforce-subscribe-cleanup` script starts destructive apex deploys through the Metadata API. Metadata deploys serialize per org, so a deploy can sit `Pending` in the queue indefinitely; the connector exposes the deploy lifecycle (`DeployMetadataZip`/`DeployMetadataZipWithTests`/`CheckDeployStatus`) but no way to cancel one.

## What

Adds `CancelDeploy(ctx, deployID)` through the same three layers as `CheckDeployStatus`:

- `internal/crm/metadata`: SOAP `cancelDeploy` call via the existing `performDeploySOAPRequest` plumbing, returning a new `CancelDeployResult{Done, ID}`.
- `internal/crm`: delegation on the CRM adapter.
- `providers/salesforce`: `Connector.CancelDeploy` (with the `CancelDeployResult` alias), `common.ErrNotImplemented` for non-CRM modules.

Cancellation is asynchronous: when `Done` is false the caller polls `CheckDeployStatus` until the deploy reports `Done` with final status `Canceled`. A deploy that already finished can't be canceled — Salesforce returns a SOAP fault, surfaced as an error.

Consumed by amp-labs/server#7007 (polling-only mode gains a cancel option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)