### PR TITLE
fix(asana): require explicit OAuth scopes

### DIFF
--- a/providers/asana.go
+++ b/providers/asana.go
@@ -21,7 +21,7 @@ func init() {
 		Oauth2Opts: &Oauth2Opts{
 			AuthURL:                   "https://app.asana.com/-/oauth_authorize",
 			TokenURL:                  "https://app.asana.com/-/oauth_token",
-			ExplicitScopesRequired:    false,
+			ExplicitScopesRequired:    true,
 			ExplicitWorkspaceRequired: false,
 			GrantType:                 AuthorizationCode,
 			TokenMetadataFields: TokenMetadataFields{


### PR DESCRIPTION
## Summary

Mark Asana OAuth scopes as explicitly required.

## Why

Asana granular-scope apps require the authorization URL to include `scope`. The current catalog setting causes registered provider-app scopes to be omitted, so Asana rejects authorization with `forbidden_scopes`.

## Validation

- `go test ./...`
- `go build ./...`
- Completed the Asana OAuth flow after explicit scopes were included

Closes #3356
