### PR TITLE
[ENG-4236] feat(salesforce): capture username post-auth via userinfo (3/5)

### DIFF
--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -181,6 +181,28 @@ func init() { // nolint:funlen
 						"found in Business Unit Setup within Salesforce Setup or Marketing Setup.",
 				},
 			},
+			// PostAuthentication metadata is fetched from Salesforce right after a
+			// connection is created (via Connector.GetPostAuthInfo) and stored on the
+			// connection's provider metadata. The username powers the flow-based
+			// Subscribe path: it becomes the outbound message's integration user
+			// without another identity lookup at subscribe time. The lookup is
+			// best-effort — tokens minted without an identity scope (id/openid/
+			// profile/full) cannot call the userinfo endpoint, and GetPostAuthInfo
+			// degrades to an empty result rather than failing the connection.
+			//
+			// The username comes from the UserInfo endpoint's preferred_username
+			// response parameter ("Username of the queried user"):
+			// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm
+			// Scope requirements ("id — Allows access to the identity URL service"):
+			// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_tokens_scopes.htm
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "username",
+					ModuleDependencies: &ModuleDependencies{
+						ModuleSalesforceCRM: {},
+					},
+				},
+			},
 		},
 		ProviderAppMetadata: &ProviderAppMetadata{
 			ProviderParams: []MetadataItemInput{

--- a/providers/salesforce/authmetadata.go
+++ b/providers/salesforce/authmetadata.go
@@ -1,0 +1,92 @@
+package salesforce
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// PostAuthCatalogVarUsername is the catalog-var key under which GetPostAuthInfo
+// reports the connected user's Salesforce username. Callers (e.g. amp-labs/server)
+// persist it on the connection's provider metadata and can later feed it into
+// FlowSubscriptionConfig.IntegrationUsername without a fresh identity lookup.
+const PostAuthCatalogVarUsername = "username"
+
+var errUserinfoMissingUsername = errors.New("userinfo response carries no preferred_username")
+
+// GetPostAuthInfo returns authentication metadata fetched from Salesforce right
+// after a connection is established (see the PostAuthentication items in the
+// provider catalog). It currently reports the connected user's username.
+//
+// Best-effort by design: the userinfo endpoint is only reachable by tokens
+// minted with an identity scope (id/openid/profile/full — permission sets play
+// no role), so a scope-limited token gets a 403 here. That must not fail
+// connection creation, so any lookup error degrades to an empty PostAuthInfo
+// with a warning. Downstream, a missing username simply means the flow-based
+// Subscribe path falls back to its own userinfo lookup or the caller-supplied
+// IntegrationUsername.
+func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
+	resp, username, err := c.getUserinfo(ctx)
+	if err != nil {
+		logging.Logger(ctx).WarnContext(ctx,
+			"could not resolve the connected user's username post-auth; "+
+				"continuing without it (token likely lacks an identity scope)",
+			"provider", c.Provider(),
+			"error", err,
+		)
+
+		return &common.PostAuthInfo{}, nil
+	}
+
+	return &common.PostAuthInfo{
+		RawResponse: resp,
+		CatalogVars: &map[string]string{
+			PostAuthCatalogVarUsername: username,
+		},
+	}, nil
+}
+
+// GetCurrentUsername returns the Salesforce username of the user the connector
+// is authenticated as, via the OpenID Connect userinfo endpoint. Requires the
+// token to carry an identity scope (id/openid/profile/full).
+//
+// Official docs with example request/response (see the preferred_username
+// response parameter — "Username of the queried user"):
+// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm
+func (c *Connector) GetCurrentUsername(ctx context.Context) (string, error) {
+	_, username, err := c.getUserinfo(ctx)
+
+	return username, err
+}
+
+// getUserinfo calls /services/oauth2/userinfo and extracts preferred_username.
+func (c *Connector) getUserinfo(ctx context.Context) (*common.JSONHTTPResponse, string, error) {
+	url, err := urlbuilder.New(c.getModuleURL(), "services/oauth2/userinfo")
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch userinfo: %w", err)
+	}
+
+	type userinfo struct {
+		PreferredUsername string `json:"preferred_username"`
+	}
+
+	info, err := common.UnmarshalJSON[userinfo](resp)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if info == nil || info.PreferredUsername == "" {
+		return nil, "", errUserinfoMissingUsername
+	}
+
+	return resp, info.PreferredUsername, nil
+}

--- a/providers/salesforce/authmetadata_test.go
+++ b/providers/salesforce/authmetadata_test.go
@@ -1,0 +1,129 @@
+package salesforce
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+)
+
+const userinfoResponse = `{
+	"sub": "https://login.salesforce.com/id/00Dxx0000001gPFEAY/005xx000001SvokAAC",
+	"user_id": "005xx000001SvokAAC",
+	"organization_id": "00Dxx0000001gPFEAY",
+	"preferred_username": "integration@example.com",
+	"name": "Integration User"
+}`
+
+func TestGetCurrentUsername(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns preferred_username from userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Conditional{
+			Setup: mockserver.ContentJSON(),
+			If:    mockcond.Path("/services/oauth2/userinfo"),
+			Then:  mockserver.Response(http.StatusOK, []byte(userinfoResponse)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		username, err := connector.GetCurrentUsername(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if username != "integration@example.com" {
+			t.Errorf("username = %q, want integration@example.com", username)
+		}
+	})
+
+	t.Run("Errors when preferred_username is absent", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Fixed{
+			Setup:  mockserver.ContentJSON(),
+			Always: mockserver.Response(http.StatusOK, []byte(`{"sub": "only"}`)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		if _, err := connector.GetCurrentUsername(t.Context()); err == nil {
+			t.Error("expected error for missing preferred_username")
+		}
+	})
+}
+
+func TestGetPostAuthInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Reports the username as a catalog var", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Conditional{
+			Setup: mockserver.ContentJSON(),
+			If:    mockcond.Path("/services/oauth2/userinfo"),
+			Then:  mockserver.Response(http.StatusOK, []byte(userinfoResponse)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		info, err := connector.GetPostAuthInfo(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if info.CatalogVars == nil {
+			t.Fatal("expected catalog vars, got nil")
+		}
+
+		if got := (*info.CatalogVars)[PostAuthCatalogVarUsername]; got != "integration@example.com" {
+			t.Errorf("username catalog var = %q, want integration@example.com", got)
+		}
+	})
+
+	t.Run("Degrades to empty info when userinfo is scope-blocked", func(t *testing.T) {
+		t.Parallel()
+
+		// Tokens minted without an identity scope get a 403 from userinfo.
+		// GetPostAuthInfo must NOT propagate the error: the server treats a
+		// post-auth error as fatal for connection creation.
+		server := mockserver.Fixed{
+			Setup:  mockserver.ContentJSON(),
+			Always: mockserver.Response(http.StatusForbidden, []byte(`[{"errorCode":"FORBIDDEN"}]`)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		info, err := connector.GetPostAuthInfo(t.Context())
+		if err != nil {
+			t.Fatalf("expected graceful degradation, got error: %v", err)
+		}
+
+		if info == nil {
+			t.Fatal("expected empty PostAuthInfo, got nil")
+		}
+
+		if info.CatalogVars != nil {
+			t.Errorf("expected no catalog vars on failure, got %v", *info.CatalogVars)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

**PR 3 of 5** in the flow-based Subscribe stack — isolated from the wiring PR so the identity concern can be reviewed on its own.

Captures the connected user's Salesforce username once at connection time and stores it on the connection's provider metadata, so subscribe callers can supply the outbound message's integration user straight from the connection record.

- `PostAuthentication` catalog item (`username`) on the Salesforce provider — the server's existing generic post-auth machinery calls `GetPostAuthInfo` and persists the catalog var into `connections.metadata` (`source: provider`). No server code changes
- `GetPostAuthInfo` reads `/services/oauth2/userinfo` → `preferred_username` ([UserInfo endpoint docs](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm))
- `GetCurrentUsername` exposes the same lookup for on-demand use (the wiring PR's fallback when no username is configured or cached)

**Best-effort by design**: userinfo requires an identity scope (`id`/`openid`/`profile`/`full` — [scopes docs](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_tokens_scopes.htm)); a scope-limited token gets a 403, which degrades to an empty `PostAuthInfo` with a warning instead of an error — the server treats post-auth errors as fatal for connection creation, so this must never fail the OAuth connect.

## Stack

1. #3417 — outbound message builder
2. #3418 — flow builder
3. **→ this PR** — post-auth username capture
4. #3407 — `UseFlow` wiring
5. #3419 — inbound message parsing

## Testing

Mockserver tests: username extraction, missing `preferred_username`, catalog-var reporting, and the 403 graceful-degradation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)