### PR TITLE
[CON-3513] fix(acculynx): honour the associations argument in GetRecordsByIds

### DIFF
--- a/providers/acculynx/batchRecordReader.go
+++ b/providers/acculynx/batchRecordReader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/amp-labs/connectors/common"
@@ -16,6 +17,10 @@ import (
 
 // AccuLynx has no batch read endpoint; GetRecordsByIds fans out per id
 // (capped by maxConcurrentChildFetch) and preserves input order.
+//
+// Associations are served from the single-record payload itself: AccuLynx
+// expands them inline via ?includes= rather than exposing a separate endpoint,
+// so no extra request is needed to satisfy the associations argument.
 
 var errBatchReadEmptyResponse = errors.New("acculynx: empty response body for record fetch")
 
@@ -34,7 +39,7 @@ func (c *Connector) GetRecordsByIds(
 	objectName string,
 	recordIds []string,
 	fields []string,
-	_ []string, // associations: AccuLynx single-record endpoints have no association support
+	associations []string,
 ) ([]common.ReadResultRow, error) {
 	objectName = strings.ToLower(objectName)
 
@@ -57,7 +62,7 @@ func (c *Connector) GetRecordsByIds(
 		idx, currentID := i, recordID
 
 		jobs[idx] = func(ctx context.Context) error {
-			row, err := c.fetchSingleRecord(ctx, objectName, currentID, fieldSet)
+			row, err := c.fetchSingleRecord(ctx, objectName, currentID, fieldSet, associations)
 			if err != nil {
 				// A record that no longer exists — or, for the appointment->user
 				// edge, a calendar id that is not a user — must not sink the whole
@@ -82,7 +87,16 @@ func (c *Connector) GetRecordsByIds(
 		return nil, err
 	}
 
-	return compactFound(rows, found), nil
+	out := compactFound(rows, found)
+
+	// The embedded payload requested above still has to be lifted into
+	// Associations; without this the caller receives a full record and an empty
+	// associations map. Mirrors what the read path does via parseReadResponse.
+	if objectName == objectJobs && slices.Contains(associations, jobContactsAssociation) {
+		extractJobContacts(out)
+	}
+
+	return out, nil
 }
 
 // isNotFound reports whether err represents a 404 from AccuLynx. The base JSON
@@ -118,13 +132,20 @@ func (c *Connector) fetchSingleRecord(
 	ctx context.Context,
 	objectName, recordID string,
 	fieldSet datautils.StringSet,
+	associations []string,
 ) (common.ReadResultRow, error) {
-	u, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectName, recordID)
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectName, recordID)
 	if err != nil {
 		return common.ReadResultRow{}, err
 	}
 
-	resp, err := c.JSONHTTPClient().Get(ctx, u.String())
+	// Single-record endpoints accept the same ?includes= expansions as their
+	// list counterparts, so the enriched record carries the object's default
+	// expansions plus any requested association — keeping an enriched webhook
+	// payload identical in shape to the same record read from a list.
+	applyIncludes(url, objectName, common.ReadParams{AssociatedObjects: associations})
+
+	resp, err := c.JSONHTTPClient().Get(ctx, url.String())
 	if err != nil {
 		return common.ReadResultRow{}, err
 	}

--- a/providers/acculynx/batchRecordReader_test.go
+++ b/providers/acculynx/batchRecordReader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
@@ -11,6 +12,23 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"gotest.tools/v3/assert"
 )
+
+// singleRecordServer answers one GET for a record path, asserting the includes
+// expansion the connector is expected to send. Only the response body differs
+// between the by-id tests, so each case stays a single line.
+func singleRecordServer(t *testing.T, path, includes, body string) *httptest.Server {
+	t.Helper()
+
+	return mockserver.Conditional{
+		Setup: mockserver.ContentJSON(),
+		If: mockcond.And{
+			mockcond.MethodGET(),
+			mockcond.Path(path),
+			mockcond.QueryParam("includes", includes),
+		},
+		Then: mockserver.ResponseString(http.StatusOK, body),
+	}.Server()
+}
 
 func TestGetRecordsByIds_RejectsUnsupportedObject(t *testing.T) {
 	t.Parallel()
@@ -210,4 +228,157 @@ func TestGetRecordsByIds_HydratesUsers(t *testing.T) {
 	assert.Equal(t, len(rows), 1)
 	assert.Equal(t, rows[0].Id, "794f06f5")
 	assert.Equal(t, rows[0].Fields["displayName"], "Diane Hatch")
+}
+
+func TestGetRecordsByIds_AttachesJobContactsAssociation(t *testing.T) {
+	t.Parallel()
+
+	// The enrichment path the server uses for subscription events: a job id plus
+	// the association the customer configured. AccuLynx expands contacts inline
+	// on the single-record endpoint, so the association is served from the same
+	// response — no second request.
+	srv := singleRecordServer(t, "/api/v2/jobs/job-001", "initialAppointment,contacts",
+		`{"id":"job-001","jobName":"Roof repair","contacts":[
+			{"id":"jc-1","isPrimary":true,"contact":{"id":"ctc-100","firstName":"Diane"}}]}`)
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-001"}, []string{"id", "jobName"}, []string{jobContactsAssociation})
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+
+	assocs := rows[0].Associations[jobContactsAssociation]
+	assert.Equal(t, len(assocs), 1)
+	assert.Equal(t, assocs[0].ObjectId, "ctc-100")
+	assert.Equal(t, assocs[0].ProviderAssociationMetadata["isPrimary"], true)
+}
+
+func TestGetRecordsByIds_NoAssociationsRequestedAttachesNone(t *testing.T) {
+	t.Parallel()
+
+	// Without a requested association the job is still fetched with its default
+	// initialAppointment expansion, and Associations stays empty.
+	srv := singleRecordServer(t, "/api/v2/jobs/job-001", "initialAppointment",
+		`{"id":"job-001","contacts":[{"id":"jc-1","contact":{"id":"ctc-100"}}]}`)
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-001"}, []string{"id"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, len(rows[0].Associations), 0)
+}
+
+func TestGetRecordsByIds_AttachesEveryContactNotJustPrimary(t *testing.T) {
+	t.Parallel()
+
+	// A job commonly carries several contacts. The association must be a list
+	// with one entry per contact, each keeping its own isPrimary flag — not just
+	// the primary, and not the last one overwriting the rest.
+	srv := singleRecordServer(t, "/api/v2/jobs/job-001", "initialAppointment,contacts",
+		`{"id":"job-001","contacts":[
+			{"id":"jc-1","isPrimary":true,"contact":{"id":"ctc-100","firstName":"Diane"}},
+			{"id":"jc-2","isPrimary":false,"contact":{"id":"ctc-200","firstName":"Alan"}},
+			{"id":"jc-3","isPrimary":false,"contact":{"id":"ctc-300","firstName":"Marina"}}]}`)
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-001"}, []string{"id"}, []string{jobContactsAssociation})
+
+	assert.NilError(t, err)
+
+	assocs := rows[0].Associations[jobContactsAssociation]
+	assert.Equal(t, len(assocs), 3)
+	assert.Equal(t, assocs[0].ObjectId, "ctc-100")
+	assert.Equal(t, assocs[1].ObjectId, "ctc-200")
+	assert.Equal(t, assocs[2].ObjectId, "ctc-300")
+	assert.Equal(t, assocs[0].ProviderAssociationMetadata["isPrimary"], true)
+	assert.Equal(t, assocs[1].ProviderAssociationMetadata["isPrimary"], false)
+}
+
+func TestGetRecordsByIds_EmptyContactsLeavesNoAssociationKey(t *testing.T) {
+	t.Parallel()
+
+	// A job with no contacts must not gain an empty "contacts" key — the caller
+	// distinguishes "no associations" from "an association with nothing in it".
+	srv := singleRecordServer(t, "/api/v2/jobs/job-001", "initialAppointment,contacts",
+		`{"id":"job-001","contacts":[]}`)
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-001"}, []string{"id"}, []string{jobContactsAssociation})
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, len(rows[0].Associations), 0)
+}
+
+func TestGetRecordsByIds_AssociationsAttachPerRowAcrossBatch(t *testing.T) {
+	t.Parallel()
+
+	// Batch fan-out and association extraction have to work together: each row
+	// keeps its own contacts, and a job without contacts stays clean even when
+	// a sibling in the same batch has them.
+	srv := mockserver.Switch{
+		Setup: mockserver.ContentJSON(),
+		Cases: []mockserver.Case{
+			{
+				If: mockcond.And{mockcond.MethodGET(), mockcond.Path("/api/v2/jobs/job-1")},
+				Then: mockserver.ResponseString(http.StatusOK,
+					`{"id":"job-1","contacts":[{"id":"jc-1","isPrimary":true,"contact":{"id":"ctc-1"}}]}`),
+			},
+			{
+				If:   mockcond.And{mockcond.MethodGET(), mockcond.Path("/api/v2/jobs/job-2")},
+				Then: mockserver.ResponseString(http.StatusOK, `{"id":"job-2"}`),
+			},
+			{
+				If: mockcond.And{mockcond.MethodGET(), mockcond.Path("/api/v2/jobs/job-3")},
+				Then: mockserver.ResponseString(http.StatusOK,
+					`{"id":"job-3","contacts":[{"id":"jc-3","isPrimary":false,"contact":{"id":"ctc-3"}}]}`),
+			},
+		},
+		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectJobs,
+		[]string{"job-1", "job-2", "job-3"}, []string{"id"}, []string{jobContactsAssociation})
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 3)
+	assert.Equal(t, rows[0].Associations[jobContactsAssociation][0].ObjectId, "ctc-1")
+	assert.Equal(t, len(rows[1].Associations), 0)
+	assert.Equal(t, rows[2].Associations[jobContactsAssociation][0].ObjectId, "ctc-3")
+}
+
+func TestGetRecordsByIds_AssociationOnObjectWithoutOneIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Only jobs define an association today. Asking for one on contacts must be
+	// accepted and simply yield nothing, rather than erroring — matching how a
+	// read of the same object behaves.
+	srv := singleRecordServer(t, "/api/v2/contacts/ctc-100", "emailAddress,phoneNumber",
+		`{"id":"ctc-100","firstName":"Diane"}`)
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), objectContacts,
+		[]string{"ctc-100"}, []string{"id"}, []string{jobContactsAssociation})
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, len(rows[0].Associations), 0)
 }


### PR DESCRIPTION

## Problem

`GetRecordsByIds` took the associations argument as `_` and discarded it, and `fetchSingleRecord` never set `Associations`. Webhook enrichment returned a full record with an empty associations map — the customer saw a job with no contacts.

## Live findings

The `// AccuLynx single-record endpoints have no association support` comment was stale. Verified against the live API:

| Request | Result |
|---|---|
| `GET /jobs/{id}?includes=contacts` | contacts expand inline, fully |
| `GET /contacts/{id}?includes=emailAddress,phoneNumber` | email/phone expand from id-stubs to real values |

So associations are served from the single-record payload itself — no extra call.

## Fix

- Accept the argument and pass it through to `fetchSingleRecord`.
- Apply the read path's own `applyIncludes`, so a by-id fetch requests exactly
  what a list read requests.
- Lift embedded contacts into `Associations` via the existing `extractJobContacts`,
  right before the return (matching `providers/housecallPro/record.go`).

Two consequences beyond the reported bug:
- **Jobs** now carry `initialAppointment`, which the single-record fetch omitted
  while list reads always included it.
- **Contacts** now return real email addresses and phone numbers instead of
  id-only stubs.

## Known limitation

A contact nested inside a job association keeps stub phone numbers. AccuLynx expands one level only — ` includes=contacts,phoneNumber,emailAddress` returns the same stubs. Going deeper needs one extra call per contact per webhook; raising separately rather than deciding it here.

## Verification

### unit tests · 
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/5d938830-0ee5-4ecb-8b05-66364fa33c93" />
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/3d62e850-db66-4497-b006-1b0d42482c67" />
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/a5312608-3d06-4597-87d7-153194b5d603" />


### live response
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/35dfce7f-e049-4928-badd-c3c1b95e303a" />
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/15cb29fe-0add-4ffd-9a81-a43f6df5ea22" />
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/43c3bcd2-0d22-4638-9c61-f4237ea3d18c" />
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/2ce002cb-4e9f-486d-8df2-a2d5b89daf66" />

