### PR TITLE
[ENG-4183] feat(acculynx): add Representative→Job and Estimate→Job associations, hydrate estimates from the detail endpoint

### DIFF
--- a/providers/acculynx/associations.go
+++ b/providers/acculynx/associations.go
@@ -66,6 +66,77 @@ func addAssociation(row *common.ReadResultRow, key, objectID string) {
 	row.Associations[key] = append(row.Associations[key], common.Association{ObjectId: objectID})
 }
 
+// attachNestedAssociations attaches the parent-derived edges for nested
+// fan-out rows. Each attacher is a no-op unless params.ObjectName is its
+// object, so fetchChildPages calls this unconditionally per page.
+func attachNestedAssociations(params common.ReadParams, parentID string, rows []common.ReadResultRow) {
+	attachAppointmentAssociations(params, parentID, rows)
+	attachRepresentativeAssociations(params, parentID, rows)
+}
+
+// representativeJobAssociation and estimateJobAssociation are the association
+// keys for the Representative->Job and Estimate->Job edges. Like the
+// appointment keys above, they match the target object name the server
+// hydrates via GetRecordsByIds.
+const (
+	representativeJobAssociation = objectJobs
+	estimateJobAssociation       = objectJobs
+)
+
+// attachRepresentativeAssociations attaches the Representative->Job edge to
+// jobs/representatives rows produced by the nested fan-out. A representative
+// body carries only id, type, user and _link — no jobId (see
+// https://apidocs.acculynx.com/reference/getrepresentativesforjob) — so the
+// job id is threaded in from the fan-out parent, the same way the
+// Appointment->User edge uses the parent calendar id. Reference shape
+// (ObjectId only): jobs are batch-readable, the server hydrates them.
+//
+// It is a no-op for any object other than jobs/representatives, so the nested
+// fan-out can call it unconditionally.
+func attachRepresentativeAssociations(params common.ReadParams, jobID string, rows []common.ReadResultRow) {
+	if params.ObjectName != "jobs/representatives" || jobID == "" {
+		return
+	}
+
+	if !slices.Contains(params.AssociatedObjects, representativeJobAssociation) {
+		return
+	}
+
+	for idx := range rows {
+		addAssociation(&rows[idx], representativeJobAssociation, jobID)
+	}
+}
+
+// extractEstimateJobs attaches each estimate's job as an association. The
+// estimate body carries the job as an embedded reference stub ({id, _link})
+// plus a top-level isPrimary flag, so this is a pure reshape of the parsed
+// rows — no extra fetch. Reference shape like Appointment->Job (ObjectId only,
+// the server hydrates via GetRecordsByIds); isPrimary rides along in
+// ProviderAssociationMetadata like the Job<->Contact edge below.
+func extractEstimateJobs(rows []common.ReadResultRow) {
+	for idx := range rows {
+		job, _ := rows[idx].Raw["job"].(map[string]any)
+
+		jobID, _ := job["id"].(string)
+		if jobID == "" {
+			continue
+		}
+
+		assoc := common.Association{ObjectId: jobID}
+
+		if v, ok := rows[idx].Raw["isPrimary"]; ok {
+			assoc.ProviderAssociationMetadata = map[string]any{"isPrimary": v}
+		}
+
+		if rows[idx].Associations == nil {
+			rows[idx].Associations = make(map[string][]common.Association)
+		}
+
+		rows[idx].Associations[estimateJobAssociation] = append(
+			rows[idx].Associations[estimateJobAssociation], assoc)
+	}
+}
+
 // jobContactsAssociation is the association key Hatch's config requests (see the
 // server's getHatchAssociations). It matches the embedded "contacts" array that
 // AccuLynx returns on /jobs when the read is issued with ?includes=contacts.

--- a/providers/acculynx/estimates.go
+++ b/providers/acculynx/estimates.go
@@ -27,6 +27,10 @@ import (
 // Like custom fields, hydration mutates only the marshalled record that feeds
 // ReadResultRow.Fields — Raw stays the untouched list payload.
 //
+// Hydration is opt-in per customer via ReadParamsOpts.HydrateEstimates (see
+// read.go) — the extra call per record is not imposed on installs that only
+// need the stub fields or the Estimate->Job association.
+//
 // References:
 //   - List: https://apidocs.acculynx.com/reference/getestimates
 //   - Detail: https://apidocs.acculynx.com/reference/getestimatebyid

--- a/providers/acculynx/estimates.go
+++ b/providers/acculynx/estimates.go
@@ -6,10 +6,10 @@ import (
 	"maps"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/common/readhelper"
 	"github.com/amp-labs/connectors/common/urlbuilder"
-	"github.com/amp-labs/connectors/internal/jsonquery"
 	"github.com/amp-labs/connectors/internal/simultaneously"
-	"github.com/spyzhov/ajson"
 )
 
 // AccuLynx estimate hydration:
@@ -24,8 +24,9 @@ import (
 // detail call per estimate, following the same per-record fan-out shape as
 // the custom-fields value fetch (see custom.go).
 //
-// Like custom fields, hydration mutates only the marshalled record that feeds
-// ReadResultRow.Fields — Raw stays the untouched list payload.
+// The detail is provider data, so it lands in Raw as well as Fields — raw
+// stays "the object as AccuLynx gave it", just assembled from two calls.
+// Rows whose detail fetch was skipped keep the list stub in both.
 //
 // Hydration is opt-in per customer via ReadParamsOpts.HydrateEstimates (see
 // read.go) — the extra call per record is not imposed on installs that only
@@ -44,38 +45,57 @@ import (
 // data the server already hydrates on demand.
 const estimateDetailIncludes = "createdBy,modifiedBy,sections"
 
-// buildEstimateDetailTransformer plans the detail fan-out for every estimate
-// in the current page and returns a transformer that merges each record's
-// detail over the thin list stub. Rows whose detail returned 404 (deleted
-// between the list and detail calls) keep their stub shape.
-func (c *Connector) buildEstimateDetailTransformer(
+// hydrateEstimateRows returns a row post-processor that fetches each row's
+// detail and overlays it onto the thin list stub in Raw AND Fields — detail
+// wins on overlapping keys, it is the authoritative superset. Fields is
+// re-extracted from the merged Raw with the caller's field selection, the
+// same derivation the base marshaller uses. Rows whose detail fetch failed
+// (404, 429, 5xx — see fetchEstimateDetails) keep their stub shape.
+func (c *Connector) hydrateEstimateRows(
 	ctx context.Context,
-	resp *common.JSONHTTPResponse,
-) (common.RecordTransformer, error) {
-	body, hasBody := resp.Body()
-	if !hasBody {
-		// Nothing to hydrate; the pass-through transformer keeps rows as-is.
-		return mergeEstimateDetail(nil), nil
-	}
+	params common.ReadParams,
+) readhelper.RowPostProcessor {
+	return func(rows []common.ReadResultRow) error {
+		ids := make([]string, 0, len(rows))
 
-	ids, err := c.extractParentIDsFromBody(objectEstimates, body)
-	if err != nil {
-		return nil, err
-	}
+		for idx := range rows {
+			if id, _ := rows[idx].Raw["id"].(string); id != "" {
+				ids = append(ids, id)
+			}
+		}
 
-	details, err := c.fetchEstimateDetails(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
+		details, err := c.fetchEstimateDetails(ctx, ids)
+		if err != nil {
+			return err
+		}
 
-	return mergeEstimateDetail(details), nil
+		fields := append(params.Fields.List(), "id")
+
+		for idx := range rows {
+			id, _ := rows[idx].Raw["id"].(string)
+
+			detail, ok := details[id]
+			if !ok {
+				continue
+			}
+
+			maps.Copy(rows[idx].Raw, detail)
+			rows[idx].Fields = common.ExtractLowercaseFieldsFromRaw(fields, rows[idx].Raw)
+		}
+
+		return nil
+	}
 }
 
 // fetchEstimateDetails fans out one GET /estimates/{id} per estimate
 // concurrently, honouring the per-key rate limit via maxConcurrentChildFetch.
-// A 404 is skipped rather than sinking the read — the row keeps its thin list
-// shape, matching GetRecordsByIds's "missing ids simply don't come back"
-// semantics.
+// A failed detail fetch is skipped rather than sinking the whole page — 404
+// (deleted between the list and detail calls), 429 (a page bursts up to
+// pageSize calls against the 10 req/sec key limit and the base client does
+// not retry), or 5xx: the row keeps its thin list shape either way, so a
+// partial result beats no result. Skips are logged because a skipped row is
+// otherwise indistinguishable from an estimate with no data. Only the read's
+// own cancellation aborts the fan-out.
 func (c *Connector) fetchEstimateDetails(
 	ctx context.Context,
 	estimateIDs []string,
@@ -93,11 +113,14 @@ func (c *Connector) fetchEstimateDetails(
 		jobs[idx] = func(ctx context.Context) error {
 			detail, err := c.fetchEstimateDetail(ctx, id)
 			if err != nil {
-				if isNotFound(err) {
-					return nil
+				if ctx.Err() != nil {
+					return fmt.Errorf("fetch estimate %s detail: %w", id, ctx.Err())
 				}
 
-				return fmt.Errorf("fetch estimate %s detail: %w", id, err)
+				logging.Logger(ctx).Warn("could not fetch estimate detail, keeping thin row",
+					"estimateId", id, "error", err.Error())
+
+				return nil
 			}
 
 			results[idx] = detail
@@ -145,28 +168,4 @@ func (c *Connector) fetchEstimateDetail(ctx context.Context, estimateID string) 
 	}
 
 	return *detail, nil
-}
-
-// mergeEstimateDetail returns a RecordTransformer that overlays the record's
-// detail payload onto the thin list stub. Detail wins on overlapping keys —
-// it is the authoritative superset. Records without a detail (404 mid-read)
-// pass through unchanged.
-func mergeEstimateDetail(details map[string]map[string]any) common.RecordTransformer {
-	return func(node *ajson.Node) (map[string]any, error) {
-		object, err := jsonquery.Convertor.ObjectToMap(node)
-		if err != nil {
-			return nil, err
-		}
-
-		id, _ := object["id"].(string)
-
-		detail, ok := details[id]
-		if !ok {
-			return object, nil
-		}
-
-		maps.Copy(object, detail)
-
-		return object, nil
-	}
 }

--- a/providers/acculynx/estimates.go
+++ b/providers/acculynx/estimates.go
@@ -1,0 +1,168 @@
+package acculynx
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/internal/simultaneously"
+	"github.com/spyzhov/ajson"
+)
+
+// AccuLynx estimate hydration:
+//
+// The /estimates list returns reference stubs only — id, isPrimary and a job
+// {id, _link} — while every substantive field (financials.*, createdDate,
+// modifiedDate, sections, title, estimateNumber, ...) lives exclusively on
+// GET /estimates/{estimateId}. The list endpoint's ?includes= supports only
+// "job" per the docs; every other value is silently ignored (verified live
+// with financials, sections, all, details, full and combinations — items stay
+// stubs in every case). So the only way to populate those fields is one
+// detail call per estimate, following the same per-record fan-out shape as
+// the custom-fields value fetch (see custom.go).
+//
+// Like custom fields, hydration mutates only the marshalled record that feeds
+// ReadResultRow.Fields — Raw stays the untouched list payload.
+//
+// References:
+//   - List: https://apidocs.acculynx.com/reference/getestimates
+//   - Detail: https://apidocs.acculynx.com/reference/getestimatebyid
+
+// estimateDetailIncludes expands the detail response's reference stubs in
+// full: sections (title, dates, financials per section) and the createdBy/
+// modifiedBy users. Documented detail ?includes= values are job, createdBy,
+// modifiedBy, sections; "job" is deliberately omitted — the Estimate->Job
+// relationship is delivered as an association (see extractEstimateJobs) and
+// the expanded job (with its contacts array) would bloat every record with
+// data the server already hydrates on demand.
+const estimateDetailIncludes = "createdBy,modifiedBy,sections"
+
+// buildEstimateDetailTransformer plans the detail fan-out for every estimate
+// in the current page and returns a transformer that merges each record's
+// detail over the thin list stub. Rows whose detail returned 404 (deleted
+// between the list and detail calls) keep their stub shape.
+func (c *Connector) buildEstimateDetailTransformer(
+	ctx context.Context,
+	resp *common.JSONHTTPResponse,
+) (common.RecordTransformer, error) {
+	body, hasBody := resp.Body()
+	if !hasBody {
+		// Nothing to hydrate; the pass-through transformer keeps rows as-is.
+		return mergeEstimateDetail(nil), nil
+	}
+
+	ids, err := c.extractParentIDsFromBody(objectEstimates, body)
+	if err != nil {
+		return nil, err
+	}
+
+	details, err := c.fetchEstimateDetails(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeEstimateDetail(details), nil
+}
+
+// fetchEstimateDetails fans out one GET /estimates/{id} per estimate
+// concurrently, honouring the per-key rate limit via maxConcurrentChildFetch.
+// A 404 is skipped rather than sinking the read — the row keeps its thin list
+// shape, matching GetRecordsByIds's "missing ids simply don't come back"
+// semantics.
+func (c *Connector) fetchEstimateDetails(
+	ctx context.Context,
+	estimateIDs []string,
+) (map[string]map[string]any, error) {
+	if len(estimateIDs) == 0 {
+		return map[string]map[string]any{}, nil
+	}
+
+	results := make([]map[string]any, len(estimateIDs))
+	jobs := make([]simultaneously.Job, len(estimateIDs))
+
+	for i, estimateID := range estimateIDs {
+		idx, id := i, estimateID
+
+		jobs[idx] = func(ctx context.Context) error {
+			detail, err := c.fetchEstimateDetail(ctx, id)
+			if err != nil {
+				if isNotFound(err) {
+					return nil
+				}
+
+				return fmt.Errorf("fetch estimate %s detail: %w", id, err)
+			}
+
+			results[idx] = detail
+
+			return nil
+		}
+	}
+
+	if err := simultaneously.DoCtx(ctx, maxConcurrentChildFetch, jobs...); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]map[string]any, len(estimateIDs))
+
+	for i, id := range estimateIDs {
+		if results[i] != nil {
+			out[id] = results[i]
+		}
+	}
+
+	return out, nil
+}
+
+func (c *Connector) fetchEstimateDetail(ctx context.Context, estimateID string) (map[string]any, error) {
+	u, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectEstimates, estimateID)
+	if err != nil {
+		return nil, err
+	}
+
+	u.WithQueryParam("includes", estimateDetailIncludes)
+
+	resp, err := c.JSONHTTPClient().Get(ctx, u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	detail, err := common.UnmarshalJSON[map[string]any](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if detail == nil {
+		// Empty detail body: hydrate nothing, keep the thin list row.
+		return map[string]any{}, nil
+	}
+
+	return *detail, nil
+}
+
+// mergeEstimateDetail returns a RecordTransformer that overlays the record's
+// detail payload onto the thin list stub. Detail wins on overlapping keys —
+// it is the authoritative superset. Records without a detail (404 mid-read)
+// pass through unchanged.
+func mergeEstimateDetail(details map[string]map[string]any) common.RecordTransformer {
+	return func(node *ajson.Node) (map[string]any, error) {
+		object, err := jsonquery.Convertor.ObjectToMap(node)
+		if err != nil {
+			return nil, err
+		}
+
+		id, _ := object["id"].(string)
+
+		detail, ok := details[id]
+		if !ok {
+			return object, nil
+		}
+
+		maps.Copy(object, detail)
+
+		return object, nil
+	}
+}

--- a/providers/acculynx/metadata/openapi/file.go
+++ b/providers/acculynx/metadata/openapi/file.go
@@ -14,3 +14,9 @@ var (
 
 	FileManager = api3.NewOpenapiFileManager[any](apiFile) // nolint:gochecknoglobals
 )
+
+// FileBytes exposes the raw spec for generators that need direct component
+// schema access beyond what api3's collection-oriented readers extract.
+func FileBytes() []byte {
+	return apiFile
+}

--- a/providers/acculynx/metadata/schemas.json
+++ b/providers/acculynx/metadata/schemas.json
@@ -714,6 +714,31 @@
               "valueType": "string",
               "providerType": "string"
             },
+            "createdBy": {
+              "displayName": "createdBy",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "createdDate": {
+              "displayName": "createdDate",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "description": {
+              "displayName": "description",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "estimateNumber": {
+              "displayName": "estimateNumber",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "financials": {
+              "displayName": "financials",
+              "valueType": "other",
+              "providerType": "object"
+            },
             "id": {
               "displayName": "id",
               "valueType": "string",
@@ -728,6 +753,41 @@
               "displayName": "job",
               "valueType": "other",
               "providerType": "object"
+            },
+            "modifiedBy": {
+              "displayName": "modifiedBy",
+              "valueType": "other",
+              "providerType": "object"
+            },
+            "modifiedDate": {
+              "displayName": "modifiedDate",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "notes": {
+              "displayName": "notes",
+              "valueType": "string",
+              "providerType": "string"
+            },
+            "profitMarginRate": {
+              "displayName": "profitMarginRate",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "profitMarginTotal": {
+              "displayName": "profitMarginTotal",
+              "valueType": "other",
+              "providerType": "number"
+            },
+            "sections": {
+              "displayName": "sections",
+              "valueType": "other",
+              "providerType": "array"
+            },
+            "title": {
+              "displayName": "title",
+              "valueType": "string",
+              "providerType": "string"
             }
           }
         },

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -61,6 +61,23 @@ const (
 	objectUsers       = "users"
 )
 
+// ReadParamsOpts is the connector-specific shape of common.ReadParams.Opts,
+// set by the server per customer (gong's ReadParamsOpts is the precedent).
+type ReadParamsOpts struct {
+	// HydrateEstimates enriches each /estimates row from its detail endpoint
+	// at the cost of one extra API call per record (up to pageSize per page).
+	// Off by default: plain estimates reads return the list stubs unchanged.
+	HydrateEstimates bool
+}
+
+// shouldHydrateEstimates reports whether the caller opted into estimate
+// hydration. False when Opts is unset or carries a different type.
+func shouldHydrateEstimates(params common.ReadParams) bool {
+	opts, ok := params.Opts.(ReadParamsOpts)
+
+	return ok && opts.HydrateEstimates
+}
+
 // includesByObject lists the AccuLynx ?includes= expansions applied
 // unconditionally on every read of the object. Contacts return phone/email as
 // reference-only stubs unless expanded, so we always request them — downstream
@@ -230,7 +247,7 @@ func (c *Connector) parseReadResponse(
 		if err != nil {
 			return nil, err
 		}
-	case params.ObjectName == objectEstimates:
+	case params.ObjectName == objectEstimates && shouldHydrateEstimates(params):
 		// /estimates rows are reference stubs; every substantive field needs
 		// the per-record detail endpoint — see estimates.go.
 		transformer, err = c.buildEstimateDetailTransformer(ctx, resp)

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -241,16 +241,8 @@ func (c *Connector) parseReadResponse(
 
 	var transformer common.RecordTransformer
 
-	switch {
-	case usesCustomFields(params.ObjectName):
+	if usesCustomFields(params.ObjectName) {
 		transformer, err = c.buildCustomFieldsTransformer(ctx, params, resp)
-		if err != nil {
-			return nil, err
-		}
-	case params.ObjectName == objectEstimates && shouldHydrateEstimates(params):
-		// /estimates rows are reference stubs; every substantive field needs
-		// the per-record detail endpoint — see estimates.go.
-		transformer, err = c.buildEstimateDetailTransformer(ctx, resp)
 		if err != nil {
 			return nil, err
 		}
@@ -261,20 +253,30 @@ func (c *Connector) parseReadResponse(
 		resp,
 		c.recordsFunc(params.ObjectName),
 		c.makeFilterFunc(params, reqURL),
-		readMarshaller(params, transformer),
+		c.readMarshaller(ctx, params, transformer),
 		params.Fields,
 	)
 }
 
-// readMarshaller wraps the base marshaller with association post-processors
-// for objects whose related-object references ride on the list payload
-// itself — pure reshapes of the parsed rows, no extra API calls:
+// readMarshaller wraps the base marshaller with row post-processors:
 //
-//   - jobs -> contacts: embedded contacts arrive via ?includes=contacts.
-//   - estimates -> jobs: the job stub ({id, _link}) and isPrimary are on
-//     every estimate row.
-func readMarshaller(params common.ReadParams, transformer common.RecordTransformer) common.MarshalFromNodeFunc {
+//   - estimates hydration (opt-in, one detail call per row — see
+//     estimates.go), chained first so the association extractors below see
+//     the final rows;
+//   - jobs -> contacts association: embedded contacts arrive via
+//     ?includes=contacts, pure reshape;
+//   - estimates -> jobs association: the job stub ({id, _link}) and
+//     isPrimary are on every estimate row, pure reshape.
+func (c *Connector) readMarshaller(
+	ctx context.Context,
+	params common.ReadParams,
+	transformer common.RecordTransformer,
+) common.MarshalFromNodeFunc {
 	marshaller := common.MakeMarshaledDataFunc(transformer)
+
+	if params.ObjectName == objectEstimates && shouldHydrateEstimates(params) {
+		marshaller = readhelper.ChainedMarshaller(marshaller, c.hydrateEstimateRows(ctx, params))
+	}
 
 	if params.ObjectName == objectJobs &&
 		slices.Contains(params.AssociatedObjects, jobContactsAssociation) {

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -224,18 +224,41 @@ func (c *Connector) parseReadResponse(
 
 	var transformer common.RecordTransformer
 
-	if usesCustomFields(params.ObjectName) {
+	switch {
+	case usesCustomFields(params.ObjectName):
 		transformer, err = c.buildCustomFieldsTransformer(ctx, params, resp)
+		if err != nil {
+			return nil, err
+		}
+	case params.ObjectName == objectEstimates:
+		// /estimates rows are reference stubs; every substantive field needs
+		// the per-record detail endpoint — see estimates.go.
+		transformer, err = c.buildEstimateDetailTransformer(ctx, resp)
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	return common.ParseResultFiltered(
+		params,
+		resp,
+		c.recordsFunc(params.ObjectName),
+		c.makeFilterFunc(params, reqURL),
+		readMarshaller(params, transformer),
+		params.Fields,
+	)
+}
+
+// readMarshaller wraps the base marshaller with association post-processors
+// for objects whose related-object references ride on the list payload
+// itself — pure reshapes of the parsed rows, no extra API calls:
+//
+//   - jobs -> contacts: embedded contacts arrive via ?includes=contacts.
+//   - estimates -> jobs: the job stub ({id, _link}) and isPrimary are on
+//     every estimate row.
+func readMarshaller(params common.ReadParams, transformer common.RecordTransformer) common.MarshalFromNodeFunc {
 	marshaller := common.MakeMarshaledDataFunc(transformer)
 
-	// Attach the job's embedded contacts as associations when requested. The
-	// contacts ride inline on the job payload (?includes=contacts), so this is a
-	// pure post-process of the parsed rows — no extra API call.
 	if params.ObjectName == objectJobs &&
 		slices.Contains(params.AssociatedObjects, jobContactsAssociation) {
 		marshaller = readhelper.ChainedMarshaller(marshaller, func(rows []common.ReadResultRow) error {
@@ -245,14 +268,16 @@ func (c *Connector) parseReadResponse(
 		})
 	}
 
-	return common.ParseResultFiltered(
-		params,
-		resp,
-		c.recordsFunc(params.ObjectName),
-		c.makeFilterFunc(params, reqURL),
-		marshaller,
-		params.Fields,
-	)
+	if params.ObjectName == objectEstimates &&
+		slices.Contains(params.AssociatedObjects, estimateJobAssociation) {
+		marshaller = readhelper.ChainedMarshaller(marshaller, func(rows []common.ReadResultRow) error {
+			extractEstimateJobs(rows)
+
+			return nil
+		})
+	}
+
+	return marshaller
 }
 
 // buildCustomFieldsTransformer fetches custom-field definitions and per-record
@@ -459,7 +484,7 @@ func (c *Connector) fetchChildPages(
 			return nil, err
 		}
 
-		attachAppointmentAssociations(params, parentID, result.Data)
+		attachNestedAssociations(params, parentID, result.Data)
 		allRows = append(allRows, result.Data...)
 
 		if result.NextPage == "" {

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -874,8 +874,9 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				Rows: 2,
 				Data: []common.ReadResultRow{
 					{
-						// Fields come from the detail payload; Raw stays the thin
-						// list stub.
+						// The detail is provider data, so it lands in Raw as
+						// well as Fields — raw stays "the object as AccuLynx
+						// gave it", assembled from the list and detail calls.
 						Fields: map[string]any{
 							"id":             "est-1",
 							"estimatenumber": "1042",
@@ -891,7 +892,13 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 								"totalPrice":    142.86,
 							},
 						},
-						Raw: map[string]any{"id": "est-1", "isPrimary": true},
+						Raw: map[string]any{
+							"id":             "est-1",
+							"isPrimary":      true,
+							"estimateNumber": "1042",
+							"createdDate":    "2026-05-10T17:56:54Z",
+							"title":          "Roof replacement",
+						},
 					},
 					{
 						Fields: map[string]any{
@@ -899,7 +906,12 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 							"estimatenumber": "1043",
 							"createddate":    "2026-06-01T08:15:00Z",
 						},
-						Raw: map[string]any{"id": "est-2", "isPrimary": false},
+						Raw: map[string]any{
+							"id":             "est-2",
+							"isPrimary":      false,
+							"estimateNumber": "1043",
+							"title":          "Gutter repair",
+						},
 					},
 				},
 				Done: true,
@@ -1000,11 +1012,67 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{"id": "est-1", "estimatenumber": "1042"},
-						Raw:    map[string]any{"id": "est-1"},
+						Raw:    map[string]any{"id": "est-1", "estimateNumber": "1042"},
 					},
 					{
+						// Skipped detail: the row keeps the thin list stub.
 						Fields: map[string]any{"id": "est-2"},
-						Raw:    map[string]any{"id": "est-2"},
+						Raw:    map[string]any{"id": "est-2", "isPrimary": false},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			// A transient failure (429/5xx) on one estimate's detail must not
+			// sink the page — that row keeps its thin shape, the rest hydrate.
+			Name: "Read estimates keeps the thin row when its detail returns 500",
+			Input: common.ReadParams{
+				ObjectName: "estimates",
+				Fields:     connectors.Fields("id", "estimateNumber"),
+				Opts:       ReadParamsOpts{HydrateEstimates: true},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-1"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst1Response),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-2"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"boom"}`),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{"id": "est-1", "estimatenumber": "1042"},
+						Raw:    map[string]any{"id": "est-1", "estimateNumber": "1042"},
+					},
+					{
+						// Skipped detail: the row keeps the thin list stub.
+						Fields: map[string]any{"id": "est-2"},
+						Raw:    map[string]any{"id": "est-2", "isPrimary": false},
 					},
 				},
 				Done: true,

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -832,11 +832,13 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 		{
 			// The /estimates list returns stubs only (id, isPrimary, job) and
 			// ignores ?includes=; the substantive fields must come from one
-			// GET /estimates/{id} per record.
-			Name: "Read estimates hydrates each row from the detail endpoint",
+			// GET /estimates/{id} per record. Hydration requires the
+			// server-set opt-in.
+			Name: "Read estimates with opts hydrates each row from the detail endpoint",
 			Input: common.ReadParams{
 				ObjectName: "estimates",
 				Fields:     connectors.Fields("id", "estimateNumber", "createdDate", "financials"),
+				Opts:       ReadParamsOpts{HydrateEstimates: true},
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -904,7 +906,10 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			},
 		},
 		{
-			Name: "Read estimates with jobs association attaches the job edge",
+			// No Opts set: the association is a pure reshape of the list
+			// payload. The mock serves only the list — any hydration call
+			// would hit the 500 default and fail the read.
+			Name: "Read estimates with jobs association attaches the job edge without hydration calls",
 			Input: common.ReadParams{
 				ObjectName:        "estimates",
 				Fields:            connectors.Fields("id"),
@@ -919,22 +924,6 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 							mockcond.Path("/api/v2/estimates"),
 						},
 						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
-					},
-					{
-						If: mockcond.And{
-							mockcond.MethodGET(),
-							mockcond.Path("/api/v2/estimates/est-1"),
-							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
-						},
-						Then: mockserver.Response(http.StatusOK, estimateDetailEst1Response),
-					},
-					{
-						If: mockcond.And{
-							mockcond.MethodGET(),
-							mockcond.Path("/api/v2/estimates/est-2"),
-							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
-						},
-						Then: mockserver.Response(http.StatusOK, estimateDetailEst2Response),
 					},
 				},
 				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
@@ -974,6 +963,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			Input: common.ReadParams{
 				ObjectName: "estimates",
 				Fields:     connectors.Fields("id", "estimateNumber"),
+				Opts:       ReadParamsOpts{HydrateEstimates: true},
 			},
 			Server: mockserver.Switch{
 				Setup: mockserver.ContentJSON(),
@@ -1015,6 +1005,44 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 					{
 						Fields: map[string]any{"id": "est-2"},
 						Raw:    map[string]any{"id": "est-2"},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			// Default (no Opts): rows pass through as list stubs and no
+			// detail endpoint is called — the mock serves only the list, so
+			// a stray hydration call would hit the 500 default and fail.
+			Name: "Read estimates without opts returns stubs and skips hydration",
+			Input: common.ReadParams{
+				ObjectName: "estimates",
+				Fields:     connectors.Fields("id", "isPrimary"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{"id": "est-1", "isprimary": true},
+						Raw:    map[string]any{"id": "est-1", "isPrimary": true},
+					},
+					{
+						Fields: map[string]any{"id": "est-2", "isprimary": false},
+						Raw:    map[string]any{"id": "est-2", "isPrimary": false},
 					},
 				},
 				Done: true,

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -76,6 +76,18 @@ var contactsIncludesResponse []byte
 //go:embed test/read/jobs-with-initial-appointment.json
 var jobsWithInitialAppointmentResponse []byte
 
+//go:embed test/read/job-representatives.json
+var jobRepresentativesResponse []byte
+
+//go:embed test/read/estimates-list.json
+var estimatesListResponse []byte
+
+//go:embed test/read/estimate-detail-est-1.json
+var estimateDetailEst1Response []byte
+
+//go:embed test/read/estimate-detail-est-2.json
+var estimateDetailEst2Response []byte
+
 func TestRead(t *testing.T) { //nolint:funlen,maintidx
 	t.Parallel()
 
@@ -726,6 +738,284 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				Data: []common.ReadResultRow{
 					{Fields: map[string]any{"id": "appt-1"}, Raw: map[string]any{"id": "appt-1"}},
 					{Fields: map[string]any{"id": "appt-2"}, Raw: map[string]any{"id": "appt-2"}},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read jobs/representatives attaches the parent job association",
+			Input: common.ReadParams{
+				ObjectName:        "jobs/representatives",
+				Fields:            connectors.Fields("id", "type"),
+				AssociatedObjects: []string{"jobs"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobsListSingleResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs/job-001/representatives"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobRepresentativesResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						// The representative body carries no jobId — the edge comes
+						// from the fan-out parent (job-001), like appointment->user.
+						Fields: map[string]any{"id": "rep-1", "type": "SalesOwner"},
+						Raw:    map[string]any{"id": "rep-1", "type": "SalesOwner"},
+						Associations: map[string][]common.Association{
+							"jobs": {{ObjectId: "job-001"}},
+						},
+					},
+					{
+						Fields: map[string]any{"id": "rep-2", "type": "ArOwner"},
+						Raw:    map[string]any{"id": "rep-2", "type": "ArOwner"},
+						Associations: map[string][]common.Association{
+							"jobs": {{ObjectId: "job-001"}},
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read jobs/representatives without association request attaches nothing",
+			Input: common.ReadParams{
+				ObjectName: "jobs/representatives",
+				Fields:     connectors.Fields("id", "type"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobsListSingleResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/jobs/job-001/representatives"),
+						},
+						Then: mockserver.Response(http.StatusOK, jobRepresentativesResponse),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{Fields: map[string]any{"id": "rep-1"}, Raw: map[string]any{"id": "rep-1"}},
+					{Fields: map[string]any{"id": "rep-2"}, Raw: map[string]any{"id": "rep-2"}},
+				},
+				Done: true,
+			},
+		},
+		{
+			// The /estimates list returns stubs only (id, isPrimary, job) and
+			// ignores ?includes=; the substantive fields must come from one
+			// GET /estimates/{id} per record.
+			Name: "Read estimates hydrates each row from the detail endpoint",
+			Input: common.ReadParams{
+				ObjectName: "estimates",
+				Fields:     connectors.Fields("id", "estimateNumber", "createdDate", "financials"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-1"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst1Response),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-2"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst2Response),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						// Fields come from the detail payload; Raw stays the thin
+						// list stub.
+						Fields: map[string]any{
+							"id":             "est-1",
+							"estimatenumber": "1042",
+							"createddate":    "2026-05-10T17:56:54Z",
+							"financials": map[string]any{
+								"taxRate":       0.0,
+								"taxTotal":      0.0,
+								"overheadRate":  0.0,
+								"overheadTotal": 0.0,
+								"profitRate":    0.0,
+								"profitTotal":   0.0,
+								"totalCost":     100.0,
+								"totalPrice":    142.86,
+							},
+						},
+						Raw: map[string]any{"id": "est-1", "isPrimary": true},
+					},
+					{
+						Fields: map[string]any{
+							"id":             "est-2",
+							"estimatenumber": "1043",
+							"createddate":    "2026-06-01T08:15:00Z",
+						},
+						Raw: map[string]any{"id": "est-2", "isPrimary": false},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			Name: "Read estimates with jobs association attaches the job edge",
+			Input: common.ReadParams{
+				ObjectName:        "estimates",
+				Fields:            connectors.Fields("id"),
+				AssociatedObjects: []string{"jobs"},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-1"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst1Response),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-2"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst2Response),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{"id": "est-1"},
+						Raw:    map[string]any{"id": "est-1"},
+						Associations: map[string][]common.Association{
+							"jobs": {{
+								ObjectId:                    "job-777",
+								ProviderAssociationMetadata: map[string]any{"isPrimary": true},
+							}},
+						},
+					},
+					{
+						Fields: map[string]any{"id": "est-2"},
+						Raw:    map[string]any{"id": "est-2"},
+						Associations: map[string][]common.Association{
+							"jobs": {{
+								ObjectId:                    "job-888",
+								ProviderAssociationMetadata: map[string]any{"isPrimary": false},
+							}},
+						},
+					},
+				},
+				Done: true,
+			},
+		},
+		{
+			// An estimate deleted between the list and detail calls must not sink
+			// the read — the row keeps its thin list shape.
+			Name: "Read estimates keeps the thin row when its detail returns 404",
+			Input: common.ReadParams{
+				ObjectName: "estimates",
+				Fields:     connectors.Fields("id", "estimateNumber"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: []mockserver.Case{
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimatesListResponse),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-1"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.Response(http.StatusOK, estimateDetailEst1Response),
+					},
+					{
+						If: mockcond.And{
+							mockcond.MethodGET(),
+							mockcond.Path("/api/v2/estimates/est-2"),
+							mockcond.QueryParam("includes", "createdBy,modifiedBy,sections"),
+						},
+						Then: mockserver.ResponseString(http.StatusNotFound, `{"message":"Not Found"}`),
+					},
+				},
+				Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{"id": "est-1", "estimatenumber": "1042"},
+						Raw:    map[string]any{"id": "est-1"},
+					},
+					{
+						Fields: map[string]any{"id": "est-2"},
+						Raw:    map[string]any{"id": "est-2"},
+					},
 				},
 				Done: true,
 			},

--- a/providers/acculynx/test/read/estimate-detail-est-1.json
+++ b/providers/acculynx/test/read/estimate-detail-est-1.json
@@ -1,0 +1,46 @@
+{
+  "id": "est-1",
+  "isPrimary": true,
+  "estimateNumber": "1042",
+  "title": "Roof replacement",
+  "description": "Full tear-off and replacement",
+  "notes": "",
+  "createdDate": "2026-05-10T17:56:54Z",
+  "modifiedDate": "2026-05-11T09:00:00Z",
+  "profitMarginRate": 30.0,
+  "profitMarginTotal": 42.86,
+  "financials": {
+    "taxRate": 0.0,
+    "taxTotal": 0.0,
+    "overheadRate": 0.0,
+    "overheadTotal": 0.0,
+    "profitRate": 0.0,
+    "profitTotal": 0.0,
+    "totalCost": 100.0,
+    "totalPrice": 142.86
+  },
+  "sections": [
+    {
+      "id": "sec-1",
+      "title": "Roofing Section",
+      "description": "",
+      "createdDate": "2026-05-10T17:56:54Z",
+      "modifiedDate": "2026-05-10T17:56:54Z",
+      "_link": "https://api.acculynx.com/api/v2/estimates/est-1/sections/sec-1"
+    }
+  ],
+  "createdBy": {
+    "id": "user-10",
+    "displayName": "Diane Hatch",
+    "role": {
+      "id": 1,
+      "name": "CompanyAdmin"
+    },
+    "_link": "https://api.acculynx.com/api/v2/users/user-10"
+  },
+  "job": {
+    "id": "job-777",
+    "_link": "https://api.acculynx.com/api/v2/jobs/job-777"
+  },
+  "_link": "https://api.acculynx.com/api/v2/estimates/est-1"
+}

--- a/providers/acculynx/test/read/estimate-detail-est-2.json
+++ b/providers/acculynx/test/read/estimate-detail-est-2.json
@@ -1,0 +1,32 @@
+{
+  "id": "est-2",
+  "isPrimary": false,
+  "estimateNumber": "1043",
+  "title": "Gutter repair",
+  "description": "",
+  "notes": "",
+  "createdDate": "2026-06-01T08:15:00Z",
+  "modifiedDate": "2026-06-02T12:30:00Z",
+  "profitMarginRate": 20.0,
+  "profitMarginTotal": 15.0,
+  "financials": {
+    "taxRate": 0.0,
+    "taxTotal": 0.0,
+    "overheadRate": 0.0,
+    "overheadTotal": 0.0,
+    "profitRate": 0.0,
+    "profitTotal": 0.0,
+    "totalCost": 60.0,
+    "totalPrice": 75.0
+  },
+  "sections": [],
+  "createdBy": {
+    "id": "user-20",
+    "_link": "https://api.acculynx.com/api/v2/users/user-20"
+  },
+  "job": {
+    "id": "job-888",
+    "_link": "https://api.acculynx.com/api/v2/jobs/job-888"
+  },
+  "_link": "https://api.acculynx.com/api/v2/estimates/est-2"
+}

--- a/providers/acculynx/test/read/estimates-list.json
+++ b/providers/acculynx/test/read/estimates-list.json
@@ -1,0 +1,25 @@
+{
+  "count": 2,
+  "pageSize": 25,
+  "pageStartIndex": 0,
+  "items": [
+    {
+      "id": "est-1",
+      "isPrimary": true,
+      "job": {
+        "id": "job-777",
+        "_link": "https://api.acculynx.com/api/v2/jobs/job-777"
+      },
+      "_link": "https://api.acculynx.com/api/v2/estimates/est-1"
+    },
+    {
+      "id": "est-2",
+      "isPrimary": false,
+      "job": {
+        "id": "job-888",
+        "_link": "https://api.acculynx.com/api/v2/jobs/job-888"
+      },
+      "_link": "https://api.acculynx.com/api/v2/estimates/est-2"
+    }
+  ]
+}

--- a/providers/acculynx/test/read/job-representatives.json
+++ b/providers/acculynx/test/read/job-representatives.json
@@ -1,0 +1,25 @@
+{
+  "count": 2,
+  "pageSize": 25,
+  "recordStartIndex": 0,
+  "items": [
+    {
+      "id": "rep-1",
+      "type": "SalesOwner",
+      "user": {
+        "id": "user-10",
+        "_link": "https://api.acculynx.com/api/v2/users/user-10"
+      },
+      "_link": "https://api.acculynx.com/api/v2/jobs/job-001/representatives/sales-owner"
+    },
+    {
+      "id": "rep-2",
+      "type": "ArOwner",
+      "user": {
+        "id": "user-20",
+        "_link": "https://api.acculynx.com/api/v2/users/user-20"
+      },
+      "_link": "https://api.acculynx.com/api/v2/jobs/job-001/representatives/ar-owner"
+    }
+  ]
+}

--- a/scripts/openapi/acculynx/metadata/main.go
+++ b/scripts/openapi/acculynx/metadata/main.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	"log/slog"
+	"maps"
+	"sort"
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/datautils"
@@ -18,6 +20,7 @@ import (
 	utilsopenapi "github.com/amp-labs/connectors/scripts/openapi/utils"
 	"github.com/amp-labs/connectors/tools/fileconv/api3"
 	"github.com/amp-labs/connectors/tools/scrapper"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // objectEndpoints maps URL path → ObjectName. Templated paths ({jobId},
@@ -140,6 +143,19 @@ func main() {
 		}
 	}
 
+	// The /estimates list returns reference stubs only (id, isPrimary, job)
+	// and silently ignores ?includes= (verified live), so the read connector
+	// hydrates every estimate from GET /estimates/{estimateId}. The detail
+	// fields (financials, createdDate, sections, ...) are therefore part of
+	// the estimates read shape and merged into its schema here, keyed under
+	// the list's URL path and response key. Query params are intentionally
+	// not registered: queryParamStats tracks list endpoints only.
+	for _, field := range estimateDetailFields() {
+		schemas.Add(common.ModuleRoot, "estimates", "Estimates",
+			"/api/v2/estimates", "items",
+			utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, nil)
+	}
+
 	goutils.MustBeNil(metadata.FileManager.SaveSchemas(schemas))
 	goutils.MustBeNil(metadata.FileManager.SaveQueryParamStats(scrapper.CalculateQueryParamStats(registry)))
 
@@ -171,4 +187,69 @@ func Objects() []metadatadef.Schema {
 	goutils.MustBeNil(err)
 
 	return objects
+}
+
+// estimateDetailFields returns the flattened property set of the estimate
+// component schema — the single-object response of GET /estimates/{estimateId}.
+// api3's ReadObjects cannot extract it: its extractors are collection-oriented
+// and, pointed at the detail endpoint, auto-select the only inner array
+// (sections) and return section fields instead of the estimate's own. So the
+// properties are read directly from the spec.
+func estimateDetailFields() []metadatadef.Field {
+	doc, err := openapi3.NewLoader().LoadFromData(openapi.FileBytes())
+	goutils.MustBeNil(err)
+
+	schema, ok := doc.Components.Schemas["estimate"]
+	if !ok || schema.Value == nil {
+		panic("estimate component schema missing from AccuLynx OpenAPI spec")
+	}
+
+	props := flattenedProperties(schema.Value)
+
+	names := datautils.Map[string, *openapi3.SchemaRef](props).Keys()
+	sort.Strings(names)
+
+	fields := make([]metadatadef.Field, 0, len(names))
+	for _, name := range names {
+		fields = append(fields, metadatadef.Field{
+			Name: name,
+			Type: propertyTypeName(props[name]),
+		})
+	}
+
+	return fields
+}
+
+// flattenedProperties merges a schema's own properties with those of its
+// allOf components, recursively. Own properties win on collisions.
+func flattenedProperties(schema *openapi3.Schema) map[string]*openapi3.SchemaRef {
+	out := make(map[string]*openapi3.SchemaRef)
+
+	for _, ref := range schema.AllOf {
+		if ref != nil && ref.Value != nil {
+			maps.Copy(out, flattenedProperties(ref.Value))
+		}
+	}
+
+	maps.Copy(out, schema.Properties)
+
+	return out
+}
+
+// propertyTypeName resolves a property's provider type. Schemas composed via
+// $ref/allOf frequently omit an explicit type; those are objects.
+func propertyTypeName(ref *openapi3.SchemaRef) string {
+	if ref == nil || ref.Value == nil {
+		return ""
+	}
+
+	if types := ref.Value.Type; types != nil && len(types.Slice()) > 0 {
+		return types.Slice()[0]
+	}
+
+	if len(ref.Value.AllOf) > 0 || len(ref.Value.Properties) > 0 {
+		return "object"
+	}
+
+	return ""
 }

--- a/test/acculynx/associations/main.go
+++ b/test/acculynx/associations/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx"
+	testAccuLynx "github.com/amp-labs/connectors/test/acculynx"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// Live validation for the representative/estimate associations and estimate
+// hydration work:
+//
+//  1. Read jobs/representatives with AssociatedObjects=[jobs] and show every
+//     representative row carries a "jobs" edge with the fan-out parent job id
+//     (the representative body itself has no jobId, only _link).
+//  2. Read estimates with AssociatedObjects=[jobs] and show every estimate row
+//     carries a "jobs" edge taken from the embedded job stub, with isPrimary
+//     in ProviderAssociationMetadata.
+//  3. Read estimates and show rows are hydrated from GET /estimates/{id}:
+//     estimateNumber, createdDate and financials populate Fields even though
+//     the list payload is a reference stub (verified: ?includes= is ignored
+//     on the list endpoint).
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testAccuLynx.GetAccuLynxConnector(ctx)
+
+	slog.Info("=== 1) Read jobs/representatives with the parent job association ===")
+
+	if err := readRepresentativesWithJobEdge(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	slog.Info("=== 2) Read estimates with the job association ===")
+
+	if err := readEstimatesWithJobEdge(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+
+	slog.Info("=== 3) Read estimates hydrated from the detail endpoint ===")
+
+	if err := readEstimatesHydrated(ctx, conn); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func readRepresentativesWithJobEdge(ctx context.Context, conn *acculynx.Connector) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName:        "jobs/representatives",
+		Fields:            connectors.Fields("id", "type"),
+		AssociatedObjects: []string{"jobs"},
+	})
+	if err != nil {
+		return fmt.Errorf("reading jobs/representatives with associations: %w", err)
+	}
+
+	withJob := 0
+
+	for _, row := range res.Data {
+		if len(row.Associations["jobs"]) > 0 {
+			withJob++
+		}
+	}
+
+	slog.Info("representative association coverage",
+		"rows", res.Rows,
+		"withJobEdge", withJob,
+		"expected", "withJobEdge == rows")
+
+	dumpFirstRows(res)
+
+	return nil
+}
+
+func readEstimatesWithJobEdge(ctx context.Context, conn *acculynx.Connector) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName:        "estimates",
+		Fields:            connectors.Fields("id"),
+		AssociatedObjects: []string{"jobs"},
+	})
+	if err != nil {
+		return fmt.Errorf("reading estimates with associations: %w", err)
+	}
+
+	withJob, withIsPrimary := 0, 0
+
+	for _, row := range res.Data {
+		edges := row.Associations["jobs"]
+		if len(edges) > 0 {
+			withJob++
+
+			if _, ok := edges[0].ProviderAssociationMetadata["isPrimary"]; ok {
+				withIsPrimary++
+			}
+		}
+	}
+
+	slog.Info("estimate association coverage",
+		"rows", res.Rows,
+		"withJobEdge", withJob,
+		"withIsPrimaryMetadata", withIsPrimary,
+		"expected", "both == rows")
+
+	dumpFirstRows(res)
+
+	return nil
+}
+
+func readEstimatesHydrated(ctx context.Context, conn *acculynx.Connector) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "estimates",
+		Fields:     connectors.Fields("id", "estimateNumber", "createdDate", "financials"),
+	})
+	if err != nil {
+		return fmt.Errorf("reading estimates hydrated: %w", err)
+	}
+
+	hydrated := 0
+
+	for _, row := range res.Data {
+		if row.Fields["estimatenumber"] != nil && row.Fields["financials"] != nil {
+			hydrated++
+		}
+	}
+
+	slog.Info("estimate hydration coverage",
+		"rows", res.Rows,
+		"hydrated", hydrated,
+		"expected", "hydrated == rows")
+
+	dumpFirstRows(res)
+
+	return nil
+}
+
+func dumpFirstRows(res *common.ReadResult) {
+	limit := 3
+	if len(res.Data) < limit {
+		limit = len(res.Data)
+	}
+
+	utils.DumpJSON(res.Data[:limit], os.Stdout)
+}

--- a/test/acculynx/associations/main.go
+++ b/test/acculynx/associations/main.go
@@ -24,10 +24,11 @@ import (
 //  2. Read estimates with AssociatedObjects=[jobs] and show every estimate row
 //     carries a "jobs" edge taken from the embedded job stub, with isPrimary
 //     in ProviderAssociationMetadata.
-//  3. Read estimates and show rows are hydrated from GET /estimates/{id}:
-//     estimateNumber, createdDate and financials populate Fields even though
-//     the list payload is a reference stub (verified: ?includes= is ignored
-//     on the list endpoint).
+//  3. Read estimates with ReadParamsOpts.HydrateEstimates and show rows are
+//     hydrated from GET /estimates/{id}: estimateNumber, createdDate and
+//     financials populate Fields even though the list payload is a reference
+//     stub (verified: ?includes= is ignored on the list endpoint). Without
+//     the opt-in (scenario 2), no detail calls are made.
 func main() {
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer done()
@@ -121,6 +122,7 @@ func readEstimatesHydrated(ctx context.Context, conn *acculynx.Connector) error 
 	res, err := conn.Read(ctx, common.ReadParams{
 		ObjectName: "estimates",
 		Fields:     connectors.Fields("id", "estimateNumber", "createdDate", "financials"),
+		Opts:       acculynx.ReadParamsOpts{HydrateEstimates: true},
 	})
 	if err != nil {
 		return fmt.Errorf("reading estimates hydrated: %w", err)


### PR DESCRIPTION
## Representative→Job and Estimate→Job associations + estimate hydration.

### What changed

- Representative→Job: attached in the jobs/representatives fan-out (fetchChildPages, same mechanism as Appointment→User). The representative body has no jobId (docs (https://apidocs.acculynx.com/reference/getrepresentativesforjob)), so the edge uses the fan-out parent job id. Reference shape, jobs are batch-readable, the server hydrates.
- Estimate→Job: from the embedded job stub + top-level isPrimary on every /estimates row, emitted under jobs with isPrimary in ProviderAssociationMetadata. Pure reshape, no extra fetch.
- Estimate hydration: /estimates rows are stubs (id, isPrimary, job); all substantive fields live only on GET /estimates/{estimateId}. Each row is hydrated via one detail call with ?includes=createdBy,modifiedBy,sections (concurrency-capped fan-out, custom-fields pattern). Detail populates Fields, Raw stays the list payload, a 404 mid-read keeps the thin row. job is not expanded that's the association.
- Metadata: generator merges the estimate detail schema into estimates (4 → 16 fields); api3's extractor can't read the single-object response, so properties come directly from the spec.

### Resolved open question

?includes=financials on the list can't avoid the per-record fetch: the docs support only job on the list, and live probes with financials/sections/all/details/full are silently ignored. Cost: 1+N requests per page (N ≤ 25, concurrency 4, within the 10 req/s key limit).


## Testing

### Unit: go test ./providers/acculynx/...

<img width="1479" height="715" alt="image" src="https://github.com/user-attachments/assets/3967cf61-efcd-4f42-bd2a-a95d6fdd3c48" />


### Live: go run ./test/acculynx/associations (needs acculynx-creds.json)

- 27/27 representatives carry the job edge (ObjectId matches the parent job in _link)
- 8/8 estimates carry the jobs edge with isPrimary
- 8/8 estimates hydrate financials/createdDate/estimateNumber

<img width="1479" height="833" alt="image" src="https://github.com/user-attachments/assets/66a6a288-b82a-4dbc-81d0-5428e963b0a3" />
<img width="1479" height="833" alt="image" src="https://github.com/user-attachments/assets/219a7830-994b-4207-a1ee-cad906c583d8" />
<img width="1479" height="833" alt="image" src="https://github.com/user-attachments/assets/b8391a2a-9358-4ef7-b3ec-08d92423be7b" />
<img width="1479" height="833" alt="image" src="https://github.com/user-attachments/assets/0bcbf078-176d-4a00-b913-0a6ed642cbe3" />
