### PR TITLE
[CON-3513] fix(acculynx): Fixed support jobs/representatives as a subscribe object

### DIFF
--- a/providers/acculynx/batchRecordReader.go
+++ b/providers/acculynx/batchRecordReader.go
@@ -29,9 +29,15 @@ var errBatchReadEmptyResponse = errors.New("acculynx: empty response body for re
 // an appointment's calendar id equals its user id, so the server hydrates the
 // user directly. Not every calendar is a user (company/crew calendars 404), so
 // GetRecordsByIds skips ids that are not found — see isNotFound below.
+// jobs/representatives hydrates the per-job company-representative singleton:
+// the record id is the job id (matching write/delete for representatives), and
+// the fetch routes to /jobs/{jobId}/representatives/company — see
+// singleRecordURL. AccuLynx rotates the representative's own id on every
+// assignment, so the job id is the only stable identity for the slot.
 //
 //nolint:gochecknoglobals
-var batchReadableObjects = datautils.NewStringSet(objectContacts, objectJobs, objectUsers)
+var batchReadableObjects = datautils.NewStringSet(
+	objectContacts, objectJobs, objectUsers, objectJobsRepresentatives)
 
 //nolint:revive
 func (c *Connector) GetRecordsByIds(
@@ -44,7 +50,7 @@ func (c *Connector) GetRecordsByIds(
 	objectName = strings.ToLower(objectName)
 
 	if !batchReadableObjects.Has(objectName) {
-		return nil, fmt.Errorf("%w: %s (only contacts, jobs and users supported)",
+		return nil, fmt.Errorf("%w: %s (only contacts, jobs, users and jobs/representatives supported)",
 			common.ErrGetRecordNotSupportedForObject, objectName)
 	}
 
@@ -128,13 +134,25 @@ func compactFound(rows []common.ReadResultRow, found []bool) []common.ReadResult
 	return out
 }
 
+// singleRecordURL builds the get-by-id URL for a batch-readable object. Most
+// objects follow /{object}/{id}; jobs/representatives is the exception — its
+// id is the job id and the record lives at the role-singleton path.
+func (c *Connector) singleRecordURL(objectName, recordID string) (*urlbuilder.URL, error) {
+	if objectName == objectJobsRepresentatives {
+		return urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(),
+			"jobs", recordID, "representatives", "company")
+	}
+
+	return urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectName, recordID)
+}
+
 func (c *Connector) fetchSingleRecord(
 	ctx context.Context,
 	objectName, recordID string,
 	fieldSet datautils.StringSet,
 	associations []string,
 ) (common.ReadResultRow, error) {
-	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, c.modulePath(), objectName, recordID)
+	url, err := c.singleRecordURL(objectName, recordID)
 	if err != nil {
 		return common.ReadResultRow{}, err
 	}

--- a/providers/acculynx/batchRecordReader_test.go
+++ b/providers/acculynx/batchRecordReader_test.go
@@ -230,6 +230,49 @@ func TestGetRecordsByIds_HydratesUsers(t *testing.T) {
 	assert.Equal(t, rows[0].Fields["displayName"], "Diane Hatch")
 }
 
+func TestGetRecordsByIds_HydratesJobsRepresentativesViaCompanyRole(t *testing.T) {
+	t.Parallel()
+
+	// jobs/representatives hydrates by job id via the role-singleton path
+	// /jobs/{jobId}/representatives/company — not /{object}/{id}, which does
+	// not exist. Payload mirrors the live endpoint: the record carries the
+	// rotating representative id in Raw while the row keeps the stable job id.
+	srv := mockserver.Switch{
+		Setup: mockserver.ContentJSON(),
+		Cases: []mockserver.Case{
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/job-1/representatives/company"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK,
+					`{"id":"rep-77","type":"CompanyRepresentative",`+
+						`"user":{"id":"user-9"},"_link":"https://example/link"}`),
+			},
+			{
+				If: mockcond.And{
+					mockcond.MethodGET(),
+					mockcond.Path("/api/v2/jobs/no-rep-job/representatives/company"),
+				},
+				Then: mockserver.ResponseString(http.StatusNotFound, `{"detail":"NotFound"}`),
+			},
+		},
+		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
+	}.Server()
+
+	conn, err := constructTestReadConnector(srv.URL)
+	assert.NilError(t, err)
+
+	rows, err := conn.GetRecordsByIds(context.Background(), "jobs/representatives",
+		[]string{"job-1", "no-rep-job"}, []string{"id", "type"}, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(rows), 1)
+	assert.Equal(t, rows[0].Id, "job-1")
+	assert.Equal(t, rows[0].Fields["type"], "CompanyRepresentative")
+	assert.Equal(t, rows[0].Raw["id"], "rep-77")
+}
+
 func TestGetRecordsByIds_AttachesJobContactsAssociation(t *testing.T) {
 	t.Parallel()
 

--- a/providers/acculynx/read.go
+++ b/providers/acculynx/read.go
@@ -64,6 +64,10 @@ const (
 	objectSupplements = "supplements"
 	objectCalendars   = "calendars"
 	objectUsers       = "users"
+
+	// objectJobsRepresentatives is a nested read object that is also a
+	// subscribe object: AccuLynx emits job.representatives.* topics for it.
+	objectJobsRepresentatives = "jobs/representatives"
 )
 
 // ReadParamsOpts is the connector-specific shape of common.ReadParams.Opts,

--- a/providers/acculynx/subscribe.go
+++ b/providers/acculynx/subscribe.go
@@ -89,6 +89,18 @@ var objectEventTopics = map[common.ObjectName]map[common.SubscriptionEventType][
 		common.SubscriptionEventTypeCreate: {"job_created"},
 		common.SubscriptionEventTypeUpdate: {"job_updated"},
 	},
+	// The company representative is a per-job singleton with its own read
+	// object and get-by-id path (/jobs/{jobId}/representatives/company), so it
+	// is a real subscribe object rather than a pass-through topic on jobs —
+	// mirroring salesloft's nested "activities/emails" subscription object.
+	// Both topics are updates: company_assigned fills the slot, company_changed
+	// replaces it; AccuLynx emits no create or delete topic for the slot.
+	objectJobsRepresentatives: {
+		common.SubscriptionEventTypeUpdate: {
+			"job.representatives.company_assigned",
+			"job.representatives.company_changed",
+		},
+	},
 }
 
 // validAcculynxTopics is the complete set of topicNames AccuLynx accepts on

--- a/providers/acculynx/subscribe_test.go
+++ b/providers/acculynx/subscribe_test.go
@@ -33,6 +33,42 @@ func TestResolveTopics_StandardEvents(t *testing.T) {
 	assert.DeepEqual(t, got, expected)
 }
 
+func TestResolveTopics_JobsRepresentativesUpdateEvent(t *testing.T) {
+	t.Parallel()
+
+	// jobs/representatives as its own subscribe object with updateEvent —
+	// resolves both representative topics, no otherEvents involved.
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectJobsRepresentatives: {Events: []common.SubscriptionEventType{
+			common.SubscriptionEventTypeUpdate,
+		}},
+	}
+
+	got, err := resolveTopics(events)
+	assert.NilError(t, err)
+
+	expected := []string{
+		"job.representatives.company_assigned",
+		"job.representatives.company_changed",
+	}
+	assert.DeepEqual(t, got, expected)
+}
+
+func TestResolveTopics_JobsRepresentativesRejectsCreateEvent(t *testing.T) {
+	t.Parallel()
+
+	// AccuLynx has no create topic for the representative slot — assignment is
+	// an update (the slot always exists), so createEvent must be rejected.
+	events := map[common.ObjectName]common.ObjectEvents{
+		objectJobsRepresentatives: {Events: []common.SubscriptionEventType{
+			common.SubscriptionEventTypeCreate,
+		}},
+	}
+
+	_, err := resolveTopics(events)
+	assert.Assert(t, errors.Is(err, errUnsupportedSubscribeEvent))
+}
+
 func TestResolveTopics_MergesPassThroughEvents(t *testing.T) {
 	t.Parallel()
 

--- a/providers/acculynx/subscriptionEvent.go
+++ b/providers/acculynx/subscriptionEvent.go
@@ -79,6 +79,29 @@ var topicsWithoutParentRecordID = datautils.NewStringSet(
 	"job.custom-field.status_changed",
 )
 
+// topicObjectOverrides maps topics that belong to a nested subscribe object,
+// consulted before the topic-prefix fallback in ObjectName. The company
+// representative is a per-job singleton with its own get-by-id path, so its
+// topics resolve to jobs/representatives rather than jobs (the inverse of
+// housecallPro, which routes employee.* to "other" because no get-by-id
+// endpoint exists there).
+//
+//nolint:gochecknoglobals
+var topicObjectOverrides = map[string]string{
+	"job.representatives.company_assigned": objectJobsRepresentatives,
+	"job.representatives.company_changed":  objectJobsRepresentatives,
+}
+
+// topicEventTypeOverrides pins topics whose suffix misclassifies them.
+// company_assigned ends in _assigned (suffix heuristic: other), but it is an
+// update to the job's representative slot: the slot always exists, assignment
+// fills it. Consulted before the suffix switch in EventType.
+//
+//nolint:gochecknoglobals
+var topicEventTypeOverrides = map[string]common.SubscriptionEventType{
+	"job.representatives.company_assigned": common.SubscriptionEventTypeUpdate,
+}
+
 // PreLoadData is a no-op for AccuLynx — webhook payloads are self-contained.
 func (e SubscriptionEvent) PreLoadData(_ *common.SubscriptionEventPreLoadData) error {
 	return nil
@@ -113,12 +136,17 @@ func (e SubscriptionEvent) RawEventName() (string, error) {
 	return topic, nil
 }
 
-// EventType maps the topic suffix to Create / Update / Other. AccuLynx has
-// no delete topics.
+// EventType classifies the topic: exact overrides first (see
+// topicEventTypeOverrides), then the suffix heuristic. AccuLynx has no
+// delete topics.
 func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 	topic, err := e.RawEventName()
 	if err != nil {
 		return common.SubscriptionEventTypeOther, err
+	}
+
+	if evtType, ok := topicEventTypeOverrides[topic]; ok {
+		return evtType, nil
 	}
 
 	switch {
@@ -133,12 +161,17 @@ func (e SubscriptionEvent) EventType() (common.SubscriptionEventType, error) {
 	}
 }
 
-// ObjectName derives the target object from the topic prefix
+// ObjectName resolves the target object: exact topic overrides first (see
+// topicObjectOverrides, e.g. jobs/representatives), then the topic prefix
 // (contact* → contacts, job* → jobs).
 func (e SubscriptionEvent) ObjectName() (string, error) {
 	topic, err := e.RawEventName()
 	if err != nil {
 		return "", err
+	}
+
+	if obj, ok := topicObjectOverrides[topic]; ok {
+		return obj, nil
 	}
 
 	switch {
@@ -163,7 +196,10 @@ func (e SubscriptionEvent) Workspace() (string, error) {
 	return "", nil
 }
 
-// RecordId returns the affected contact/job id from event.<object>.id.
+// RecordId returns the affected record id from event.<wrapper>.id. For
+// contacts/jobs that is the record's own id; for jobs/representatives it is
+// the job id read from the same event.job wrapper — the slot's only stable
+// identity, since AccuLynx rotates the representative id on every assignment.
 // Returns errParentRecordIDUnavailable for topics where AccuLynx omits the
 // parent id (see topicsWithoutParentRecordID).
 func (e SubscriptionEvent) RecordId() (string, error) {
@@ -207,7 +243,10 @@ func (e SubscriptionEvent) EventTimeStampNano() (int64, error) {
 
 // topicToUpdatedFields maps each specific-change topic to its wire-format
 // field name under event.<object>. Generic and create topics resolve to an
-// empty slice in UpdatedFields.
+// empty slice in UpdatedFields. Representative topics are absent on purpose:
+// they are updates to the jobs/representatives object itself, where no single
+// field can express the change, so UpdatedFields stays empty and consumers
+// watch with watchFieldsAuto.
 //
 //nolint:gochecknoglobals
 var topicToUpdatedFields = map[string][]string{
@@ -218,8 +257,6 @@ var topicToUpdatedFields = map[string][]string{
 	"job.work-type_changed":                             {"workType"},
 	"job.trade-type_changed":                            {"tradeTypes"},
 	"job.contacts.primary_changed":                      {"contacts"},
-	"job.representatives.company_assigned":              {"companyRepresentative"},
-	"job.representatives.company_changed":               {"companyRepresentative"},
 	"job.appointments.initial_created":                  {"initialAppointment"},
 	"job.appointments.initial_updated":                  {"initialAppointment"},
 	"job.invoice_updated":                               {"invoice"},
@@ -271,7 +308,9 @@ func (e SubscriptionEvent) objectWrapper() (map[string]any, error) {
 	switch objName {
 	case objectContacts:
 		key = objectWrapperContact
-	case objectJobs:
+	case objectJobs, objectJobsRepresentatives:
+		// Representative topics are delivered inside the job wrapper
+		// (event.job.companyRepresentative); the record id is the job id.
 		key = objectWrapperJob
 	}
 

--- a/providers/acculynx/subscriptionEvent_test.go
+++ b/providers/acculynx/subscriptionEvent_test.go
@@ -25,6 +25,8 @@ func TestSubscriptionEvent_ObjectName(t *testing.T) {
 		{"job_updated", objectJobs, nil},
 		{"job.milestone.current_changed", objectJobs, nil},
 		{"job.financials.approved-value_changed", objectJobs, nil},
+		{"job.representatives.company_assigned", objectJobsRepresentatives, nil},
+		{"job.representatives.company_changed", objectJobsRepresentatives, nil},
 		{"unsupported_topic", "", errUnsupportedTopicName},
 	}
 
@@ -61,6 +63,10 @@ func TestSubscriptionEvent_EventType(t *testing.T) {
 		{"job_updated", common.SubscriptionEventTypeUpdate},
 		{"job.milestone.current_changed", common.SubscriptionEventTypeUpdate},
 		{"job.invoice_voided", common.SubscriptionEventTypeUpdate},
+		// _assigned would suffix-classify as "other"; the override pins it to
+		// update — the representative slot always exists, assignment fills it.
+		{"job.representatives.company_assigned", common.SubscriptionEventTypeUpdate},
+		{"job.representatives.company_changed", common.SubscriptionEventTypeUpdate},
 		{"job.something_weird", common.SubscriptionEventTypeOther},
 	}
 
@@ -128,6 +134,25 @@ func TestSubscriptionEvent_RecordId_RoutesByObjectType(t *testing.T) {
 	contactID, err := contactEvt.RecordId()
 	assert.NilError(t, err)
 	assert.Equal(t, contactID, "contact-456")
+
+	// Representative topics deliver inside the job wrapper and the record id
+	// is the job id: AccuLynx rotates the representative's own id on every
+	// assignment, so the job id is the slot's only stable identity.
+	repEvt := SubscriptionEvent{
+		eventFieldTopicName: "job.representatives.company_assigned",
+		eventFieldEvent: map[string]any{
+			objectWrapperJob: map[string]any{
+				innerFieldID: "job-789",
+				"companyRepresentative": map[string]any{
+					innerFieldID: "rep-001",
+				},
+			},
+		},
+	}
+
+	repID, err := repEvt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, repID, "job-789")
 }
 
 func TestSubscriptionEvent_RecordId_MissingObjectWrapperReturnsError(t *testing.T) {
@@ -233,8 +258,10 @@ func TestSubscriptionEvent_UpdatedFields(t *testing.T) {
 		{"job.work-type_changed", []string{"workType"}},
 		{"job.trade-type_changed", []string{"tradeTypes"}},
 		{"job.contacts.primary_changed", []string{"contacts"}},
-		{"job.representatives.company_assigned", []string{"companyRepresentative"}},
-		{"job.representatives.company_changed", []string{"companyRepresentative"}},
+		// Representative topics are updates to jobs/representatives itself, so
+		// no single job field describes the change — empty, per watchFieldsAuto.
+		{"job.representatives.company_assigned", []string{}},
+		{"job.representatives.company_changed", []string{}},
 		{"job.appointments.initial_created", []string{"initialAppointment"}},
 		{"job.appointments.initial_updated", []string{"initialAppointment"}},
 		{"job.invoice_updated", []string{"invoice"}},


### PR DESCRIPTION
## Problem

The connector supports subscriptions on `jobs` and `contacts` only. The representative topics were reachable solely as `otherEvents` under `jobs`, delivered as job updates. Review outcome: `jobs/representatives` should be a first-class object read and subscribe, `objectName: jobs/representatives`, not under `otherEvents`, with `job.representatives.company_assigned` treated as an update and `watchFieldsAuto: all` (no single field expresses the change). Configuring that shape today fails at the Subscription Updated operation during installation update:

```
acculynx: object does not support subscriptions: jobs/representatives

```
<img width="1431" height="897" alt="image" src="https://github.com/user-attachments/assets/618a34cb-ce6d-4e80-97c7-60aca4b319eb" />


## Live findings

Two facts drove the design, both verified against the live API:

| Finding | Evidence |
|---|---|
| AccuLynx rotates the representative's own id on **every** assignment | the same job produced `677c7f8a` → `01740a46` → `9ced12bc` across consecutive changes |
| The company representative is a per-job singleton with its own getter | `GET /jobs/{jobId}/representatives/company` → 200, full record including `type`, which the webhook payload omits |

So the record id is the **job id** — the slot's only stable identity. Keying on the representative id would create a new record per change instead of updating one. This also matches the existing `RecordId` convention for `jobs/representatives/*` in write and delete.

## Fix

- `subscribe.go` — `objectEventTopics` entry: `updateEvent` resolves both topics (`company_assigned`, `company_changed`). Both are updates — the slot always exists, assignment fills it; AccuLynx has no create/delete topic for it. Mirrors salesloft's nested `activities/emails` subscription object.
- `subscriptionEvent.go` — exact topic→object overrides consulted before the prefix fallback, so the two topics resolve to `jobs/representatives`; `company_assigned` pinned to update ahead of the suffix heuristic (`_assigned` would classify as "other" — the inverse of housecallPro's `employee.*` case, which stays "other" because no get-by-id endpoint exists there); `objectWrapper` maps the new object to the `job` wrapper; representative topics removed from `topicToUpdatedFields` — they are updates to the object itself, so `UpdatedFields` stays empty and `watchFieldsAuto` covers it.
- `batchRecordReader.go` — `jobs/representatives` added to `batchReadableObjects`; `singleRecordURL` routes it to the company-role path (the default `/{object}/{id}` join would build a nonexistent URL). Keeps every subscribable object hydratable, matching the invariant jobber enforces by construction.
- Read support needs no change — the nested fan-out and the Representative→Job association already exist.

## Known limitation

`company_assigned` cannot be re-fired in the sandbox: every job already has a company representative and the slot has no DELETE, so assignment is a one-way door. It is covered by the captured live payload in unit tests; `company_changed` is exercised live.

## Verification

### unit tests
- registration: `jobs/representatives` + `updateEvent` → exactly the two topics; `createEvent` rejected
- inbound: object, event type and record id resolution for both topics, against the live payload shape
- hydration: routed to `/jobs/{jobId}/representatives/company`, missing rep → 404 skipped without failing the batch

<img width="1478" height="887" alt="image" src="https://github.com/user-attachments/assets/7296d0ac-7034-4f83-8f5f-8b2c5871ab01" />


### live
- `Subscribe` with the target shape created a subscription carrying exactly the two topics
- a real rep swap (`POST /jobs/{id}/representatives/company`) delivered `company_changed` within seconds; the payload resolved to `jobs/representatives` / update / job id, and `GetRecordsByIds` with that id returned the full record matching the state the webhook announced
- platform read backfill for the object: 146 records, paginated, job associations attached

<img width="1728" height="901" alt="image" src="https://github.com/user-attachments/assets/28370a4b-3641-4b97-b6e3-486e7b4f832d" />


<img width="1465" height="989" alt="image" src="https://github.com/user-attachments/assets/13a15641-40e3-45f8-8a8c-015301b18663" />

<img width="1465" height="989" alt="image" src="https://github.com/user-attachments/assets/730ca790-a0d9-4bf6-ac2e-3aaca664095b" />

