### PR TITLE
feat(slack): Delete functionality

### DIFF
--- a/providers/attio/associations_test.go
+++ b/providers/attio/associations_test.go
@@ -57,8 +57,8 @@ func TestExtractRecordReferenceAssociations(t *testing.T) {
 			"name": []any{
 				map[string]any{
 					"attribute_type": "text",
-					"value":            "Example deal",
-					"active_until":     nil,
+					"value":          "Example deal",
+					"active_until":   nil,
 				},
 			},
 		},

--- a/providers/slack/connector.go
+++ b/providers/slack/connector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/amp-labs/connectors"
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/deleter"
 	"github.com/amp-labs/connectors/internal/components/operations"
 	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
@@ -36,6 +37,7 @@ type Connector struct {
 	components.SchemaProvider
 	components.Reader
 	components.Writer
+	components.Deleter
 	*webhook.Verifier
 
 	teamId string
@@ -89,6 +91,17 @@ func constructor(params common.ConnectorParams, base *components.Connector) (*Co
 		operations.WriteHandlers{
 			BuildRequest:  connector.buildWriteRequest,
 			ParseResponse: connector.parseWriteResponse,
+			ErrorHandler:  common.InterpretError,
+		},
+	)
+
+	connector.Deleter = deleter.NewHTTPDeleter(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.DeleteHandlers{
+			BuildRequest:  connector.buildDeleteRequest,
+			ParseResponse: connector.parseDeleteResponse,
 			ErrorHandler:  common.InterpretError,
 		},
 	)

--- a/providers/slack/delete.go
+++ b/providers/slack/delete.go
@@ -1,0 +1,62 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/providers/slack/internal/mappings"
+)
+
+func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
+	info, err := mappings.GetDeleteInfo(c.Provider(), params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, info.Href)
+	if err != nil {
+		return nil, err
+	}
+
+	// The record for deletion is passed inside payload.
+	body := map[string]string{
+		info.RequestIdField: params.RecordId,
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Method POST is used across all objects.
+	// Example: https://docs.slack.dev/reference/methods/files.remote.remove/
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+func (c *Connector) parseDeleteResponse(
+	ctx context.Context,
+	params common.DeleteParams,
+	request *http.Request,
+	resp *common.JSONHTTPResponse,
+) (*common.DeleteResult, error) {
+	if resp.Code != http.StatusOK {
+		return nil, fmt.Errorf("%w: failed to delete record: %d", common.ErrRequestFailed, resp.Code)
+	}
+
+	// A successful delete returns 200 OK
+	return &common.DeleteResult{
+		Success: true,
+	}, nil
+}

--- a/providers/slack/delete_test.go
+++ b/providers/slack/delete_test.go
@@ -1,0 +1,55 @@
+package slack
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+)
+
+func TestDelete(t *testing.T) { // nolint:funlen,cyclop
+	t.Parallel()
+
+	tests := []testconn.TestCaseDelete{
+		{
+			Name:         "Delete object must be included",
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "Write object and its ID must be included",
+			Input:        common.DeleteParams{ObjectName: "calls"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingRecordID},
+		},
+		{
+			Name:  "Remove a call",
+			Input: common.DeleteParams{ObjectName: "calls", RecordId: "R0BRK953BTP"},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodPOST(),
+					mockcond.Path("/api/calls.end"),
+					mockcond.Body(`{"id":"R0BRK953BTP"}`),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{"ok": true, "call": {"id": "R0BRK953BTP"}}`),
+			}.Server(),
+			Expected:     &common.DeleteResult{Success: true},
+			ExpectedErrs: nil,
+		},
+	}
+
+	for _, tt := range tests { // nolint:dupl
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableDeleter, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/slack/internal/mappings/definitions.go
+++ b/providers/slack/internal/mappings/definitions.go
@@ -60,7 +60,6 @@ type WriteUpdateInfo struct {
 
 type DeleteInfo struct {
 	Href           string
-	Method         string
 	RequestIdField string
 }
 

--- a/providers/slack/internal/mappings/scope-bot-user.go
+++ b/providers/slack/internal/mappings/scope-bot-user.go
@@ -28,7 +28,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/bookmarks.remove
 			deleteInfo: &DeleteInfo{
 				Href:           "bookmarks.remove",
-				Method:         http.MethodPost,
 				RequestIdField: "bookmark_id", // Looks like channel_id is also required.
 			},
 		},
@@ -69,7 +68,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/calls.end
 			deleteInfo: &DeleteInfo{
 				Href:           "calls.end",
-				Method:         http.MethodPost,
 				RequestIdField: "id",
 			},
 		},
@@ -92,7 +90,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/canvases.delete
 			deleteInfo: &DeleteInfo{
 				Href:           "canvases.delete",
-				Method:         http.MethodPost,
 				RequestIdField: "canvas_id",
 			},
 		},
@@ -128,7 +125,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/conversations.archive
 			deleteInfo: &DeleteInfo{
 				Href:           "conversations.archive",
-				Method:         http.MethodPost,
 				RequestIdField: "channel",
 			},
 		},
@@ -164,7 +160,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/files.delete
 			deleteInfo: &DeleteInfo{
 				Href:           "files.delete",
-				Method:         http.MethodPost,
 				RequestIdField: "file",
 			},
 		},
@@ -267,7 +262,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/usergroups.disable
 			deleteInfo: &DeleteInfo{
 				Href:           "usergroups.disable",
-				Method:         http.MethodPost,
 				RequestIdField: "usergroup",
 			},
 		},

--- a/providers/slack/internal/mappings/scope-bot.go
+++ b/providers/slack/internal/mappings/scope-bot.go
@@ -56,7 +56,6 @@ func init() {
 			// "https://docs.slack.dev/reference/methods/files.remote.remove"
 			deleteInfo: &DeleteInfo{
 				Href:           "files.remote.remove",
-				Method:         http.MethodPost,
 				RequestIdField: "file",
 			},
 		},

--- a/providers/slack/internal/mappings/scope-user.go
+++ b/providers/slack/internal/mappings/scope-user.go
@@ -78,7 +78,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/admin.barriers.delete
 			deleteInfo: &DeleteInfo{
 				Href:           "admin.barriers.delete",
-				Method:         http.MethodPost,
 				RequestIdField: "barrier_id",
 			},
 		},
@@ -94,7 +93,6 @@ func init() { // nolint:funlen,maintidx
 			// https://docs.slack.dev/reference/methods/admin.conversations.delete
 			deleteInfo: &DeleteInfo{
 				Href:           "admin.conversations.delete",
-				Method:         http.MethodPost,
 				RequestIdField: "channel_id",
 			},
 		},

--- a/providers/slack/support-read_test.go
+++ b/providers/slack/support-read_test.go
@@ -44,6 +44,11 @@ func TestReadMappingsForBot(t *testing.T) {
 	}
 
 	readRequestMap := map[string]mockcond.Condition{
+		"admin.apps.activities": mockcond.And{
+			mockcond.MethodPOST(),
+			mockcond.Path("/api/admin.apps.activities.list"),
+			mockcond.Body(`{"limit":"200","min_date_created":"1050","max_date_created":"2050"}`),
+		},
 		"auth.teams": mockcond.And{
 			mockcond.MethodPOST(),
 			mockcond.Path("/api/auth.teams.list"),

--- a/providers/surveymonkey/delete.go
+++ b/providers/surveymonkey/delete.go
@@ -15,7 +15,7 @@ import (
 // SurveyMonkey delete API references:
 // - DELETE /contacts/{contact_id}
 // - DELETE /contact_lists/{contact_list_id}
-// - DELETE /surveys/{survey_id}
+// - DELETE /surveys/{survey_id}.
 func (c *Connector) buildDeleteRequest(ctx context.Context, params common.DeleteParams) (*http.Request, error) {
 	if err := params.ValidateParams(); err != nil {
 		return nil, err

--- a/providers/surveymonkey/write.go
+++ b/providers/surveymonkey/write.go
@@ -19,7 +19,7 @@ import (
 // - POST /contact_lists, PATCH /contact_lists/{contact_list_id}
 // - POST /surveys, PATCH /surveys/{survey_id}
 // - POST /survey_folders (create only)
-// - PATCH /contact_fields/{contact_field_id} (update only)
+// - PATCH /contact_fields/{contact_field_id} (update only).
 func (c *Connector) buildWriteRequest(ctx context.Context, params common.WriteParams) (*http.Request, error) {
 	if err := params.ValidateParams(); err != nil {
 		return nil, err

--- a/test/slack/slackbot/write/main.go
+++ b/test/slack/slackbot/write/main.go
@@ -2,93 +2,37 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 
-	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/providers"
-	"github.com/amp-labs/connectors/providers/slack"
 	slackshared "github.com/amp-labs/connectors/test/slack"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
 func main() {
-	if err := run(); err != nil {
-		slog.Error(err.Error())
-	}
-}
-
-func run() error {
 	ctx := context.Background()
 
 	conn := slackshared.NewConnector(ctx, providers.Slack)
 
-	callId, err := testCreatingCalls(ctx, conn)
-	if err != nil {
-		return err
-	}
-
-	err = testUpdatingCalls(ctx, conn, callId)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func testCreatingCalls(ctx context.Context, conn *slack.Connector) (string, error) {
-	params := common.WriteParams{
-		ObjectName: "calls",
-		RecordData: map[string]any{
+	externalId := fmt.Sprintf("ext-id-%d", os.Getpid())
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"calls",
+		map[string]any{
 			"join_url":           "https://example.com/join",
-			"external_unique_id": fmt.Sprintf("ext-id-%d", os.Getpid()),
+			"external_unique_id": externalId,
 		},
-	}
-
-	slog.Info("Creating calls...")
-
-	res, err := conn.Write(ctx, params)
-	if err != nil {
-		return "", err
-	}
-
-	// Print the results
-	jsonStr, err := json.MarshalIndent(res, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("error marshalling JSON: %w", err)
-	}
-
-	_, _ = os.Stdout.Write(jsonStr)
-	_, _ = os.Stdout.WriteString("\n")
-
-	return res.Data["id"].(string), nil
-}
-
-func testUpdatingCalls(ctx context.Context, conn *slack.Connector, callId string) error {
-	params := common.WriteParams{
-		ObjectName: "calls",
-		RecordId:   callId,
-		RecordData: map[string]any{
+		map[string]any{
 			"title": "Updated Call Name",
 		},
-	}
-
-	slog.Info("Updating calls...")
-
-	res, err := conn.Write(ctx, params)
-	if err != nil {
-		return err
-	}
-
-	// Print the results
-	jsonStr, err := json.MarshalIndent(res, "", "  ")
-	if err != nil {
-		return fmt.Errorf("error marshalling JSON: %w", err)
-	}
-
-	_, _ = os.Stdout.Write(jsonStr)
-	_, _ = os.Stdout.WriteString("\n")
-
-	return nil
+		testscenario.CRUDTestSuite{
+			ReadFields:          datautils.NewSet("join_url", "external_unique_id", "title"),
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"join_url":           "https://example.com/join",
+				"external_unique_id": externalId,
+				"title":              "Updated Call Name",
+			},
+		})
 }

--- a/test/slack/slackuser/write/main.go
+++ b/test/slack/slackuser/write/main.go
@@ -2,93 +2,37 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 
-	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/datautils"
 	"github.com/amp-labs/connectors/providers"
-	"github.com/amp-labs/connectors/providers/slack"
 	slackshared "github.com/amp-labs/connectors/test/slack"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
 )
 
 func main() {
-	if err := run(); err != nil {
-		slog.Error(err.Error())
-	}
-}
-
-func run() error {
 	ctx := context.Background()
 
 	conn := slackshared.NewConnector(ctx, providers.SlackUserScope)
 
-	callId, err := testCreatingCalls(ctx, conn)
-	if err != nil {
-		return err
-	}
-
-	err = testUpdatingCalls(ctx, conn, callId)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func testCreatingCalls(ctx context.Context, conn *slack.Connector) (string, error) {
-	params := common.WriteParams{
-		ObjectName: "calls",
-		RecordData: map[string]any{
+	externalId := fmt.Sprintf("ext-id-%d", os.Getpid())
+	testscenario.ValidateCreateUpdateDelete(ctx, conn,
+		"calls",
+		map[string]any{
 			"join_url":           "https://example.com/join",
-			"external_unique_id": fmt.Sprintf("ext-id-%d", os.Getpid()),
+			"external_unique_id": externalId,
 		},
-	}
-
-	slog.Info("Creating calls...")
-
-	res, err := conn.Write(ctx, params)
-	if err != nil {
-		return "", err
-	}
-
-	// Print the results
-	jsonStr, err := json.MarshalIndent(res, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("error marshalling JSON: %w", err)
-	}
-
-	_, _ = os.Stdout.Write(jsonStr)
-	_, _ = os.Stdout.WriteString("\n")
-
-	return res.Data["id"].(string), nil
-}
-
-func testUpdatingCalls(ctx context.Context, conn *slack.Connector, callId string) error {
-	params := common.WriteParams{
-		ObjectName: "calls",
-		RecordId:   callId,
-		RecordData: map[string]any{
+		map[string]any{
 			"title": "Updated Call Name",
 		},
-	}
-
-	slog.Info("Updating calls...")
-
-	res, err := conn.Write(ctx, params)
-	if err != nil {
-		return err
-	}
-
-	// Print the results
-	jsonStr, err := json.MarshalIndent(res, "", "  ")
-	if err != nil {
-		return fmt.Errorf("error marshalling JSON: %w", err)
-	}
-
-	_, _ = os.Stdout.Write(jsonStr)
-	_, _ = os.Stdout.WriteString("\n")
-
-	return nil
+		testscenario.CRUDTestSuite{
+			ReadFields:          datautils.NewSet("join_url", "external_unique_id", "title"),
+			RecordIdentifierKey: "id",
+			UpdatedFields: map[string]string{
+				"join_url":           "https://example.com/join",
+				"external_unique_id": externalId,
+				"title":              "Updated Call Name",
+			},
+		})
 }

--- a/test/surveymonkey/contact_fields/write/main.go
+++ b/test/surveymonkey/contact_fields/write/main.go
@@ -28,8 +28,8 @@ func main() {
 
 	testscenario.ValidateUpdate(ctx, conn, "contact_fields", updatePayload,
 		testscenario.UpdateTestSuite{
-			ReadFields:          datautils.NewSet("id", "label"),
-			RecordIdentifierKey: "id",
+			ReadFields:            datautils.NewSet("id", "label"),
+			RecordIdentifierKey:   "id",
 			RestoreOriginalFields: true,
 			PreprocessUpdatePayload: func(record *common.ReadResultRow) any {
 				expectedLabel = fmt.Sprintf("Amp Integration %s", record.Id)

--- a/test/utils/testscenario/crud.go
+++ b/test/utils/testscenario/crud.go
@@ -97,17 +97,17 @@ func ValidateCreateUpdateDelete[CP, UP any](
 		time.Sleep(suite.WaitBeforeSearch)
 	}
 
-	// READ
-	fmt.Println("Reading", objectName)
-	res, err := readObjects(ctx, conn, objectName, suite.ReadFields, suite.SearchBy.Since)
-	failOnError(err)
-
-	// SEARCH
-	fmt.Println("Finding recently created", objectName)
-
 	objectID := createResult.RecordId
 
 	if !suite.SearchBy.isZero() {
+		// READ
+		fmt.Println("Reading", objectName)
+		res, err := readObjects(ctx, conn, objectName, suite.ReadFields, suite.SearchBy.Since)
+		failOnError(err)
+
+		// SEARCH
+		fmt.Println("Finding recently created", objectName)
+
 		search := suite.SearchBy
 		object, err := searchObjectRecord(res, search.Key, search.Value)
 		failOnError(err)
@@ -127,7 +127,7 @@ func ValidateCreateUpdateDelete[CP, UP any](
 
 	// UPDATE
 	fmt.Println("Updating some object properties")
-	_, err = updateObject(ctx, conn, objectName, objectID, &updatePayload)
+	updateRes, err := updateObject(ctx, conn, objectName, objectID, &updatePayload)
 	failOnError(err)
 	fmt.Println("Validate object has changed accordingly")
 
@@ -150,11 +150,20 @@ func ValidateCreateUpdateDelete[CP, UP any](
 		}
 	}
 
-	res, err = readObjects(ctx, conn, objectName, suite.ReadFields, suite.SearchBy.Since)
-	failOnError(err)
-	object, err := searchObjectRecord(res, suite.RecordIdentifierKey, objectID)
-	failOnError(err)
-	validateUpdatedFieldsFunc(object.Fields)
+	var updatedFields map[string]any
+
+	if !suite.SearchBy.isZero() {
+		res, err := readObjects(ctx, conn, objectName, suite.ReadFields, suite.SearchBy.Since)
+		failOnError(err)
+		object, err := searchObjectRecord(res, suite.RecordIdentifierKey, objectID)
+		failOnError(err)
+		updatedFields = object.Fields
+	} else {
+		fmt.Println("Using response of update operation to validate the changes")
+		updatedFields = updateRes.Data
+	}
+
+	validateUpdatedFieldsFunc(updatedFields)
 
 	// DELETE
 	fmt.Println("Removing this", objectName)


### PR DESCRIPTION
# Description

This PR uses the `mappings.DeleteInfo` specification to support record deletion.

The live test scripts `slackbot/write` and `slackuser/write` now use `ValidateCreateUpdateDelete`.

`ValidateCreateUpdateDelete` was updated so that it does not perform a read-based search when SearchBy is not specified. Instead, it uses the record ID returned by the **create** operation.

As a result, both Slack Bot and Slack User connectors can now delete records for supported objects.

# Live Tests

<img width="1295" height="1436" alt="Peek 2026-08-21 01-16" src="https://github.com/user-attachments/assets/03f5fef6-aabb-4d87-9582-b59152b42656" />

