### PR TITLE
[ENG-4190] feat: add BulkSubscriptionEvent interface for event dedup

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -881,6 +881,33 @@ type CollapsedSubscriptionEvent interface {
 	SubscriptionEventList() ([]SubscriptionEvent, error)
 }
 
+// BulkSubscriptionEvent is an optional interface implemented only by provider
+// events that originate from a bulk provider operation and may therefore be
+// delivered more than once (e.g. provider retries, overlapping delivery
+// channels, or fan-out of a single bulk change). It lets the server deduplicate
+// such events with a short-lived idempotency key.
+//
+// It is a separate interface from SubscriptionEvent, detected downstream via a
+// type assertion, so adding it does not change the SubscriptionEvent contract or
+// require any change to existing providers. Only providers with real bulk
+// semantics implement it.
+type BulkSubscriptionEvent interface {
+	SubscriptionEvent
+
+	// IsBulk reports whether this specific event came from a bulk operation and
+	// may be delivered more than once. A provider whose event type is only
+	// sometimes bulk can decide this per event at runtime.
+	IsBulk() (bool, error)
+
+	// UniqueRef returns a stable idempotency key for this event — the same
+	// logical event, redelivered, must yield the same value. It should be
+	// derived from the provider's own event/delivery id, not from RecordId (the
+	// same record changing twice is two legitimate events). Returns "" when the
+	// provider gives us nothing to deduplicate on, in which case the event is
+	// always processed.
+	UniqueRef() (string, error)
+}
+
 // WebhookRequest is a struct that contains the request parameters for a webhook.
 type WebhookRequest struct {
 	Headers http.Header


### PR DESCRIPTION
**Draft** · part of the bulk subscribe-event dedup stack (ENG-4190).

## What
Adds a new optional `BulkSubscriptionEvent` interface in `common/types.go`:

```go
type BulkSubscriptionEvent interface {
    SubscriptionEvent
    IsBulk() (bool, error)
    UniqueRef() (string, error)
}
```

## Why
Some providers emit the same logical webhook event more than once for bulk operations (provider retries, overlapping delivery channels, fan-out of a single bulk change). The server dedups these using a short-TTL idempotency key. This interface is how a connector opts in and supplies that key:

- `IsBulk()` — is this specific event a bulk event that may be redelivered? (runtime, so an event type that is only *sometimes* bulk can decide per event)
- `UniqueRef()` — a stable idempotency key; the same logical event redelivered must yield the same value. Derived from the provider's own event/delivery id, not `RecordId`.

## Design notes
- **Separate interface, not a change to `SubscriptionEvent`.** The server detects it via a type assertion, so **no existing provider changes** and the `SubscriptionEvent` contract is untouched. Only providers with real bulk semantics implement it.
- Provider implementations (e.g. Stripe's event `id`) are follow-ups.

## Related
- Server (dedup logic + Redis cluster client): amp-labs/server `jlim/subscribe-event-dedupe`
- Argocd (messenger env): amp-labs/argocd `jlim/subscribe-event-dedupe`
- Proposal: *Deduplicating Bulk-Processed Subscribe Events* (ENG-4190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
