### PR TITLE
[CON-3466] feat(housecallpro): populate estimate and lead customer associations

### DIFF
--- a/providers/housecallPro/associations.go
+++ b/providers/housecallPro/associations.go
@@ -7,8 +7,16 @@ import (
 
 const customerObject = "customers"
 
+// Jobs, estimates and leads all embed the customer object under the same "customer" field,
+// so the association is lifted off the list payload without extra API calls.
 var embeddedAssociationFields = map[string]map[string]string{ //nolint:gochecknoglobals
 	"jobs": {
+		customerObject: "customer",
+	},
+	"estimates": {
+		customerObject: "customer",
+	},
+	"leads": {
 		customerObject: "customer",
 	},
 }

--- a/providers/housecallPro/associations_test.go
+++ b/providers/housecallPro/associations_test.go
@@ -53,6 +53,29 @@ func TestExtractAssociationsAttachesJobCustomer(t *testing.T) {
 	assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f", rows[0].Associations[customerObject][0].ObjectId)
 }
 
+func TestExtractAssociationsAttachesEstimateAndLeadCustomer(t *testing.T) {
+	t.Parallel()
+
+	customer := map[string]any{
+		"id":         "cus_b0f661aa89324111b575da039c45e19f",
+		"first_name": "Walter",
+	}
+
+	for _, objectName := range []string{"estimates", "leads"} {
+		rows := []common.ReadResultRow{{
+			Id:  "rec_2fad85ca2c6c43b7bdbc01f0d12ff1c4",
+			Raw: map[string]any{"id": "rec_2fad85ca2c6c43b7bdbc01f0d12ff1c4", "customer": customer},
+		}}
+
+		extractAssociations(objectName, []string{customerObject}, rows)
+
+		require.Len(t, rows[0].Associations[customerObject], 1, "object %v", objectName)
+		assert.Equal(t, "cus_b0f661aa89324111b575da039c45e19f",
+			rows[0].Associations[customerObject][0].ObjectId, "object %v", objectName)
+		assert.Equal(t, customer, rows[0].Associations[customerObject][0].Raw, "object %v", objectName)
+	}
+}
+
 func TestAttachEmbeddedAssociation(t *testing.T) {
 	t.Parallel()
 

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -26,6 +26,8 @@ func TestRead(t *testing.T) {
 	responseEmployees := testutils.DataFromFile(t, "read-employees.json")
 	responseRoutes := testutils.DataFromFile(t, "read-routes.json")
 	responseJobs := testutils.DataFromFile(t, "read-jobs.json")
+	responseEstimates := testutils.DataFromFile(t, "read-estimates.json")
+	responseLeads := testutils.DataFromFile(t, "read-leads.json")
 
 	tests := []testconn.TestCaseRead{
 		{
@@ -441,6 +443,144 @@ func TestRead(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read estimates attaches embedded customer as association",
+			Input: common.ReadParams{
+				ObjectName:        "estimates",
+				Fields:            connectors.Fields("id", "estimate_number", "updated_at"),
+				PageSize:          1,
+				AssociatedObjects: []string{"customers"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/estimates"),
+					mockcond.QueryParam("page_size", "1"),
+					mockcond.QueryParam("sort_by", "updated_at"),
+					mockcond.QueryParam("sort_direction", "desc"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseEstimates),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":              "est_00000000000000000000000000000001",
+							"estimate_number": "12",
+							"updated_at":      "2026-01-02T00:00:00Z",
+						},
+						Raw: map[string]any{
+							"id":              "est_00000000000000000000000000000001",
+							"estimate_number": "12",
+						},
+						Associations: map[string][]common.Association{
+							"customers": {
+								{
+									ObjectId: "cus_00000000000000000000000000000001",
+									Raw: map[string]any{
+										"id":         "cus_00000000000000000000000000000001",
+										"first_name": "Jane",
+										"last_name":  "Sample",
+										"email":      "jane.sample@example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read leads attaches embedded customer as association",
+			Input: common.ReadParams{
+				ObjectName:        "leads",
+				Fields:            connectors.Fields("id", "number", "status"),
+				PageSize:          1,
+				AssociatedObjects: []string{"customers"},
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/leads"),
+					mockcond.QueryParam("page_size", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseLeads),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":     "lead_00000000000000000000000000000001",
+							"number": "7",
+							"status": "open",
+						},
+						Raw: map[string]any{
+							"id":     "lead_00000000000000000000000000000001",
+							"number": "7",
+						},
+						Associations: map[string][]common.Association{
+							"customers": {
+								{
+									ObjectId: "cus_00000000000000000000000000000001",
+									Raw: map[string]any{
+										"id":         "cus_00000000000000000000000000000001",
+										"first_name": "Jane",
+										"last_name":  "Sample",
+										"email":      "jane.sample@example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				NextPage: "",
+				Done:     true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read leads without customer association request",
+			Input: common.ReadParams{
+				ObjectName: "leads",
+				Fields:     connectors.Fields("id", "number", "status"),
+				PageSize:   1,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/leads"),
+					mockcond.QueryParam("page_size", "1"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseLeads),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{
+					{
+						Fields: map[string]any{
+							"id":     "lead_00000000000000000000000000000001",
+							"number": "7",
+							"status": "open",
+						},
+						Raw: map[string]any{
+							"id":     "lead_00000000000000000000000000000001",
+							"number": "7",
 						},
 					},
 				},

--- a/providers/housecallPro/read_test.go
+++ b/providers/housecallPro/read_test.go
@@ -475,13 +475,13 @@ func TestRead(t *testing.T) {
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
-							"id":              "est_00000000000000000000000000000001",
-							"estimate_number": "12",
+							"id":              "csr_00000000000000000000000000000001",
+							"estimate_number": "15",
 							"updated_at":      "2026-01-02T00:00:00Z",
 						},
 						Raw: map[string]any{
-							"id":              "est_00000000000000000000000000000001",
-							"estimate_number": "12",
+							"id":              "csr_00000000000000000000000000000001",
+							"estimate_number": "15",
 						},
 						Associations: map[string][]common.Association{
 							"customers": {
@@ -507,7 +507,7 @@ func TestRead(t *testing.T) {
 			Name: "Read leads attaches embedded customer as association",
 			Input: common.ReadParams{
 				ObjectName:        "leads",
-				Fields:            connectors.Fields("id", "number", "status"),
+				Fields:            connectors.Fields("id", "status"),
 				PageSize:          1,
 				AssociatedObjects: []string{"customers"},
 			},
@@ -525,13 +525,11 @@ func TestRead(t *testing.T) {
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
-							"id":     "lead_00000000000000000000000000000001",
-							"number": "7",
-							"status": "open",
+							"id":     "lea_00000000000000000000000000000001",
+							"status": "won",
 						},
 						Raw: map[string]any{
-							"id":     "lead_00000000000000000000000000000001",
-							"number": "7",
+							"id": "lea_00000000000000000000000000000001",
 						},
 						Associations: map[string][]common.Association{
 							"customers": {
@@ -557,7 +555,7 @@ func TestRead(t *testing.T) {
 			Name: "Read leads without customer association request",
 			Input: common.ReadParams{
 				ObjectName: "leads",
-				Fields:     connectors.Fields("id", "number", "status"),
+				Fields:     connectors.Fields("id", "status"),
 				PageSize:   1,
 			},
 			Server: mockserver.Conditional{
@@ -574,13 +572,11 @@ func TestRead(t *testing.T) {
 				Data: []common.ReadResultRow{
 					{
 						Fields: map[string]any{
-							"id":     "lead_00000000000000000000000000000001",
-							"number": "7",
-							"status": "open",
+							"id":     "lea_00000000000000000000000000000001",
+							"status": "won",
 						},
 						Raw: map[string]any{
-							"id":     "lead_00000000000000000000000000000001",
-							"number": "7",
+							"id": "lea_00000000000000000000000000000001",
 						},
 					},
 				},

--- a/providers/housecallPro/test/read-estimates.json
+++ b/providers/housecallPro/test/read-estimates.json
@@ -5,8 +5,8 @@
     "total_items": 1,
     "estimates": [
         {
-            "id": "est_00000000000000000000000000000001",
-            "estimate_number": "12",
+            "id": "csr_00000000000000000000000000000001",
+            "estimate_number": "15",
             "customer": {
                 "id": "cus_00000000000000000000000000000001",
                 "first_name": "Jane",
@@ -36,8 +36,33 @@
                 "zip": "00000",
                 "country": "USA"
             },
-            "work_status": "estimate scheduled",
-            "options": [],
+            "assigned_employees": [],
+            "estimate_fields": {
+                "business_unit": null,
+                "job_type": null
+            },
+            "options": [
+                {
+                    "id": "est_00000000000000000000000000000001",
+                    "approval_status": null,
+                    "created_at": "2026-01-02T00:00:00Z"
+                }
+            ],
+            "schedule": {
+                "appointments": [],
+                "arrival_window": 0,
+                "scheduled_end": null,
+                "scheduled_start": null
+            },
+            "work_status": "needs scheduling",
+            "work_timestamps": {
+                "completed_at": null,
+                "on_my_way_at": null,
+                "started_at": null
+            },
+            "lead_source": null,
+            "company_id": "00000000-0000-0000-0000-000000000000",
+            "company_name": "Acme",
             "created_at": "2026-01-02T00:00:00Z",
             "updated_at": "2026-01-02T00:00:00Z"
         }

--- a/providers/housecallPro/test/read-estimates.json
+++ b/providers/housecallPro/test/read-estimates.json
@@ -1,0 +1,45 @@
+{
+    "page": 1,
+    "page_size": 1,
+    "total_pages": 1,
+    "total_items": 1,
+    "estimates": [
+        {
+            "id": "est_00000000000000000000000000000001",
+            "estimate_number": "12",
+            "customer": {
+                "id": "cus_00000000000000000000000000000001",
+                "first_name": "Jane",
+                "last_name": "Sample",
+                "email": "jane.sample@example.com",
+                "mobile_number": "5550000000",
+                "home_number": "5550000000",
+                "work_number": "5550000000",
+                "company": "Sample Co",
+                "company_name": "Acme",
+                "company_id": "00000000-0000-0000-0000-000000000000",
+                "kind": "homeowner",
+                "lead_source": null,
+                "notes": "Sample customer for tests.",
+                "notifications_enabled": true,
+                "tags": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z"
+            },
+            "address": {
+                "id": "adr_00000000000000000000000000000001",
+                "type": "service",
+                "street": "1 Example St",
+                "street_line_2": null,
+                "city": "Sampleville",
+                "state": "CA",
+                "zip": "00000",
+                "country": "USA"
+            },
+            "work_status": "estimate scheduled",
+            "options": [],
+            "created_at": "2026-01-02T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z"
+        }
+    ]
+}

--- a/providers/housecallPro/test/read-leads.json
+++ b/providers/housecallPro/test/read-leads.json
@@ -5,8 +5,8 @@
     "total_items": 1,
     "leads": [
         {
-            "id": "lead_00000000000000000000000000000001",
-            "number": "7",
+            "id": "lea_00000000000000000000000000000001",
+            "number": 14,
             "customer": {
                 "id": "cus_00000000000000000000000000000001",
                 "first_name": "Jane",
@@ -36,14 +36,25 @@
                 "zip": "00000",
                 "country": "USA"
             },
-            "status": "open",
-            "pipeline_status": {
-                "id": "pst_00000000000000000000000000000001",
-                "name": "New Lead"
+            "assigned_employee": null,
+            "conversions": [
+                {
+                    "id": "job_00000000000000000000000000000001",
+                    "type": "Job"
+                }
+            ],
+            "job_fields": {
+                "business_unit_uuid": null,
+                "job_type_uuid": null
             },
-            "total_amount": 0,
             "lead_source": null,
-            "tags": []
+            "lost_at": null,
+            "pipeline_status": null,
+            "status": "won",
+            "tags": [],
+            "total_amount": 0,
+            "company_id": "00000000-0000-0000-0000-000000000000",
+            "company_name": "Acme"
         }
     ]
 }

--- a/providers/housecallPro/test/read-leads.json
+++ b/providers/housecallPro/test/read-leads.json
@@ -1,0 +1,49 @@
+{
+    "page": 1,
+    "page_size": 1,
+    "total_pages": 1,
+    "total_items": 1,
+    "leads": [
+        {
+            "id": "lead_00000000000000000000000000000001",
+            "number": "7",
+            "customer": {
+                "id": "cus_00000000000000000000000000000001",
+                "first_name": "Jane",
+                "last_name": "Sample",
+                "email": "jane.sample@example.com",
+                "mobile_number": "5550000000",
+                "home_number": "5550000000",
+                "work_number": "5550000000",
+                "company": "Sample Co",
+                "company_name": "Acme",
+                "company_id": "00000000-0000-0000-0000-000000000000",
+                "kind": "homeowner",
+                "lead_source": null,
+                "notes": "Sample customer for tests.",
+                "notifications_enabled": true,
+                "tags": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z"
+            },
+            "address": {
+                "id": "adr_00000000000000000000000000000001",
+                "type": "service",
+                "street": "1 Example St",
+                "street_line_2": null,
+                "city": "Sampleville",
+                "state": "CA",
+                "zip": "00000",
+                "country": "USA"
+            },
+            "status": "open",
+            "pipeline_status": {
+                "id": "pst_00000000000000000000000000000001",
+                "name": "New Lead"
+            },
+            "total_amount": 0,
+            "lead_source": null,
+            "tags": []
+        }
+    ]
+}

--- a/test/housecallPro/associations/main.go
+++ b/test/housecallPro/associations/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	housecallpro "github.com/amp-labs/connectors/providers/housecallPro"
+	testHousecallPro "github.com/amp-labs/connectors/test/housecallPro"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+// Live validation for the embedded customer association:
+//
+//  1. Read jobs with AssociatedObjects=[customers] and show every row carries a
+//     "customers" edge lifted off the embedded customer object (pre-existing
+//     behaviour, checked as a regression).
+//  2. Read estimates with AssociatedObjects=[customers] and show the same edge.
+//  3. Read leads with AssociatedObjects=[customers] and show the same edge.
+//  4. Read estimates and leads WITHOUT requesting the association and show no
+//     edges are attached.
+//
+// No extra API calls are involved: the customer is already embedded in each
+// list payload, so the edge is lifted during marshalling.
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	utils.SetupLogging()
+
+	conn := testHousecallPro.GetConnector(ctx)
+
+	for _, tc := range []struct {
+		object string
+		fields []string
+	}{
+		{"jobs", []string{"id", "work_status", "updated_at"}},
+		{"estimates", []string{"id", "estimate_number", "updated_at"}},
+		{"leads", []string{"id", "number", "status"}},
+	} {
+		slog.Info(fmt.Sprintf("=== %v with customers association requested ===", tc.object))
+
+		if err := readWithCustomerEdge(ctx, conn, tc.object, tc.fields); err != nil {
+			slog.Error(err.Error())
+		}
+	}
+
+	for _, tc := range []struct {
+		object string
+		fields []string
+	}{
+		{"estimates", []string{"id", "estimate_number", "updated_at"}},
+		{"leads", []string{"id", "number", "status"}},
+	} {
+		slog.Info(fmt.Sprintf("=== %v without the association requested ===", tc.object))
+
+		if err := readWithoutCustomerEdge(ctx, conn, tc.object, tc.fields); err != nil {
+			slog.Error(err.Error())
+		}
+	}
+}
+
+func readWithCustomerEdge(
+	ctx context.Context, conn *housecallpro.Connector, objectName string, fields []string,
+) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName:        objectName,
+		Fields:            connectors.Fields(fields...),
+		PageSize:          5,
+		AssociatedObjects: []string{"customers"},
+	})
+	if err != nil {
+		return fmt.Errorf("reading %v with associations: %w", objectName, err)
+	}
+
+	withCustomer, withEmbedded, withRawPayload := 0, 0, 0
+
+	for _, row := range res.Data {
+		edges := row.Associations["customers"]
+		if len(edges) > 0 {
+			withCustomer++
+
+			if edges[0].ObjectId != "" {
+				withEmbedded++
+			}
+
+			if len(edges[0].Raw) > 0 {
+				withRawPayload++
+			}
+		}
+	}
+
+	slog.Info("customer association coverage",
+		"object", objectName,
+		"rows", res.Rows,
+		"withCustomerEdge", withCustomer,
+		"withObjectId", withEmbedded,
+		"withRawPayload", withRawPayload,
+		"expected", "all three == rows")
+
+	dumpFirstRows(res)
+
+	return nil
+}
+
+func readWithoutCustomerEdge(
+	ctx context.Context, conn *housecallpro.Connector, objectName string, fields []string,
+) error {
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: objectName,
+		Fields:     connectors.Fields(fields...),
+		PageSize:   5,
+	})
+	if err != nil {
+		return fmt.Errorf("reading %v without associations: %w", objectName, err)
+	}
+
+	withAny := 0
+
+	for _, row := range res.Data {
+		if len(row.Associations) > 0 {
+			withAny++
+		}
+	}
+
+	slog.Info("association leakage check",
+		"object", objectName,
+		"rows", res.Rows,
+		"rowsWithAnyAssociation", withAny,
+		"expected", "rowsWithAnyAssociation == 0")
+
+	return nil
+}
+
+func dumpFirstRows(res *common.ReadResult) {
+	utils.DumpJSON(res.Data[:min(2, len(res.Data))], os.Stdout)
+}


### PR DESCRIPTION
- When customers is requested as an associated object, estimate and lead reads attach the embedded customer under associations.customers, matching jobs behavior.

Live Tests
<img width="1364" height="753" alt="Screenshot 2026-08-17 at 17 04 46" src="https://github.com/user-attachments/assets/907b0e0d-e5ea-490a-8785-cfb821107613" />
