### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	cloud.google.com/go/bigquery v1.79.1
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260818225121-ed2cc9ea08b1
+	github.com/amp-labs/amp-common v0.0.0-20260819152657-d251dd8a0276
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260818225121-ed2cc9ea08b1 h1:Y9vPyKD4oGs3skZS3NLVZrR21BeEc+F34CcR2CHFtoQ=
-github.com/amp-labs/amp-common v0.0.0-20260818225121-ed2cc9ea08b1/go.mod h1:jbTw6fXlE4qWGsAjxrwnRz8lA7UoX3JkLtXHd17hLSM=
+github.com/amp-labs/amp-common v0.0.0-20260819152657-d251dd8a0276 h1:A9y4dv6XMJk9ap/g6iHTL2RhnSGdpjInaN/1wN0QWWw=
+github.com/amp-labs/amp-common v0.0.0-20260819152657-d251dd8a0276/go.mod h1:0IMXQvCt1V1U+c12JQoyUuBMOAvNbOz/MQ3R/1Jgoqs=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [d251dd8a02769e496017e62063bc79fedc5c325a](https://github.com/amp-labs/amp-common/commit/d251dd8a02769e496017e62063bc79fedc5c325a) from [main](https://github.com/amp-labs/amp-common/tree/main)