### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	cloud.google.com/go/bigquery v1.81.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260826221625-06740f6a30d2
+	github.com/amp-labs/amp-common v0.0.0-20260828211559-73c0b187d18b
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.43.7

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260826221625-06740f6a30d2 h1:XgZiH8BfgxYZPuqvnBdrLXFcNIx8MEetqGYW4hETg3o=
-github.com/amp-labs/amp-common v0.0.0-20260826221625-06740f6a30d2/go.mod h1:7sWUUIzwXq6BcktrGY1oItcsKc+8+edlnHjYpCXJK5I=
+github.com/amp-labs/amp-common v0.0.0-20260828211559-73c0b187d18b h1:sAfBBkiDhIEJgamCHaQgleQ4d7T+TuHBFfDNrn8UFIU=
+github.com/amp-labs/amp-common v0.0.0-20260828211559-73c0b187d18b/go.mod h1:7sWUUIzwXq6BcktrGY1oItcsKc+8+edlnHjYpCXJK5I=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [73c0b187d18b5944d51e7305fe4dd93dec16055f](https://github.com/amp-labs/amp-common/commit/73c0b187d18b5944d51e7305fe4dd93dec16055f) from [main](https://github.com/amp-labs/amp-common/tree/main)