### PR TITLE
fix(salesforce): interpret object-shaped error bodies, pass metadata to catalog

### DIFF
--- a/providers/salesforce/catalog_variables_test.go
+++ b/providers/salesforce/catalog_variables_test.go
@@ -1,0 +1,70 @@
+package salesforce
+
+import (
+	"testing"
+
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
+)
+
+func TestCatalogVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workspace string
+		metadata  map[string]string
+		want      map[string]string
+	}{
+		{
+			name:      "workspace only",
+			workspace: "acme",
+			metadata:  nil,
+			want:      map[string]string{"workspace": "acme"},
+		},
+		{
+			name:      "metadata keys are available for substitution",
+			workspace: "acme",
+			metadata:  map[string]string{"apiDomain": "proxy.example.com"},
+			want: map[string]string{
+				"workspace": "acme",
+				"apiDomain": "proxy.example.com",
+			},
+		},
+		{
+			name:      "workspace wins over a metadata entry of the same name",
+			workspace: "acme",
+			metadata:  map[string]string{"workspace": "stale"},
+			want:      map[string]string{"workspace": "acme"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params := &parameters{}
+			params.WithWorkspace(tt.workspace)
+			params.WithMetadata(tt.metadata, nil)
+
+			registry := catalogreplacer.NewCatalogSubstitutionRegistry(catalogVariables(params))
+
+			if len(registry) != len(tt.want) {
+				t.Errorf("expected %d substitution variables, got %d: %v",
+					len(tt.want), len(registry), registry)
+			}
+
+			for key, want := range tt.want {
+				got, ok := registry[key]
+				if !ok {
+					t.Errorf("expected substitution variable %q to be present", key)
+
+					continue
+				}
+
+				if got != want {
+					t.Errorf("substitution variable %q: want %q, got %q", key, want, got)
+				}
+			}
+		})
+	}
+}

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -136,17 +136,19 @@ func oldConstructor(params *parameters) (*Connector, error) {
 // catalogVariables returns the substitution variables used to resolve this
 // connector's ProviderInfo. Connection metadata is included alongside the
 // workspace so that catalog entries may reference any metadata key, matching
-// what components.NewProviderContext supplies to the module adapters. Workspace
-// is appended last so it wins over a metadata entry of the same name.
+// what components.NewProviderContext supplies to the module adapters.
+//
+// The metadata map is copied because the workspace entry is written into it,
+// and callers should not observe that.
 func catalogVariables(params *parameters) []catalogreplacer.CatalogVariable {
-	metadataVars := params.Metadata.GetCatalogVars()
-	vars := make([]catalogreplacer.CatalogVariable, 0, len(metadataVars)+1)
-
-	for _, variable := range metadataVars {
-		vars = append(vars, variable)
+	metadata := maps.Clone(params.Metadata.Map)
+	if metadata == nil {
+		metadata = make(map[string]string)
 	}
 
-	return append(vars, &params.Workspace)
+	metadata[catalogreplacer.VariableWorkspace] = params.Workspace.Name
+
+	return paramsbuilder.NewCatalogVariables(metadata)
 }
 
 // Provider returns the connector provider. For twin providers such as

--- a/providers/salesforce/connector.go
+++ b/providers/salesforce/connector.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amp-labs/connectors/common"
 	"github.com/amp-labs/connectors/common/paramsbuilder"
+	"github.com/amp-labs/connectors/common/substitutions/catalogreplacer"
 	"github.com/amp-labs/connectors/common/urlbuilder"
 	"github.com/amp-labs/connectors/internal/components"
 	"github.com/amp-labs/connectors/providers"
@@ -116,7 +117,7 @@ func oldConstructor(params *parameters) (*Connector, error) {
 
 	var err error
 
-	conn.providerInfo, err = providers.ReadInfo(conn.Provider(), &params.Workspace)
+	conn.providerInfo, err = providers.ReadInfo(conn.Provider(), catalogVariables(params)...)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +131,22 @@ func oldConstructor(params *parameters) (*Connector, error) {
 	conn.Client.HTTPClient.ErrorHandler = crmcore.NewErrorHandler().Handle
 
 	return conn, nil
+}
+
+// catalogVariables returns the substitution variables used to resolve this
+// connector's ProviderInfo. Connection metadata is included alongside the
+// workspace so that catalog entries may reference any metadata key, matching
+// what components.NewProviderContext supplies to the module adapters. Workspace
+// is appended last so it wins over a metadata entry of the same name.
+func catalogVariables(params *parameters) []catalogreplacer.CatalogVariable {
+	metadataVars := params.Metadata.GetCatalogVars()
+	vars := make([]catalogreplacer.CatalogVariable, 0, len(metadataVars)+1)
+
+	for _, variable := range metadataVars {
+		vars = append(vars, variable)
+	}
+
+	return append(vars, &params.Workspace)
 }
 
 // Provider returns the connector provider. For twin providers such as

--- a/providers/salesforce/internal/crm/core/errors.go
+++ b/providers/salesforce/internal/crm/core/errors.go
@@ -99,7 +99,17 @@ func (e *fieldNotFoundError) Unwrap() []error {
 func interpretJSONError(res *http.Response, body []byte) error { // nolint:cyclop
 	var errs []jsonError
 	if err := json.Unmarshal(body, &errs); err != nil {
-		return fmt.Errorf("json.Unmarshal failed: %w", err)
+		// Salesforce reports errors as a JSON array, but a single JSON object is
+		// also accepted so that payloads shaped that way — such as those authored
+		// by an intermediary in front of Salesforce — are still interpreted.
+		var single jsonError
+		if json.Unmarshal(body, &single) != nil || single.Message == "" {
+			// The body matches neither shape, so fall back to status-based handling
+			// rather than reporting the decode failure as the error itself.
+			return common.InterpretError(res, body)
+		}
+
+		errs = []jsonError{single}
 	}
 
 	for _, sfErr := range errs {

--- a/providers/salesforce/internal/crm/core/errors_test.go
+++ b/providers/salesforce/internal/crm/core/errors_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
@@ -127,5 +128,73 @@ func TestInterpretXMLError_WrapsHTTPErrorWithBody(t *testing.T) {
 
 	if !errors.Is(err, common.ErrAccessToken) {
 		t.Errorf("expected error to wrap ErrAccessToken via errors.Is")
+	}
+}
+
+func TestInterpretJSONError_AcceptsSingleObjectBody(t *testing.T) {
+	t.Parallel()
+
+	// A lone JSON object rather than Salesforce's usual array. Bodies shaped this
+	// way come from an intermediary sitting in front of Salesforce.
+	body := []byte(`{"message":"daily api request limit exceeded","errorCode":"REQUEST_LIMIT_EXCEEDED"}`)
+	res := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}}
+
+	err := interpretJSONError(res, body)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, common.ErrLimitExceeded) {
+		t.Errorf("expected error to wrap ErrLimitExceeded via errors.Is, got: %v", err)
+	}
+
+	var httpErr *common.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected error chain to contain *common.HTTPError, got %T: %v", err, err)
+	}
+
+	if string(httpErr.Body) != string(body) {
+		t.Errorf("expected body to be preserved\n  want: %s\n  got:  %s", body, httpErr.Body)
+	}
+}
+
+func TestInterpretJSONError_FallsBackOnUnrecognizedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "not JSON at all", body: []byte(`<html>502 Bad Gateway</html>`)},
+		{name: "JSON object without a message", body: []byte(`{"detail":"something went wrong"}`)},
+		{name: "empty body", body: []byte(``)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}}
+
+			err := interpretJSONError(res, tt.body)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			// An unrecognized body falls through to status-based handling rather
+			// than surfacing the JSON decode failure as the error itself.
+			if strings.Contains(err.Error(), "json.Unmarshal failed") {
+				t.Errorf("expected fallback to status-based handling, got decode error: %v", err)
+			}
+
+			var httpErr *common.HTTPError
+			if !errors.As(err, &httpErr) {
+				t.Fatalf("expected error chain to contain *common.HTTPError, got %T: %v", err, err)
+			}
+
+			if httpErr.Status != http.StatusForbidden {
+				t.Errorf("expected status %d, got %d", http.StatusForbidden, httpErr.Status)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Two independent Salesforce fixes, both surfaced while scoping [ENG-4237](https://linear.app/ampersand/issue/ENG-4237). Neither depends on that work — they are live bugs today.

## 1. `interpretJSONError` rejected object-shaped bodies

It unmarshalled only into `[]jsonError`, so any error body that was a bare JSON object failed to decode and we returned `json.Unmarshal failed: ...` — discarding the provider's actual message and leaving the error unclassified.

It now accepts a single object as a one-element array. A body matching neither shape falls through to `common.InterpretError` for status-based handling, rather than surfacing the decode failure as the error itself.

## 2. The connector passed only `workspace` into `ReadInfo`

`oldConstructor` called `providers.ReadInfo(provider, &params.Workspace)`, while `components.NewProviderContext` supplies the **full metadata map** as catalog variables to the module adapters.

A catalog entry referencing any metadata key therefore resolved differently for the two halves of the same connector — the outer `Connector` would see an unsubstituted template while `crmAdapter` and its sub-adapters resolved correctly. Both now receive the same variables, with `workspace` appended last so it wins a name collision.

## Testing

- `TestInterpretJSONError_AcceptsSingleObjectBody` — object body maps to the right sentinel and preserves the raw body
- `TestInterpretJSONError_FallsBackOnUnrecognizedBody` — non-JSON, object-without-message, and empty bodies all fall through to status handling instead of a decode error
- `TestCatalogVariables` — metadata keys are available for substitution, and workspace wins a collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)