### PR TITLE
feat(salesforce): 2h deploy poll with backoff; proceed when trigger deploys outlive the window

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -83,8 +83,20 @@ type DeployResult = metadata.DeployResult
 type CancelDeployResult = metadata.CancelDeployResult
 
 const (
-	deployPollInterval = 10 * time.Second
-	deployPollTimeout  = 15 * time.Minute
+	// deployPollTimeout bounds how long pollDeployStatus waits for a single deploy.
+	// Metadata deploys serialize per org, so on a busy org a deploy can sit queued
+	// (status Pending) far longer than the deploy itself takes to execute — the
+	// window has to cover queue time, not just run time.
+	deployPollTimeout = 2 * time.Hour
+
+	// Deploy status checks back off in steps: quick checks while a fast deploy
+	// might still finish, then progressively sparser ones for the long-haul wait
+	// (see deployPollInterval).
+	deployPollIntervalFast = 10 * time.Second
+	deployPollIntervalSlow = 1 * time.Minute
+	deployPollIntervalIdle = 5 * time.Minute
+	deployPollFastWindow   = 1 * time.Minute
+	deployPollSlowWindow   = 10 * time.Minute
 
 	// apexDeployMaxAttempts is the maximum number of attempts for deploying an apex trigger.
 	// Retries handle the race condition where a custom field was just created via Metadata API
@@ -560,8 +572,25 @@ func (c *Connector) deployDestructiveApex(
 	return deployResult, nil
 }
 
+// deployPollInterval returns the pause before the next deploy status check,
+// stepped by how long the deploy has already been polled: 10s checks during the
+// first minute (a fast deploy finishes almost immediately), 1m checks until ten
+// minutes have passed, then 5m checks for the long-haul wait behind a busy
+// org's deploy queue.
+func deployPollInterval(elapsed time.Duration) time.Duration {
+	switch {
+	case elapsed < deployPollFastWindow:
+		return deployPollIntervalFast
+	case elapsed < deployPollSlowWindow:
+		return deployPollIntervalSlow
+	default:
+		return deployPollIntervalIdle
+	}
+}
+
 func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*DeployResult, error) {
 	timeout := time.After(deployPollTimeout)
+	start := time.Now()
 
 	for {
 		deployResult, err := c.CheckDeployStatus(ctx, deployID)
@@ -580,7 +609,7 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 			return nil, ctx.Err()
 		case <-timeout:
 			return nil, fmt.Errorf("%w after %s for deployId %s", errDeployPollTimeout, deployPollTimeout, deployID)
-		case <-time.After(deployPollInterval):
+		case <-time.After(deployPollInterval(time.Since(start))):
 			// continue polling
 		}
 	}

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -593,17 +593,36 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 	timeout := time.After(deployPollTimeout)
 	start := time.Now()
 
+	slog.InfoContext(ctx, "polling metadata deploy status",
+		"deployId", deployID,
+		"timeout", deployPollTimeout.String(),
+	)
+
 	for {
 		deployResult, err := c.CheckDeployStatus(ctx, deployID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check deploy status: %w", err)
 		}
 
+		elapsed := time.Since(start).Round(time.Second)
+
 		if deployResult.Done {
+			slog.InfoContext(ctx, "metadata deploy finished",
+				"deployId", deployID,
+				"status", deployResult.Status,
+				"success", deployResult.Success,
+				"elapsed", elapsed.String(),
+			)
 			logApexCoverage(ctx, deployID, deployResult)
 
 			return deployResult, nil
 		}
+
+		slog.InfoContext(ctx, "still polling metadata deploy",
+			"deployId", deployID,
+			"status", deployResult.Status,
+			"elapsed", elapsed.String(),
+		)
 
 		select {
 		case <-ctx.Done():

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -608,7 +609,7 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-timeout:
-			return nil, fmt.Errorf("%w after %s for deployId %s", errDeployPollTimeout, deployPollTimeout, deployID)
+			return nil, fmt.Errorf("%w after %s for deployId %s", ErrDeployPollTimeout, deployPollTimeout, deployID)
 		case <-time.After(deployPollInterval(time.Since(start))):
 			// continue polling
 		}
@@ -654,21 +655,59 @@ func filterSuccessfulTriggers(
 	return successful
 }
 
+// onlyDeployPollTimeouts reports whether out carries at least one per-object
+// deploy error and every one of them is a poll timeout — i.e. no deploy
+// actually failed; they are all still queued/running org-side and expected to
+// land on their own.
+func onlyDeployPollTimeouts(out *DeployApexTriggersResult) bool {
+	if out == nil || len(out.Errors) == 0 {
+		return false
+	}
+
+	for _, err := range out.Errors {
+		if !errors.Is(err, ErrDeployPollTimeout) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// timedOutTriggerObjects lists the object names whose trigger deploy hit the
+// poll timeout, for logging.
+func timedOutTriggerObjects(out *DeployApexTriggersResult) []string {
+	objects := make([]string, 0, len(out.Errors))
+
+	for objName, err := range out.Errors {
+		if errors.Is(err, ErrDeployPollTimeout) {
+			objects = append(objects, string(objName))
+		}
+	}
+
+	sort.Strings(objects)
+
+	return objects
+}
+
 // toApexTriggers converts deploy results to the ApexTrigger type stored in
-// SubscribeResult. Only successfully deployed triggers (non-empty DeployID) are
-// emitted, so the returned map faithfully describes triggers that exist in
-// Salesforce. Per-object deploy errors are aggregated into out.Errors and
-// surfaced through the error chain returned from Subscribe / UpdateSubscription;
-// they are also logged here per object so that, even if the caller swallows the
-// aggregate error, a failed-deploy entry has a corresponding warn log keyed to
-// the object name.
+// SubscribeResult. Successfully deployed triggers (non-empty DeployID) are
+// emitted, and so are triggers whose deploy merely outlived the poll window
+// (ErrDeployPollTimeout) — those are still running org-side and expected to
+// land, so recording the intended entry keeps later lifecycle operations
+// (update/unsubscribe) tracking them, mirroring the manual-verify path which
+// records intent. Genuinely failed deploys are omitted so the map never
+// describes a trigger that will not exist. Per-object deploy errors are
+// aggregated into out.Errors and surfaced through the error chain returned
+// from Subscribe / UpdateSubscription; they are also logged here per object so
+// that, even if the caller swallows the aggregate error, a failed-deploy entry
+// has a corresponding warn log keyed to the object name.
 func toApexTriggers(
 	out *DeployApexTriggersResult,
 ) map[common.ObjectName]*ApexTrigger {
 	triggers := make(map[common.ObjectName]*ApexTrigger, len(out.Results))
 
 	for objName, result := range out.Results {
-		if result.DeployID == "" {
+		if result.DeployID == "" && !errors.Is(out.Errors[objName], ErrDeployPollTimeout) {
 			slog.Warn("apex trigger deploy failed; entry omitted from sfRes.ApexTriggers",
 				"object", objName,
 				"error", out.Errors[objName],

--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/internal/simultaneously"
 	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/metadata"
 )
@@ -593,7 +594,11 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 	timeout := time.After(deployPollTimeout)
 	start := time.Now()
 
-	slog.InfoContext(ctx, "polling metadata deploy status",
+	// logging.Logger (rather than raw slog) inherits the caller's structured
+	// fields set via logging.With — e.g. amp-labs/server enriches the subscribe
+	// context with installation/subscription/project ids, so every poll line
+	// below carries them.
+	logging.Logger(ctx).InfoContext(ctx, "polling metadata deploy status",
 		"deployId", deployID,
 		"timeout", deployPollTimeout.String(),
 	)
@@ -607,7 +612,7 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 		elapsed := time.Since(start).Round(time.Second)
 
 		if deployResult.Done {
-			slog.InfoContext(ctx, "metadata deploy finished",
+			logging.Logger(ctx).InfoContext(ctx, "metadata deploy finished",
 				"deployId", deployID,
 				"status", deployResult.Status,
 				"success", deployResult.Success,
@@ -618,7 +623,7 @@ func (c *Connector) pollDeployStatus(ctx context.Context, deployID string) (*Dep
 			return deployResult, nil
 		}
 
-		slog.InfoContext(ctx, "still polling metadata deploy",
+		logging.Logger(ctx).InfoContext(ctx, "still polling metadata deploy",
 			"deployId", deployID,
 			"status", deployResult.Status,
 			"elapsed", elapsed.String(),

--- a/providers/salesforce/register.go
+++ b/providers/salesforce/register.go
@@ -11,11 +11,17 @@ import (
 	"github.com/go-playground/validator"
 )
 
+// ErrDeployPollTimeout is returned (wrapped) when a Metadata API deploy did not
+// finish within the poll window. The deploy itself is NOT canceled — metadata
+// deploys serialize per org, so it stays queued/running org-side and can still
+// land later. Exported so callers can distinguish "still running" from a real
+// deploy failure via errors.Is.
+var ErrDeployPollTimeout = errors.New("deploy poll timeout")
+
 var (
 	errInvalidRequestType      = errors.New("invalid request type")
 	errMissingParams           = errors.New("missing required parameters")
 	errDeployFailed            = errors.New("apex trigger deployment failed")
-	errDeployPollTimeout       = errors.New("deploy poll timeout")
 	errDestructiveDeployFailed = errors.New("destructive apex trigger deployment failed")
 )
 

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
 	"github.com/amp-labs/connectors/common/naming"
 	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/go-playground/validator"
@@ -245,31 +246,8 @@ func (c *Connector) executeSubscribe(
 		if err != nil {
 			return sfRes, progress, err
 		}
-	} else {
-		deployOut, err := c.deployApexTriggersForCDC(ctx, params, req)
-
-		progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
-		sfRes.ApexTriggers = toApexTriggers(deployOut)
-
-		switch {
-		case err == nil:
-		case onlyDeployPollTimeouts(deployOut):
-			// Every deploy failure is a poll timeout: the deploys are still
-			// queued/running org-side (metadata deploys serialize per org, so queue
-			// wait can exceed any reasonable poll window) and will land on their
-			// own. Proceed instead of rolling the whole subscribe back —
-			// CREATE/DELETE events flow as soon as the channel members below exist;
-			// UPDATE events for the affected objects are dropped by the member
-			// filter until the trigger lands and starts flipping the indicator
-			// field. If a deploy ultimately fails org-side, UPDATE events keep
-			// being dropped — check Setup > Deployment Status for the verdict.
-			slog.WarnContext(ctx,
-				"apex trigger deploy(s) still running after poll timeout; proceeding without waiting — "+
-					"UPDATE events are dropped until the trigger lands",
-				"objects", timedOutTriggerObjects(deployOut))
-		default:
-			return sfRes, progress, err
-		}
+	} else if err := c.deployTriggersToleratingTimeouts(ctx, params, req, sfRes, progress); err != nil {
+		return sfRes, progress, err
 	}
 
 	if err := c.createEventChannelMembers(ctx, params, registrationParams, req, sfRes); err != nil {
@@ -277,6 +255,45 @@ func (c *Connector) executeSubscribe(
 	}
 
 	return sfRes, progress, nil
+}
+
+// deployTriggersToleratingTimeouts deploys the CDC apex triggers and records the
+// outcome on sfRes/progress. A poll timeout is not treated as failure: when
+// EVERY deploy error is ErrDeployPollTimeout, the deploys are still
+// queued/running org-side (metadata deploys serialize per org, so queue wait can
+// exceed any reasonable poll window) and will land on their own, so Subscribe
+// proceeds instead of rolling back — CREATE/DELETE events flow as soon as the
+// channel members exist; UPDATE events for the affected objects are dropped by
+// the member filter until the trigger lands and starts flipping the indicator
+// field. If a deploy ultimately fails org-side, UPDATE events keep being
+// dropped — check Setup > Deployment Status for the verdict. Any real deploy
+// failure is returned and fails Subscribe as before.
+func (c *Connector) deployTriggersToleratingTimeouts(
+	ctx context.Context,
+	params common.SubscribeParams,
+	req *SubscriptionRequest,
+	sfRes *SubscribeResult,
+	progress *subscribeProgress,
+) error {
+	deployOut, err := c.deployApexTriggersForCDC(ctx, params, req)
+
+	progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
+	sfRes.ApexTriggers = toApexTriggers(deployOut)
+
+	if err == nil {
+		return nil
+	}
+
+	if !onlyDeployPollTimeouts(deployOut) {
+		return err
+	}
+
+	logging.Logger(ctx).WarnContext(ctx,
+		"apex trigger deploy(s) still running after poll timeout; proceeding without waiting — "+
+			"UPDATE events are dropped until the trigger lands",
+		"objects", timedOutTriggerObjects(deployOut))
+
+	return nil
 }
 
 // createEventChannelMembers creates CDC event channel members for each subscribed object,

--- a/providers/salesforce/subscribe.go
+++ b/providers/salesforce/subscribe.go
@@ -251,7 +251,23 @@ func (c *Connector) executeSubscribe(
 		progress.deployedTriggers = filterSuccessfulTriggers(deployOut)
 		sfRes.ApexTriggers = toApexTriggers(deployOut)
 
-		if err != nil {
+		switch {
+		case err == nil:
+		case onlyDeployPollTimeouts(deployOut):
+			// Every deploy failure is a poll timeout: the deploys are still
+			// queued/running org-side (metadata deploys serialize per org, so queue
+			// wait can exceed any reasonable poll window) and will land on their
+			// own. Proceed instead of rolling the whole subscribe back —
+			// CREATE/DELETE events flow as soon as the channel members below exist;
+			// UPDATE events for the affected objects are dropped by the member
+			// filter until the trigger lands and starts flipping the indicator
+			// field. If a deploy ultimately fails org-side, UPDATE events keep
+			// being dropped — check Setup > Deployment Status for the verdict.
+			slog.WarnContext(ctx,
+				"apex trigger deploy(s) still running after poll timeout; proceeding without waiting — "+
+					"UPDATE events are dropped until the trigger lands",
+				"objects", timedOutTriggerObjects(deployOut))
+		default:
 			return sfRes, progress, err
 		}
 	}


### PR DESCRIPTION
## Why

Metadata deploys serialize per org, so an apex trigger deploy can sit `Pending` in the org's deploy queue far longer than the 15-minute poll window. When the poll gave up, the whole Subscribe rolled back — but the deploy keeps running org-side and its trigger can land later, orphaned (the wedged states amp-labs/server's `salesforce-subscribe-cleanup` script keeps cleaning up).

## What

**Poll window & cadence**
- `deployPollTimeout`: 15m → **2h** per deploy — sized to cover queue time, not just run time. Affects both apex deploy paths (`deployApexTrigger` and `deployDestructiveApex`).
- Stepped backoff via `deployPollInterval(elapsed)`: **10s** checks during the first minute, **1m** until ten minutes elapsed, then **5m** — worst case ~40 status calls over 2h instead of 720.

**Timeout ≠ failure**
- `ErrDeployPollTimeout` is now exported so callers can `errors.Is` it.
- `executeSubscribe` no longer fails/rolls back when **every** trigger-deploy error is a poll timeout: it warns and proceeds to channel-member creation. CREATE/DELETE events flow immediately; UPDATE events for the affected objects are dropped by the member filter until the trigger lands and starts flipping the indicator field. Any **real** deploy failure still fails and rolls back.
- Timed-out triggers are recorded in `SubscribeResult.ApexTriggers` (intent — mirroring the manual-verify path) so update/unsubscribe keep tracking them.

Note for consumers: amp-labs/server's subscribe activity ceilings (`ActivityMaxExecutionTime` 30m / no-heartbeat `HeartbeatTimeout` 20m) are sized above the old 15m window — raised in amp-labs/server#7016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)