### PR TITLE
[ENG-4095] fix(stripe): Pass connected accounts for Treasury

### DIFF
--- a/common/interpreter/error.go
+++ b/common/interpreter/error.go
@@ -24,7 +24,7 @@ type ErrorHandler struct {
 	Custom map[Mime]FaultyResponseHandler
 
 	// Fallback handles responses no handler above claimed: missing or
-	// unparseable Content-Type, or a media type with none registered.
+	// unparsable Content-Type, or a media type with none registered.
 	// Nil defers to common.InterpretError. A Fallback that recognizes only
 	// certain responses should return common.InterpretError(res, body) for
 	// the rest, leaving them unchanged.

--- a/providers/stripe/internal/reader/financial-accounts.go
+++ b/providers/stripe/internal/reader/financial-accounts.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/amp-labs/connectors/common"
@@ -40,13 +41,15 @@ func (s *Strategy) readTreasuryForMainAccount(ctx context.Context,
 	return executeReadTasksTreasury(ctx, tasks, financialAccounts)
 }
 
-// readTreasuryForConnectedAccounts creates parallel read tasks for financial accounts
-// belonging to connected accounts.
+// readTreasuryForConnectedAccounts reads a Treasury-scoped object across
+// Financial Accounts owned by connected accounts.
 //
-// Each request includes:
-//   - the financial_account query parameter to identify the target Treasury account.
-//   - the Stripe-Account header to execute the request in the context of the
-//     connected account that owns the financial account.
+// financialAccounts must not contain main-account Financial Accounts: an empty
+// ConnectedAccountId denotes main-account ownership and is invalid for this
+// method.
+//
+// For each Financial Account, the request includes its ID in the
+// financial_account query parameter and sends the Stripe-Account header for its owning connected account.
 func (s *Strategy) readTreasuryForConnectedAccounts(
 	ctx context.Context,
 	params common.ReadParams,
@@ -56,14 +59,24 @@ func (s *Strategy) readTreasuryForConnectedAccounts(
 	tasks := make([]parallelfetch.Task[string, common.ReadResult], len(financialAccounts))
 
 	index := 0
+
 	for _, financialAccount := range financialAccounts {
+		finAccId := financialAccount.Id
+
+		connAccId := financialAccount.ConnectedAccountId
+		if connAccId == "" {
+			return nil, fmt.Errorf("%w: connected-account Treasury read "+
+				"received main-account financial account %q", common.ErrInvalidImplementation, finAccId)
+		}
+
 		tasks[index] = func(ctx context.Context) (taskID string, data *common.ReadResult, err error) {
 			taskUrl := urlTemplate.Clone()
-			taskUrl.WithQueryParam("financial_account", financialAccount.Id)
-			header := makeConnectedAccountHeader(financialAccount.ConnectedAccountId)
+			taskUrl.WithQueryParam("financial_account", finAccId)
+
+			header := makeConnectedAccountHeader(connAccId)
 			result, err := s.readRecords(ctx, params.ObjectName, params.Fields, taskUrl, header)
 
-			return financialAccount.Id, result, err
+			return finAccId, result, err
 		}
 		index += 1
 	}

--- a/providers/stripe/internal/reader/financial-accounts_test.go
+++ b/providers/stripe/internal/reader/financial-accounts_test.go
@@ -83,7 +83,7 @@ func TestReadForTreasury(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 						Then: mockserver.Response(http.StatusOK, responseAcc1FinAccounts2),
 					},
 					// ========
-					// Financial accounts (for Connected Account 1)
+					// Financial accounts (for Connected Account 2)
 					// ========
 					{
 						If: mockcond.And{
@@ -264,6 +264,69 @@ func TestReadForTreasury(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintid
 						"finAccId": "finAcc_00b_a9981a9bdebe"
 					},
 					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00b_a9981a9bdebe&limit=100&starting_after=2"
+				}]`,
+				Done: false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Read Treasury transactions for selected connected accounts",
+			Input: common.ReadParams{
+				ObjectName: "treasury/transaction_entries",
+				Fields:     connectors.Fields("id"),
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{"acct_1Nv0FGQ9RKHgCVdK"},
+				},
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{
+					// ========
+					// Financial accounts
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/financial_accounts"),
+							mockcond.QueryParamsMissing("starting_after"), // first page
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1FinAccounts2),
+					},
+					// ========
+					// Transactions for Connected Account
+					// ========
+					{
+						If: mockcond.And{
+							mockcond.Path("/v1/treasury/transaction_entries"),
+							mockcond.QueryParam("financial_account", "finAcc_00b_a9981a9bdebe"), // Fin #B
+							mockcond.Header(map[string][]string{
+								"Stripe-Account": {"acct_1Nv0FGQ9RKHgCVdK"}, // Account #1
+							}),
+						},
+						Then: mockserver.Response(http.StatusOK, responseAcc1Fin00bTransactions),
+					},
+				},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetReadSorted,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Fields: map[string]any{
+						"AMPERSAND-connectedAccountId": "acct_1Nv0FGQ9RKHgCVdK",
+						"id":                           "transaction_0b0_76f1bb782252",
+					},
+					Raw: map[string]any{"object": "treasury.transaction_entry"},
+					Id:  "transaction_0b0_76f1bb782252",
+				}},
+				// We are not done reading
+				NextPage: `[{
+					"context": {
+						"conAccId": "acct_1Nv0FGQ9RKHgCVdK",
+						"finAccId": "finAcc_00b_a9981a9bdebe"
+					},
+					"value": "` + testconn.URLTestServer + `/v1/treasury/transaction_entries?financial_account=finAcc_00b_a9981a9bdebe&limit=100&starting_after=transaction_0b0_76f1bb782252"
 				}]`,
 				Done: false,
 			},

--- a/providers/stripe/internal/reader/tasks.go
+++ b/providers/stripe/internal/reader/tasks.go
@@ -45,7 +45,10 @@ func inferReadTarget(params common.ReadParams) readTarget {
 
 	if len(opts.ReadForConnectedAccounts) > 0 {
 		if scopedObjectsForFinancialAccount.Has(params.ObjectName) {
-			return readTarget{Scope: ReadScopeSelectedConnectedAccountsTreasury}
+			return readTarget{
+				Scope:      ReadScopeSelectedConnectedAccountsTreasury,
+				AccountIDs: opts.ReadForConnectedAccounts,
+			}
 		}
 
 		return readTarget{

--- a/providers/stripe/internal/reader/tasks_test.go
+++ b/providers/stripe/internal/reader/tasks_test.go
@@ -1,0 +1,197 @@
+package reader
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestInferReadTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		regularObject  = "customers"
+		treasuryObject = "treasury/transactions"
+	)
+
+	tests := []struct {
+		name   string
+		params common.ReadParams
+		want   readTarget
+	}{
+		{
+			name: "Main account when options are absent",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+			},
+			want: readTarget{
+				Scope: ReadScopeMainAccount,
+			},
+		},
+		{
+			name: "Main Treasury account when options are absent",
+			params: common.ReadParams{
+				ObjectName: treasuryObject,
+			},
+			want: readTarget{
+				Scope: ReadScopeMainAccountTreasury,
+			},
+		},
+		{
+			name: "Main account when options have their zero value",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts:       ReadParamsOpts{},
+			},
+			want: readTarget{
+				Scope: ReadScopeMainAccount,
+			},
+		},
+		{
+			name: "Main Treasury account when options have their zero value",
+			params: common.ReadParams{
+				ObjectName: treasuryObject,
+				Opts:       ReadParamsOpts{},
+			},
+			want: readTarget{
+				Scope: ReadScopeMainAccountTreasury,
+			},
+		},
+		{
+			name: "Selected connected accounts for a regular object",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{
+						"acct_connected_1",
+						"acct_connected_2",
+					},
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeSelectedConnectedAccounts,
+				AccountIDs: []string{
+					"acct_connected_1",
+					"acct_connected_2",
+				},
+			},
+		},
+		{
+			name: "Selected connected accounts for a Treasury object",
+			params: common.ReadParams{
+				ObjectName: treasuryObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{
+						"acct_connected_1",
+						"acct_connected_2",
+					},
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeSelectedConnectedAccountsTreasury,
+				AccountIDs: []string{
+					"acct_connected_1",
+					"acct_connected_2",
+				},
+			},
+		},
+		{
+			name: "All connected accounts for a regular object",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts: ReadParamsOpts{
+					ReadForAllConnectedAccounts: true,
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeAllConnectedAccounts,
+			},
+		},
+		{
+			name: "All connected accounts for a Treasury object",
+			params: common.ReadParams{
+				ObjectName: treasuryObject,
+				Opts: ReadParamsOpts{
+					ReadForAllConnectedAccounts: true,
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeAllConnectedAccountsTreasury,
+			},
+		},
+		{
+			name: "Selected connected accounts take precedence over all connected accounts",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{
+						"acct_connected_1",
+					},
+					ReadForAllConnectedAccounts: true,
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeSelectedConnectedAccounts,
+				AccountIDs: []string{
+					"acct_connected_1",
+				},
+			},
+		},
+		{
+			name: "Selected Treasury connected accounts take precedence over all connected accounts",
+			params: common.ReadParams{
+				ObjectName: treasuryObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{
+						"acct_connected_1",
+					},
+					ReadForAllConnectedAccounts: true,
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeSelectedConnectedAccountsTreasury,
+				AccountIDs: []string{
+					"acct_connected_1",
+				},
+			},
+		},
+		{
+			name: "Empty selected account list does not select connected accounts",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts: []string{},
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeMainAccount,
+			},
+		},
+		{
+			name: "Empty selected account list falls back to all connected accounts",
+			params: common.ReadParams{
+				ObjectName: regularObject,
+				Opts: ReadParamsOpts{
+					ReadForConnectedAccounts:    []string{},
+					ReadForAllConnectedAccounts: true,
+				},
+			},
+			want: readTarget{
+				Scope: ReadScopeAllConnectedAccounts,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := inferReadTarget(tt.params)
+
+			result := testutils.NewCompareResult()
+			result.Assert("readTarget", tt.want, got)
+			result.Validate(t, tt.name)
+		})
+	}
+}


### PR DESCRIPTION
# Description

The `ReadForConnectedAccounts` was not propagated for Treasury API. The mode was selected correctly as `ReadScopeSelectedConnectedAccountsTreasury` but with empty list of accounts.
The empty connected account is an allowed value on struct:
```
type FinancialAccount struct {
	Id                 string `json:"finAccId"`
	ConnectedAccountId string `json:"conAccId"`
}
```
It means that the financial account belongs to the main account.

# Fix

<img width="635" height="358" alt="image" src="https://github.com/user-attachments/assets/399944b0-8077-497b-8779-80cb9f2a84e1" />

Also added the explicit error to indicate that empty connected account is not compatible input for this function.
<img width="1003" height="141" alt="image" src="https://github.com/user-attachments/assets/a155be28-29c0-46bb-b0d1-dbcd141b0a5d" />

# Validation

Without the fix the connector makes the following requests which matches the bug report:

<img width="1002" height="769" alt="image" src="https://github.com/user-attachments/assets/88f9ae4b-8659-490b-9b3d-70db864a0d3d" />

New unit tests focus on `inferReadTarget`, commenting out the accounts demonstrates previous behaviour and tests indicate an error:
<img width="1418" height="974" alt="image" src="https://github.com/user-attachments/assets/d262df1c-8b98-43d3-9e9a-95f0a74bf9d4" />


## Conclusion

The unit tests for `inferReadTarget` and `conn.Read` are all passing with the new requirement.
