### PR TITLE
[ENG-4236] feat(salesforce): parse outbound message notifications into subscription events (5/5)

### DIFF
--- a/providers/salesforce/outboundmessage_event.go
+++ b/providers/salesforce/outboundmessage_event.go
@@ -1,0 +1,319 @@
+package salesforce
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// This file parses the SOAP messages Salesforce POSTs to the outbound message
+// endpoint of a flow-based subscription (see subscribe_flow.go).
+//
+// Wire format: one SOAP 1.1 envelope whose body carries a <notifications>
+// element (namespace http://soap.sforce.com/2005/09/outbound) with envelope-
+// level metadata (OrganizationId, ActionId, EnterpriseUrl, PartnerUrl) and up
+// to 100 <Notification> children. Each Notification holds the message id and
+// an <sObject> whose xsi:type names the object (e.g. "sf:Account") and whose
+// children are the fields configured on the outbound message.
+// https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_understanding.htm
+//
+// The receiver must respond with an Ack=true SOAP body (BuildOutboundMessageAck)
+// or Salesforce keeps retrying delivery for up to 24 hours.
+//
+// Outbound messages carry NO event type. The parser infers it from the audit
+// fields the outbound message builder always includes (see
+// ensureOutboundMessageFields): CreatedDate == LastModifiedDate means the save
+// that fired the flow created the record; a later LastModifiedDate means an
+// update. Deletes never produce outbound messages.
+//
+// Outbound messages are also unsigned — there is no HMAC. Verification options
+// are the unguessable per-subscription endpoint URL (current posture, matching
+// VerifyWebhookMessage's allow-all), validating Salesforce's client certificate
+// at the TLS layer, or checking OrganizationId against the connection.
+
+var (
+	errNotOutboundMessage = errors.New("body is not a Salesforce outbound message notification")
+	errMissingSObject     = errors.New("outbound message notification carries no sObject")
+	errMissingTimestamps  = errors.New("outbound message sObject carries no CreatedDate/LastModifiedDate")
+)
+
+const (
+	omKeyObjectName     = "objectName"
+	omKeyNotificationID = "notificationId"
+	omKeyOrganizationID = "organizationId"
+	omKeyActionID       = "actionId"
+	omKeyEnterpriseURL  = "enterpriseUrl"
+	omKeySObject        = "sObject"
+
+	omFieldID               = "Id"
+	omFieldCreatedDate      = "CreatedDate"
+	omFieldLastModifiedDate = "LastModifiedDate"
+
+	rawEventNameCreate          = "CREATE"
+	rawEventNameUpdate          = "UPDATE"
+	rawEventNameOutboundMessage = "OUTBOUND_MESSAGE"
+)
+
+// soap/xml shapes for the inbound notification envelope. They mirror the
+// notifications element of the outbound messaging WSDL; official docs with an
+// example SOAP message and the required acknowledgment:
+// https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_understanding.htm
+// https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_wsdl.htm
+
+type omEnvelopeXML struct {
+	XMLName xml.Name `xml:"Envelope"`
+	Body    struct {
+		Notifications omNotificationsXML `xml:"notifications"`
+	} `xml:"Body"`
+}
+
+type omNotificationsXML struct {
+	OrganizationID string              `xml:"OrganizationId"`
+	ActionID       string              `xml:"ActionId"`
+	EnterpriseURL  string              `xml:"EnterpriseUrl"`
+	PartnerURL     string              `xml:"PartnerUrl"`
+	Notifications  []omNotificationXML `xml:"Notification"`
+}
+
+type omNotificationXML struct {
+	ID      string       `xml:"Id"`
+	SObject omSObjectXML `xml:"sObject"`
+}
+
+type omSObjectXML struct {
+	// Type mirrors the xsi:type attribute, e.g. "sf:Account".
+	Type   string       `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr"`
+	Fields []omFieldXML `xml:",any"`
+}
+
+type omFieldXML struct {
+	XMLName xml.Name
+	Nil     string `xml:"http://www.w3.org/2001/XMLSchema-instance nil,attr"`
+	Value   string `xml:",chardata"`
+}
+
+// ParseOutboundMessage parses the SOAP body of one outbound message POST into
+// a collapsed event that expands to one SubscriptionEvent per Notification.
+func ParseOutboundMessage(body []byte) (*OutboundMessageEnvelope, error) {
+	var envelope omEnvelopeXML
+
+	// nolint:musttag // omFieldXML.XMLName is intentionally untagged: it captures
+	// each sObject child element's dynamic name (the configured field names).
+	if err := xml.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("%w: %w", errNotOutboundMessage, err)
+	}
+
+	notifications := envelope.Body.Notifications
+	if len(notifications.Notifications) == 0 {
+		return nil, fmt.Errorf("%w: no Notification elements", errNotOutboundMessage)
+	}
+
+	events := make([]OutboundMessageEvent, 0, len(notifications.Notifications))
+
+	for _, notification := range notifications.Notifications {
+		if len(notification.SObject.Fields) == 0 && notification.SObject.Type == "" {
+			return nil, fmt.Errorf("%w: notification %s", errMissingSObject, notification.ID)
+		}
+
+		fields := make(map[string]any, len(notification.SObject.Fields))
+
+		for _, field := range notification.SObject.Fields {
+			if field.Nil == "true" {
+				fields[field.XMLName.Local] = nil
+
+				continue
+			}
+
+			fields[field.XMLName.Local] = field.Value
+		}
+
+		events = append(events, OutboundMessageEvent{
+			omKeyNotificationID: notification.ID,
+			omKeyObjectName:     objectNameFromSObjectType(notification.SObject.Type),
+			omKeyOrganizationID: notifications.OrganizationID,
+			omKeyActionID:       notifications.ActionID,
+			omKeyEnterpriseURL:  notifications.EnterpriseURL,
+			omKeySObject:        fields,
+		})
+	}
+
+	return &OutboundMessageEnvelope{events: events}, nil
+}
+
+// objectNameFromSObjectType strips the namespace prefix from an xsi:type value:
+// "sf:Account" → "Account".
+func objectNameFromSObjectType(sObjectType string) string {
+	if _, name, found := strings.Cut(sObjectType, ":"); found {
+		return name
+	}
+
+	return sObjectType
+}
+
+var _ common.CollapsedSubscriptionEvent = &OutboundMessageEnvelope{}
+
+// OutboundMessageEnvelope is the collapsed form of one outbound message POST,
+// which batches up to 100 notifications.
+type OutboundMessageEnvelope struct {
+	events []OutboundMessageEvent
+}
+
+func (e *OutboundMessageEnvelope) RawMap() (map[string]any, error) {
+	raw := make([]any, len(e.events))
+	for index, event := range e.events {
+		raw[index] = map[string]any(event)
+	}
+
+	return map[string]any{"notifications": raw}, nil
+}
+
+func (e *OutboundMessageEnvelope) SubscriptionEventList() ([]common.SubscriptionEvent, error) {
+	events := make([]common.SubscriptionEvent, len(e.events))
+	for index, event := range e.events {
+		events[index] = event
+	}
+
+	return events, nil
+}
+
+var _ common.SubscriptionEvent = OutboundMessageEvent{}
+
+// OutboundMessageEvent is one Notification from an outbound message, flattened
+// into a map with envelope-level metadata attached.
+type OutboundMessageEvent map[string]any
+
+func (e OutboundMessageEvent) PreLoadData(_ *common.SubscriptionEventPreLoadData) error {
+	return nil
+}
+
+func (e OutboundMessageEvent) RawMap() (map[string]any, error) {
+	return maps.Clone(e), nil
+}
+
+// EventType infers create vs update from the record's audit timestamps, which
+// the outbound message builder always includes: a record whose
+// LastModifiedDate equals its CreatedDate was created by the save that fired
+// the flow. When either timestamp is missing (caller-managed outbound message
+// without audit fields), the type is Other rather than a guess.
+func (e OutboundMessageEvent) EventType() (common.SubscriptionEventType, error) {
+	created, createdErr := e.fieldTime(omFieldCreatedDate)
+	modified, modifiedErr := e.fieldTime(omFieldLastModifiedDate)
+
+	if createdErr != nil || modifiedErr != nil {
+		return common.SubscriptionEventTypeOther, nil //nolint:nilerr
+	}
+
+	if created.Equal(modified) {
+		return common.SubscriptionEventTypeCreate, nil
+	}
+
+	return common.SubscriptionEventTypeUpdate, nil
+}
+
+func (e OutboundMessageEvent) RawEventName() (string, error) {
+	eventType, err := e.EventType()
+	if err != nil {
+		return "", err
+	}
+
+	switch eventType { //nolint:exhaustive
+	case common.SubscriptionEventTypeCreate:
+		return rawEventNameCreate, nil
+	case common.SubscriptionEventTypeUpdate:
+		return rawEventNameUpdate, nil
+	default:
+		return rawEventNameOutboundMessage, nil
+	}
+}
+
+func (e OutboundMessageEvent) ObjectName() (string, error) {
+	return common.StringMap(e).GetString(omKeyObjectName)
+}
+
+func (e OutboundMessageEvent) Workspace() (string, error) {
+	// Not applicable: the endpoint URL is unique per subscription, so the
+	// receiver already knows which connection the message belongs to.
+	return "", nil
+}
+
+func (e OutboundMessageEvent) RecordId() (string, error) {
+	fields, err := e.sObjectFields()
+	if err != nil {
+		return "", err
+	}
+
+	return fields.GetString(omFieldID)
+}
+
+// EventTimeStampNano reports when the change was committed, using the
+// record's LastModifiedDate (CreatedDate as fallback).
+func (e OutboundMessageEvent) EventTimeStampNano() (int64, error) {
+	if modified, err := e.fieldTime(omFieldLastModifiedDate); err == nil {
+		return modified.UnixNano(), nil
+	}
+
+	created, err := e.fieldTime(omFieldCreatedDate)
+	if err != nil {
+		return 0, errMissingTimestamps
+	}
+
+	return created.UnixNano(), nil
+}
+
+func (e OutboundMessageEvent) sObjectFields() (common.StringMap, error) {
+	fieldsAny, ok := e[omKeySObject]
+	if !ok {
+		return nil, errMissingSObject
+	}
+
+	fields, ok := fieldsAny.(map[string]any)
+	if !ok {
+		return nil, errMissingSObject
+	}
+
+	return common.StringMap(fields), nil
+}
+
+func (e OutboundMessageEvent) fieldTime(fieldName string) (time.Time, error) {
+	fields, err := e.sObjectFields()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	value, err := fields.GetString(fieldName)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse %s %q: %w", fieldName, value, err)
+	}
+
+	return parsed, nil
+}
+
+// outboundMessageAckTemplate is the SOAP body Salesforce expects in response
+// to an outbound message POST. Anything other than Ack=true (or a non-2xx
+// status) makes Salesforce retry delivery for up to 24 hours.
+const outboundMessageAckTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    <soapenv:Body>
+        <notificationsResponse xmlns="http://soap.sforce.com/2005/09/outbound">
+            <Ack>%t</Ack>
+        </notificationsResponse>
+    </soapenv:Body>
+</soapenv:Envelope>
+`
+
+// BuildOutboundMessageAck returns the SOAP acknowledgment body the receiver
+// must send back for an outbound message POST. Pass false to make Salesforce
+// redeliver the batch later (e.g. on transient downstream failure).
+func BuildOutboundMessageAck(ack bool) []byte {
+	return fmt.Appendf(nil, outboundMessageAckTemplate, ack)
+}

--- a/providers/salesforce/outboundmessage_event_test.go
+++ b/providers/salesforce/outboundmessage_event_test.go
@@ -1,0 +1,189 @@
+package salesforce
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/amp-labs/connectors/common"
+)
+
+// sampleOutboundMessage mirrors the SOAP envelope Salesforce POSTs to an
+// outbound message endpoint, per
+// https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_understanding.htm
+const sampleOutboundMessage = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <notifications xmlns="http://soap.sforce.com/2005/09/outbound">
+      <OrganizationId>00Dxx0000001gPFEAY</OrganizationId>
+      <ActionId>04kxx00000000blAAA</ActionId>
+      <SessionId xsi:nil="true"/>
+      <EnterpriseUrl>https://yourInstance.salesforce.com/services/Soap/c/60.0/00Dxx0000001gPF</EnterpriseUrl>
+      <PartnerUrl>https://yourInstance.salesforce.com/services/Soap/u/60.0/00Dxx0000001gPF</PartnerUrl>
+      <Notification>
+        <Id>04lxx000000CaSdAAK</Id>
+        <sObject xsi:type="sf:Account" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+          <sf:Id>001xx000003DGb2AAG</sf:Id>
+          <sf:CreatedDate>2026-09-01T10:00:00.000Z</sf:CreatedDate>
+          <sf:LastModifiedDate>2026-09-01T10:00:00.000Z</sf:LastModifiedDate>
+          <sf:Name>Acme</sf:Name>
+        </sObject>
+      </Notification>
+      <Notification>
+        <Id>04lxx000000CaSeAAK</Id>
+        <sObject xsi:type="sf:Account" xmlns:sf="urn:sobject.enterprise.soap.sforce.com">
+          <sf:Id>001xx000003DGb3AAG</sf:Id>
+          <sf:CreatedDate>2026-08-20T08:30:00.000Z</sf:CreatedDate>
+          <sf:LastModifiedDate>2026-09-01T11:15:00.000Z</sf:LastModifiedDate>
+          <sf:Name xsi:nil="true"/>
+        </sObject>
+      </Notification>
+    </notifications>
+  </soapenv:Body>
+</soapenv:Envelope>`
+
+func parseSampleEvents(t *testing.T) []common.SubscriptionEvent {
+	t.Helper()
+
+	envelope, err := ParseOutboundMessage([]byte(sampleOutboundMessage))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	events, err := envelope.SubscriptionEventList()
+	if err != nil {
+		t.Fatalf("unexpected expand error: %v", err)
+	}
+
+	return events
+}
+
+func TestParseOutboundMessageExpandsNotifications(t *testing.T) {
+	t.Parallel()
+
+	events := parseSampleEvents(t)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	for index, expectedID := range []string{"001xx000003DGb2AAG", "001xx000003DGb3AAG"} {
+		recordID, err := events[index].RecordId()
+		if err != nil {
+			t.Fatalf("RecordId(%d): %v", index, err)
+		}
+
+		if recordID != expectedID {
+			t.Errorf("RecordId(%d) = %q, want %q", index, recordID, expectedID)
+		}
+
+		objectName, err := events[index].ObjectName()
+		if err != nil {
+			t.Fatalf("ObjectName(%d): %v", index, err)
+		}
+
+		if objectName != "Account" {
+			t.Errorf("ObjectName(%d) = %q, want Account", index, objectName)
+		}
+	}
+}
+
+func TestOutboundMessageEventTypeInference(t *testing.T) {
+	t.Parallel()
+
+	events := parseSampleEvents(t)
+
+	// First notification: CreatedDate == LastModifiedDate → the save that
+	// fired the flow created the record.
+	eventType, err := events[0].EventType()
+	if err != nil {
+		t.Fatalf("EventType(0): %v", err)
+	}
+
+	if eventType != common.SubscriptionEventTypeCreate {
+		t.Errorf("EventType(0) = %q, want create", eventType)
+	}
+
+	rawName, err := events[0].RawEventName()
+	if err != nil || rawName != "CREATE" {
+		t.Errorf("RawEventName(0) = %q, %v; want CREATE", rawName, err)
+	}
+
+	// Second notification: LastModifiedDate after CreatedDate → update.
+	eventType, err = events[1].EventType()
+	if err != nil {
+		t.Fatalf("EventType(1): %v", err)
+	}
+
+	if eventType != common.SubscriptionEventTypeUpdate {
+		t.Errorf("EventType(1) = %q, want update", eventType)
+	}
+}
+
+func TestOutboundMessageEventTimestampAndNilFields(t *testing.T) {
+	t.Parallel()
+
+	events := parseSampleEvents(t)
+
+	nano, err := events[1].EventTimeStampNano()
+	if err != nil {
+		t.Fatalf("EventTimeStampNano: %v", err)
+	}
+
+	// 2026-09-01T11:15:00Z
+	const expectedNano = int64(1788261300000000000)
+	if nano != expectedNano {
+		t.Errorf("EventTimeStampNano = %d, want %d", nano, expectedNano)
+	}
+
+	// xsi:nil fields parse as explicit nils rather than empty strings.
+	raw, err := events[1].RawMap()
+	if err != nil {
+		t.Fatalf("RawMap: %v", err)
+	}
+
+	fields, ok := raw[omKeySObject].(map[string]any)
+	if !ok {
+		t.Fatalf("sObject missing from raw map: %v", raw)
+	}
+
+	if value, exists := fields["Name"]; !exists || value != nil {
+		t.Errorf("nil Name field = %v (exists=%t), want nil", value, exists)
+	}
+
+	if raw[omKeyOrganizationID] != "00Dxx0000001gPFEAY" {
+		t.Errorf("organizationId = %v", raw[omKeyOrganizationID])
+	}
+}
+
+func TestParseOutboundMessageRejectsNonSoapBodies(t *testing.T) {
+	t.Parallel()
+
+	for name, body := range map[string]string{
+		"JSON":             `{"not": "soap"}`,
+		"empty":            ``,
+		"no notifications": `<?xml version="1.0"?><Envelope><Body></Body></Envelope>`,
+		"other SOAP":       `<?xml version="1.0"?><Envelope><Body><other/></Body></Envelope>`, //nolint:dupword
+	} {
+		if _, err := ParseOutboundMessage([]byte(body)); !errors.Is(err, errNotOutboundMessage) {
+			t.Errorf("%s: expected errNotOutboundMessage, got %v", name, err)
+		}
+	}
+}
+
+func TestBuildOutboundMessageAck(t *testing.T) {
+	t.Parallel()
+
+	ack := string(BuildOutboundMessageAck(true))
+	if !strings.Contains(ack, "<Ack>true</Ack>") ||
+		!strings.Contains(ack, `<notificationsResponse xmlns="http://soap.sforce.com/2005/09/outbound">`) {
+		t.Errorf("ack body malformed:\n%s", ack)
+	}
+
+	nack := string(BuildOutboundMessageAck(false))
+	if !strings.Contains(nack, "<Ack>false</Ack>") {
+		t.Errorf("nack body malformed:\n%s", nack)
+	}
+}


### PR DESCRIPTION
## Summary

**PR 5 of 5** in the flow-based Subscribe stack — stacked on #3407 (UseFlow wiring). Parses the SOAP messages Salesforce POSTs to a flow subscription's outbound message endpoint into the standard `common.SubscriptionEvent` shapes.

## Wire format being parsed

One SOAP 1.1 envelope per POST, headers `Content-Type: text/xml; charset=UTF-8` + `SOAPAction: ""`, body `<notifications>` (ns `http://soap.sforce.com/2005/09/outbound`) with org-level metadata and **up to 100 `<Notification>` elements**, each carrying the message id and an `<sObject xsi:type="sf:Account">` whose children are the configured fields. The receiver must reply `<Ack>true</Ack>` or Salesforce retries for up to 24 hours.

## What's included

- `ParseOutboundMessage` → `OutboundMessageEnvelope` (`common.CollapsedSubscriptionEvent`), expanding to one `OutboundMessageEvent` (`common.SubscriptionEvent`) per notification with envelope metadata attached
- **Event-type inference**: outbound messages carry no event type, so it's derived from the audit fields the OM builder (in #3417) always includes — `CreatedDate == LastModifiedDate` ⇒ `create`, later `LastModifiedDate` ⇒ `update`, missing timestamps ⇒ `other` (never a guess). Deletes can't occur on this path
- `EventTimeStampNano` from `LastModifiedDate` (fallback `CreatedDate`); `xsi:nil` fields parse as explicit nils
- `BuildOutboundMessageAck(bool)` — the SOAP ack body; `false` triggers Salesforce-side redelivery for transient downstream failures

## Notes

- Outbound messages are **unsigned** (no HMAC). Current posture matches the existing `VerifyWebhookMessage` allow-all; hardening options documented in code: unguessable per-subscription endpoint URL, Salesforce client-cert validation at TLS, `OrganizationId` cross-check
- Server-side wiring (webhook route calling `ParseOutboundMessage` + replying with the ack) is intentionally out of scope for the connectors repo

## Testing

Round-trip tests against a doc-faithful SOAP fixture: multi-notification expansion, create/update inference, timestamps, nil fields, non-SOAP rejection, ack rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
