### PR TITLE
[CON-3468] feat(reply): add Reply proxy

### DIFF
--- a/providers/reply.go
+++ b/providers/reply.go
@@ -1,0 +1,57 @@
+package providers
+
+import "net/http"
+
+const Reply Provider = "reply"
+
+func init() {
+	// Reply (reply.io) API key authentication.
+	// Keys are created in the Reply app under Settings > API keys and are sent
+	// as a bearer token. Personal keys act on behalf of the user; team and
+	// organization keys exist but require X-User-Id/X-Team-Id impersonation
+	// headers on every request, so personal keys are the fit for connections.
+	// Reply also runs an OAuth2 server (oauth.reply.io), but clients are
+	// allow-listed by Reply and there is no self-serve OAuth app registration.
+	// https://docs.reply.io/api-reference/authentication
+	SetInfo(Reply, ProviderInfo{
+		DisplayName: "Reply",
+		AuthType:    ApiKey,
+		BaseURL:     "https://api.reply.io",
+		ApiKeyOpts: &ApiKeyOpts{
+			AttachmentType: Header,
+			Header: &ApiKeyOptsHeader{
+				Name:        "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+			DocsURL: "https://docs.reply.io/api-reference/authentication",
+		},
+		AuthHealthCheck: &AuthHealthCheck{
+			Method:             http.MethodGet,
+			SuccessStatusCodes: []int{http.StatusOK},
+			Url:                "https://api.reply.io/v3/whoami",
+		},
+		//nolint:lll
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787152537/media/Catalog_1787152536.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787152567/media/Catalog_1787152567.svg",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787152537/media/Catalog_1787152536.svg",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1787152567/media/Catalog_1787152567.svg",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+	})
+}


### PR DESCRIPTION
## Checklist
- Ran linter
- Catalog tests passing

## Catalog Variables
```text
const Reply Provider = "reply"
```

## GET

### GET Whoami
URL: `localhost:4444/v3/whoami`

<img width="1299" height="993" alt="image" src="https://github.com/user-attachments/assets/4643566e-610a-4c1d-9bda-56fa9faaa4db" />

### GET Schedules
URL: `localhost:4444/v3/schedules`

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/a55ad76b-f89c-42a1-a0b0-98d72673c1dc" />

### GET Contacts
URL: `localhost:4444/v3/contacts`

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/12bf56de-9fa1-421d-a79a-4e9728d2217c" />

## POST

### POST Create Contact
URL: `localhost:4444/v3/contacts`
Expected: 201 Created

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/52504f4d-5dae-4e0c-a9d8-7814e89c82e2" />

## PATCH

### PATCH Update Contact
URL: `localhost:4444/v3/contacts/{id}`

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/7a44be0a-905a-48b1-bed6-2d4eaa9baa87" />

## DELETE

### DELETE Contact
URL: `localhost:4444/v3/contacts/{id}`
Expected: 204 No Content

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/24cca71c-efce-4e71-bbf9-a2e702d962b3" />

## Invalid requests

### Invalid Endpoint
URL: `localhost:4444/v3/does-not-exist`
Expected: 404, Reply's `application/problem+json` error passed through unchanged

<img width="1299" height="999" alt="image" src="https://github.com/user-attachments/assets/6e967ceb-ab4d-4ddd-af66-16b95f1125d6" />

## Logo & Icons

- Icon:
<img width="252" height="239" alt="image" src="https://github.com/user-attachments/assets/a6de4270-13a0-4b8b-b2ec-7a1c1eb80607" />



- Logo:
<img width="417" height="168" alt="image" src="https://github.com/user-attachments/assets/480c0679-db9f-41f6-a961-7dd3a902668a" />



