### PR TITLE
fix(slack): nil-safe webhook verifier for zero-value connector

### DIFF
--- a/providers/slack/connector.go
+++ b/providers/slack/connector.go
@@ -48,6 +48,16 @@ func NewBotConnector(params common.ConnectorParams) (*Connector, error) {
 	return components.Init(providers.Slack, params, constructor)
 }
 
+// NewWebhookVerifierConnector returns a minimal Connector for webhook signature verification
+// only. It carries a constructed webhook Verifier and nothing else — no auth client, no base
+// connector — so it must not be used for API calls. The subscribe registry uses it as the
+// shared verifierConnector: verification is stateless HMAC math, and a zero-value Connector's
+// nil *Verifier embed would otherwise fail every verification (and, before the verifier's nil
+// guard existed, panicked in the method-promotion wrapper).
+func NewWebhookVerifierConnector() *Connector {
+	return &Connector{Verifier: webhook.NewVerifier()}
+}
+
 func NewUserConnector(params common.ConnectorParams) (*Connector, error) {
 	return components.Init(providers.SlackUserScope, params, constructor)
 }

--- a/providers/slack/internal/webhook/verifier.go
+++ b/providers/slack/internal/webhook/verifier.go
@@ -20,6 +20,10 @@ type VerificationParams struct {
 
 type Verifier struct{}
 
+// errVerifierNotInitialized is returned when VerifyWebhookMessage is called through a Connector
+// whose embedded *Verifier was never constructed.
+var errVerifierNotInitialized = errors.New("slack webhook verifier is not initialized")
+
 // NewVerifier constructs an event message verifier.
 // The empty signingSecret won't trigger a failure to preserve backward compatibility.
 // However, no event message will be accepted.
@@ -42,9 +46,18 @@ func NewVerifier() *Verifier {
 //	signature = "v0=" + HMAC-SHA256(signing_secret, sig_basestring).hex()
 //
 // The request is rejected if the timestamp is more than 5 minutes old (replay attack protection).
-func (v Verifier) VerifyWebhookMessage(
+//
+// Pointer receiver with an explicit nil guard: a slack.Connector whose embedded *Verifier was
+// never initialized (e.g. a zero-value literal) must fail verification with a clear error, never
+// panic in the method-promotion wrapper. The subscribe registry constructs the Verifier via
+// slack.NewWebhookVerifierConnector, so the guard is a backstop, not the expected path.
+func (v *Verifier) VerifyWebhookMessage(
 	ctx context.Context, request *common.WebhookRequest, params *common.VerificationParams,
 ) (bool, error) {
+	if v == nil {
+		return false, errVerifierNotInitialized
+	}
+
 	signingSecret, err := v.resolveSigningSecret(params)
 	if err != nil {
 		return false, err
@@ -83,7 +96,7 @@ func (v Verifier) VerifyWebhookMessage(
 	return hmac.Equal([]byte(computedSignature), []byte(slackSignature)), nil
 }
 
-func (v Verifier) resolveSigningSecret(params *common.VerificationParams) (string, error) {
+func (v *Verifier) resolveSigningSecret(params *common.VerificationParams) (string, error) {
 	if params == nil || params.Param == nil {
 		return "", common.ErrMissingVerificationParams
 	}

--- a/providers/slack/internal/webhook/verifier_test.go
+++ b/providers/slack/internal/webhook/verifier_test.go
@@ -1,9 +1,11 @@
 package webhook
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -150,6 +152,24 @@ func constructTestVerifier() (*Verifier, error) {
 	verifier := NewVerifier()
 
 	return verifier, nil
+}
+
+// TestVerifyWebhookMessageNilVerifier pins the backstop for an unconstructed verifier: a nil
+// *Verifier (e.g. the nil embed of a zero-value slack.Connector) must return a clear error from
+// the promoted call, never panic in the method-promotion wrapper.
+func TestVerifyWebhookMessageNilVerifier(t *testing.T) {
+	t.Parallel()
+
+	var v *Verifier
+
+	ok, err := v.VerifyWebhookMessage(context.Background(), &common.WebhookRequest{}, nil)
+	if ok {
+		t.Error("VerifyWebhookMessage() = true, want false on nil verifier")
+	}
+
+	if !errors.Is(err, errVerifierNotInitialized) {
+		t.Errorf("VerifyWebhookMessage() error = %v, want errVerifierNotInitialized", err)
+	}
 }
 
 func computeSlackSignature(signingKey, timestamp, body string) string {

--- a/subscribe/deps_test.go
+++ b/subscribe/deps_test.go
@@ -79,6 +79,33 @@ func TestSlackVerificationParamsIntegrationScoped(t *testing.T) {
 	}
 }
 
+// TestSlackVerifierConnectorZeroValueNoPanic pins the 2026-09-02 production panic: the registry's
+// Slack verifierConnector is a zero-value slack.Connector whose embedded *webhook.Verifier is nil,
+// and the promoted VerifyWebhookMessage call dereferenced it. The verifier must be callable through
+// the zero-value connector — bad input yields an error, never a panic.
+func TestSlackVerifierConnectorZeroValueNoPanic(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := GetProviderConfig("", makeProviderInfo(providers.Slack, ""), deps.Dependencies{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	conn, err := cfg.Verification.Connector(context.Background())
+	if err != nil {
+		t.Fatalf("Connector() error = %v, want nil", err)
+	}
+
+	ok, err := conn.VerifyWebhookMessage(context.Background(), &common.WebhookRequest{}, nil)
+	if ok {
+		t.Error("VerifyWebhookMessage() = true, want false for request without verification params")
+	}
+
+	if !errors.Is(err, common.ErrMissingVerificationParams) {
+		t.Errorf("VerifyWebhookMessage() error = %v, want ErrMissingVerificationParams", err)
+	}
+}
+
 // TestVerificationParamsInstallationDerived verifies providers whose verification secret derives
 // from the installation ID (Outreach) read it off deps.VerificationRequest.Installation.
 func TestVerificationParamsInstallationDerived(t *testing.T) {

--- a/subscribe/slack.go
+++ b/subscribe/slack.go
@@ -15,7 +15,7 @@ import (
 var slackConfig = ProviderConfig{
 	Verification: VerificationConfig{
 		paramsFn:          getSlackVerificationParams,
-		verifierConnector: &slack.Connector{},
+		verifierConnector: slack.NewWebhookVerifierConnector(),
 	},
 }
 


### PR DESCRIPTION
## Problem

Production messenger pods are panicking on Slack subscribe webhooks (recovered in the pubsub receiver, so the message nacks and redelivers):

```
runtime error: invalid memory address or nil pointer dereference
github.com/amp-labs/connectors/providers/slack.(*Connector).VerifyWebhookMessage(...)
	<autogenerated>:1
main.verifyWebhook .../messenger/subscribeEventProcessor_verify.go:183
```

The subscribe registry declared `verifierConnector: &slack.Connector{}` — a zero value. `slack.Connector` embeds `*webhook.Verifier`, which is **nil** in that zero value, and `VerifyWebhookMessage` had a value receiver — so the autogenerated method-promotion wrapper dereferences the nil embed and panics on every call.

This was latent until #3422: previously the params step failed first (`installation not found`) and verification never reached the connector call. With that fixed, every Slack event — including stray non-event traffic like Slack's own `Slackbot-LinkExpanding` GET probes forwarded by the gateway — now reaches the promoted call and panics.

## Fix — three layers

1. **Constructed verifier in the registry** (the expected path): the registry now uses `slack.NewWebhookVerifierConnector()`, a minimal Connector carrying a constructed `webhook.Verifier`. Verification-only — no auth client, no base connector; not for API calls.
2. **Pointer receivers** on `webhook.Verifier` methods, so a promoted call through a nil embed can never panic in the wrapper.
3. **Explicit nil guard**: `VerifyWebhookMessage` returns `errVerifierNotInitialized` on a nil receiver — a clean verification failure instead of a panic, as a backstop for any future unconstructed connector.

A signature-less request like the link-expansion GET now fails verification cleanly (missing signature header) and is dropped.

## Audit of other providers

Checked every registered `verifierConnector` for the same shape:
- All other non-bypassed providers define `VerifyWebhookMessage` directly on `*Connector` (no nil-able embed) — safe on zero values. Attio also defines `Provider()` directly, which is why the older zero-value connectors never hit this.
- **Microsoft** and **ConnectWise** have the identical nil `*NoopVerifier` embed, but both declare `bypassed: true`, so the server returns before the connector call — latent, unreachable today.
- Residual (out of scope): the zero-value pattern also leaves `*components.Connector` nil, so promoted methods like `Provider()` would panic if `CONNECTOR_METRICS_ENABLED` were turned on (the server's metrics wrapper calls `connector.Provider()` before wrapping; messenger prod sets the flag to `false`, which is why the panic surfaced at the verify call instead).

## Testing

- `TestSlackVerifierConnectorZeroValueNoPanic` (subscribe pkg): resolves the registered connector via `Verification.Connector()` and calls `VerifyWebhookMessage` end-to-end — asserts an error, not a panic.
- `TestVerifyWebhookMessageNilVerifier` (webhook pkg): pins the nil-receiver backstop.
- `go test ./subscribe/... ./providers/slack/...` passes; `make fix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
