### PR TITLE
feat(ci): Concise test logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+        # git ls-remote https://github.com/actions/checkout.git refs/tags/v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        # git ls-remote https://github.com/actions/setup-go.git refs/tags/v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: "^1.25.5"
+          go-version: "1.26.5"
           cache: false
 
       - name: Build
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -90,17 +90,23 @@ fix/sort:
 .PHONY: format
 format: fix
 
+GOTESTSUM_VERSION := v1.13.0
 .PHONY: test
 test:
-	go test -v ./...
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) \
+		--format-hide-empty-pkg \
+		--hide-summary=skipped \
+		./...
 
 .PHONY: test-parallel
 test-parallel:
-	go test -v ./... -parallel=8 -count=3
-
-.PHONY: test-pretty
-test-pretty:
-	go run gotest.tools/gotestsum@latest
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) \
+		--format-hide-empty-pkg \
+		--hide-summary=skipped \
+		-- \
+		-parallel=8 \
+		-count=3 \
+		./...
 
 # Creates PR URLs for each template
 # Click on one of them or manually add ?template=<file.md> to the URL if you are creating a PR via the Github website


### PR DESCRIPTION
# Description

CI test output is currently overly verbose, which makes failures difficult to identify and investigate. In particular, large volumes of successful test output can obscure the actual failing test, error message, and relevant context.

This is especially unhelpful when a failure cannot be reproduced locally.

This PR updates the test output.


## Examples

### Failure

Here is a sample output of logs with failing tests. The issue is clear and at the end of github step:
<img width="1112" height="542" alt="image" src="https://github.com/user-attachments/assets/551e3a94-9d90-4ae8-ba68-dc17335dcfc4" />


### Success

<img width="598" height="677" alt="image" src="https://github.com/user-attachments/assets/f7a2d7b7-ab3e-4f0e-93a6-507f9b10076b" />

<img width="562" height="546" alt="image" src="https://github.com/user-attachments/assets/52aebc87-35fb-4559-b182-50d8b7493c7d" />
