### PR TITLE
[ENG-4236] feat(salesforce): metadata builder for subscription record-triggered flows (2/5)

### DIFF
--- a/providers/salesforce/internal/crm/metadata/flowsubscription.go
+++ b/providers/salesforce/internal/crm/metadata/flowsubscription.go
@@ -1,0 +1,385 @@
+package metadata
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/core"
+)
+
+// This file builds Metadata API deploy packages for the record-triggered Flow
+// of a flow-based subscription. The flow fires after a record is created
+// and/or updated and invokes a Workflow Outbound Message action (see
+// outboundmessage.go), which POSTs a SOAP notification to the configured
+// endpoint.
+//
+// DELETE events are not supported on this path: record-triggered delete flows
+// run before-delete and do not support the outbound message action.
+
+var (
+	errFlowRequiredParams = errors.New(
+		"objectName, flowName, and outboundMessageName are required")
+	errFlowInvalidTriggerType = errors.New(
+		"recordTriggerType must be Create, Update, or CreateAndUpdate")
+	errNoFlowComponents = errors.New(
+		"at least one flow subscription component is required")
+)
+
+// FlowSubscriptionComponent pairs the two artifacts deployed for one object
+// of a flow-based subscription: the workflow outbound message and the
+// record-triggered flow that invokes it.
+type FlowSubscriptionComponent struct {
+	OutboundMessage OutboundMessageParams
+	Flow            FlowParams
+}
+
+// validateFlowSubscriptionComponent checks one component's params, that the
+// pair is internally consistent, and that its object was not already seen.
+func validateFlowSubscriptionComponent(
+	component FlowSubscriptionComponent, seenObjects map[string]bool,
+) error {
+	omParams, flowParams := component.OutboundMessage, component.Flow
+
+	if err := ValidateOutboundMessageParams(omParams); err != nil {
+		return err
+	}
+
+	if err := ValidateFlowParams(flowParams); err != nil {
+		return err
+	}
+
+	if omParams.ObjectName != flowParams.ObjectName || omParams.Name != flowParams.OutboundMessageName {
+		return fmt.Errorf("%w: outbound message %s.%s does not match flow reference %s.%s",
+			errFlowRequiredParams,
+			omParams.ObjectName, omParams.Name,
+			flowParams.ObjectName, flowParams.OutboundMessageName)
+	}
+
+	if seenObjects[omParams.ObjectName] {
+		return fmt.Errorf("%w: duplicate object %s", errFlowRequiredParams, omParams.ObjectName)
+	}
+
+	return nil
+}
+
+// RecordTriggerType maps to Flow.start.recordTriggerType in the Metadata API.
+type RecordTriggerType string
+
+const (
+	RecordTriggerTypeCreate          RecordTriggerType = "Create"
+	RecordTriggerTypeUpdate          RecordTriggerType = "Update"
+	RecordTriggerTypeCreateAndUpdate RecordTriggerType = "CreateAndUpdate"
+)
+
+// FlowParams contains the parameters for constructing the deploy package of
+// one record-triggered flow that invokes an outbound message.
+//
+// Field semantics mirror the Flow metadata type (FlowStart's recordTriggerType
+// and filterFormula in particular); see the official docs (with declaration
+// details and example XML):
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_visual_workflow.htm
+type FlowParams struct {
+	// ObjectName is the Salesforce object the flow runs on (e.g., "Lead").
+	ObjectName string
+
+	// FlowName is the Flow API name (e.g., "AmpSubscribe_Lead").
+	// Use GenerateFlowNameForSubscription() to generate this.
+	FlowName string
+
+	// OutboundMessageName is the developer name (WITHOUT the object prefix)
+	// of the outbound message the flow invokes. The referenced outbound
+	// message must already exist in Salesforce when the flow deploys.
+	OutboundMessageName string
+
+	// RecordTriggerType selects when the flow fires (Create / Update /
+	// CreateAndUpdate).
+	RecordTriggerType RecordTriggerType
+
+	// WatchFields optionally narrows Update triggers to changes of specific
+	// fields via an ISCHANGED() entry-condition formula. Only applied when
+	// RecordTriggerType is Update: ISCHANGED is not available in entry
+	// conditions of flows that also fire on Create.
+	WatchFields []string
+}
+
+// GenerateFlowNameForSubscription returns the Flow API name used for the
+// flow-based subscription on a given Salesforce object. Flow API names must
+// not contain consecutive underscores, so custom-object suffixes like "__c"
+// are collapsed (e.g. "My_Object__c" → "AmpSubscribe_My_Object_c").
+func GenerateFlowNameForSubscription(objectName string) (string, error) {
+	if objectName == "" {
+		return "", errEmptyObjectName
+	}
+
+	return "AmpSubscribe_" + sanitizeDeveloperName(objectName), nil
+}
+
+// ValidateFlowParams checks that all required fields are present and the
+// trigger type is one Salesforce accepts for after-save flows.
+func ValidateFlowParams(params FlowParams) error {
+	if params.ObjectName == "" || params.FlowName == "" || params.OutboundMessageName == "" {
+		return errFlowRequiredParams
+	}
+
+	switch params.RecordTriggerType {
+	case RecordTriggerTypeCreate, RecordTriggerTypeUpdate, RecordTriggerTypeCreateAndUpdate:
+		return nil
+	default:
+		return fmt.Errorf("%w: got %q", errFlowInvalidTriggerType, params.RecordTriggerType)
+	}
+}
+
+// The XML structs below mirror the Metadata API WSDL. Element order matters:
+// Salesforce validates deploy XML against an XSD sequence, so struct fields
+// are declared in the order a metadata retrieve produces them.
+//
+// Official field reference and example XML for Flow (incl. FlowActionCall,
+// FlowStart, and the outboundMessage action type):
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_visual_workflow.htm
+
+type flowActionCallXML struct {
+	Name                 string `xml:"name"`
+	Label                string `xml:"label"`
+	LocationX            int    `xml:"locationX"`
+	LocationY            int    `xml:"locationY"`
+	ActionName           string `xml:"actionName"`
+	ActionType           string `xml:"actionType"`
+	FlowTransactionModel string `xml:"flowTransactionModel"`
+	NameSegment          string `xml:"nameSegment"`
+}
+
+type flowConnectorXML struct {
+	TargetReference string `xml:"targetReference"`
+}
+
+type flowStartXML struct {
+	LocationX         int               `xml:"locationX"`
+	LocationY         int               `xml:"locationY"`
+	Connector         *flowConnectorXML `xml:"connector,omitempty"`
+	FilterFormula     string            `xml:"filterFormula,omitempty"`
+	Object            string            `xml:"object"`
+	RecordTriggerType string            `xml:"recordTriggerType"`
+	TriggerType       string            `xml:"triggerType"`
+}
+
+type flowXML struct {
+	XMLName        xml.Name          `xml:"Flow"`
+	Xmlns          string            `xml:"xmlns,attr"`
+	ActionCalls    flowActionCallXML `xml:"actionCalls"`
+	APIVersion     string            `xml:"apiVersion"`
+	Environments   string            `xml:"environments"`
+	InterviewLabel string            `xml:"interviewLabel"`
+	Label          string            `xml:"label"`
+	ProcessType    string            `xml:"processType"`
+	Start          flowStartXML      `xml:"start"`
+	Status         string            `xml:"status"`
+}
+
+// flowSendActionName is the flow element name of the single outbound message
+// action call inside a generated flow.
+const flowSendActionName = "Send_Outbound_Message"
+
+// GenerateFlowXML returns the .flow file content for the record-triggered
+// flow of a flow-based subscription: a single after-save start element wired
+// to one outbound message action call. Exported so the deactivation path can
+// rebuild the same flow with a different status.
+func GenerateFlowXML(params FlowParams, status string) (string, error) {
+	omFullName := OutboundMessageFullName(params.ObjectName, params.OutboundMessageName)
+
+	flow := flowXML{
+		Xmlns: metadataXmlns,
+		ActionCalls: flowActionCallXML{
+			Name:       flowSendActionName,
+			Label:      "Send Outbound Message",
+			LocationX:  176, //nolint:mnd // canvas coordinates; arbitrary but required
+			LocationY:  287, //nolint:mnd
+			ActionName: omFullName,
+			ActionType: "outboundMessage",
+			// CurrentTransaction sends the message when the trigger's
+			// transaction commits — a rolled-back save sends nothing.
+			FlowTransactionModel: "CurrentTransaction",
+			NameSegment:          omFullName,
+		},
+		APIVersion:     core.APIVersion,
+		Environments:   "Default",
+		InterviewLabel: params.FlowName + " {!$Flow.CurrentDateTime}",
+		Label:          params.FlowName,
+		ProcessType:    "AutoLaunchedFlow",
+		Start: flowStartXML{
+			LocationX:         50, //nolint:mnd
+			LocationY:         0,
+			Connector:         &flowConnectorXML{TargetReference: flowSendActionName},
+			FilterFormula:     buildWatchFieldsFilterFormula(params),
+			Object:            params.ObjectName,
+			RecordTriggerType: string(params.RecordTriggerType),
+			TriggerType:       "RecordAfterSave",
+		},
+		Status: status,
+	}
+
+	out, err := xml.MarshalIndent(flow, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal flow XML: %w", err)
+	}
+
+	return xml.Header + string(out) + "\n", nil
+}
+
+// buildWatchFieldsFilterFormula returns the flow entry-condition formula that
+// restricts Update triggers to changes of the watched fields, or "" when the
+// flow also fires on Create (ISCHANGED is rejected there) or no watch fields
+// are configured.
+func buildWatchFieldsFilterFormula(params FlowParams) string {
+	if params.RecordTriggerType != RecordTriggerTypeUpdate || len(params.WatchFields) == 0 {
+		return ""
+	}
+
+	changed := make([]string, 0, len(params.WatchFields))
+	for _, field := range params.WatchFields {
+		changed = append(changed, fmt.Sprintf("ISCHANGED({!$Record.%s})", field))
+	}
+
+	if len(changed) == 1 {
+		return changed[0]
+	}
+
+	return "OR(" + strings.Join(changed, ", ") + ")"
+}
+
+// ConstructFlow builds a zip deployment package containing ONLY the
+// record-triggered flow, deployed with the given status:
+//
+//   - "Active" for the subscribe path. On production orgs an Active deploy
+//     requires either flow test coverage or the "Deploy processes and flows
+//     as active" setting; an activation failure surfaces as a component
+//     failure on the deploy. The outbound message the flow references must
+//     already exist (deploy ConstructOutboundMessage first).
+//   - "Draft" for the deactivation fallback used before deletion when the
+//     Tooling API deactivation is unavailable.
+func ConstructFlow(params FlowParams, status string) ([]byte, error) {
+	if err := ValidateFlowParams(params); err != nil {
+		return nil, err
+	}
+
+	flowContent, err := GenerateFlowXML(params, status)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types: []triggerPackageType{
+			{
+				Members: []string{params.FlowName},
+				Name:    "Flow",
+			},
+		},
+	}
+
+	pkgXML, err := xml.MarshalIndent(pkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package.xml: %w", err)
+	}
+
+	return buildZip(map[string][]byte{
+		"package.xml":                        []byte(xml.Header + string(pkgXML)),
+		"flows/" + params.FlowName + ".flow": []byte(flowContent),
+	})
+}
+
+// ConstructDestructiveFlow builds a zipped destructive changes package that
+// removes the flow. The flow must be inactive before this deploy — Salesforce
+// rejects deletion of active flows.
+func ConstructDestructiveFlow(flowName string) ([]byte, error) {
+	if flowName == "" {
+		return nil, errEmptyObjectName
+	}
+
+	return constructDestructiveZip(triggerPackageType{
+		Members: []string{flowName},
+		Name:    "Flow",
+	})
+}
+
+// ConstructFlowSubscription builds ONE deploy package carrying both artifacts
+// of a flow-based subscription for a single object: the workflow outbound
+// message and the Active record-triggered flow that invokes it. Salesforce
+// metadata deploys are atomic per package (our deploy options set
+// rollbackOnError=true) — either every component lands or none do — so an
+// entire subscription costs ONE deploy() call and one status poll regardless
+// of object count, and a failed deploy leaves nothing to tear down.
+//
+// Each component's param sets must describe the same pair: same object, and
+// the flow's OutboundMessageName must match the outbound message being
+// deployed. Objects must be unique across components (one workflow file per
+// object).
+//
+// No dependency declaration is needed (or possible): package.xml only lists
+// members, and Salesforce resolves references between components of the same
+// deployment automatically — the flow's actionName reference to the outbound
+// message is satisfied because the outbound message ships in the same
+// package. See "Deploying and Retrieving Metadata":
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm
+func ConstructFlowSubscription(components []FlowSubscriptionComponent) ([]byte, error) {
+	if len(components) == 0 {
+		return nil, errNoFlowComponents
+	}
+
+	entries := make(map[string][]byte, 2*len(components)+1) //nolint:mnd
+	omMembers := make([]string, 0, len(components))
+	flowMembers := make([]string, 0, len(components))
+	seenObjects := make(map[string]bool, len(components))
+
+	for _, component := range components {
+		omParams, flowParams := component.OutboundMessage, component.Flow
+
+		if err := validateFlowSubscriptionComponent(component, seenObjects); err != nil {
+			return nil, err
+		}
+
+		seenObjects[omParams.ObjectName] = true
+
+		workflowContent, err := generateWorkflowXML(omParams)
+		if err != nil {
+			return nil, err
+		}
+
+		flowContent, err := GenerateFlowXML(flowParams, "Active")
+		if err != nil {
+			return nil, err
+		}
+
+		entries["workflows/"+omParams.ObjectName+".workflow"] = []byte(workflowContent)
+		entries["flows/"+flowParams.FlowName+".flow"] = []byte(flowContent)
+
+		omMembers = append(omMembers, OutboundMessageFullName(omParams.ObjectName, omParams.Name))
+		flowMembers = append(flowMembers, flowParams.FlowName)
+	}
+
+	pkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types: []triggerPackageType{
+			{
+				Members: omMembers,
+				Name:    "WorkflowOutboundMessage",
+			},
+			{
+				Members: flowMembers,
+				Name:    "Flow",
+			},
+		},
+	}
+
+	pkgXML, err := xml.MarshalIndent(pkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package.xml: %w", err)
+	}
+
+	entries["package.xml"] = []byte(xml.Header + string(pkgXML))
+
+	return buildZip(entries)
+}

--- a/providers/salesforce/internal/crm/metadata/flowsubscription_test.go
+++ b/providers/salesforce/internal/crm/metadata/flowsubscription_test.go
@@ -1,0 +1,344 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateFlowNameForSubscription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		object    string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "Standard object",
+			object:   "Lead",
+			expected: "AmpSubscribe_Lead",
+		},
+		{
+			name:     "Custom object collapses consecutive underscores",
+			object:   "My_Object__c",
+			expected: "AmpSubscribe_My_Object_c",
+		},
+		{
+			name:      "Empty object name returns error",
+			object:    "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GenerateFlowNameForSubscription(tt.object)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.expected {
+				t.Errorf("GenerateFlowNameForSubscription(%q) = %q, want %q", tt.object, got, tt.expected)
+			}
+		})
+	}
+}
+
+func validFlowParams() FlowParams {
+	return FlowParams{
+		ObjectName:          "Account",
+		FlowName:            "AmpSubscribe_Account",
+		OutboundMessageName: "amp_Account",
+		RecordTriggerType:   RecordTriggerTypeCreateAndUpdate,
+	}
+}
+
+func TestValidateFlowParams(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateFlowParams(validFlowParams()); err != nil {
+		t.Fatalf("unexpected error for valid params: %v", err)
+	}
+
+	missingFlowName := validFlowParams()
+	missingFlowName.FlowName = ""
+
+	if err := ValidateFlowParams(missingFlowName); err == nil {
+		t.Error("expected error for missing flow name")
+	}
+
+	missingOMName := validFlowParams()
+	missingOMName.OutboundMessageName = ""
+
+	if err := ValidateFlowParams(missingOMName); err == nil {
+		t.Error("expected error for missing outbound message name")
+	}
+
+	badTrigger := validFlowParams()
+	badTrigger.RecordTriggerType = "Delete"
+
+	if err := ValidateFlowParams(badTrigger); err == nil {
+		t.Error("expected error for unsupported record trigger type")
+	}
+}
+
+func TestBuildWatchFieldsFilterFormula(t *testing.T) {
+	t.Parallel()
+
+	params := validFlowParams()
+	params.RecordTriggerType = RecordTriggerTypeUpdate
+	params.WatchFields = []string{"Email"}
+
+	if got := buildWatchFieldsFilterFormula(params); got != "ISCHANGED({!$Record.Email})" {
+		t.Errorf("single watch field formula = %q", got)
+	}
+
+	params.WatchFields = []string{"Email", "Phone"}
+
+	expected := "OR(ISCHANGED({!$Record.Email}), ISCHANGED({!$Record.Phone}))"
+	if got := buildWatchFieldsFilterFormula(params); got != expected {
+		t.Errorf("multi watch field formula = %q, want %q", got, expected)
+	}
+
+	// ISCHANGED is invalid in flows that also fire on Create.
+	params.RecordTriggerType = RecordTriggerTypeCreateAndUpdate
+	if got := buildWatchFieldsFilterFormula(params); got != "" {
+		t.Errorf("expected no formula for CreateAndUpdate, got %q", got)
+	}
+
+	params.RecordTriggerType = RecordTriggerTypeUpdate
+	params.WatchFields = nil
+
+	if got := buildWatchFieldsFilterFormula(params); got != "" {
+		t.Errorf("expected no formula without watch fields, got %q", got)
+	}
+}
+
+func TestConstructFlowActive(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructFlow(validFlowParams(), "Active")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	pkg, ok := entries["package.xml"]
+	if !ok {
+		t.Fatalf("package.xml missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<name>Flow</name>",
+		"<members>AmpSubscribe_Account</members>",
+	} {
+		if !strings.Contains(pkg, want) {
+			t.Errorf("package.xml missing %q:\n%s", want, pkg)
+		}
+	}
+
+	if strings.Contains(pkg, "WorkflowOutboundMessage") {
+		t.Errorf("flow package.xml must not carry the outbound message:\n%s", pkg)
+	}
+
+	if _, exists := entries["workflows/Account.workflow"]; exists {
+		t.Error("flow zip must not carry the workflow file")
+	}
+
+	flow, ok := entries["flows/AmpSubscribe_Account.flow"]
+	if !ok {
+		t.Fatalf("flow file missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<actionName>Account.amp_Account</actionName>",
+		"<actionType>outboundMessage</actionType>",
+		"<object>Account</object>",
+		"<recordTriggerType>CreateAndUpdate</recordTriggerType>",
+		"<triggerType>RecordAfterSave</triggerType>",
+		"<status>Active</status>",
+		"<processType>AutoLaunchedFlow</processType>",
+	} {
+		if !strings.Contains(flow, want) {
+			t.Errorf("flow XML missing %q:\n%s", want, flow)
+		}
+	}
+
+	if strings.Contains(flow, "<filterFormula>") {
+		t.Errorf("flow XML must not carry a filter formula for CreateAndUpdate:\n%s", flow)
+	}
+}
+
+func TestConstructFlowUpdateOnlyWatchFields(t *testing.T) {
+	t.Parallel()
+
+	params := validFlowParams()
+	params.RecordTriggerType = RecordTriggerTypeUpdate
+	params.WatchFields = []string{"Email", "Phone"}
+
+	zipData, err := ConstructFlow(params, "Active")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	flow := entries["flows/AmpSubscribe_Account.flow"]
+	want := "<filterFormula>OR(ISCHANGED({!$Record.Email}), ISCHANGED({!$Record.Phone}))</filterFormula>"
+
+	if !strings.Contains(flow, want) {
+		t.Errorf("flow XML missing %q:\n%s", want, flow)
+	}
+}
+
+func TestConstructFlowDraft(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructFlow(validFlowParams(), "Draft")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	flow := entries["flows/AmpSubscribe_Account.flow"]
+	if !strings.Contains(flow, "<status>Draft</status>") {
+		t.Errorf("flow XML missing Draft status:\n%s", flow)
+	}
+}
+
+func TestConstructDestructiveFlow(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructDestructiveFlow("AmpSubscribe_Account")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	destructive, ok := entries["destructiveChanges.xml"]
+	if !ok {
+		t.Fatalf("destructiveChanges.xml missing; entries: %v", keysOf(entries))
+	}
+
+	if !strings.Contains(destructive, "<members>AmpSubscribe_Account</members>") ||
+		!strings.Contains(destructive, "<name>Flow</name>") {
+		t.Errorf("destructiveChanges.xml missing flow member:\n%s", destructive)
+	}
+
+	if _, ok := entries["package.xml"]; !ok {
+		t.Error("destructive zip requires an empty package.xml")
+	}
+
+	if _, err := ConstructDestructiveFlow(""); err == nil {
+		t.Error("expected error for empty flow name")
+	}
+}
+
+// subscriptionComponentFor builds a consistent component for the given object.
+func subscriptionComponentFor(objectName string) FlowSubscriptionComponent {
+	omName := "amp_" + objectName
+	flowName := "AmpSubscribe_" + objectName
+
+	return FlowSubscriptionComponent{
+		OutboundMessage: OutboundMessageParams{
+			ObjectName:          objectName,
+			Name:                omName,
+			EndpointURL:         "https://example.com/webhook",
+			IntegrationUsername: "integration@example.com",
+		},
+		Flow: FlowParams{
+			ObjectName:          objectName,
+			FlowName:            flowName,
+			OutboundMessageName: omName,
+			RecordTriggerType:   RecordTriggerTypeCreateAndUpdate,
+		},
+	}
+}
+
+func TestConstructFlowSubscription(t *testing.T) {
+	t.Parallel()
+
+	// The whole subscription (multiple objects) ships as ONE package.
+	zipData, err := ConstructFlowSubscription([]FlowSubscriptionComponent{
+		subscriptionComponentFor("Account"),
+		subscriptionComponentFor("Contact"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	pkg := entries["package.xml"]
+	for _, want := range []string{
+		"<name>WorkflowOutboundMessage</name>",
+		"<members>Account.amp_Account</members>",
+		"<members>Contact.amp_Contact</members>",
+		"<name>Flow</name>",
+		"<members>AmpSubscribe_Account</members>",
+		"<members>AmpSubscribe_Contact</members>",
+	} {
+		if !strings.Contains(pkg, want) {
+			t.Errorf("package.xml missing %q:\n%s", want, pkg)
+		}
+	}
+
+	for _, file := range []string{
+		"workflows/Account.workflow",
+		"workflows/Contact.workflow",
+		"flows/AmpSubscribe_Account.flow",
+		"flows/AmpSubscribe_Contact.flow",
+	} {
+		if _, ok := entries[file]; !ok {
+			t.Errorf("package missing %s; entries: %v", file, keysOf(entries))
+		}
+	}
+
+	if !strings.Contains(entries["flows/AmpSubscribe_Account.flow"], "<status>Active</status>") {
+		t.Error("package must deploy flows as Active")
+	}
+}
+
+func TestConstructFlowSubscriptionValidation(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ConstructFlowSubscription(nil); err == nil {
+		t.Error("expected error for empty component list")
+	}
+
+	mismatchedName := subscriptionComponentFor("Account")
+	mismatchedName.Flow.OutboundMessageName = "amp_Other"
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{mismatchedName}); err == nil {
+		t.Error("expected error for outbound message name mismatch")
+	}
+
+	mismatchedObject := subscriptionComponentFor("Account")
+	mismatchedObject.Flow.ObjectName = "Contact"
+	mismatchedObject.Flow.FlowName = "AmpSubscribe_Contact"
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{mismatchedObject}); err == nil {
+		t.Error("expected error for object name mismatch")
+	}
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{
+		subscriptionComponentFor("Account"),
+		subscriptionComponentFor("Account"),
+	}); err == nil {
+		t.Error("expected error for duplicate object")
+	}
+}


### PR DESCRIPTION
## Summary

**PR 2 of 5** in the flow-based Subscribe stack — stacked on #3417 (outbound message builder).

Adds construction of Metadata API deploy packages for the **record-triggered flow** that invokes the outbound message:

- `FlowParams` + validation (`Create` / `Update` / `CreateAndUpdate` trigger types only)
- Flow XML generation: after-save start element wired to a single outbound message action call (`actionType: outboundMessage`), `AutoLaunchedFlow`, transaction model `CurrentTransaction` (a rolled-back save sends nothing)
- **Watched-field filtering** via an `ISCHANGED()` entry-condition formula — applied only to Update-only triggers (Salesforce rejects `ISCHANGED` in flows that also fire on Create)
- Deploy zip with selectable status: `Active` for subscribe, `Draft` for the pre-delete deactivation fallback (Salesforce rejects deletion of active flows)
- Destructive-changes zip for teardown
- `ConstructFlowSubscription([]FlowSubscriptionComponent)`: ONE deploy package carrying **every object**s outbound message and Active flow — Salesforce deploys are atomic per package (`rollbackOnError=true`), so the wiring PR subscribes an entire subscription with a single deploy call + one poll, and a failure leaves nothing behind. No dependency declaration is needed: Salesforce resolves references between components of the same deployment automatically ([Deploying and Retrieving Metadata](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm))

**DELETE events are unsupported by design**: record-triggered delete flows run before-delete and cannot call the outbound message action.

Note for production orgs: deploying flows as `Active` via Metadata API is gated by the org's "Deploy processes and flows as active" setting + flow test coverage; with default settings the flow lands inactive. The wiring PR tracks this as a known live-verification item ([docs](https://help.salesforce.com/s/articleView?language=en_US&id=platform.flow_distribute_deploy_active.htm&type=5)).

## Stack

1. #3417 — outbound message builder
2. **→ this PR** (#3418) — record-triggered flow builder
3. #3420 — post-auth username capture
4. #3407 — `UseFlow` wiring into Subscribe/Delete/Update
5. #3419 — inbound message parsing


## Testing

Unit tests for name generation, validation, flow XML content, the ISCHANGED formula matrix, Active/Draft statuses, and the destructive zip. Pure construction — no live-org calls in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


