### PR TITLE
fix(stripe): AggregateReadResults

### DIFF
--- a/common/readhelper/aggregation.go
+++ b/common/readhelper/aggregation.go
@@ -2,9 +2,11 @@ package readhelper
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/goutils"
 )
 
 // AggregateNextPage holds a collection of next page tokens, each associated with a context.
@@ -42,8 +44,16 @@ func AggregateReadResults[C any](
 	registry map[string]common.ReadResult,
 	createPageContext PageContextCreator[C],
 	modifyReadResultRow ReadResultRowModifier,
-) *common.ReadResult {
-	result := &common.ReadResult{
+) (result *common.ReadResult, err error) {
+	defer goutils.PanicRecovery(func(cause error) {
+		// Recover if modifyReadResultRow incorrectly uses a row field.
+		// This can happen when ReadResultRow gains a new map field that
+		// has not been initialized before calling the modifier.
+		// Update this function to initialize any newly added map fields.
+		err = fmt.Errorf("%w: invalid impl of modifyReadResultRow", cause)
+	})
+
+	result = &common.ReadResult{
 		Rows:     0,
 		Data:     make([]common.ReadResultRow, 0),
 		NextPage: "",
@@ -55,8 +65,9 @@ func AggregateReadResults[C any](
 
 	for key, value := range registry {
 		result.Rows += value.Rows
-		// hasMore is true if at least one result has more data to read
-		hasMore = hasMore || !(value.Done)
+
+		// Set hasMore if at least one result contains additional data.
+		hasMore = hasMore || !value.Done
 
 		if value.NextPage != "" {
 			aggregate = append(aggregate, NextPageToken[C]{
@@ -66,7 +77,16 @@ func AggregateReadResults[C any](
 		}
 
 		for _, row := range value.Data {
-			modifyReadResultRow(key, &row) // side effect: modifies the row
+			// Initialize maps so modifyReadResultRow can safely write to them.
+			if row.Fields == nil {
+				row.Fields = make(map[string]any)
+			}
+
+			if row.Associations == nil {
+				row.Associations = make(map[string][]common.Association)
+			}
+
+			modifyReadResultRow(key, &row) // Modifies row in place.
 			result.Data = append(result.Data, row)
 		}
 	}
@@ -74,7 +94,18 @@ func AggregateReadResults[C any](
 	result.NextPage = aggregate.token()
 	result.Done = !hasMore
 
-	return result
+	for _, data := range result.Data {
+		// Clear empty maps that were initialized only for modifyReadResultRow.
+		if len(data.Fields) == 0 {
+			data.Fields = nil
+		}
+
+		if len(data.Associations) == 0 {
+			data.Associations = nil
+		}
+	}
+
+	return result, nil
 }
 
 // token marshals AggregateNextPage into a single common.NextPageToken.

--- a/providers/stripe/internal/reader/tasks.go
+++ b/providers/stripe/internal/reader/tasks.go
@@ -100,7 +100,7 @@ func executeReadTasksAccounts(ctx context.Context,
 			// Enhance fields to indicate what account this row is associated with.
 			row.Fields[fieldConnectedAccountId] = accountId
 		},
-	), nil
+	)
 }
 
 // executeReadTasksTreasury executes multiple read tasks in parallel and aggregates their results.
@@ -141,5 +141,5 @@ func executeReadTasksTreasury(ctx context.Context,
 			row.Fields[fieldConnectedAccountId] = financialAccounts[financialAccountId].ConnectedAccountId
 			row.Fields[fieldFinancialAccountId] = financialAccountId
 		},
-	), nil
+	)
 }

--- a/test/stripe/read/received_credits/connected-account/main.go
+++ b/test/stripe/read/received_credits/connected-account/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/stripe"
+	connTest "github.com/amp-labs/connectors/test/stripe"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetStripeConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "treasury/received_credits",
+		Fields:     connectors.Fields("amount"),
+		Opts: stripe.ReadParamsOpts{
+			ReadForAllConnectedAccounts: true,
+		},
+	})
+	if err != nil {
+		utils.Fail("error reading from provider", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.PrintReadResultWithoutRaw(res, os.Stdout)
+}

--- a/test/stripe/read/received_credits/main-account/main.go
+++ b/test/stripe/read/received_credits/main-account/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	connTest "github.com/amp-labs/connectors/test/stripe"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	// Handle Ctrl-C gracefully.
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	// Set up slog logging.
+	utils.SetupLogging()
+
+	conn := connTest.GetStripeConnector(ctx)
+
+	res, err := conn.Read(ctx, common.ReadParams{
+		ObjectName: "treasury/received_credits",
+		Fields:     connectors.Fields("amount"),
+	})
+	if err != nil {
+		utils.Fail("error reading from provider", "error", err)
+	}
+
+	slog.Info("Reading...")
+	utils.PrintReadResultWithoutRaw(res, os.Stdout)
+}


### PR DESCRIPTION
# Description

`AggregateReadResults` can process read result rows whose map fields are nil. This change initializes those maps before invoking `modifyReadResultRow`, preventing nil-map panics caused by modifier implementations that write to them without initialization.

Empty maps are cleared afterwards to preserve the existing output across connectors. Callers providing `modifyReadResultRow` no longer need to initialize row maps themselves. This could've been a common silent bug, this way it is non-existent.

# Live tests
Error happened when no valid field was specified and therefore the map was empty, causing panic here:
<img width="1008" height="595" alt="image" src="https://github.com/user-attachments/assets/ec84f0ed-08c4-4442-b036-b43ac2cbf7d5" />

Example:
<img width="1436" height="969" alt="image" src="https://github.com/user-attachments/assets/7fc73964-a7d3-4cec-b0fd-aad69214fcac" />

After the fix:
<img width="854" height="482" alt="image" src="https://github.com/user-attachments/assets/6db011f7-45fa-42cf-8909-48b1b39a1a3a" />
