### PR TITLE
[CON-2590] feat: enable callRail read & write support

### DIFF
--- a/providers/callRail.go
+++ b/providers/callRail.go
@@ -24,9 +24,9 @@ func init() {
 				Delete: false,
 			},
 			Proxy:     true,
-			Read:      false,
+			Read:      true,
 			Subscribe: false,
-			Write:     false,
+			Write:     true,
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{


### PR DESCRIPTION
# Conventions
Read more: https://ampersand.slab.com/posts/deep-connectors-guide-6x4fhxne#ht0ds-reviewer-checklist

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [x] Write payloads should accept what `ReadResults.Fields` is returning. Any unnecessary nesting around the input is removed.
- [ ] Provider errors are mapped if non-standard (errors with 200 response code are converted to 4XX)
- [ ] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read/write/metadata logic (placed in /tests/<provider>)
- [x] Appropriate object names are used. Objects need to be resources, not actions (`jobs` and not `jobs.list`).
- [ ] Modules are only being added because:
  - [ ] They share the same authentication scheme
  - [ ] The same base URL cannot be used to make a proxy call to objects in all modules
  - [ ] Different base URLs (drive.google.com vs google.com)
  - [ ] Object name collisions (same object name exists in two or more modules)

# Read
For each read object:
- [x] Insert screenshot of metadata fields from read object installation.
<img width="1462" height="882" alt="Screenshot 2026-09-01 at 15 15 29" src="https://github.com/user-attachments/assets/3fe863de-9294-4eaa-9d65-58aac84b9868" />
<img width="1469" height="795" alt="Screenshot 2026-09-01 at 15 15 36" src="https://github.com/user-attachments/assets/da256277-e821-47e8-bfc8-37bf661c48b0" />
<img width="1470" height="885" alt="Screenshot 2026-09-01 at 15 15 43" src="https://github.com/user-attachments/assets/e1b62395-810c-4087-a2d9-4bf889ba615a" />
<img width="1468" height="884" alt="Screenshot 2026-09-01 at 15 15 51" src="https://github.com/user-attachments/assets/9f5d4a77-f690-4e8a-853b-2ad7ffd67764" />

- [x] Insert screenshot of Svix destination.
<img width="1457" height="885" alt="Screenshot 2026-09-01 at 14 46 52" src="https://github.com/user-attachments/assets/5c5dbd56-9f83-4a6b-9a64-310aba4102e6" />
<img width="1465" height="884" alt="Screenshot 2026-09-01 at 14 47 05" src="https://github.com/user-attachments/assets/b954292f-4482-492e-877a-b60228205249" />
<img width="1462" height="883" alt="Screenshot 2026-09-01 at 14 47 14" src="https://github.com/user-attachments/assets/8abe3188-8b77-4477-be98-6a4cfd99bfc0" />
<img width="1463" height="884" alt="Screenshot 2026-09-01 at 14 47 25" src="https://github.com/user-attachments/assets/f73ef762-7195-4c0a-993b-72986a1e2a33" />

- [x] Screenshot of operations on dashboard
<img width="1460" height="879" alt="Screenshot 2026-09-01 at 15 16 09" src="https://github.com/user-attachments/assets/e92bd194-d9a7-477e-8963-7ce12433e523" />
<img width="1460" height="879" alt="Screenshot 2026-09-01 at 15 16 09" src="https://github.com/user-attachments/assets/6c459deb-1c2d-418b-b5d1-81229aa57f88" />


# Write
For each write object:
- [x] Insert screenshot of dashboard.
<img width="1470" height="886" alt="Screenshot 2026-09-01 at 15 16 23" src="https://github.com/user-attachments/assets/cb25f1f5-67cd-47ab-9533-54bd4528cb6d" />

- [x] Insert screenshot of HTTP call.
<img width="1409" height="803" alt="Screenshot 2026-09-01 at 15 13 19" src="https://github.com/user-attachments/assets/8da398da-5628-45bc-a345-939c240be41c" />
<img width="1414" height="844" alt="Screenshot 2026-09-01 at 15 11 50" src="https://github.com/user-attachments/assets/647b152f-ef59-4bfd-903e-f308cd01d223" />


# Examples
[Test data PR](https://github.com/amp-labs/testdata/pull/162)
