### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	cloud.google.com/go/bigquery v1.82.0
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260903233810-1f726c8f0c8d
+	github.com/amp-labs/amp-common v0.0.0-20260908201037-700455187f3d
 	github.com/antchfx/xmlquery v1.5.1
 	github.com/apache/arrow/go/v15 v15.0.2
 	github.com/aws/aws-sdk-go-v2 v1.45.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260903233810-1f726c8f0c8d h1:yxPstgvSrzdQ7oeSHdyaKXQqUYzyJ2ZZ/J8Hemc+mT4=
-github.com/amp-labs/amp-common v0.0.0-20260903233810-1f726c8f0c8d/go.mod h1:VaYK0tIYXkxNyIXsFYEgP0T8EmeQD9zEZNjXuXEPx6A=
+github.com/amp-labs/amp-common v0.0.0-20260908201037-700455187f3d h1:eY/j4NlYExEXOkB12sFTOCxsw0PKYnqW1FI5T2HxHRU=
+github.com/amp-labs/amp-common v0.0.0-20260908201037-700455187f3d/go.mod h1:VaYK0tIYXkxNyIXsFYEgP0T8EmeQD9zEZNjXuXEPx6A=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [700455187f3d8f2dd184a171788ff47170510d55](https://github.com/amp-labs/amp-common/commit/700455187f3d8f2dd184a171788ff47170510d55) from [main](https://github.com/amp-labs/amp-common/tree/main)