### PR TITLE
fix(slack): do not require installation for webhook verification params

### DIFF
--- a/subscribe/deps_test.go
+++ b/subscribe/deps_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/amp-labs/connectors/providers/attio"
 	"github.com/amp-labs/connectors/providers/hubspot"
 	"github.com/amp-labs/connectors/providers/salesforce"
+	"github.com/amp-labs/connectors/providers/slack"
 	"github.com/amp-labs/connectors/subscribe/deps"
 )
 
@@ -40,6 +41,41 @@ func TestVerificationParamsClientSecret(t *testing.T) {
 
 	if hubspotParams.ClientSecret != "shh-secret" {
 		t.Errorf("ClientSecret = %q, want shh-secret", hubspotParams.ClientSecret)
+	}
+}
+
+// TestSlackVerificationParamsIntegrationScoped verifies the Slack verification-params builder
+// needs no installation: Slack webhooks are integration-scoped (the Events API request URL is
+// configured once per Slack app), so at verification time deps.VerificationRequest.Installation
+// is nil. The signing secret comes from the provider app's metadata.providerParams alone.
+func TestSlackVerificationParamsIntegrationScoped(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := GetProviderConfig("", makeProviderInfo(providers.Slack, ""), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	params, err := cfg.Verification.Params(context.Background(), &deps.VerificationRequest{
+		ProviderApp: &openapi.ProviderApp{
+			Metadata: &openapi.ProviderAppMetadata{
+				ProviderParams: &map[string]string{
+					providers.ProviderParamSlackSigningSecret: "slack-signing-secret",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Params() without installation error = %v, want nil", err)
+	}
+
+	slackParams, ok := params.Param.(*slack.VerificationParams)
+	if !ok {
+		t.Fatalf("Params().Param = %T, want *slack.VerificationParams", params.Param)
+	}
+
+	if slackParams.SigningSecret != "slack-signing-secret" {
+		t.Errorf("SigningSecret = %q, want slack-signing-secret", slackParams.SigningSecret)
 	}
 }
 

--- a/subscribe/slack.go
+++ b/subscribe/slack.go
@@ -19,17 +19,18 @@ var slackConfig = ProviderConfig{
 	},
 }
 
+// getSlackVerificationParams resolves the Slack signing secret from the provider app's metadata
+// (ProviderApp.metadata.providerParams). Like Hubspot, Slack webhooks are integration-scoped —
+// the Events API request URL is configured once per Slack app, so no installation exists at
+// verification time and req.Installation must not be required here. An empty secret is passed
+// through; the verifier rejects it with a clear ErrMissingProviderParam.
 func getSlackVerificationParams(
-	ctx context.Context,
-	deps deps.Dependencies,
+	_ context.Context,
+	_ deps.Dependencies,
 	req *deps.VerificationRequest,
 ) (*common.VerificationParams, error) {
-	if req == nil || req.Installation == nil {
-		return nil, errInstallationNotFound
-	}
-
-	if deps.Subscriptions == nil {
-		return nil, errSubscriptionListerNotConfigured
+	if req == nil {
+		return nil, errNilVerificationRequest
 	}
 
 	secret := ""

--- a/subscribe/subscribe.go
+++ b/subscribe/subscribe.go
@@ -51,3 +51,9 @@ import "errors"
 // errInstallationNotFound is a shared sentinel returned by per-provider request builders when an
 // installation cannot be found while constructing subscribe params.
 var errInstallationNotFound = errors.New("installation not found")
+
+// errNilVerificationRequest is a shared sentinel returned by per-provider verification-params
+// builders handed a nil deps.VerificationRequest. Distinct from errInstallationNotFound so
+// providers that don't need an installation (integration-scoped webhooks) don't report a
+// misleading installation lookup failure.
+var errNilVerificationRequest = errors.New("verification request is nil")


### PR DESCRIPTION
## Problem

Every Slack subscribe event is currently rejected by the messenger's subscribe event processor with:

```
failed to get verification params: installation not found
```

Slack webhooks are **integration-scoped**: the Events API request URL is configured once per Slack app, so the webhook path (`/v1/projects/{projectId}/integrations/{integrationId}`) carries no `installationId`. That means `VerificationRequest.Installation` is always nil at verification time — verification runs *before* the `team_id` → `providerWorkspaceRef` installation routing in the server's event processor.

`getSlackVerificationParams` guarded `req.Installation == nil` (and `deps.Subscriptions == nil`) without ever using either value — the signing secret comes solely from `ProviderApp.metadata.providerParams`. The guards made verification structurally impossible for Slack, and every event was dropped.

## Fix

Mirror the Hubspot paramsFn — the existing integration-scoped reference, whose secret is likewise provider-app-level:

- Guard only `req == nil`, returning a new shared `errNilVerificationRequest` sentinel — the inherited `errInstallationNotFound` was misleading for a nil request (no installation lookup is involved).
- Drop the unused `deps.Subscriptions` check.
- Resolve the signing secret from `ProviderApp.metadata.providerParams` alone.

An empty secret still passes through the paramsFn (per #3410, the provider var is optional); the verifier rejects it with a clear `ErrMissingProviderParam: SigningSecret is empty`.

## Testing

- Added `TestSlackVerificationParamsIntegrationScoped` pinning the no-installation contract (params resolve with `Installation` nil).
- `go test ./subscribe/...` passes; `make fix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

