### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	cloud.google.com/go/bigquery v1.79.1
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260819152748-7681e6ccfa17
+	github.com/amp-labs/amp-common v0.0.0-20260819220508-eadc789a6849
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260819152748-7681e6ccfa17 h1:2P2iDKOmpTADrx7ceu8BdYBWFwsjb1GODrHAWWnn7gw=
-github.com/amp-labs/amp-common v0.0.0-20260819152748-7681e6ccfa17/go.mod h1:smvMr31dXd5yApJ+S+TSVJTsV7UNyw8kpUrStfe+v4w=
+github.com/amp-labs/amp-common v0.0.0-20260819220508-eadc789a6849 h1:OWB3x/hpWhV6mw6zTuH1CgUbMoQh9wkPJqsQitXVyHA=
+github.com/amp-labs/amp-common v0.0.0-20260819220508-eadc789a6849/go.mod h1:smvMr31dXd5yApJ+S+TSVJTsV7UNyw8kpUrStfe+v4w=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [eadc789a6849017dd2fe19896d2da03d68042ef4](https://github.com/amp-labs/amp-common/commit/eadc789a6849017dd2fe19896d2da03d68042ef4) from [main](https://github.com/amp-labs/amp-common/tree/main)