### PR TITLE
docs(mocksub): use float64 id in Seed usage example

### DIFF
--- a/mocksub/doc.go
+++ b/mocksub/doc.go
@@ -12,7 +12,7 @@
 // test:
 //
 //	providers.SetupMockSalesloftProvider()
-//	mocksub.StoreFor(providers.MockSalesloft).Seed("people", "42", map[string]any{"id": 42, ...})
+//	mocksub.StoreFor(providers.MockSalesloft).Seed("people", "42", map[string]any{"id": float64(42), ...})
 //
 // The connector constructed by the connector.New factory for a mock provider reads from that
 // same store.


### PR DESCRIPTION
Follow-up to #3291 review feedback (landed via merge queue before the nit could be amended in).

`common.GetMarshaledData` only maps `string`/`float64`/`json.Number` ids into `ReadResultRow.Id`; a plain Go int silently yields an empty `Id`. The package's tests already seed `float64` ids — make the doc example match so it doesn't teach a pattern the read path silently rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)