### PR TITLE
feat(salesforce): shorten deploy poll window to 15m now that timeouts proceed

### DIFF
--- a/providers/salesforce/apex.go
+++ b/providers/salesforce/apex.go
@@ -87,9 +87,13 @@ type CancelDeployResult = metadata.CancelDeployResult
 const (
 	// deployPollTimeout bounds how long pollDeployStatus waits for a single deploy.
 	// Metadata deploys serialize per org, so on a busy org a deploy can sit queued
-	// (status Pending) far longer than the deploy itself takes to execute — the
-	// window has to cover queue time, not just run time.
-	deployPollTimeout = 2 * time.Hour
+	// (status Pending) far longer than the deploy itself takes to execute. The
+	// window is deliberately SHORT: a timeout is not a failure — Subscribe proceeds
+	// without waiting (see deployTriggersToleratingTimeouts), the deploy keeps
+	// running org-side and lands on its own. Keeping the wait short bounds the
+	// activity's wall-clock, which minimizes exposure to Temporal worker churn
+	// (rollouts/autoscaling) cancelling the attempt mid-poll.
+	deployPollTimeout = 15 * time.Minute
 
 	// Deploy status checks back off in steps: quick checks while a fast deploy
 	// might still finish, then progressively sparser ones for the long-haul wait


### PR DESCRIPTION
## Why

With proceed-on-timeout in place (#3326), a poll timeout is no longer a failure: Subscribe continues without waiting, the deploy keeps running org-side and lands on its own, and the stored result tracks the trigger as intent. Given that, a **2h** poll window buys nothing and costs a lot — it holds the Temporal subscribe activity open for the entire org deploy-queue wait, maximizing exposure to worker churn (rollouts / autoscaler) cancelling the attempt mid-poll. A cancelled activity runs its rollback on a dead context (nothing cleans up) and strands the attempt; observed repeatedly in production today.

## What

`deployPollTimeout`: 2h → **15m**. The stepped backoff (10s → 1m → 5m) is unchanged.

Semantics after this change:

- **Fast/normal deploys** confirm inside the window — nothing changes.
- **Real deploy failures** (compile/test errors) that execute within the window still fail properly and roll back — a Failed result is a result, not a timeout.
- **Queue-jammed deploys** hit the 15m timeout → warn log ("proceeding without waiting — UPDATE events are dropped until the trigger lands") → Subscribe proceeds to channel members; the server then does DB updates, AWS post-process, and marks the subscription active. The deploy lands in the background.
- The whole subscribe activity now has a bounded ~15-20m wall-clock, shrinking the worker-churn exposure window ~8×.

Trade-off (accepted): a deploy that both outlives 15m **and** ultimately fails org-side goes active with UPDATE events silently dropped for that object — visible only via the warn log + Setup > Deployment Status. Same trade-off as #3326, just reached sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)