### PR TITLE
[CON-3488] feat(lob): New Connector

### DIFF
--- a/providers/lob.go
+++ b/providers/lob.go
@@ -1,0 +1,34 @@
+package providers
+
+const Lob = "lob"
+
+func init() {
+	SetInfo(Lob, ProviderInfo{
+		DisplayName: "Lob",
+		AuthType:    Basic,
+		BaseURL:     "https://api.lob.com",
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787090538/lob_icon_smybnm.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787089526/media/lob_1787089525.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787090538/lob_icon_smybnm.jpg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787089543/media/lob_1787089543.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     false,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [ ] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [ ] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ]  They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## Testing

### GET
<img width="704" height="1060" alt="image" src="https://github.com/user-attachments/assets/687d5ed0-ea58-4379-a253-e448445d7b4b" />

### POST
<img width="545" height="831" alt="image" src="https://github.com/user-attachments/assets/9010f634-1e96-448e-8e17-c5df8f4d360f" />

### DELETE
<img width="516" height="336" alt="image" src="https://github.com/user-attachments/assets/a9dc18c4-0238-40e5-8b1e-2abaf62ae756" />


## Pagination

### Page 1 with limit
<img width="733" height="667" alt="image" src="https://github.com/user-attachments/assets/fc29d406-bcae-405a-bee5-31289a2fe5f5" />

### Page 2
<img width="1080" height="732" alt="image" src="https://github.com/user-attachments/assets/3d9cc95b-ef83-46a9-90e3-3aa2889719db" />


## Raw token response
N/A -- not Oauth2.


# Logo & Icons
<img width="1433" height="261" alt="image" src="https://github.com/user-attachments/assets/0a78a247-4e48-4ab3-8769-bb783d8cdfc8" />