### PR TITLE
[ENG-4220] fix(hubspot): continue GET pagination when search receives a URL next-page token

### DIFF
--- a/providers/hubspot/internal/core/parse.go
+++ b/providers/hubspot/internal/core/parse.go
@@ -24,14 +24,31 @@ Pagination format:
     }
   }
 }
+
+The two extractors below produce next-page tokens of different styles, and the
+values are NOT interchangeable:
+
+  - GET read responses carry both fields: "after" is the record ID of the next
+    record (e.g. "22222625904") and "link" is a ready-made URL embedding it.
+    The GET read path stores the "link" URL as the token (GetNextRecordsURL).
+  - Search responses carry only "after", an integer position into the result
+    set capped at 10,000 (e.g. "200"). The search path stores it as the token
+    (GetNextRecordsAfter) and sends it back in the "after" request body field.
+
+A URL token resumed into the search path is rejected by the provider with a
+400 VALIDATION_ERROR; searchCRMObjectsAPI detects that case (isFullURL) and
+continues the GET pagination instead.
 */
 
 // GetNextRecordsAfter returns the "after" value for the next page of results.
+// Used by the search path, where "after" is an integer offset (see above).
 func GetNextRecordsAfter(node *ajson.Node) (string, error) {
 	return jsonquery.New(node, "paging", "next").StrWithDefault("after", "")
 }
 
 // GetNextRecordsURL returns the URL for the next page of results.
+// Used by the plain GET read path, which paginates with the full
+// "link" URL (see above).
 func GetNextRecordsURL(node *ajson.Node) (string, error) {
 	return jsonquery.New(node, "paging", "next").StrWithDefault("link", "")
 }

--- a/providers/hubspot/read_test.go
+++ b/providers/hubspot/read_test.go
@@ -145,6 +145,37 @@ func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
 			},
 		},
 		{
+			// Regression test for ENG-4220. A read that starts without filters
+			// paginates via GET with full-URL tokens (paging.next.link). When such
+			// a read is resumed with Since set, the search path receives the URL
+			// token and must continue the GET pagination instead of sending the
+			// URL as the numeric "after" cursor, which the provider rejects.
+			Name: "Since read with URL next page token continues GET pagination",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("email"),
+				Since: time.Date(2024, 9, 19, 4, 30, 45, 600,
+					time.FixedZone("UTC-8", -8*60*60)),
+				NextPage: common.NextPageToken(
+					testconn.URLTestServer + "/crm/v3/objects/contacts?limit=100&properties=email&after=394"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/crm/v3/objects/contacts"),
+					mockcond.QueryParam("after", "394"),
+				},
+				Then: mockserver.Response(http.StatusOK, responseContacts),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows:     3,
+				NextPage: "https://api.hubapi.com/crm/v3/objects/contacts?limit=100&properties=listId%2Cname&after=394", // nolint:lll
+				Done:     false,
+			},
+		},
+		{
 			Name: "Contacts records until time",
 			Input: common.ReadParams{
 				ObjectName: "contacts",

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -136,8 +136,12 @@ func (c *Connector) readCRMObjectsNextPage(ctx context.Context, params SearchPar
 }
 
 // isFullURL reports whether the next-page token is a complete URL. The plain
-// GET read path paginates with paging.next.link (a URL), while the search path
-// paginates with paging.next.after (a numeric cursor).
+// GET read path paginates with paging.next.link (a URL, embedding the next
+// record ID as the "after" query param), while the search path paginates with
+// paging.next.after (an integer position into the result set, capped at 10,000).
+// The two cursors are not interchangeable values.
+// GET paging: https://developers.hubspot.com/docs/api-reference/crm-objects-v3/objects/get-crm-v3-objects-objecttype
+// Search paging: https://developers.hubspot.com/docs/api/crm/search
 func isFullURL(token common.NextPageToken) bool {
 	value := token.String()
 

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/amp-labs/connectors/common"
@@ -86,6 +87,15 @@ func (c *Connector) ReadUsingSearchAPI( // nolint:cyclop
 }
 
 func (c *Connector) searchCRMObjectsAPI(ctx context.Context, params SearchParams) (*common.ReadResult, error) {
+	if isFullURL(params.NextPage) {
+		// The token was produced by the plain GET read path (paging.next.link).
+		// This happens when a read that started without filters is resumed with
+		// Since/Until set: the search endpoint paginates with a numeric "after"
+		// cursor and rejects a URL with a 400 VALIDATION_ERROR. Honor the token
+		// by continuing the GET pagination it belongs to.
+		return c.readCRMObjectsNextPage(ctx, params)
+	}
+
 	url, err := c.getCRMObjectsSearchURL(params.ObjectName)
 	if err != nil {
 		return nil, err
@@ -104,6 +114,34 @@ func (c *Connector) searchCRMObjectsAPI(ctx context.Context, params SearchParams
 			ctx, c.associationsFiller, params.ObjectName, params.AssociatedObjects),
 		params.Fields,
 	)
+}
+
+// readCRMObjectsNextPage fetches the next page of a plain GET read whose token
+// reached the search path. The response has the same shape for both endpoints,
+// so the regular GET parsing applies.
+func (c *Connector) readCRMObjectsNextPage(ctx context.Context, params SearchParams) (*common.ReadResult, error) {
+	rsp, err := c.JSONHTTPClient().Get(ctx, params.NextPage.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResult(
+		rsp,
+		core.GetRecords,
+		core.GetNextRecordsURL,
+		associations.CreateDataMarshallerWithAssociations(
+			ctx, c.associationsFiller, params.ObjectName, params.AssociatedObjects),
+		params.Fields,
+	)
+}
+
+// isFullURL reports whether the next-page token is a complete URL. The plain
+// GET read path paginates with paging.next.link (a URL), while the search path
+// paginates with paging.next.after (a numeric cursor).
+func isFullURL(token common.NextPageToken) bool {
+	value := token.String()
+
+	return strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "http://")
 }
 
 // searchCRM is intended for objects outside HubSpot's ObjectAPI.

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -139,10 +139,26 @@ func (c *Connector) readCRMObjectsNextPage(ctx context.Context, params SearchPar
 // GET read path paginates with paging.next.link (a URL, embedding the next
 // record ID as the "after" query param), while the search path paginates with
 // paging.next.after (an integer position into the result set, capped at 10,000).
-// The two cursors are not interchangeable values:
+// The two cursors are not interchangeable values.
 //
-//	GET read:  "https://api.hubapi.com/crm/v3/objects/deals?limit=100&after=22222625904&properties=closedate"
-//	Search:    "200"
+// A GET read response paginates with a record-ID cursor plus a ready-made URL,
+// and the connector stores the "link" as the next-page token:
+//
+//	"paging": {
+//	  "next": {
+//	    "after": "22222625904",
+//	    "link": "https://api.hubapi.com/crm/v3/objects/deals?limit=100&after=22222625904"
+//	  }
+//	}
+//
+// A search response paginates with an integer offset only, sent back in the
+// "after" field of the next request body:
+//
+//	"paging": {
+//	  "next": {
+//	    "after": "200"
+//	  }
+//	}
 //
 // GET paging: https://developers.hubspot.com/docs/api-reference/crm-objects-v3/objects/get-crm-v3-objects-objecttype
 // Search paging: https://developers.hubspot.com/docs/api/crm/search

--- a/providers/hubspot/search.go
+++ b/providers/hubspot/search.go
@@ -139,7 +139,11 @@ func (c *Connector) readCRMObjectsNextPage(ctx context.Context, params SearchPar
 // GET read path paginates with paging.next.link (a URL, embedding the next
 // record ID as the "after" query param), while the search path paginates with
 // paging.next.after (an integer position into the result set, capped at 10,000).
-// The two cursors are not interchangeable values.
+// The two cursors are not interchangeable values:
+//
+//	GET read:  "https://api.hubapi.com/crm/v3/objects/deals?limit=100&after=22222625904&properties=closedate"
+//	Search:    "200"
+//
 // GET paging: https://developers.hubspot.com/docs/api-reference/crm-objects-v3/objects/get-crm-v3-objects-objecttype
 // Search paging: https://developers.hubspot.com/docs/api/crm/search
 func isFullURL(token common.NextPageToken) bool {


### PR DESCRIPTION
## Problem

[ENG-4220](https://linear.app/ampersand/issue/ENG-4220/provider-400-bad-request): HubSpot reads fail with `400 VALIDATION_ERROR: unable to deserialize field "after"` when a full next-page URL is sent as the search cursor.

HubSpot's two CRM pagination modes return incompatible next-page tokens:

- Plain GET reads paginate with `paging.next.link` — a **full URL**
- Search (`POST /search`) paginates with `paging.next.after` — a **numeric offset cursor**

A read that starts without `Since`/`Until`/filters runs on the GET path and produces URL tokens. When such a read is interrupted, the server persists the token in the read state and resumes with a freshly computed non-zero `Since` (`PrepareParams` in `server/shared/workflow/read/state.go`). With `Since` set, the connector routes to the search path and drops the URL into the `"after"` body field, which the provider rejects. Note this is not an escaping issue: the GET cursor is an object-id-style value, never a valid search offset (which must stay under 10,000).

## Fix

In `searchCRMObjectsAPI`, detect a URL-shaped `NextPage` token and honor it as the GET-pagination continuation it is — fetch that URL and parse with the GET parser (same response shape, same associations marshaller). The interrupted unfiltered read finishes on the GET path; once exhausted, subsequent runs start filtered search reads normally.

Caveat: pages served through this recovery path don't apply the `Since` filter — same behavior as if the original run had finished uninterrupted, so a resumed backfill may deliver records outside the delta window.

## Testing

- Added regression test `Since read with URL next page token continues GET pagination`; verified it fails without the fix and passes with it
- `go test ./providers/hubspot/...` and `make fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)