### PR TITLE
tidy(subscribe): Unexport private methods, fields

### DIFF
--- a/docs/subscribe-onboarding/pr-6-provider-config.md
+++ b/docs/subscribe-onboarding/pr-6-provider-config.md
@@ -37,13 +37,13 @@ type ProviderConfigRegistry struct {
 }
 ```
 
-**Use `DefaultModuleConfig`** when subscribe behavior is module-agnostic (Outreach, Salesloft, Hubspot, Gong, HousecallPro).
+**Use `defaultModuleConfig`** when subscribe behavior is module-agnostic (Outreach, Salesloft, Hubspot, Gong, HousecallPro).
 
 **Use `Modules`** when your provider has multiple modules with differing subscribe behavior (Salesforce, Zoho, Google all do this — their non-subscribe modules have no entry).
 
-You can use both (one `DefaultModuleConfig` plus a few module overrides) if needed.
+You can use both (one `defaultModuleConfig` plus a few module overrides) if needed.
 
-`GetProviderConfig(module, providerInfo, deps)` resolves the module in this order: the `module` argument (typically the installation revision's module) → `providerInfo.DefaultModule` → empty string. If the resolved module has an entry in `Modules`, that's used; otherwise `DefaultModuleConfig`; if neither matches, it returns `ErrProviderConfigNotFound`. On success the returned pointer is a fresh copy with `module` / `providerInfo` / `deps` bound onto each subcomponent, so subcomponent methods answer module-aware questions without callers threading the arguments per call.
+`GetProviderConfig(module, providerInfo, deps)` resolves the module in this order: the `module` argument (typically the installation revision's module) → `providerInfo.DefaultModule` → empty string. If the resolved module has an entry in `Modules`, that's used; otherwise `defaultModuleConfig`; if neither matches, it returns `ErrProviderConfigNotFound`. On success the returned pointer is a fresh copy with `module` / `providerInfo` / `deps` bound onto each subcomponent, so subcomponent methods answer module-aware questions without callers threading the arguments per call.
 
 ---
 
@@ -152,7 +152,7 @@ var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
 }
 ```
 
-Use `DefaultModuleConfig` when the provider has no module-specific differences. Use `Modules` when it does.
+Use `defaultModuleConfig` when the provider has no module-specific differences. Use `Modules` when it does.
 
 ---
 
@@ -377,7 +377,7 @@ var salesloftConfig = ProviderConfig{
 
 ### Google (Gmail / Calendar) — module-scoped with maintenance and bypass
 
-Only the `gmail` and `calendar` modules support subscribe, so they're registered under `Modules` (as `googleConfig` and `googleCalendarConfig` respectively), not `DefaultModuleConfig`. Webhooks arrive as synthetic Pub/Sub republishes so verification is bypassed.
+Only the `gmail` and `calendar` modules support subscribe, so they're registered under `Modules` (as `googleConfig` and `googleCalendarConfig` respectively), not `defaultModuleConfig`. Webhooks arrive as synthetic Pub/Sub republishes so verification is bypassed.
 
 ```go
 var googleConfig = ProviderConfig{
@@ -448,7 +448,7 @@ This is the recommended way to validate the whole stack (PR 2–6) before openin
 ## Checklist
 
 - [ ] `subscribe/<provider>.go` declares `var <provider>Config = ProviderConfig{...}` populating only the subcomponents the provider needs.
-- [ ] Registered in `providerConfigs` (`subscribe/config.go`) — `DefaultModuleConfig` vs `Modules` matches the provider's module story.
+- [ ] Registered in `providerConfigs` (`subscribe/config.go`) — `defaultModuleConfig` vs `Modules` matches the provider's module story.
 - [ ] Builders use only the wire types and `deps.Dependencies` — no new external dependencies.
 - [ ] If maintenance is declared: `renewalInterval` set **and** `maintenancePeriods` entry added.
 - [ ] Twin providers: `providerInfoAliases` entry + same config pointer under both keys.
@@ -459,4 +459,4 @@ This is the recommended way to validate the whole stack (PR 2–6) before openin
 - The config shape matches the provider's actual capabilities from PR 2–5 (e.g. no `buildRequestFn` for a look-up-only provider; `verifierConnector` matches the PR 2 connector).
 - Zero-value subcomponents are left alone — only populated concerns appear in the literal.
 - Secrets: verification params take secrets from `VerificationRequest` (`req.ProviderAppClientSecret`) or stored results via `deps` — never hardcoded.
-- The registry entry's module scoping is right (module-agnostic providers under `DefaultModuleConfig`; module-specific ones under `Modules` with no entries for non-subscribe modules).
+- The registry entry's module scoping is right (module-agnostic providers under `defaultModuleConfig`; module-specific ones under `Modules` with no entries for non-subscribe modules).

--- a/subscribe/acculynx.go
+++ b/subscribe/acculynx.go
@@ -26,7 +26,7 @@ var acculynxConfig = ProviderConfig{
 	Verification: VerificationConfig{
 		verifierConnector: &acculynx.Connector{},
 		bypassed:          true,
-		eventCaster:       CastSubscriptionEvents[acculynx.SubscriptionEvent],
+		eventCaster:       castSubscriptionEvents[acculynx.SubscriptionEvent],
 	},
 }
 

--- a/subscribe/aliases.go
+++ b/subscribe/aliases.go
@@ -23,7 +23,7 @@ var providerInfoAliases = map[providers.Provider]providers.Provider{
 // stays accurate. Otherwise the input is returned unchanged.
 //
 // Callers should apply this once, immediately after fetching ProviderInfo from the providers
-// catalog, before passing it into subscribe helpers (SubscriptionViaApiSupported,
+// catalog, before passing it into subscribe helpers (subscriptionViaApiSupported,
 // ProviderRequires*, Should*). Those helpers expect an already-resolved ProviderInfo and do not
 // re-resolve internally.
 func ResolveProviderInfoAlias(providerInfo *providers.ProviderInfo) *providers.ProviderInfo {

--- a/subscribe/config.go
+++ b/subscribe/config.go
@@ -58,74 +58,74 @@ type ProviderConfig struct {
 	deps         deps.Dependencies
 }
 
-// ProviderConfigRegistry holds a provider's declarative ProviderConfig entries. A provider may
-// declare module-specific configs in Modules (keyed by module ID, e.g. "crm", "gmail") and/or a
-// DefaultModuleConfig used when no module-specific entry matches the resolved module (or the
+// providerConfigRegistry holds a provider's declarative ProviderConfig entries. A provider may
+// declare module-specific configs in modules (keyed by module ID, e.g. "crm", "gmail") and/or a
+// defaultModuleConfig used when no module-specific entry matches the resolved module (or the
 // provider has no modules). Mirrors the structure of the connectors-library ProviderInfo.Modules.
-type ProviderConfigRegistry struct {
-	// DefaultModuleConfig is the config used when the resolved module has no entry in Modules.
+type providerConfigRegistry struct {
+	// defaultModuleConfig is the config used when the resolved module has no entry in modules.
 	// Nil when the provider declares only module-specific configs.
-	DefaultModuleConfig *ProviderConfig
+	defaultModuleConfig *ProviderConfig
 
-	// Modules holds module-specific configs, keyed by module ID (e.g. ModuleSalesforceCRM "crm",
+	// modules holds module-specific configs, keyed by module ID (e.g. ModuleSalesforceCRM "crm",
 	// ModuleGoogleGmail "gmail"). Nil/empty when the provider's config is module-agnostic.
-	Modules map[common.ModuleID]*ProviderConfig
+	modules map[common.ModuleID]*ProviderConfig
 }
 
 // getConfig resolves the ProviderConfig for the given module: the module-specific entry in
-// Modules if one exists, otherwise DefaultModuleConfig. Returns nil when neither is declared.
-func (r ProviderConfigRegistry) getConfig(module common.ModuleID) *ProviderConfig {
+// modules if one exists, otherwise defaultModuleConfig. Returns nil when neither is declared.
+func (r providerConfigRegistry) getConfig(module common.ModuleID) *ProviderConfig {
 	if module != "" {
-		if cfg, ok := r.Modules[module]; ok {
+		if cfg, ok := r.modules[module]; ok {
 			return cfg
 		}
 	}
 
-	return r.DefaultModuleConfig
+	return r.defaultModuleConfig
 }
 
 // providerConfigs is the registry of per-provider declarative configs. Each provider maps to a
-// ProviderConfigRegistry holding its module-specific configs (Modules) and/or a
+// providerConfigRegistry holding its module-specific configs (Modules) and/or a
 // DefaultModuleConfig fallback. GetProviderConfig resolves the module (falling back to
-// ProviderInfo.DefaultModule) and calls ProviderConfigRegistry.getConfig.
+// ProviderInfo.DefaultModule) and calls providerConfigRegistry.getConfig.
 //
 // Aliases (e.g. SalesforceJWT → Salesforce) register the same config pointer under both provider
 // keys. providerInfoAliases is used by callers fetching ProviderInfo so that twins missing
 // connectors-side SubscribeRequirements resolve correctly.
-var providerConfigs = map[providers.Provider]ProviderConfigRegistry{
+var providerConfigs = map[providers.Provider]providerConfigRegistry{
 	providers.Salesforce: {
-		Modules: map[common.ModuleID]*ProviderConfig{
+		modules: map[common.ModuleID]*ProviderConfig{
 			providers.ModuleSalesforceCRM: &salesforceConfig,
 		},
 	},
 	providers.SalesforceJWT: {
-		Modules: map[common.ModuleID]*ProviderConfig{
+		modules: map[common.ModuleID]*ProviderConfig{
 			providers.ModuleSalesforceCRM: &salesforceConfig,
 		},
 	},
 	providers.Zoho: {
-		Modules: map[common.ModuleID]*ProviderConfig{
+		modules: map[common.ModuleID]*ProviderConfig{
 			providers.ModuleZohoCRM: &zohoConfig,
 		},
 	},
-	providers.Outreach:  {DefaultModuleConfig: &outreachConfig},
-	providers.Salesloft: {DefaultModuleConfig: &salesloftConfig},
+	providers.Outreach:  {defaultModuleConfig: &outreachConfig},
+	providers.Salesloft: {defaultModuleConfig: &salesloftConfig},
 	providers.Google: {
-		Modules: map[common.ModuleID]*ProviderConfig{
+		modules: map[common.ModuleID]*ProviderConfig{
 			providers.ModuleGoogleGmail:    &googleConfig,
 			providers.ModuleGoogleCalendar: &googleCalendarConfig,
 		},
 	},
-	providers.Hubspot:      {DefaultModuleConfig: &hubspotConfig},
-	providers.Gong:         {DefaultModuleConfig: &gongConfig},
-	providers.HousecallPro: {DefaultModuleConfig: &housecallproConfig},
-	providers.ConnectWise:  {DefaultModuleConfig: &connectWiseConfig},
-	providers.AccuLynx:     {DefaultModuleConfig: &acculynxConfig},
-	providers.Jobber:       {DefaultModuleConfig: &jobberConfig},
-	providers.Slack:        {DefaultModuleConfig: &slackConfig},
-	providers.Microsoft:    {DefaultModuleConfig: &microsoftConfig},
-	providers.Attio:        {DefaultModuleConfig: &attioConfig},
-	providers.Stripe:       {DefaultModuleConfig: &stripeConfig},
+	providers.Hubspot:      {defaultModuleConfig: &hubspotConfig},
+	providers.Gong:         {defaultModuleConfig: &gongConfig},
+	providers.HousecallPro: {defaultModuleConfig: &housecallproConfig},
+	providers.ConnectWise:  {defaultModuleConfig: &connectWiseConfig},
+	providers.AccuLynx:     {defaultModuleConfig: &acculynxConfig},
+	providers.Jobber:       {defaultModuleConfig: &jobberConfig},
+	providers.Slack:        {defaultModuleConfig: &slackConfig},
+	providers.Microsoft:    {defaultModuleConfig: &microsoftConfig},
+	providers.Attio:        {defaultModuleConfig: &attioConfig},
+	providers.Stripe:       {defaultModuleConfig: &stripeConfig},
 }
 
 // ErrProviderConfigNotFound is returned by GetProviderConfig when no entry exists in
@@ -195,14 +195,14 @@ func GetProviderConfig(
 // the provider's RegistrationConfig has no buildParamsFn declared.
 var ErrRegistrationParamsBuilderNotDeclared = errors.New("registration params builder not declared for provider")
 
-// IsProviderLookUpOnly reports whether a provider's webhook subscriptions are managed outside of
+// isProviderLookUpOnly reports whether a provider's webhook subscriptions are managed outside of
 // Ampersand. When true, the subscribe workflow persists lookup rows for event routing but skips
 // all provider-side create/update/delete calls.
 //
 // The answer comes from the ProviderInfo: a provider is look-up-only when it supports
 // subscriptions (Support.Subscribe = true) but does NOT support programmatic subscription via API
 // (SubscribeRequirements.SubscribeByAPI is nil or false).
-func IsProviderLookUpOnly(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
+func isProviderLookUpOnly(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
 	if providerInfo == nil {
 		return false
 	}
@@ -263,13 +263,13 @@ func providerInfoIsLookUpOnly(module common.ModuleID, providerInfo *providers.Pr
 	return requirements == nil || requirements.SubscribeByAPI == nil || !*requirements.SubscribeByAPI
 }
 
-// ProviderRequiresRegistration determines if a provider requires a one-time registration step
+// providerRequiresRegistration determines if a provider requires a one-time registration step
 // before per-object subscriptions can be created.
 //
 // The answer comes from the ProviderInfo (per-module SubscribeRequirements.Registration, falling
 // back to the provider's DefaultModule, and finally to the top-level
 // SubscribeRequirements.Registration).
-func ProviderRequiresRegistration(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
+func providerRequiresRegistration(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
 	// If provider info is nil, we can't determine if registration is required
 	if providerInfo == nil {
 		return false
@@ -292,13 +292,13 @@ func providerInfoRegistrationRequired(module common.ModuleID, providerInfo *prov
 	return *requirements.Registration
 }
 
-// SubscriptionViaApiSupported reports whether the provider supports programmatic subscription via
+// subscriptionViaApiSupported reports whether the provider supports programmatic subscription via
 // API for the given module.
 //
 // The answer comes from the ProviderInfo (per-module SubscribeRequirements.SubscribeByAPI,
 // falling back to the provider's DefaultModule, and finally to the top-level
 // SubscribeRequirements).
-func SubscriptionViaApiSupported(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
+func subscriptionViaApiSupported(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
 	if providerInfo == nil {
 		return false
 	}
@@ -324,15 +324,15 @@ func providerInfoSubscribeSupported(module common.ModuleID, providerInfo *provid
 	return *requirements.SubscribeByAPI
 }
 
-// ShouldCreateRegistration determines if registration should be created based on provider info
+// shouldCreateRegistration determines if registration should be created based on provider info
 // and connector. Returns false if the provider doesn't require registration, the connector is
 // nil, or the connector doesn't support registration.
-func ShouldCreateRegistration(
+func shouldCreateRegistration(
 	module common.ModuleID,
 	providerInfo *providers.ProviderInfo,
 	connector connectors.SubscribeConnector,
 ) bool {
-	if !ProviderRequiresRegistration(module, providerInfo) {
+	if !providerRequiresRegistration(module, providerInfo) {
 		return false
 	}
 
@@ -341,18 +341,18 @@ func ShouldCreateRegistration(
 		return false
 	}
 
-	_, ok := CastConnector[connectors.RegisterSubscribeConnector](connector)
+	_, ok := castConnector[connectors.RegisterSubscribeConnector](connector)
 
 	return ok
 }
 
-// ShouldPostProcess determines if a provider requires a third-party setup step after the
+// shouldPostProcess determines if a provider requires a third-party setup step after the
 // connector's subscribe call returns (e.g. Salesforce → AWS EventBridge wiring).
 //
 // The answer comes from the ProviderInfo (per-module SubscribeRequirements.PostProcess, falling
 // back to the provider's DefaultModule, and finally to the top-level
 // SubscribeRequirements.PostProcess).
-func ShouldPostProcess(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
+func shouldPostProcess(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
 	// If provider info is nil, we can't determine if post-processing is required
 	if providerInfo == nil {
 		return false
@@ -375,15 +375,15 @@ func providerInfoPostProcessRequired(module common.ModuleID, providerInfo *provi
 	return *requirements.PostProcess
 }
 
-// ShouldPerformMaintenance determines if a provider's webhooks require periodic maintenance
+// shouldPerformMaintenance determines if a provider's webhooks require periodic maintenance
 // (renewal). For example, Gmail watch subscriptions expire after 7 days and must be re-issued
 // before expiry.
 //
 // The answer comes from the ProviderInfo (per-module SubscribeRequirements.Maintenance, falling
 // back to the provider's DefaultModule, and finally to the top-level
 // SubscribeRequirements.Maintenance). The renewal interval itself, when maintenance is required,
-// is read separately from GetMaintenancePeriod / MaintenanceConfig.Interval.
-func ShouldPerformMaintenance(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
+// is read separately from getMaintenancePeriod / MaintenanceConfig.Interval.
+func shouldPerformMaintenance(module common.ModuleID, providerInfo *providers.ProviderInfo) bool {
 	if providerInfo == nil {
 		return false
 	}
@@ -411,15 +411,15 @@ type connectorWithUnwrap interface {
 	Unwrap() connectors.Connector
 }
 
-// CastConnector attempts to cast a connector to a specific type. If the connector is nil, it
+// castConnector attempts to cast a connector to a specific type. If the connector is nil, it
 // returns a nil value and true. If the cast is successful, it returns the cast connector and
 // true. If the cast fails, it attempts to unwrap the connector if it implements the
-// connectorWithUnwrap interface and recursively calls CastConnector on the unwrapped connector.
+// connectorWithUnwrap interface and recursively calls castConnector on the unwrapped connector.
 // If the cast is still unsuccessful, it returns a nil value and false.
 //
 // Mirrors the server's utils.CastConnector so decorated (e.g. metrics-wrapped) connectors passed
 // in by the server cast identically.
-func CastConnector[ConnectorType connectors.Connector](connector connectors.Connector) (ConnectorType, bool) {
+func castConnector[ConnectorType connectors.Connector](connector connectors.Connector) (ConnectorType, bool) {
 	if connector == nil {
 		var empty ConnectorType
 
@@ -433,7 +433,7 @@ func CastConnector[ConnectorType connectors.Connector](connector connectors.Conn
 
 	unwrapper, ok := connector.(connectorWithUnwrap)
 	if ok {
-		return CastConnector[ConnectorType](unwrapper.Unwrap())
+		return castConnector[ConnectorType](unwrapper.Unwrap())
 	}
 
 	var empty ConnectorType

--- a/subscribe/google.go
+++ b/subscribe/google.go
@@ -33,7 +33,7 @@ var googleConfig = ProviderConfig{
 		// Gmail webhooks arriving at verification are synthetic republishes from the Gmail
 		// event workflow carrying no provider signature, so verification is bypassed.
 		bypassed:    true,
-		eventCaster: CastSubscriptionEvents[google.SubscriptionEvent],
+		eventCaster: castSubscriptionEvents[google.SubscriptionEvent],
 	},
 }
 
@@ -52,15 +52,15 @@ var (
 	errNilRevision = errors.New("nil revision")
 )
 
-// ProviderParamGCPProjectID and ProviderParamGCPPubSubTopicName are the well-known provider-app
+// providerParamGCPProjectID and providerParamGCPPubSubTopicName are the well-known provider-app
 // metadata ProviderParams keys carrying the Gmail Pub/Sub topic configuration. Mirror the
 // server's common.ProviderParam* constants.
 const (
-	ProviderParamGCPProjectID       = "gcpProjectId"
-	ProviderParamGCPPubSubTopicName = "gcpPubSubTopicName"
+	providerParamGCPProjectID       = "gcpProjectId"
+	providerParamGCPPubSubTopicName = "gcpPubSubTopicName"
 )
 
-// GetGmailTopicFullPath resolves the fully qualified Pub/Sub topic path for Gmail
+// getGmailTopicFullPath resolves the fully qualified Pub/Sub topic path for Gmail
 // push notifications (e.g. "projects/my-project/topics/gmail-subscribe").
 //
 // The topic path is built from the provider app's metadata fields:
@@ -82,7 +82,7 @@ const (
 //     subscription that delivers messages via HTTP POST to the Hookdeck endpoint.
 //
 //nolint:cyclop // nil-guards on the nested wire type dominate; the logic is two linear paths.
-func GetGmailTopicFullPath(ctx context.Context, conn *openapi.Connection) (string, error) {
+func getGmailTopicFullPath(ctx context.Context, conn *openapi.Connection) (string, error) {
 	log := logger.Get(ctx)
 
 	var connId, providerAppId string
@@ -98,8 +98,8 @@ func GetGmailTopicFullPath(ctx context.Context, conn *openapi.Connection) (strin
 	if conn != nil && conn.ProviderApp != nil && conn.ProviderApp.Metadata != nil &&
 		conn.ProviderApp.Metadata.ProviderParams != nil {
 		params := *conn.ProviderApp.Metadata.ProviderParams
-		gcpProject := params[ProviderParamGCPProjectID]
-		topicName := params[ProviderParamGCPPubSubTopicName]
+		gcpProject := params[providerParamGCPProjectID]
+		topicName := params[providerParamGCPPubSubTopicName]
 
 		if gcpProject != "" && topicName != "" {
 			fullPath := fmt.Sprintf("projects/%s/topics/%s", gcpProject, topicName)
@@ -121,7 +121,7 @@ func GetGmailTopicFullPath(ctx context.Context, conn *openapi.Connection) (strin
 		return "", fmt.Errorf("%w: GCP_PROJECT_ID unavailable: %w", ErrMissingGmailTopicConfig, err)
 	}
 
-	fullPath := fmt.Sprintf("projects/%s/topics/%s", gcpProjectID, GmailSubscribeTopic(ctx))
+	fullPath := fmt.Sprintf("projects/%s/topics/%s", gcpProjectID, buildGmailSubscribeTopic(ctx))
 	log.Warn("resolved gmail topic via fallback; provider app missing GCP topic config",
 		"topic", fullPath,
 		"connectionId", connId,
@@ -136,7 +136,7 @@ func GetGmailTopicFullPath(ctx context.Context, conn *openapi.Connection) (strin
 //
 // The Gmail watch API requires the topic to reside in the same GCP project as the OAuth
 // credentials (the provider app's project). The fully qualified topic path is resolved
-// via GetGmailTopicFullPath.
+// via getGmailTopicFullPath.
 //
 // Only the "gmail" module is supported here; the calendar module has its own builder
 // (getGoogleCalendarRequest), and other Google modules return ErrUnsupportedGoogleModule.
@@ -157,7 +157,7 @@ func getGoogleRequest(
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedGoogleModule, rev.Content.Module)
 	}
 
-	topicName, err := GetGmailTopicFullPath(ctx, conn)
+	topicName, err := getGmailTopicFullPath(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving Gmail topic name: %w", err)
 	}
@@ -168,24 +168,24 @@ func getGoogleRequest(
 }
 
 // gmailSubscribeTopic is the base topic ID for Gmail subscribe Pub/Sub topics.
-// GetPubSubName applies the environment prefix to produce the short topic name
+// getPubSubName applies the environment prefix to produce the short topic name
 // (e.g. "jay-local-gmail-subscribe" in local dev, "gmail-subscribe" in prod).
 //
-// The full topic path used by the Gmail watch API is built by GetGmailTopicFullPath:
+// The full topic path used by the Gmail watch API is built by getGmailTopicFullPath:
 //
 //	"projects/{GCP_PROJECT_ID}/topics/{env-prefix}-gmail-subscribe"
 const gmailSubscribeTopic = "gmail-subscribe"
 
-// GmailSubscribeTopic returns the environment-prefixed short topic name for Gmail
+// buildGmailSubscribeTopic returns the environment-prefixed short topic name for Gmail
 // subscription events (e.g. "jay-local-gmail-subscribe"). This is the topic ID
-// portion only — use GetGmailTopicFullPath for the fully qualified resource path.
-func GmailSubscribeTopic(ctx context.Context) string {
-	return GetPubSubName(ctx, gmailSubscribeTopic)
+// portion only — use getGmailTopicFullPath for the fully qualified resource path.
+func buildGmailSubscribeTopic(ctx context.Context) string {
+	return getPubSubName(ctx, gmailSubscribeTopic)
 }
 
-// GetPubSubName applies the environment prefix (PUBSUB_TOPIC_PREFIX, falling back to
+// getPubSubName applies the environment prefix (PUBSUB_TOPIC_PREFIX, falling back to
 // SUBSCRIBE_E2E_PREFIX) to a base Pub/Sub name. Mirrors the server's pubsub.GetPubSubName.
-func GetPubSubName(ctx context.Context, base string) string {
+func getPubSubName(ctx context.Context, base string) string {
 	return env.String(ctx, "PUBSUB_TOPIC_PREFIX").
 		Map(func(s string) (string, error) {
 			return fmt.Sprintf("%s-%s", s, base), nil

--- a/subscribe/hubspot.go
+++ b/subscribe/hubspot.go
@@ -18,7 +18,7 @@ var hubspotConfig = ProviderConfig{
 		paramsFn:          getHubspotVerificationParams,
 		verifierConnector: &hubspot.Connector{},
 		bypassed:          true,
-		eventCaster:       CastSubscriptionEvents[hubspot.SubscriptionEvent],
+		eventCaster:       castSubscriptionEvents[hubspot.SubscriptionEvent],
 	},
 }
 

--- a/subscribe/jobber.go
+++ b/subscribe/jobber.go
@@ -27,7 +27,7 @@ var jobberConfig = ProviderConfig{
 	Verification: VerificationConfig{
 		paramsFn:          getJobberVerificationParams,
 		verifierConnector: &jobber.Connector{},
-		eventCaster:       CastSubscriptionEvents[jobber.SubscriptionEvent],
+		eventCaster:       castSubscriptionEvents[jobber.SubscriptionEvent],
 	},
 }
 

--- a/subscribe/maintenance.go
+++ b/subscribe/maintenance.go
@@ -16,7 +16,7 @@ var errMaintenanceUnsupportedProvider = errors.New("maintenance is not supported
 // runs daily to renew them before expiry.
 //
 // This is the renewal *interval*, which has no ProviderInfo equivalent today; whether maintenance
-// is required at all is derived from ProviderInfo (see ShouldPerformMaintenance).
+// is required at all is derived from ProviderInfo (see shouldPerformMaintenance).
 //
 //nolint:mnd
 var maintenancePeriods = map[providers.Provider]time.Duration{
@@ -24,9 +24,9 @@ var maintenancePeriods = map[providers.Provider]time.Duration{
 	providers.Google: time.Hour * 24,
 }
 
-// GetMaintenancePeriod returns the scheduled maintenance interval for a provider's webhooks.
+// getMaintenancePeriod returns the scheduled maintenance interval for a provider's webhooks.
 // Returns an error if the provider does not require periodic maintenance.
-func GetMaintenancePeriod(provider providers.Provider) (time.Duration, error) {
+func getMaintenancePeriod(provider providers.Provider) (time.Duration, error) {
 	if period, ok := maintenancePeriods[provider]; ok {
 		return period, nil
 	}
@@ -62,9 +62,9 @@ type MaintenanceConfig struct {
 }
 
 // ShouldPerform reports whether the provider's webhook subscriptions require periodic maintenance
-// (renewal). Delegates to ShouldPerformMaintenance.
+// (renewal). Delegates to shouldPerformMaintenance.
 func (m MaintenanceConfig) ShouldPerform() bool {
-	return ShouldPerformMaintenance(m.module, m.providerInfo)
+	return shouldPerformMaintenance(m.module, m.providerInfo)
 }
 
 // Interval returns the renewal interval declared for the provider's webhooks and true, or

--- a/subscribe/postprocess.go
+++ b/subscribe/postprocess.go
@@ -26,7 +26,7 @@ type PostProcessConfig struct {
 }
 
 // ShouldPerform reports whether the provider requires a post-subscribe setup step. Derived from
-// ProviderInfo via ShouldPostProcess.
+// ProviderInfo via shouldPostProcess.
 func (p PostProcessConfig) ShouldPerform() bool {
-	return ShouldPostProcess(p.module, p.providerInfo)
+	return shouldPostProcess(p.module, p.providerInfo)
 }

--- a/subscribe/registration.go
+++ b/subscribe/registration.go
@@ -50,7 +50,7 @@ type RegistrationConfig struct {
 // The connector parameter is passed in at call time because connectors are not always
 // available when ProviderConfig is fetched.
 func (r RegistrationConfig) IsRequired(connector connectors.SubscribeConnector) bool {
-	return ShouldCreateRegistration(r.module, r.providerInfo, connector)
+	return shouldCreateRegistration(r.module, r.providerInfo, connector)
 }
 
 // EmptyResult returns a fresh empty registration result instance with the appropriate provider-
@@ -76,7 +76,7 @@ func (r RegistrationConfig) BuildParams(ctx context.Context, inst *openapi.Insta
 		return r.buildParamsFn(ctx, inst)
 	}
 
-	if !ProviderRequiresRegistration(r.module, r.providerInfo) {
+	if !providerRequiresRegistration(r.module, r.providerInfo) {
 		return nil, ErrRegistrationParamsBuilderNotDeclared
 	}
 

--- a/subscribe/salesforce.go
+++ b/subscribe/salesforce.go
@@ -140,7 +140,7 @@ func buildCDCEventFlagFields(
 		return nil, ErrAppNameRequired
 	}
 
-	sanitizedAppName := SanitizeAppNameForSalesforce(appName)
+	sanitizedAppName := sanitizeAppNameForSalesforce(appName)
 	if sanitizedAppName == "" {
 		return nil, ErrAppNameInvalid
 	}

--- a/subscribe/salesforce_test.go
+++ b/subscribe/salesforce_test.go
@@ -190,7 +190,7 @@ func TestSanitizeAppNameForSalesforce(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := SanitizeAppNameForSalesforce(testCase.input)
+			result := sanitizeAppNameForSalesforce(testCase.input)
 			if result != testCase.expected {
 				t.Errorf("SanitizeAppNameForSalesforce(%q) = %q, want %q", testCase.input, result, testCase.expected)
 			}

--- a/subscribe/salesforceappname.go
+++ b/subscribe/salesforceappname.go
@@ -2,12 +2,12 @@ package subscribe
 
 import "strings"
 
-// SanitizeAppNameForSalesforce normalizes an app name for use in Salesforce custom field names.
+// sanitizeAppNameForSalesforce normalizes an app name for use in Salesforce custom field names.
 // It lowercases all characters, keeps alphanumerics and underscores, replaces hyphens
 // and spaces with underscores, removes all other characters, and trims trailing underscores.
 //
 // Mirrors the server's salesforce.SanitizeAppNameForSalesforce.
-func SanitizeAppNameForSalesforce(appName string) string {
+func sanitizeAppNameForSalesforce(appName string) string {
 	var result strings.Builder
 
 	for _, char := range appName {

--- a/subscribe/stripe.go
+++ b/subscribe/stripe.go
@@ -33,7 +33,7 @@ var stripeConfig = ProviderConfig{
 	Verification: VerificationConfig{
 		paramsFn:          getStripeVerificationParams,
 		verifierConnector: &stripe.Connector{},
-		eventCaster:       CastSubscriptionEvents[stripe.SubscriptionEvent],
+		eventCaster:       castSubscriptionEvents[stripe.SubscriptionEvent],
 	},
 }
 

--- a/subscribe/subscribe.go
+++ b/subscribe/subscribe.go
@@ -32,17 +32,17 @@
 // File layout mirrors the server package:
 //
 //   - aliases.go:            ResolveProviderInfoAlias and the providerInfoAliases registry.
-//   - config.go:             ProviderConfig + ProviderConfigRegistry + providerConfigs registry +
+//   - config.go:             ProviderConfig + providerConfigRegistry + providerConfigs registry +
 //     GetProviderConfig + the ProviderInfo derivation helpers.
 //   - deps/ (package):       the resolver seam — types.go (Dependencies, VerificationRequest)
 //     plus one file per resolver interface (project.go, cdcoptimization.go, subscriptions.go).
 //   - events.go:             object-type subscribe-event unwrapping (provider-specific shapes).
-//   - maintenance.go:        MaintenanceConfig + maintenancePeriods + GetMaintenancePeriod.
+//   - maintenance.go:        MaintenanceConfig + maintenancePeriods + getMaintenancePeriod.
 //   - postprocess.go:        PostProcessConfig (derived ShouldPerform only).
 //   - registration.go:       RegistrationConfig + methods.
 //   - subscription.go:       SubscriptionConfig + methods.
-//   - subscriptionevents.go: SubscriptionEventCaster + generic Cast helpers.
-//   - verification.go:       VerificationConfig + methods + IsHookdeckGatewayProvider.
+//   - subscriptionevents.go: subscriptionEventCaster + generic Cast helpers.
+//   - verification.go:       VerificationConfig + methods + isHookdeckGatewayProvider.
 //   - <provider>.go:         per-provider <name>Config literal and helpers.
 package subscribe
 

--- a/subscribe/subscription.go
+++ b/subscribe/subscription.go
@@ -9,7 +9,7 @@ import (
 	"github.com/amp-labs/connectors/subscribe/deps"
 )
 
-// SubscriptionRequestBuilder constructs the provider-specific subscribe-time request payload
+// subscriptionRequestBuilder constructs the provider-specific subscribe-time request payload
 // (e.g. Pub/Sub topic name for Google, webhook URL for Outreach/Salesloft/Zoho) that is passed
 // to the connector's Subscribe method.
 //
@@ -17,7 +17,7 @@ import (
 // inst.Connection. deps carries the caller-provided resolver capabilities (bound at
 // GetProviderConfig time). webhookURL is the event-receipt endpoint constructed by the caller;
 // providers that do not need it (e.g. Google's Pub/Sub topic builder) simply ignore it.
-type SubscriptionRequestBuilder func(
+type subscriptionRequestBuilder func(
 	ctx context.Context,
 	deps deps.Dependencies,
 	inst *openapi.Installation,
@@ -49,7 +49,7 @@ type SubscriptionConfig struct {
 
 	// buildRequestFn constructs the subscribe-time request payload passed to the connector's
 	// Subscribe method. Nil when the provider needs no custom payload.
-	buildRequestFn SubscriptionRequestBuilder
+	buildRequestFn subscriptionRequestBuilder
 
 	// module, providerInfo, and deps are bound by GetProviderConfig at call time.
 	module       common.ModuleID
@@ -58,16 +58,16 @@ type SubscriptionConfig struct {
 }
 
 // IsSupportedViaAPI reports whether the provider supports programmatic subscription via API.
-// Derived from ProviderInfo via SubscriptionViaApiSupported.
+// Derived from ProviderInfo via subscriptionViaApiSupported.
 func (s SubscriptionConfig) IsSupportedViaAPI() bool {
-	return SubscriptionViaApiSupported(s.module, s.providerInfo)
+	return subscriptionViaApiSupported(s.module, s.providerInfo)
 }
 
 // SubscribeManually reports whether the provider's webhook subscriptions are configured manually
 // at the provider level (rather than registered programmatically via API by Ampersand). Derived
-// from ProviderInfo via IsProviderLookUpOnly.
+// from ProviderInfo via isProviderLookUpOnly.
 func (s SubscriptionConfig) SubscribeManually() bool {
-	return IsProviderLookUpOnly(s.module, s.providerInfo)
+	return isProviderLookUpOnly(s.module, s.providerInfo)
 }
 
 // RequiresWatchFieldsAutoAll reports whether the provider requires WatchFieldsAuto="all" for

--- a/subscribe/subscriptionevents.go
+++ b/subscribe/subscriptionevents.go
@@ -12,16 +12,16 @@ import (
 // provider's VerificationConfig declares no eventCaster.
 var errSubscriptionEventCasterNotDeclared = errors.New("subscription event caster not declared for provider")
 
-// SubscriptionEventCaster converts a list of generic maps into a list of typed
+// subscriptionEventCaster converts a list of generic maps into a list of typed
 // SubscriptionEvent implementations for a specific provider. Declared per-provider via
 // VerificationConfig.eventCaster (see the per-provider configs).
-type SubscriptionEventCaster func(list []map[string]any) ([]common.SubscriptionEvent, error)
+type subscriptionEventCaster func(list []map[string]any) ([]common.SubscriptionEvent, error)
 
-// CastSubscriptionEvents wraps CastArray with the conversion to []common.SubscriptionEvent.
-func CastSubscriptionEvents[T common.SubscriptionEvent](
+// castSubscriptionEvents wraps castArray with the conversion to []common.SubscriptionEvent.
+func castSubscriptionEvents[T common.SubscriptionEvent](
 	list []map[string]any,
 ) ([]common.SubscriptionEvent, error) {
-	typedList, err := CastArray[T](list)
+	typedList, err := castArray[T](list)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cast to array: %w", err)
 	}
@@ -34,9 +34,9 @@ func CastSubscriptionEvents[T common.SubscriptionEvent](
 	return result, nil
 }
 
-// CastArray converts a slice of generic maps to a slice of typed structs using mapstructure.
+// castArray converts a slice of generic maps to a slice of typed structs using mapstructure.
 // Generic function that works for any struct type T.
-func CastArray[T any](list []map[string]any) ([]T, error) {
+func castArray[T any](list []map[string]any) ([]T, error) {
 	result := make([]T, len(list))
 
 	for i, item := range list {

--- a/subscribe/verification.go
+++ b/subscribe/verification.go
@@ -10,11 +10,11 @@ import (
 	"github.com/amp-labs/connectors/subscribe/deps"
 )
 
-// VerificationParamsFunc is a function that retrieves webhook verification parameters for a
+// verificationParamsFunc is a function that retrieves webhook verification parameters for a
 // specific provider. It takes the bound deps.Dependencies plus the deps.VerificationRequest (payload,
 // integration, installation, provider app details) and returns the verification parameters
 // needed to validate incoming webhook requests from that provider.
-type VerificationParamsFunc func(
+type verificationParamsFunc func(
 	ctx context.Context,
 	deps deps.Dependencies,
 	req *deps.VerificationRequest,
@@ -25,13 +25,15 @@ var (
 	errWebhookVerificationNotSupported = errors.New("webhook verification not supported")
 )
 
-// IsHookdeckGatewayProvider reports whether the given provider's webhooks are routed through
+// isHookdeckGatewayProvider reports whether the given provider's webhooks are routed through
 // Hookdeck. Used both to gate Hookdeck signature verification and to choose between Hookdeck and
 // CloudFunction event endpoints.
 //
 // Salesforce / SalesforceJWT use a CloudFunction endpoint with their own AWS EventBridge wiring,
 // and Hubspot delivers webhooks directly. Everyone else routes through Hookdeck.
-func IsHookdeckGatewayProvider(provider providers.Provider) bool {
+//
+// TODO should this be preserved?
+func isHookdeckGatewayProvider(provider providers.Provider) bool { // nolint:unused
 	return provider != providers.Hubspot &&
 		provider != providers.Salesforce &&
 		provider != providers.SalesforceJWT
@@ -51,7 +53,7 @@ func IsHookdeckGatewayProvider(provider providers.Provider) bool {
 type VerificationConfig struct {
 	// paramsFn builds the provider-specific webhook verification params. Nil when the provider
 	// has none (e.g. Gong, HousecallPro).
-	paramsFn VerificationParamsFunc
+	paramsFn verificationParamsFunc
 
 	// verifierConnector is the connector instance used to verify incoming webhook signatures.
 	// Nil when the provider has no verifier connector. Shared across calls — a zero-value
@@ -64,7 +66,7 @@ type VerificationConfig struct {
 
 	// eventCaster casts raw event maps into typed SubscriptionEvents. Nil when the provider's
 	// events need no provider-specific casting.
-	eventCaster SubscriptionEventCaster
+	eventCaster subscriptionEventCaster
 
 	// deps is bound by GetProviderConfig at call time and threaded into paramsFn.
 	deps deps.Dependencies

--- a/subscribe/zoho.go
+++ b/subscribe/zoho.go
@@ -63,7 +63,7 @@ func getZohoRequest(
 	conn *openapi.Connection,
 	webhookURL string,
 ) (any, error) {
-	dur, err := GetMaintenancePeriod(conn.Provider)
+	dur, err := getMaintenancePeriod(conn.Provider)
 	if err != nil {
 		return nil, fmt.Errorf("error getting maintenance period: %w", err)
 	}


### PR DESCRIPTION
# Description

Unexport some methods and fields of `"github.com/amp-labs/connectors/subscribe` package.