### PR TITLE
[CON-39] feat: update basecamp OAuth requirements

### DIFF
--- a/providers/basecamp.go
+++ b/providers/basecamp.go
@@ -46,7 +46,7 @@ func init() {
 				{
 					Name:        "workspace",
 					DisplayName: "Account ID",
-					Prompt:      "our account ID is the unique number located in your Basecamp URL. For example, in `https://app.basecamp.com/6258233/projects`, the account ID is 6258233.`",
+					Prompt:      "our account ID is the unique number located in your Basecamp URL. For example, in `https://app.basecamp.com/6258233/projects`, the account ID is 6258233.`", // nolint:lll
 				},
 			},
 		},

--- a/providers/basecamp.go
+++ b/providers/basecamp.go
@@ -3,8 +3,11 @@ package providers
 const Basecamp Provider = "basecamp"
 
 func init() {
-	// Basecamp Configuration
-	// The wokspace in baseURL should be mapped to accounts.id
+	// Basecamp Configuration.
+	// The workspace in baseURL maps to accounts[].id from the authorization document.
+	// Every Basecamp resource endpoint is prefixed with the account ID; only
+	// https://launchpad.37signals.com/authorization.json can be reached without it,
+	// which is where a user can look the account ID up if the URL is not to hand.
 	SetInfo(Basecamp, ProviderInfo{
 		DisplayName: "Basecamp",
 		AuthType:    Oauth2,
@@ -21,8 +24,8 @@ func init() {
 		},
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
-			AuthURL:                   "https://launchpad.37signals.com/authorization/new?type=web_server",
-			TokenURL:                  "https://launchpad.37signals.com/authorization/token?type=refresh",
+			AuthURL:                   "https://launchpad.37signals.com/authorization/new",
+			TokenURL:                  "https://launchpad.37signals.com/authorization/token",
 			ExplicitScopesRequired:    false,
 			ExplicitWorkspaceRequired: false,
 		},
@@ -43,6 +46,8 @@ func init() {
 				{
 					Name:        "workspace",
 					DisplayName: "Account ID",
+					Prompt: "The number in your Basecamp URL. In " +
+						"https://app.basecamp.com/6258233/projects the account ID is 6258233.",
 				},
 			},
 		},

--- a/providers/basecamp.go
+++ b/providers/basecamp.go
@@ -46,8 +46,7 @@ func init() {
 				{
 					Name:        "workspace",
 					DisplayName: "Account ID",
-					Prompt: "The number in your Basecamp URL. In " +
-						"https://app.basecamp.com/6258233/projects the account ID is 6258233.",
+					Prompt:      "our account ID is the unique number located in your Basecamp URL. For example, in `https://app.basecamp.com/6258233/projects`, the account ID is 6258233.`",
 				},
 			},
 		},


### PR DESCRIPTION
The blocker is gone. Basecamp rewrote Launchpad's OAuth to accept standard OAuth 2.0 parameters. One TokenURL now serves both grants, so a plain oauth2.Config works no per-grant URL trickery needed.

# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
<img width="1467" height="809" alt="Screenshot 2026-08-12 at 09 26 55" src="https://github.com/user-attachments/assets/920e2c2a-f9be-4aa5-b67f-e7b687b69315" />


## POST
<img width="1464" height="770" alt="Screenshot 2026-08-12 at 09 34 46" src="https://github.com/user-attachments/assets/24edaa46-44b1-4a57-bd1b-f168ab5c47e2" />

## PUT
<img width="1468" height="536" alt="Screenshot 2026-08-12 at 09 30 05" src="https://github.com/user-attachments/assets/092e46c0-9769-4331-b5ec-0e69a0bb1a4a" />


## DELETE
<img width="1462" height="502" alt="Screenshot 2026-08-12 at 09 35 26" src="https://github.com/user-attachments/assets/2aeb1986-a027-479e-a6eb-840ed362656c" />

## Invalid requests
<img width="1466" height="456" alt="Screenshot 2026-08-12 at 09 28 03" src="https://github.com/user-attachments/assets/1734b2a8-2df5-4fb5-a2cd-31a85bed09f8" />

