### PR TITLE
[auto] Update amp-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,43 +1,6 @@
 module github.com/amp-labs/connectors
 
-go 1.26.5
-
-require (
-	cloud.google.com/go/bigquery v1.82.0
-	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/amp-labs/amp-common v0.0.0-20260908201524-747c72091278
-	github.com/antchfx/xmlquery v1.5.1
-	github.com/apache/arrow/go/v15 v15.0.2
-	github.com/aws/aws-sdk-go-v2 v1.45.1
-	github.com/aws/aws-sdk-go-v2/config v1.33.2
-	github.com/aws/aws-sdk-go-v2/credentials v1.20.2
-	github.com/brianvoe/gofakeit/v6 v6.28.0
-	github.com/chromedp/chromedp v0.16.0
-	github.com/deiu/linkparser v0.0.0-20170608193052-9b6849e15168
-	github.com/gertd/go-pluralize v0.2.1
-	github.com/getkin/kin-openapi v0.149.0
-	github.com/go-playground/validator v9.31.0+incompatible
-	github.com/go-test/deep v1.1.1
-	github.com/gobwas/glob v0.2.3
-	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
-	github.com/iancoleman/strcase v0.3.0
-	github.com/invopop/jsonschema v0.14.0
-	github.com/invopop/yaml v0.3.1
-	github.com/kaptinlin/jsonschema v0.9.8
-	github.com/mitchellh/hashstructure v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0
-	github.com/spyzhov/ajson v0.9.6
-	github.com/stretchr/testify v1.12.1
-	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
-	go.uber.org/atomic v1.11.0
-	golang.org/x/net v0.58.0
-	golang.org/x/oauth2 v0.36.0
-	golang.org/x/text v0.41.0
-	google.golang.org/api v0.295.0
-	google.golang.org/grpc v1.83.2
-)
+go 1.27.0
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
@@ -124,6 +87,40 @@ require (
 )
 
 require (
+	cloud.google.com/go/bigquery v1.82.0
+	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/amp-labs/amp-common v0.0.0-20260908230013-b0066040a105
+	github.com/antchfx/xmlquery v1.5.1
+	github.com/apache/arrow/go/v15 v15.0.2
+	github.com/aws/aws-sdk-go-v2 v1.45.1
+	github.com/aws/aws-sdk-go-v2/config v1.33.2
+	github.com/aws/aws-sdk-go-v2/credentials v1.20.2
+	github.com/brianvoe/gofakeit/v6 v6.28.0
+	github.com/chromedp/chromedp v0.16.0
+	github.com/deiu/linkparser v0.0.0-20170608193052-9b6849e15168
+	github.com/gertd/go-pluralize v0.2.1
+	github.com/getkin/kin-openapi v0.149.0
+	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/go-test/deep v1.1.1
+	github.com/gobwas/glob v0.2.3
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
+	github.com/iancoleman/strcase v0.3.0
+	github.com/invopop/jsonschema v0.14.0
+	github.com/invopop/yaml v0.3.1
+	github.com/kaptinlin/jsonschema v0.9.8
+	github.com/mitchellh/hashstructure v1.1.0
+	github.com/mitchellh/mapstructure v1.5.0
+	github.com/spyzhov/ajson v0.9.6
+	github.com/stretchr/testify v1.12.1
+	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
+	go.uber.org/atomic v1.11.0
+	golang.org/x/net v0.58.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/text v0.41.0
+	google.golang.org/api v0.295.0
+	google.golang.org/grpc v1.83.2
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/amp-labs/amp-common v0.0.0-20260908201524-747c72091278 h1:T1HL+fldJ442qQIX+yT1/h9WkXemEpYam+w4dY4sVRY=
-github.com/amp-labs/amp-common v0.0.0-20260908201524-747c72091278/go.mod h1:oCEHvKhZT8DI31xLuPLsB5b51DDKfLUMupb0s4WjLFA=
+github.com/amp-labs/amp-common v0.0.0-20260908230013-b0066040a105 h1:PxToD4yJ0oYahtp7dTtK+UUzUJmrm8BXUDJG6ESJalM=
+github.com/amp-labs/amp-common v0.0.0-20260908230013-b0066040a105/go.mod h1:QN5Tam7Bi3oBMFLsTRBW0F/8fP3rQfNd1xbghUdoDn4=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=


### PR DESCRIPTION
This PR updates the amp-common dependency to version [b0066040a105166bf92161c7194e003ac644a264](https://github.com/amp-labs/amp-common/commit/b0066040a105166bf92161c7194e003ac644a264) from [main](https://github.com/amp-labs/amp-common/tree/main)