### PR TITLE
[CON-41] feat: enable basecamp proxy support

### DIFF
--- a/providers/basecamp.go
+++ b/providers/basecamp.go
@@ -36,7 +36,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     false,
+			Proxy:     true,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
# Conventions
- [x] Provider name is camelcase (`goTo` and not `goto`)
- [ ] Should cover all modules within the connector (ex, `goTo` has modules `webinar` and `meeting` or `google` has modules `drive` and `calendar`)
- [x] Base URLs do NOT have version information
- [ ] DocsURLs actually link to user-friendly documentation (do not link to very technical documentation)
- [x] All required metadata variables are templated (`{{.var}}`) and defined in `ProviderInfo.Metadata`
- [ ] If OAuth2 connector, if `workspace` is required, `Oauth2Opts.ExplicitWorkspaceRequired` is ALSO set to true
- [x] Basic smoke tests added (valid request succeeds, invalid request fails)
- [x] Docs and logos attached or linked
- [ ] Modules are only being added because:
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

## GET
<img width="2554" height="1088" alt="Screenshot 2026-08-20 at 16 48 23" src="https://github.com/user-attachments/assets/c5fb95d5-ed5a-47ca-8d32-d2077c840740" />


## POST
<img width="2558" height="1284" alt="Screenshot 2026-08-20 at 16 51 46" src="https://github.com/user-attachments/assets/1e419fce-9e1f-4a80-82ed-4e607f849b7c" />

## PUT
<img width="2558" height="1067" alt="Screenshot 2026-08-20 at 16 49 46" src="https://github.com/user-attachments/assets/c6247048-857d-46b6-b58e-97818917d8e4" />


## DELETE
<img width="2557" height="487" alt="Screenshot 2026-08-20 at 16 51 29" src="https://github.com/user-attachments/assets/fc3d4fde-5593-464a-a2c9-696918935528" />

## Invalid requests
invalid path.
<img width="2559" height="748" alt="Screenshot 2026-08-20 at 16 56 55" src="https://github.com/user-attachments/assets/2644bd2d-0e8c-4883-961f-02ad87817b3b" />

## console operation (operation & events)
<img width="2252" height="845" alt="Screenshot 2026-08-20 at 16 57 45" src="https://github.com/user-attachments/assets/d6720926-d8af-4185-996b-263a27af75a4" />
