### PR TITLE
feat(slack): verify subscribe webhooks with signing secret from provider app metadata

### DIFF
--- a/providers/slack.go
+++ b/providers/slack.go
@@ -58,7 +58,7 @@ func init() { // nolint:funlen
 		ProviderAppMetadata: &ProviderAppMetadata{
 			ProviderParams: []MetadataItemInput{
 				{
-					Name:        "signingSecret",
+					Name:        "webhookSigningSecret",
 					DisplayName: "Signing Secret",
 					Prompt: "If you are using Slack subscribe actions, " +
 						"grab your Slack 'Signing Secret', available in the app admin panel under Basic Info.",
@@ -122,7 +122,7 @@ func init() { // nolint:funlen
 		ProviderAppMetadata: &ProviderAppMetadata{
 			ProviderParams: []MetadataItemInput{
 				{
-					Name:        "signingSecret",
+					Name:        "webhookSigningSecret",
 					DisplayName: "Signing Secret",
 					Prompt: "If you are using Slack subscribe actions, " +
 						"grab your Slack 'Signing Secret', available in the app admin panel under Basic Info.",

--- a/providers/slack/connector.go
+++ b/providers/slack/connector.go
@@ -17,7 +17,13 @@ import (
 type (
 	SubscriptionEvent          = webhook.Event
 	CollapsedSubscriptionEvent = webhook.CollapsedSubscriptionEvent
+	VerificationParams         = webhook.VerificationParams
 )
+
+// ProviderParamWebhookSigningSecret is the well-known ProviderApp.metadata.providerParams key
+// carrying the Slack app's signing secret, used to verify inbound webhooks. Declared in the
+// catalog's ProviderAppMetadata for Slack (the dashboard collects it from the builder).
+const ProviderParamWebhookSigningSecret = "webhookSigningSecret"
 
 var (
 	_ connectors.ReadConnector              = (*Connector)(nil)

--- a/providers/slack/internal/webhook/verifier.go
+++ b/providers/slack/internal/webhook/verifier.go
@@ -16,6 +16,14 @@ import (
 
 var ErrSigningSecretIsNotSet = errors.New("signing secret is not set")
 
+// VerificationParams carries the caller-resolved inputs for Slack webhook verification.
+// SigningSecret is the Slack app's signing secret (Basic Information > App Credentials in the
+// Slack app dashboard); in the Ampersand subscribe flow it is collected from the builder by the
+// dashboard and stored in ProviderApp.metadata.providerParams.
+type VerificationParams struct {
+	SigningSecret string
+}
+
 type Verifier struct {
 	signingSecret string
 }
@@ -44,11 +52,17 @@ func NewVerifier(signingSecret string) *Verifier {
 //	signature = "v0=" + HMAC-SHA256(signing_secret, sig_basestring).hex()
 //
 // The request is rejected if the timestamp is more than 5 minutes old (replay attack protection).
-func (v Verifier) VerifyWebhookMessage(
+//
+// The signing secret is resolved from params (VerificationParams.SigningSecret) when provided,
+// falling back to the secret the Verifier was constructed with. The params path is what the
+// subscribe flow uses: its verifier connector is a zero value (no construction metadata), so the
+// secret must arrive per-request — hence the pointer receiver and nil-safety.
+func (v *Verifier) VerifyWebhookMessage(
 	ctx context.Context, request *common.WebhookRequest, params *common.VerificationParams,
 ) (bool, error) {
-	if v.signingSecret == "" {
-		return false, ErrSigningSecretIsNotSet
+	secret, err := v.resolveSigningSecret(params)
+	if err != nil {
+		return false, err
 	}
 
 	slackSignature, err := httpkit.ExtractRequiredHeader(request.Headers, "X-Slack-Signature")
@@ -76,12 +90,35 @@ func (v Verifier) VerifyWebhookMessage(
 	sigBasestring := fmt.Sprintf("v0:%s:%s", timestampStr, requestBody)
 
 	// Compute HMAC-SHA256 signature
-	h := hmac.New(sha256.New, []byte(v.signingSecret))
+	h := hmac.New(sha256.New, []byte(secret))
 	h.Write([]byte(sigBasestring))
 	computedSignature := "v0=" + hex.EncodeToString(h.Sum(nil))
 
 	// Compare signatures using secure comparison
 	return hmac.Equal([]byte(computedSignature), []byte(slackSignature)), nil
+}
+
+// resolveSigningSecret picks the signing secret for a verification call: a non-empty secret in
+// params wins, then the constructor-provided secret. Nil-safe on the receiver so the zero-value
+// slack.Connector used by the subscribe seam (whose embedded *Verifier is nil) still verifies
+// with params-provided secrets.
+func (v *Verifier) resolveSigningSecret(params *common.VerificationParams) (string, error) {
+	if params != nil && params.Param != nil {
+		verificationParams, err := common.AssertType[*VerificationParams](params.Param)
+		if err != nil {
+			return "", fmt.Errorf("invalid verification params: %w", err)
+		}
+
+		if verificationParams.SigningSecret != "" {
+			return verificationParams.SigningSecret, nil
+		}
+	}
+
+	if v != nil && v.signingSecret != "" {
+		return v.signingSecret, nil
+	}
+
+	return "", ErrSigningSecretIsNotSet
 }
 
 // abs returns the absolute value of an integer.

--- a/providers/slack/internal/webhook/verifier_test.go
+++ b/providers/slack/internal/webhook/verifier_test.go
@@ -123,6 +123,110 @@ func TestVerifyWebhookMessage(t *testing.T) {
 	}
 }
 
+// TestVerifyWebhookMessageParamsSecret exercises the params-provided signing secret path used by
+// the subscribe flow, where the verifier connector is a zero value and the secret arrives
+// per-request via VerificationParams.
+func TestVerifyWebhookMessageParamsSecret(t *testing.T) {
+	t.Parallel()
+
+	eventMessage := testutils.DataFromFile(t, "event-for-verification.json")
+
+	validTimestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	validSlackSignature := computeSlackSignature(testSigningKey, validTimestamp, string(eventMessage))
+
+	validRequest := &common.WebhookRequest{
+		Headers: http.Header{
+			"X-Slack-Signature":         []string{validSlackSignature},
+			"X-Slack-Request-Timestamp": []string{validTimestamp},
+		},
+		Body: eventMessage,
+	}
+
+	tests := []testconn.TestCaseVerifyWebhookMessage{
+		{
+			Name: "Valid signature with params-provided secret on secretless verifier",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: validRequest,
+				Params: &common.VerificationParams{
+					Param: &VerificationParams{SigningSecret: testSigningKey},
+				},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: true,
+		},
+		{
+			Name: "Missing secret everywhere is rejected",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: validRequest,
+				Params:  &common.VerificationParams{},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: false,
+			ExpectedErrs: []error{
+				ErrSigningSecretIsNotSet,
+			},
+		},
+		{
+			Name: "Wrong params type is rejected",
+			Input: testconn.WebhookMessageVerificationParams{
+				Request: validRequest,
+				Params: &common.VerificationParams{
+					Param: "not-a-verification-params-struct",
+				},
+			},
+			Server:   mockserver.Dummy(),
+			Expected: false,
+			ExpectedErrs: []error{
+				testutils.StringError("invalid verification params"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableWebhookMessageVerifier, error) {
+				return NewVerifier(""), nil
+			})
+		})
+	}
+}
+
+// TestVerifyWebhookMessageParamsOverrideConstructor asserts the params secret wins over the
+// constructor secret.
+func TestVerifyWebhookMessageParamsOverrideConstructor(t *testing.T) {
+	t.Parallel()
+
+	eventMessage := testutils.DataFromFile(t, "event-for-verification.json")
+
+	validTimestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	paramsSigningKey := "params-signing-key"
+	signatureFromParamsKey := computeSlackSignature(paramsSigningKey, validTimestamp, string(eventMessage))
+
+	tt := testconn.TestCaseVerifyWebhookMessage{
+		Name: "Params secret overrides constructor secret",
+		Input: testconn.WebhookMessageVerificationParams{
+			Request: &common.WebhookRequest{
+				Headers: http.Header{
+					"X-Slack-Signature":         []string{signatureFromParamsKey},
+					"X-Slack-Request-Timestamp": []string{validTimestamp},
+				},
+				Body: eventMessage,
+			},
+			Params: &common.VerificationParams{
+				Param: &VerificationParams{SigningSecret: paramsSigningKey},
+			},
+		},
+		Server:   mockserver.Dummy(),
+		Expected: true,
+	}
+
+	tt.Run(t, func() (testconn.TestableWebhookMessageVerifier, error) {
+		return constructTestVerifier()
+	})
+}
+
 func constructTestVerifier() (*Verifier, error) {
 	verifier := NewVerifier(testSigningKey)
 

--- a/subscribe/slack.go
+++ b/subscribe/slack.go
@@ -1,14 +1,56 @@
 package subscribe
 
 import (
+	"context"
+	"errors"
+
+	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/providers/slack"
+	"github.com/amp-labs/connectors/subscribe/deps"
 )
+
+// errSlackSigningSecretNotConfigured is returned when the provider app has no Slack signing
+// secret in its metadata. The builder sets it in the Ampersand dashboard (Provider Apps > Slack >
+// Signing Secret); the value comes from the Slack app dashboard under Basic Information > App
+// Credentials.
+var errSlackSigningSecretNotConfigured = errors.New(
+	"slack signing secret is not configured on the provider app; set it in the Ampersand dashboard")
 
 // slackConfig is the per-provider subscribe-config bundle for Slack.
 //
-// Slack is not capable of managing subscriptions programmatically.
+// Slack is not capable of managing subscriptions programmatically. It does carry webhook
+// verification: the signing secret collected from the builder (stored in
+// ProviderApp.metadata.providerParams) is threaded to the verifier per-request via paramsFn.
 var slackConfig = ProviderConfig{
 	Verification: VerificationConfig{
+		paramsFn:          getSlackVerificationParams,
 		verifierConnector: &slack.Connector{},
 	},
+}
+
+// getSlackVerificationParams resolves the Slack signing secret from the provider app's metadata
+// (ProviderApp.metadata.providerParams.webhookSigningSecret) into the verifier's VerificationParams.
+func getSlackVerificationParams(
+	_ context.Context,
+	_ deps.Dependencies,
+	req *deps.VerificationRequest,
+) (*common.VerificationParams, error) {
+	if req == nil {
+		return nil, errInstallationNotFound
+	}
+
+	// ProviderParams is a *map on the wire type, so guard the pointer before indexing.
+	secret := ""
+	if req.ProviderApp != nil && req.ProviderApp.Metadata != nil &&
+		req.ProviderApp.Metadata.ProviderParams != nil {
+		secret = (*req.ProviderApp.Metadata.ProviderParams)[slack.ProviderParamWebhookSigningSecret]
+	}
+
+	if secret == "" {
+		return nil, errSlackSigningSecretNotConfigured
+	}
+
+	return &common.VerificationParams{
+		Param: &slack.VerificationParams{SigningSecret: secret},
+	}, nil
 }

--- a/subscribe/slack_test.go
+++ b/subscribe/slack_test.go
@@ -1,0 +1,94 @@
+package subscribe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/amp-labs/amp-common/openapi"
+	"github.com/amp-labs/connectors/providers/slack"
+	"github.com/amp-labs/connectors/subscribe/deps"
+)
+
+func TestGetSlackVerificationParams(t *testing.T) {
+	t.Parallel()
+
+	secret := "8f742231b10e8888abcd99yyyzzz85a5"
+
+	tests := []struct {
+		name       string
+		req        *deps.VerificationRequest
+		wantSecret string
+		wantErr    error
+	}{
+		{
+			name:    "nil request",
+			req:     nil,
+			wantErr: errInstallationNotFound,
+		},
+		{
+			name:    "nil provider app",
+			req:     &deps.VerificationRequest{},
+			wantErr: errSlackSigningSecretNotConfigured,
+		},
+		{
+			name: "provider app without metadata",
+			req: &deps.VerificationRequest{
+				ProviderApp: &openapi.ProviderApp{},
+			},
+			wantErr: errSlackSigningSecretNotConfigured,
+		},
+		{
+			name: "metadata without signing secret",
+			req: &deps.VerificationRequest{
+				ProviderApp: &openapi.ProviderApp{
+					Metadata: &openapi.ProviderAppMetadata{
+						ProviderParams: &map[string]string{"other": "value"},
+					},
+				},
+			},
+			wantErr: errSlackSigningSecretNotConfigured,
+		},
+		{
+			name: "signing secret present",
+			req: &deps.VerificationRequest{
+				ProviderApp: &openapi.ProviderApp{
+					Metadata: &openapi.ProviderAppMetadata{
+						ProviderParams: &map[string]string{
+							slack.ProviderParamWebhookSigningSecret: secret,
+						},
+					},
+				},
+			},
+			wantSecret: secret,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params, err := getSlackVerificationParams(t.Context(), deps.Dependencies{}, tt.req)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			verificationParams, ok := params.Param.(*slack.VerificationParams)
+			if !ok {
+				t.Fatalf("expected *slack.VerificationParams, got %T", params.Param)
+			}
+
+			if verificationParams.SigningSecret != tt.wantSecret {
+				t.Fatalf("expected signing secret %q, got %q", tt.wantSecret, verificationParams.SigningSecret)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

**Stacked on `cobalt0s/slack-subscribe`** (which adds the Slack signing-secret ProviderAppMetadata descriptors). This PR wires the existing Slack HMAC v0 webhook verifier into the subscribe flow end to end. Previously `slackConfig` registered a verifier connector but no `paramsFn`, so verification could never succeed (`errVerificationParamsFuncNotFound`), and the verifier could only get a secret at construction time — which the subscribe seam's zero-value connector never has.

## Changes

- **Catalog** (`providers/slack.go`): rename the base branch's providerParams key from `signingSecret` to **`webhookSigningSecret`** on both Slack entries (keeping its prompt/docsURL). @Cobalt0s — flagging the rename so we align on the key name before either lands; the paramsFn below reads this key, so they must match.
- **Verifier** (`providers/slack/internal/webhook/verifier.go`): resolve the signing secret from `VerificationParams` first (new exported `slack.VerificationParams`), falling back to the constructor-provided secret. Pointer receiver + nil-safety so the zero-value `slack.Connector{}` used by the subscribe seam works.
- **Subscribe config** (`subscribe/slack.go`): add `paramsFn` that reads `ProviderApp.metadata.providerParams.webhookSigningSecret` from the `VerificationRequest` and threads it to the verifier per request (HubSpot/Gmail pattern). Missing secret returns a clear error pointing the builder at the dashboard.
- **New well-known key constant**: `slack.ProviderParamWebhookSigningSecret`.

## End-to-end companions

- server: parity golden regen (amp-labs/server#7236) — lands with the next `[auto]` connectors bump after this merges
- client: no functional change needed (Provider App form renders providerParams descriptors generically); amp-labs/client#2288 masks secret-valued inputs

## Security note

`ProviderApp.metadata` is stored as plain JSONB (unlike `clientSecret`, which is encrypted) and rides on the `openapi.ProviderApp` wire type. Encrypting/redacting providerParams secrets is called out as a follow-up rather than blocking this wiring.

## Testing

- `go test ./providers/slack/... ./subscribe/... ./providers` — all pass
- New verifier tests: params-provided secret on a secretless verifier, params overriding constructor secret, missing-secret and wrong-param-type errors
- New `getSlackVerificationParams` table test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
