### PR TITLE
[CON-3296] feat(slack-user): Enable Subscribe

### DIFF
--- a/providers/slack.go
+++ b/providers/slack.go
@@ -99,7 +99,7 @@ func init() { // nolint:funlen
 			},
 			Proxy:     true,
 			Read:      true,
-			Subscribe: false,
+			Subscribe: true,
 			Write:     true,
 		},
 		SubscribeRequirements: &SubscribeRequirements{


### PR DESCRIPTION
# Description

Subscirbe is enabled for Slack for bot but not Slack for user.