### PR TITLE
[CON-3501] feat(lob): Read

### DIFF
--- a/internal/components/transport.go
+++ b/internal/components/transport.go
@@ -76,5 +76,9 @@ func (t *Transport) SetErrorHandler(handler common.ErrorHandler) {
 	t.HTTPClient().ErrorHandler = handler
 }
 
+func (t *Transport) GetErrorHandler() common.ErrorHandler {
+	return t.HTTPClient().ErrorHandler
+}
+
 func (t *Transport) JSONHTTPClient() *common.JSONHTTPClient { return t.json }
 func (t *Transport) HTTPClient() *common.HTTPClient         { return t.json.HTTPClient }

--- a/providers/lob/connector.go
+++ b/providers/lob/connector.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/internal/components/schema"
 	"github.com/amp-labs/connectors/providers/lob/internal/core"
 	"github.com/amp-labs/connectors/providers/lob/internal/metadata"
@@ -15,6 +17,7 @@ type Connector struct {
 
 	// Supported operations
 	components.SchemaProvider
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -27,6 +30,17 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 		Base:           base,
 		SchemaProvider: schema.NewOpenAPISchemaProvider(base.ProviderContext.Module(), metadata.Schemas),
 	}
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		components.NewEmptyEndpointRegistry(),
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  base.GetErrorHandler(),
+		},
+	)
 
 	return connector, nil
 }

--- a/providers/lob/internal/core/base.go
+++ b/providers/lob/internal/core/base.go
@@ -24,7 +24,7 @@ func NewBase(params common.ConnectorParams) (*Base, error) {
 
 func constructor(params common.ConnectorParams, base *components.Connector) (*Base, error) {
 	errorHandler := interpreter.ErrorHandler{
-		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+		JSON: interpreter.NewFaultyResponder(errorFormats, statusCodeMapping),
 	}.Handle
 	base.SetErrorHandler(errorHandler)
 

--- a/providers/lob/internal/core/errors.go
+++ b/providers/lob/internal/core/errors.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"fmt"
+	"net/http"
 
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/interpreter"
 )
 
@@ -14,6 +16,10 @@ var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
 		},
 	}...,
 )
+
+var statusCodeMapping = map[int]error{ // nolint:gochecknoglobals
+	http.StatusUnprocessableEntity: common.ErrBadRequest,
+}
 
 type ResponseError struct {
 	Error ErrorDetails `json:"error"`

--- a/providers/lob/read.go
+++ b/providers/lob/read.go
@@ -1,0 +1,187 @@
+package lob
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/spyzhov/ajson"
+)
+
+// Endpoints state 100 as an upper limit.
+// Exceeding such will result in error with
+// status code 422 and message: `limit must be less than or equal to 100`.
+// Example: https://docs.lob.com/#tag/Addresses/operation/addresses_list
+const defaultPageSize = "100"
+
+// Objects that use time based query param for record filtering.
+// Note: many objects could be filtered using `date_created`.
+var incrementalReadByProvider = map[string]string{ // nolint:gochecknoglobals
+	"billing_groups": "date_modified",
+}
+
+// Objects that use connector side filtering of records.
+//
+// Every object has `date_modified` in response body.
+//
+// Note: Some objects could be filtered using provider API via `date_created`
+// but this field is much more restrictive compared to the `date_modified`.
+// Therefore, in order to surface up-to-date changes connector side filtering is favored.
+var incrementalReadByConnector = datautils.NewSetFromList([]string{ // nolint:gochecknoglobals
+	"addresses",
+	"bank_accounts",
+	"booklets",
+	"buckslips",
+	"campaigns",
+	"cards",
+	"checks",
+	"informed_delivery_campaigns",
+	"letters",
+	"postcards",
+	"self_mailers",
+	"snap_packs",
+	"templates",
+})
+
+var readResponseArrayField = datautils.NewDefaultMap(map[string]string{ // nolint:gochecknoglobals
+	"update": "", // root level is an array.
+}, func(objectName string) string {
+	return "data" // most objects have records under `data` key.
+})
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := c.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if len(params.NextPage) != 0 {
+		// Next page
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	// First page
+	url, err := c.GetURL(params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	url.WithQueryParam("limit", readhelper.PageSizeWithDefaultStr(params, defaultPageSize))
+
+	if err = attachReadFilterQueryParams(url, params); err != nil {
+		return nil, err
+	}
+
+	return url, nil
+}
+
+func attachReadFilterQueryParams(url *urlbuilder.URL, params common.ReadParams) error {
+	queryParam, ok := incrementalReadByProvider[params.ObjectName]
+	if !ok {
+		// No-op, no time based query params exist
+		return nil
+	}
+
+	// https://docs.lob.com/#tag/Billing-Groups/operation/billing_groups_list
+	// Query value is a JSON type string.
+	queryValue := map[string]string{}
+
+	if !params.Since.IsZero() {
+		queryValue["gt"] = datautils.Time.FormatRFC3339inUTC(params.Since)
+	}
+
+	if !params.Until.IsZero() {
+		queryValue["lt"] = datautils.Time.FormatRFC3339inUTC(params.Until)
+	}
+
+	if len(queryValue) == 0 {
+		// Since and Until are not specified in params.
+		return nil
+	}
+
+	// Need to pass the query param.
+	value, err := json.Marshal(queryValue)
+	if err != nil {
+		return err
+	}
+
+	url.WithQueryParam(queryParam, string(value))
+
+	return nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	responseFieldName := readResponseArrayField.Get(params.ObjectName)
+
+	return common.ParseResultFiltered(
+		params,
+		response,
+		makeGetRecords(responseFieldName),
+		makeFilterFunc(params),
+		readhelper.MakeMarshaledSelectedDataFunc(
+			fieldsSelector,
+			jsonquery.Convertor.ObjectToMap,
+		),
+		params.Fields,
+	)
+}
+
+func makeGetRecords(responseFieldName string) common.NodeRecordsFunc {
+	return func(node *ajson.Node) ([]*ajson.Node, error) {
+		return jsonquery.New(node).ArrayOptional(responseFieldName)
+	}
+}
+
+func makeFilterFunc(params common.ReadParams) common.RecordsFilterFunc {
+	nextPageFunc := makeNextRecordsURL()
+
+	if incrementalReadByConnector.Has(params.ObjectName) {
+		return readhelper.MakeTimeFilterFunc(
+			readhelper.ReverseOrder,
+			readhelper.NewTimeBoundary(),
+			"date_modified",
+			time.RFC3339,
+			nextPageFunc,
+		)
+	}
+
+	// Default no filtering.
+	return readhelper.MakeIdentityFilterFunc(nextPageFunc)
+}
+
+func makeNextRecordsURL() common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		return jsonquery.New(node).StrWithDefault("next_url", "")
+	}
+}
+
+func fieldsSelector(node *ajson.Node, fields []string) (map[string]any, string, error) {
+	root, err := jsonquery.Convertor.ObjectToMap(node)
+	if err != nil {
+		return nil, "", err
+	}
+
+	identifier, err := jsonquery.New(node).StringRequired("id")
+	if err != nil {
+		return nil, "", err
+	}
+
+	selected := readhelper.SelectFields(root, datautils.NewSetFromList(fields))
+
+	return selected, identifier, nil
+}

--- a/providers/lob/read_test.go
+++ b/providers/lob/read_test.go
@@ -1,0 +1,160 @@
+package lob
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseInvalidPageSize := testutils.DataFromFile(t, "read/err-422-page-size-too-large.json")
+	responseAddressesFirst := testutils.DataFromFile(t, "read/addresses/1-first-page.json")
+	responseAddressesLast := testutils.DataFromFile(t, "read/addresses/2-last-page.json")
+
+	tests := []testconn.TestCaseRead{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "contacts"},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:  "Error response is parsed",
+			Input: common.ReadParams{ObjectName: "addresses", Fields: connectors.Fields("name")},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnprocessableEntity, responseInvalidPageSize),
+			}.Server(),
+			ExpectedErrs: []error{
+				testutils.StringError("limit must be less than or equal to 100: lob code 422"),
+				common.ErrBadRequest,
+			},
+		},
+		{
+			Name: "Read addresses first page",
+			Input: common.ReadParams{
+				ObjectName: "addresses",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/addresses"),
+					mockcond.QueryParam("limit", "100"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseAddressesFirst),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 2,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"name": "CHRISTEN GARDNER"},
+					Raw:    map[string]any{"email": "Christen@lob.com"},
+					Id:     "adr_5c49d278ef3b7986",
+				}, {
+					Fields: map[string]any{"name": "JOAN LANE"},
+					Raw:    map[string]any{"email": "Joan@lob.com"},
+					Id:     "adr_317fce961b645606",
+				}},
+				NextPage: "https://api.lob.com/v1/addresses?limit=2&after=eyJkYXRlT2Zmc2V0IjoiMjAyNi0wOC0xOVQwMToxNDoxMS4yOTJaIiwiaWRPZmZzZXQiOiJhZHJfMzE3ZmNlOTYxYjY0NTYwNiJ9",
+				Done:     false,
+			},
+		},
+		{
+			Name: "Read addresses last page",
+			Input: common.ReadParams{
+				ObjectName: "addresses",
+				Fields:     connectors.Fields("name"),
+				NextPage:   testconn.URLTestServer + "/v1/addresses?limit=2&after=eyJkYXRlT2Zmc2V0IjoiMjAyNi0wOC0xOVQwMToxNDoxMS4yOTJaIiwiaWRPZmZzZXQiOiJhZHJfMzE3ZmNlOTYxYjY0NTYwNiJ9",
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/addresses"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseAddressesLast),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{"name": "HARRY ZHANG"},
+					Raw:    map[string]any{"email": "harry@lob.com"},
+					Id:     "adr_eef4879a15726a16",
+				}},
+				NextPage: "",
+				Done:     true,
+			},
+		},
+		{
+			Name: "Read billing_groups with Since",
+			Input: common.ReadParams{
+				ObjectName: "billing_groups",
+				Fields:     connectors.Fields("id"),
+				Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/billing_groups"),
+					mockcond.QueryParam("date_modified", `{"gt":"2026-05-05T23:10:00Z"}`),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected:   &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+		},
+		{
+			Name: "Read billing_groups with Since and Until",
+			Input: common.ReadParams{
+				ObjectName: "billing_groups",
+				Fields:     connectors.Fields("id"),
+				Since:      time.Date(2026, 5, 5, 23, 10, 0, 0, time.UTC),
+				Until:      time.Date(2027, 5, 5, 23, 10, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/v1/billing_groups"),
+					mockcond.Or{
+						mockcond.QueryParam("date_modified", `{"gt":"2026-05-05T23:10:00Z","lt":"2027-05-05T23:10:00Z"}`),
+						mockcond.QueryParam("date_modified", `{"lt":"2027-05-05T23:10:00Z","gt":"2026-05-05T23:10:00Z"}`),
+					},
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{}`),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected:   &common.ReadResult{Rows: 0, NextPage: "", Done: true},
+		},
+	}
+
+	for _, tt := range tests {
+		// nolint:varnamelen
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableReader, error) {
+				return constructTestConnector(tt.Server)
+			})
+		})
+	}
+}

--- a/providers/lob/test/read/addresses/1-first-page.json
+++ b/providers/lob/test/read/addresses/1-first-page.json
@@ -1,0 +1,46 @@
+{
+  "data": [
+    {
+      "id": "adr_5c49d278ef3b7986",
+      "description": null,
+      "name": "CHRISTEN GARDNER",
+      "company": null,
+      "phone": null,
+      "email": "Christen@lob.com",
+      "address_line1": "210 KING ST",
+      "address_line2": null,
+      "address_city": "SAN FRANCISCO",
+      "address_state": "CA",
+      "address_zip": "94107-1702",
+      "address_country": "UNITED STATES",
+      "metadata": {},
+      "date_created": "2026-08-19T01:28:32.171Z",
+      "date_modified": "2026-08-19T01:28:32.171Z",
+      "recipient_moved": false,
+      "object": "address"
+    },
+    {
+      "id": "adr_317fce961b645606",
+      "description": null,
+      "name": "JOAN LANE",
+      "company": null,
+      "phone": null,
+      "email": "Joan@lob.com",
+      "address_line1": "210 KING ST",
+      "address_line2": null,
+      "address_city": "SAN FRANCISCO",
+      "address_state": "CA",
+      "address_zip": "94107-1702",
+      "address_country": "UNITED STATES",
+      "metadata": {},
+      "date_created": "2026-08-19T01:14:11.292Z",
+      "date_modified": "2026-08-19T01:14:11.292Z",
+      "recipient_moved": false,
+      "object": "address"
+    }
+  ],
+  "object": "list",
+  "next_url": "https://api.lob.com/v1/addresses?limit=2&after=eyJkYXRlT2Zmc2V0IjoiMjAyNi0wOC0xOVQwMToxNDoxMS4yOTJaIiwiaWRPZmZzZXQiOiJhZHJfMzE3ZmNlOTYxYjY0NTYwNiJ9",
+  "previous_url": null,
+  "count": 2
+}

--- a/providers/lob/test/read/addresses/2-last-page.json
+++ b/providers/lob/test/read/addresses/2-last-page.json
@@ -1,0 +1,27 @@
+{
+  "data": [
+    {
+      "id": "adr_eef4879a15726a16",
+      "description": null,
+      "name": "HARRY ZHANG",
+      "company": null,
+      "phone": null,
+      "email": "harry@lob.com",
+      "address_line1": "210 KING ST",
+      "address_line2": null,
+      "address_city": "SAN FRANCISCO",
+      "address_state": "CA",
+      "address_zip": "94107-1702",
+      "address_country": "UNITED STATES",
+      "metadata": {},
+      "date_created": "2026-08-18T21:35:23.215Z",
+      "date_modified": "2026-08-18T21:35:23.215Z",
+      "recipient_moved": false,
+      "object": "address"
+    }
+  ],
+  "object": "list",
+  "next_url": null,
+  "previous_url": "https://api.lob.com/v1/addresses?limit=2&before=eyJkYXRlT2Zmc2V0IjoiMjAyNi0wOC0xOFQyMTozNToyMy4yMTVaIiwiaWRPZmZzZXQiOiJhZHJfZWVmNDg3OWExNTcyNmExNiJ9",
+  "count": 1
+}

--- a/providers/lob/test/read/err-422-page-size-too-large.json
+++ b/providers/lob/test/read/err-422-page-size-too-large.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "limit must be less than or equal to 100",
+    "status_code": 422,
+    "code": "invalid"
+  }
+}

--- a/test/lob/read/addresses/main.go
+++ b/test/lob/read/addresses/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/lob"
+	"github.com/amp-labs/connectors/test/utils"
+	"github.com/amp-labs/connectors/test/utils/testscenario"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetLobConnector(ctx)
+
+	testscenario.ReadThroughPages(ctx, conn, common.ReadParams{
+		ObjectName: "addresses",
+		Fields:     connectors.Fields("id", "name", "email"),
+		Since:      time.Now().Add(-1 * time.Minute * 50),
+		PageSize:   2,
+	})
+}


### PR DESCRIPTION
# Description

Incremental read is done on connector side. The provider API allows filtering by the creation date while it returns the update time field in response. The later is less strict and favoured.

Pagination with max 100 records per page is applied for all objects. Exceeding the limit returns an error.


# Live Tests

Connector side filtering:
<img width="704" height="969" alt="image" src="https://github.com/user-attachments/assets/a0fd2cf6-08b6-4b6e-b1bf-eded67b6700f" />

Paginated:
<img width="693" height="810" alt="image" src="https://github.com/user-attachments/assets/fc1495cb-cbdf-4b20-8a10-cabbde913577" />
