### PR TITLE
tidy(readhelper): Early exit by Filter on empty Since/Until

### DIFF
--- a/common/readhelper/filter.go
+++ b/common/readhelper/filter.go
@@ -181,11 +181,19 @@ func MakeTimeFilterFuncWithZoom( // nolint:cyclop
 			return nil, "", nil
 		}
 
+		// No time bounds: preserve all records and continue pagination.
+		if params.Since.IsZero() && params.Until.IsZero() {
+			next, err := nextPageFunc(body)
+
+			return records, next, err
+		}
+
 		var (
 			filtered   []*ajson.Node
 			stopPaging bool
 		)
 
+		// Filter records and determine whether later pages can be skipped.
 		for _, nodeRecord := range records {
 			recordTimestamp, err := extractTimestamp(nodeRecord, timestampKey, timestampFormat, zoom...)
 			if err != nil {
@@ -216,7 +224,7 @@ func MakeTimeFilterFuncWithZoom( // nolint:cyclop
 					stopPaging = true
 				}
 			case Unordered:
-				// cannot infer anything
+				// Record order provides no basis for stopping early.
 			}
 
 			if stopPaging {
@@ -224,7 +232,7 @@ func MakeTimeFilterFuncWithZoom( // nolint:cyclop
 			}
 		}
 
-		// Proven exhaustion.
+		// A timestamp outside the boundary proves later pages cannot match.
 		if stopPaging {
 			return filtered, "", nil
 		}

--- a/common/readhelper/filter_test.go
+++ b/common/readhelper/filter_test.go
@@ -66,7 +66,8 @@ func Test_FilterSortedRecords(t *testing.T) {
 	}
 }
 
-func testEmptyRecords(createTestData func([]map[string]any) *ajson.Node, mockNextPageFunc func(*ajson.Node) (string, error),
+func testEmptyRecords(createTestData func([]map[string]any) *ajson.Node,
+	mockNextPageFunc func(*ajson.Node) (string, error),
 ) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
@@ -412,6 +413,21 @@ func TestMakeTimeFilterFuncWithZoom(t *testing.T) {
 			expectedErr:       nil,
 			expectedNextPage:  false, // ignore next page token, current page is empty
 			expectedRecordIDs: []string{},
+		},
+		{
+			name:  "Filtering without Since and Until params",
+			order: ReverseOrder,
+			payload: createPayload(true, // with next page
+				record{id: "A"},
+				record{id: "B"},
+				record{id: "C"},
+				record{id: "D"},
+			),
+			since:             "",
+			until:             "",
+			expectedErr:       nil,
+			expectedNextPage:  true,
+			expectedRecordIDs: []string{"A", "B", "C", "D"},
 		},
 		{
 			name:  "Payload without next page, reverse order",


### PR DESCRIPTION
# Description

Early exit of MakeTimeFilterFuncWithZoom.
<img width="962" height="801" alt="image" src="https://github.com/user-attachments/assets/03ff1b5e-63fe-43bc-bd33-c10a5b0df902" />


# Validation

Added unit test.
Without the new code the test fails:
<img width="1726" height="976" alt="image" src="https://github.com/user-attachments/assets/9d927220-33f7-4b32-ba95-e14ab98215d9" />

With the fix:
<img width="1532" height="934" alt="image" src="https://github.com/user-attachments/assets/4a4d2342-54d4-499c-8c51-dc300a261ae9" />
