### PR TITLE
fix(zoominfo): derive read pagination from links.next

### DIFF
--- a/providers/zoominfo/read.go
+++ b/providers/zoominfo/read.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	neturl "net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -21,6 +23,12 @@ const (
 
 	pageNumberParam = "page[number]"
 	pageSizeParam   = "page[size]"
+
+	// linksURIPrefix is a ZoomInfo serialization quirk: on the Data API surface the
+	// values inside "links" are strings of the form "uri=/data/v1/...?page[number]=2"
+	// rather than bare URLs. The Studio and Copilot surfaces return plain absolute
+	// URLs instead, so the prefix is trimmed when present.
+	linksURIPrefix = "uri="
 )
 
 // jsonAPIRequestBody is the JSON:API envelope POSTed to a search endpoint.
@@ -113,7 +121,7 @@ func (c *Connector) buildSearchReadRequest(ctx context.Context, params common.Re
 
 // parseReadResponse turns a JSON:API list response into a ReadResult: records live
 // under data[], their fields are flattened out of "attributes", and the next page
-// is derived from meta.page.
+// is derived from the "links" object.
 func (c *Connector) parseReadResponse(
 	ctx context.Context,
 	params common.ReadParams,
@@ -123,7 +131,7 @@ func (c *Connector) parseReadResponse(
 	return common.ParseResult(
 		response,
 		getRecords,
-		nextPageFromMeta,
+		nextPageFromLinks(effectivePageSize(params)),
 		common.MakeMarshaledDataFunc(common.FlattenNestedFields(attributesField)),
 		params.Fields,
 	)
@@ -136,38 +144,93 @@ func getRecords(node *ajson.Node) ([]*ajson.Node, error) {
 	return jsonquery.New(node).ArrayOptional("data")
 }
 
-// nextPageFromMeta returns the next page number (as a string token) from
-// meta.page, or "" when the current page is the last (or meta.page is absent,
-// e.g. lookup endpoints that return a single unpaginated page).
-func nextPageFromMeta(node *ajson.Node) (string, error) {
-	page := jsonquery.New(node, "meta", "page")
+// nextPageFromLinks returns the next page number (as a string token) taken from the
+// JSON:API "links" object, or "" when the read is finished.
+//
+// links.next is the only trustworthy end-of-results signal ZoomInfo provides: it is
+// sent while further pages exist and omitted on the final page. It also keeps reads
+// inside ZoomInfo's hard 10,000-record pagination limit, past which the API answers
+// PFAPI0006 ("Total record pagination is over max allowed value (10000)") — at the
+// boundary page links.next simply stops being sent.
+//
+// meta.page.total is deliberately NOT consulted. Despite its name and ZoomInfo's own
+// documentation, it is not a page count: it reports how many records the page just
+// returned holds (a full page[size]=100 page reports 100; a 60-record final page
+// reports 60). Comparing it against meta.page.number therefore compares a page
+// number to a record count, which either walks off the end of the result set into
+// PFAPI0004 ("Page number (page) requested is greater than the available results")
+// or, at small page sizes, stops after page[size] pages and silently truncates the
+// read.
+//
+// A page shorter than the requested page[size] also ends the read. That is redundant
+// with links.next against today's API and is kept so a missing or over-eager link
+// cannot resurrect the overrun.
+func nextPageFromLinks(pageSize int) func(*ajson.Node) (string, error) {
+	return func(node *ajson.Node) (string, error) {
+		records, err := getRecords(node)
+		if err != nil {
+			return "", err
+		}
 
-	number, err := page.IntegerOptional("number")
-	if err != nil || number == nil {
-		return "", nil //nolint:nilerr // absent pagination metadata means a single page
+		if pageSize > 0 && len(records) < pageSize {
+			return "", nil
+		}
+
+		// Unpaginated endpoints (e.g. lookup/{fieldName}) omit "links" entirely.
+		links, err := jsonquery.New(node).ObjectOptional("links")
+		if err != nil {
+			return "", err
+		}
+
+		if links == nil {
+			return "", nil
+		}
+
+		next, err := jsonquery.New(links).StrWithDefault("next", "")
+		if err != nil {
+			return "", err
+		}
+
+		if next == "" {
+			return "", nil
+		}
+
+		return pageNumberFromLink(next)
+	}
+}
+
+// pageNumberFromLink extracts page[number] from a "links" entry. A link we cannot
+// read is reported as an error rather than treated as end-of-results, so a change in
+// ZoomInfo's link format surfaces instead of silently truncating every read.
+func pageNumberFromLink(link string) (string, error) {
+	parsed, err := neturl.Parse(strings.TrimPrefix(link, linksURIPrefix))
+	if err != nil {
+		return "", fmt.Errorf("%w: cannot parse links.next %q: %w", common.ErrNextPageInvalid, link, err)
 	}
 
-	total, err := page.IntegerOptional("total")
-	if err != nil || total == nil {
-		return "", nil //nolint:nilerr
+	number := parsed.Query().Get(pageNumberParam)
+	if number == "" {
+		return "", fmt.Errorf("%w: links.next %q carries no %s", common.ErrNextPageInvalid, link, pageNumberParam)
 	}
 
-	if *number >= *total {
-		return "", nil
+	return number, nil
+}
+
+// effectivePageSize is the page[size] actually sent for a read, clamped to the
+// provider maximum. parseReadResponse needs the same value to recognise a short
+// final page, so both sides derive it here rather than duplicating the clamp.
+func effectivePageSize(params common.ReadParams) int {
+	if params.PageSize > 0 && params.PageSize <= maxPageSize {
+		return params.PageSize
 	}
 
-	return strconv.FormatInt(*number+1, 10), nil
+	return defaultPageSize
 }
 
 // applyPagination sets page[size] (capped at the provider max) and page[number]
 // (from the opaque NextPage token) on the request URL.
 func applyPagination(url *urlbuilder.URL, params common.ReadParams) {
-	size := defaultPageSize
-	if params.PageSize > 0 && params.PageSize <= maxPageSize {
-		size = params.PageSize
-	}
-
-	url.WithQueryParam(pageSizeParam, strconv.Itoa(size))
+	url.WithQueryParam(pageSizeParam, strconv.Itoa(effectivePageSize(params)))
 
 	if params.NextPage != "" {
 		url.WithQueryParam(pageNumberParam, params.NextPage.String())

--- a/providers/zoominfo/read_test.go
+++ b/providers/zoominfo/read_test.go
@@ -1,6 +1,7 @@
 package zoominfo
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -11,12 +12,14 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
 	"github.com/amp-labs/connectors/test/utils/testutils"
+	"github.com/spyzhov/ajson"
 )
 
 func TestRead(t *testing.T) { // nolint:funlen
 	t.Parallel()
 
 	contactsResponse := testutils.DataFromFile(t, "read-contacts.json")
+	contactsFinalPageResponse := testutils.DataFromFile(t, "read-contacts-final-page.json")
 	industriesResponse := testutils.DataFromFile(t, "read-industries.json")
 
 	tests := []testconn.TestCaseRead{
@@ -32,13 +35,14 @@ func TestRead(t *testing.T) { // nolint:funlen
 				ObjectName: objContacts,
 				Fields:     connectors.Fields("firstName"),
 				NextPage:   "2",
+				PageSize:   2,
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
 				If: mockcond.And{
 					mockcond.Path("/gtm/data/v1/contacts/search"),
 					mockcond.QueryParam("page[number]", "2"),
-					mockcond.QueryParam("page[size]", "100"),
+					mockcond.QueryParam("page[size]", "2"),
 					mockcond.Body(`{"data":{"type":"ContactSearch","attributes":{"lastUpdatedDateAfter":"1970-01-01T00:00:00Z"}}}`),
 				},
 				Then: mockserver.Response(http.StatusOK, contactsResponse),
@@ -79,6 +83,7 @@ func TestRead(t *testing.T) { // nolint:funlen
 				ObjectName: objContacts,
 				Fields:     connectors.Fields("firstName"),
 				Since:      time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+				PageSize:   2,
 			},
 			Server: mockserver.Conditional{
 				Setup: mockserver.ContentJSON(),
@@ -90,6 +95,47 @@ func TestRead(t *testing.T) { // nolint:funlen
 			}.Server(),
 			Comparator:   testconn.ComparatorPagination,
 			Expected:     &common.ReadResult{Rows: 2, Done: false, NextPage: "3"},
+			ExpectedErrs: nil,
+		},
+		{
+			// Regression test for the PFAPI0004 overrun. The final page carries no
+			// links.next, so the read must finish here. meta.page.total is 2 (the
+			// record count of this page, which is what ZoomInfo actually reports)
+			// against meta.page.number 1 — the old number-vs-total comparison read
+			// that as "more pages follow" and asked for page 2, which the API
+			// rejects with "Page number (page) requested is greater than the
+			// available results".
+			Name: "Final page without links.next ends the read",
+			Input: common.ReadParams{
+				ObjectName: objContacts,
+				Fields:     connectors.Fields("firstName"),
+				PageSize:   2,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/gtm/data/v1/contacts/search"),
+				Then:  mockserver.Response(http.StatusOK, contactsFinalPageResponse),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, Done: true, NextPage: ""},
+			ExpectedErrs: nil,
+		},
+		{
+			// Defence in depth: a page shorter than the requested page[size] ends the
+			// read even though this fixture does advertise links.next.
+			Name: "Page shorter than page[size] ends the read",
+			Input: common.ReadParams{
+				ObjectName: objContacts,
+				Fields:     connectors.Fields("firstName"),
+				PageSize:   100,
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/gtm/data/v1/contacts/search"),
+				Then:  mockserver.Response(http.StatusOK, contactsResponse),
+			}.Server(),
+			Comparator:   testconn.ComparatorPagination,
+			Expected:     &common.ReadResult{Rows: 2, Done: true, NextPage: ""},
 			ExpectedErrs: nil,
 		},
 		{
@@ -193,6 +239,102 @@ func TestRead(t *testing.T) { // nolint:funlen
 			tt.Run(t, func() (testconn.TestableReader, error) {
 				return constructTestConnector(tt.Server)
 			})
+		})
+	}
+}
+
+// TestNextPageFromLinks pins the next-page extraction to link values copied verbatim
+// from live ZoomInfo responses. The two surfaces serialise "links" differently — the
+// Data API emits strings prefixed with "uri=" and a relative path, Studio and Copilot
+// emit absolute URLs — so both forms are covered here.
+func TestNextPageFromLinks(t *testing.T) { // nolint:funlen
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pageSize int
+		body     string
+		expected string
+		wantErr  error
+	}{
+		{
+			// Verbatim links from POST /gtm/data/v1/contacts/search page 2 of 100.
+			name:     "Data API next link carries the uri= prefix",
+			pageSize: 2,
+			body: `{"data":[{"id":"1"},{"id":"2"}],"links":{
+				"first":"uri=/data/v1/contacts/search?page[number]=1&page[size]=100",
+				"prev":"uri=/data/v1/contacts/search?page[number]=1&page[size]=100",
+				"next":"uri=/data/v1/contacts/search?page[number]=3&page[size]=100",
+				"last":"uri=/data/v1/contacts/search?page[number]=100&page[size]=100"}}`,
+			expected: "3",
+		},
+		{
+			// Studio links are absolute URLs and carry extra query params.
+			name:     "Studio next link is an absolute URL",
+			pageSize: 2,
+			body: `{"data":[{"id":"1"},{"id":"2"}],"links":{
+				"first":"https://api.zoominfo.com/gtm/studio/v1/audiences?page[number]=1&page[size]=100&sort=-updatedAt",
+				"next":"https://api.zoominfo.com/gtm/studio/v1/audiences?page[number]=2&page[size]=100&sort=-updatedAt",
+				"last":"https://api.zoominfo.com/gtm/studio/v1/audiences?page[number]=9&page[size]=100&sort=-updatedAt"}}`,
+			expected: "2",
+		},
+		{
+			// The final page omits links.next. meta.page.total repeats the record
+			// count of this page, which must not be mistaken for a page count.
+			name:     "Final page omits next",
+			pageSize: 2,
+			body: `{"data":[{"id":"1"},{"id":"2"}],"meta":{"page":{"number":1,"total":2},"totalResults":2},
+				"links":{"first":"uri=/data/v1/contacts/search?page[number]=1&page[size]=2",
+				"last":"uri=/data/v1/contacts/search?page[number]=1&page[size]=2"}}`,
+			expected: "",
+		},
+		{
+			name:     "Unpaginated endpoint omits links entirely",
+			pageSize: 100,
+			body:     `{"data":[{"id":"software"}]}`,
+			expected: "",
+		},
+		{
+			name:     "Short page ends the read despite a next link",
+			pageSize: 100,
+			body: `{"data":[{"id":"1"}],"links":{
+				"next":"uri=/data/v1/contacts/search?page[number]=2&page[size]=100"}}`,
+			expected: "",
+		},
+		{
+			name:     "Unusable next link is an error, never a silent stop",
+			pageSize: 1,
+			body:     `{"data":[{"id":"1"}],"links":{"next":"uri=/data/v1/contacts/search?cursor=abc"}}`,
+			wantErr:  common.ErrNextPageInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			node, err := ajson.Unmarshal([]byte(tt.body))
+			if err != nil {
+				t.Fatalf("bad test fixture: %v", err)
+			}
+
+			token, err := nextPageFromLinks(tt.pageSize)(node)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if token != tt.expected {
+				t.Errorf("expected next page %q, got %q", tt.expected, token)
+			}
 		})
 	}
 }

--- a/providers/zoominfo/test/read-contacts-final-page.json
+++ b/providers/zoominfo/test/read-contacts-final-page.json
@@ -20,16 +20,14 @@
     }
   ],
   "meta": {
-    "totalResults": 1660,
+    "totalResults": 2,
     "page": {
-      "number": 2,
+      "number": 1,
       "total": 2
     }
   },
   "links": {
     "first": "uri=/data/v1/contacts/search?page[number]=1&page[size]=2",
-    "prev": "uri=/data/v1/contacts/search?page[number]=1&page[size]=2",
-    "next": "uri=/data/v1/contacts/search?page[number]=3&page[size]=2",
-    "last": "uri=/data/v1/contacts/search?page[number]=830&page[size]=2"
+    "last": "uri=/data/v1/contacts/search?page[number]=1&page[size]=2"
   }
 }


### PR DESCRIPTION
Fixes ZoomInfo reads failing with `400 PFAPI0004` ("Page number (page) requested is greater than the available results") and, at small page sizes, silently returning a fraction of the matching records.

Both these came from treating `meta.page.total` as a page count. It isn't  it is the record count of the page just returned